### PR TITLE
AdamW implementation, without correction

### DIFF
--- a/python/mlx/optimizers.py
+++ b/python/mlx/optimizers.py
@@ -152,3 +152,54 @@ class Adam(Optimizer):
         state["v"] = v
 
         return parameter - lr * m / (mx.sqrt(v) + eps)
+
+
+class AdamW(Optimizer):
+    r"""Implementation of the AdamW optimizer [1].
+
+    Following the above convention, in contrast with [1], we do not use bias
+    correction in the first and second moments for AdamW. We update the weights 
+    with a weight_decay (λ) value:
+
+    .. math::
+
+        m_{t+1} &= \beta_1 m_t + (1 - \beta_1) g_t \\
+        v_{t+1} &= \beta_2 v_t + (1 - \beta_2) g_t^2 \\
+        w_{t+1} &= w_t - \alpha (\frac{m_{t+1}}{\sqrt{v_{t+1} + \epsilon}} + \lambda w_t)
+
+    [1]: Loshchilov, I. and Hutter, F., 2019. Decoupled weight decay 
+    regularization. ICLR 2019.
+    """
+
+    def __init__(
+        self,
+        learning_rate: float,
+        betas: List[float] = [0.9, 0.999],
+        eps: float = 1e-8,
+        weight_decay: float = 0.01,
+    ):
+        super().__init__()
+
+        self.learning_rate = learning_rate
+        self.betas = betas
+        self.eps = eps
+        self.weight_decay = weight_decay
+
+    def apply_single(
+        self, gradient: mx.array, parameter: mx.array, state: OptimizerState
+    ):
+        """Performs the AdamW parameter update and stores :math:`v` and
+        :math:`m` in the optimizer state."""
+        lr = self.learning_rate
+        b1, b2 = self.betas
+        eps = self.eps
+        wd = self.weight_decay
+
+        m = state.get("m", gradient)
+        v = state.get("v", mx.square(gradient))
+        m = b1 * m + (1 - b1) * gradient
+        v = b2 * v + (1 - b2) * mx.square(gradient)
+        state["m"] = m
+        state["v"] = v
+
+        return parameter - lr * (m / (mx.sqrt(v) + eps) + wd * parameter)


### PR DESCRIPTION
Implementation of AdamW, but without correction of the first and second moments. Following the convention of the Adam implementation in the repo.

If you want the paper convention of correction, that implementation is here:

https://github.com/jbarrow/mlxllama/blob/cb2a808eefafc340db91e7d8f97ca334f6afff2a/mlxllama/optim.py