### PR TITLE
Expose the device from the array in python

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v14.0.6
+    rev: v17.0.6
     hooks:
     -   id: clang-format
 -   repo: https://github.com/psf/black

--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -10,6 +10,7 @@
 #include "python/src/utils.h"
 
 #include "mlx/ops.h"
+#include "mlx/primitives.h"
 #include "mlx/transforms.h"
 #include "mlx/utils.h"
 
@@ -508,6 +509,17 @@ void init_array(py::module_& m) {
           R"pbdoc(
             The array's :class:`Dtype`.
           )pbdoc")
+      .def_property_readonly(
+          "device",
+          [](const array& a) {
+            if (a.has_primitive()) {
+              return a.primitive().device();
+            }
+            return Device(Device::cpu);
+          },
+          R"pbdoc(
+          The device on which the array resides.
+        )pbdoc")
       .def(
           "item",
           &to_scalar,

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -18,6 +18,18 @@ class TestVersion(mlx_tests.MLXTestCase):
         self.assertEqual(v, mx.__version__[: len(v)])
 
 
+class TestDevice(mlx_tests.MLXTestCase):
+    def test_default_device(self):
+        mx.set_default_device(mx.cpu)
+        x = mx.ones(2)
+        self.assertEqual(x.device, mx.cpu)
+        mx.set_default_device(mx.gpu)
+        x = mx.ones(2)
+        self.assertEqual(x.device, mx.gpu)
+        y = mx.add(x, x, stream=mx.default_stream(mx.cpu))
+        self.assertEqual(y.device, mx.cpu)
+
+
 class TestDtypes(mlx_tests.MLXTestCase):
     def test_dtypes(self):
         self.assertEqual(mx.bool_.size, 1)


### PR DESCRIPTION
A common property to expose, useful for debugging like in #49. Where users may want to double check to ensure the array is on the gpu.

Added some basic tests with default device as well as switching the stream the op is performed on.

Defaulting to cpu if no primitive is found. 