### PR TITLE
add numpy and torch to extras_require for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 
 # Metal libraries
 *.metallib
+venv/
 
 # Distribution / packaging
 python/mlx/share

--- a/docs/src/install.rst
+++ b/docs/src/install.rst
@@ -55,7 +55,7 @@ For developing use an editable install:
 To make sure the install is working run the tests with:
 
 .. code-block:: shell
-
+  pip install ".[testing]"
   python -m unittest discover python/tests
 
 C++ API

--- a/setup.py
+++ b/setup.py
@@ -145,6 +145,9 @@ if __name__ == "__main__":
         package_dir=package_dir,
         package_data=package_data,
         include_package_data=True,
+        extras_require={
+            "testing": ["numpy", "torch"]
+        },
         ext_modules=[CMakeExtension("mlx.core")],
         cmdclass={"build_ext": CMakeBuild},
         zip_safe=False,


### PR DESCRIPTION
Added `extra_requires` to setup.py including numpy and pytorch to run the tests. PyTorch is optional so can be left out if desired. 

Installing the testing specific packages are now as simple as running 
```sh
pip install ".[testing]"
```