### PR TITLE
Install docs update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ option(MLX_BUILD_METAL "Build metal backend" ON)
 option(BUILD_SHARED_LIBS "Build mlx as a shared library" OFF)
 
 if(NOT MLX_VERSION)
-  set(MLX_VERSION 0.0.1)
+  set(MLX_VERSION 0.0.3)
 endif()
 
 # ----------------------------- Lib -----------------------------
@@ -41,16 +41,19 @@ elseif (MLX_BUILD_METAL)
   message(STATUS "Building METAL sources")
   add_compile_definitions(_METAL_)
 
-  execute_process(COMMAND zsh "-c" "/usr/bin/sw_vers | cut -f2- -d: | sed -n 2p | grep -Eo '[0-9]+.[0-9]+'"
+  execute_process(COMMAND zsh "-c" "/usr/bin/xcrun -sdk macosx --show-sdk-version"
                   OUTPUT_VARIABLE MACOS_VERSION)
 
-  message(STATUS "Detected macOS version ${MACOS_VERSION}")
-  if (${MACOS_VERSION} GREATER_EQUAL 14.0)
+  message(STATUS "Building with SDK for MacOS version ${MACOS_VERSION}")
+  
+  if (${MACOS_VERSION} GREATER_EQUAL 14.2)
+    set(METAL_CPP_URL https://developer.apple.com/metal/cpp/files/metal-cpp_macOS14.2_iOS17.2.zip)
+  elseif (${MACOS_VERSION} GREATER_EQUAL 14.0)
     set(METAL_CPP_URL https://developer.apple.com/metal/cpp/files/metal-cpp_macOS14_iOS17-beta.zip)
   elseif (${MACOS_VERSION} GREATER_EQUAL 13.3)
     set(METAL_CPP_URL https://developer.apple.com/metal/cpp/files/metal-cpp_macOS13.3_iOS16.4.zip)
   else()
-    set(METAL_CPP_URL https://developer.apple.com/metal/cpp/files/metal-cpp_macOS13_iOS16.zip)
+    message(FATAL_ERROR "MLX requires MacOS >= 13.4 to be built with MLX_BUILD_METAL=ON" )
   endif()
 
   FetchContent_Declare(

--- a/docs/src/install.rst
+++ b/docs/src/install.rst
@@ -63,14 +63,6 @@ To make sure the install is working run the tests with:
 
   python -m unittest discover python/tests
 
-If you have multiple Xcode installations and wish to use 
-only one while building, you can do so by adding the 
-follwing environment variable before building 
-
-.. code-block:: shell
-
-  export DEVELOPER_DIR="/path/to/Xcode.app/Contents/Developer/"
-
 C++ API
 ^^^^^^^
 
@@ -124,3 +116,21 @@ should point to the path to the built metal library.
      - ON
    * - MLX_BUILD_PYTHON_BINDINGS
      - OFF
+
+
+.. note::
+
+    If you have multiple Xcode installations and wish to use 
+    a specific one while building, you can do so by adding the 
+    following environment variable before building 
+
+    .. code-block:: shell
+
+      export DEVELOPER_DIR="/path/to/Xcode.app/Contents/Developer/"
+
+    Further, you can use the following command to find out which 
+    MacOS SDK will be used
+
+    .. code-block:: shell
+
+      xcrun -sdk macosx --show-sdk-version

--- a/docs/src/install.rst
+++ b/docs/src/install.rst
@@ -11,6 +11,10 @@ silicon computer is
 
     pip install mlx
 
+.. note::
+    MLX is only available on devices running MacOS >= 13.3 
+    It is highly recommended to use MacOS 14 (Sonoma)
+
 Build from source
 -----------------
 
@@ -19,6 +23,7 @@ Build Requirements
 
 - A C++ compiler with C++17 support (e.g. Clang >= 5.0)
 - `cmake <https://cmake.org/>`_ -- version 3.24 or later, and ``make``
+- Xcode >= 14.3 (Xcode >= 15.0 for MacOS 14 and above)
 
 
 Python API
@@ -57,6 +62,14 @@ To make sure the install is working run the tests with:
 .. code-block:: shell
 
   python -m unittest discover python/tests
+
+If you have multiple Xcode installations and wish to use 
+only one while building, you can do so by adding the 
+follwing environment variable before building 
+
+.. code-block:: shell
+
+  export DEVELOPER_DIR="/path/to/Xcode.app/Contents/Developer/"
 
 C++ API
 ^^^^^^^


### PR DESCRIPTION
* Add notes about MacOS version restrictions for mlx in install docs 
* Add notes about Xcode version requirements for building from source in install docs
* Let make detect the macosx sdk version being used 
* Throw error if trying to build metal kernels with macOS <= 13.4 
* Add metal-cpp for macOS 14.2 