### PR TITLE
Added initial support for Int8 Quantization and AbsmaxQuantizedLinear 

### DIFF
--- a/python/mlx/nn/layers/__init__.py
+++ b/python/mlx/nn/layers/__init__.py
@@ -27,7 +27,7 @@ from mlx.nn.layers.containers import Sequential
 from mlx.nn.layers.convolution import Conv1d, Conv2d
 from mlx.nn.layers.dropout import Dropout
 from mlx.nn.layers.embedding import Embedding
-from mlx.nn.layers.linear import Linear
+from mlx.nn.layers.linear import Linear, absmax_quantize, AbsmaxQuantizedLinear
 from mlx.nn.layers.normalization import GroupNorm, LayerNorm, RMSNorm
 from mlx.nn.layers.positional_encoding import RoPE, SinusoidalPositionalEncoding
 from mlx.nn.layers.transformer import (

--- a/python/mlx/nn/layers/linear.py
+++ b/python/mlx/nn/layers/linear.py
@@ -1,6 +1,7 @@
 # Copyright © 2023 Apple Inc.
 
 import math
+from typing import Any
 
 import mlx.core as mx
 from mlx.nn.layers.base import Module
@@ -68,6 +69,12 @@ class AbsmaxQuantizedLinear(Module):
         self.scale = mx.ones((output_dims, input_dims))
         if bias:
             self.bias = mx.zeros((output_dims,))
+
+    def __setattr__(self, key: str, val: Any):
+        if key == "weight" and isinstance(val, mx.array) and val.dtype != mx.int8:
+            val, scale = absmax_quantize(val)
+            self.scale = scale
+        return super().__setattr__(key, val)
 
     def __call__(self, x: mx.array) -> mx.array:
         x = x @ (self.weight.T * self.scale)

--- a/python/mlx/nn/layers/linear.py
+++ b/python/mlx/nn/layers/linear.py
@@ -1,7 +1,7 @@
 # Copyright © 2023 Apple Inc.
 
 import math
-from typing import Any
+from typing import Any, Tuple
 
 import mlx.core as mx
 from mlx.nn.layers.base import Module
@@ -37,11 +37,16 @@ class Linear(Module):
         return x
 
 
-def absmax_quantize(x: mx.array):
+def absmax_quantize(x: mx.array) -> Tuple[mx.array, mx.array]:
     """Quantize the input to int8 using absmax method.
     Returns:
         (mx.array, mx.array): (quantized x, scale)
     """
+    assert x.dtype in (
+        mx.float32,
+        mx.float16,
+        mx.bfloat16,
+    ), f"Unsupported weight for quantization dtype: {x.dtype}"
     scale = x.abs().max(axis=1) / 127.0
     new_x = (x / scale).astype(mx.int8)
     return (

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -21,7 +21,7 @@ class TestNN(mlx_tests.MLXTestCase):
     def test_int8_quantize(self):
         inputs = mx.full((2, 2), 2.0, dtype=mx.float32)
         new_inputs, scale = nn.absmax_quantize(inputs)
-        res = new_inputs.astype(mx.float32) * scale
+        res = new_inputs * scale
         assert np.allclose(res, inputs)
 
     def test_linear_quantize(self):

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -30,6 +30,16 @@ class TestNN(mlx_tests.MLXTestCase):
         outputs = layer(inputs)
         self.assertEqual(tuple(outputs.shape), (2, 2))
 
+        x = mx.full((2, 2), 10, dtype=mx.float32)
+        setattr(layer, "weight", x)
+        self.assertEqual(layer.weight.dtype, mx.int8)
+        self.assertEqual(tuple(layer.weight.shape), (2, 2))
+        res = layer(x)
+        self.assertEqual(res.dtype, mx.float32)
+        self.assertEqual(tuple(res.shape), (2, 2))
+        # note the previous test set the weight to 10 so its 10 @ 10
+        self.assertEqual(res.tolist(), mx.full((2, 2), 200, dtype=mx.float32).tolist())
+
     def test_cross_entropy(self):
         logits = mx.array([[0.0, -float("inf")], [-float("inf"), 0.0]])
         targets = mx.array([0, 1])

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -18,6 +18,18 @@ class TestNN(mlx_tests.MLXTestCase):
         outputs = layer(inputs)
         self.assertEqual(tuple(outputs.shape), (10, 8))
 
+    def test_int8_quantize(self):
+        inputs = mx.full((2, 2), 2.0, dtype=mx.float32)
+        new_inputs, scale = nn.absmax_quantize(inputs)
+        res = new_inputs.astype(mx.float32) * scale
+        assert np.allclose(res, inputs)
+
+    def test_linear_quantize(self):
+        inputs = mx.full((2, 2), 2.0, dtype=mx.float32)
+        layer = nn.AbsmaxQuantizedLinear(input_dims=2, output_dims=2)
+        outputs = layer(inputs)
+        self.assertEqual(tuple(outputs.shape), (2, 2))
+
     def test_cross_entropy(self):
         logits = mx.array([[0.0, -float("inf")], [-float("inf"), 0.0]])
         targets = mx.array([0, 1])


### PR DESCRIPTION
Added initial support for int8 quantization using absmax method

The quantize method is separate but added a check in __setattr__ to auto convert the weight if its not int8. 

Partially address #13 