### PR TITLE
Make it easier to test new optimizers implemented: no need to change test file manually

### DIFF
--- a/python/tests/test_optimizers.py
+++ b/python/tests/test_optimizers.py
@@ -1,8 +1,8 @@
 # Copyright © 2023 Apple Inc.
 
 import unittest
-import sys
 import inspect
+
 import mlx.core as mx
 import mlx.optimizers as opt
 import mlx.utils

--- a/python/tests/test_optimizers.py
+++ b/python/tests/test_optimizers.py
@@ -1,12 +1,22 @@
 # Copyright © 2023 Apple Inc.
 
 import unittest
-
+import sys
+import inspect
 import mlx.core as mx
 import mlx.optimizers as opt
 import mlx.utils
 import mlx_tests
 
+def get_all_optimizers():
+    classes = dict()
+    for name, obj in inspect.getmembers(opt):
+        if inspect.isclass(obj):
+            if obj.__name__ not in ["OptimizerState", "Optimizer"]:
+                classes[name] = obj
+    return classes
+
+optimizers_dict = get_all_optimizers()
 
 class TestOptimizers(mlx_tests.MLXTestCase):
     def test_optimizers(self):
@@ -16,7 +26,8 @@ class TestOptimizers(mlx_tests.MLXTestCase):
         }
         grads = mlx.utils.tree_map(lambda x: mx.ones_like(x), params)
 
-        for optim in [opt.SGD(0.1), opt.Adam(0.1)]:
+        for optim_class in optimizers_dict.values():
+            optim = optim_class(0.1)
             update = optim.apply_gradients(grads, params)
             mx.eval(update)
             equal_shape = mlx.utils.tree_map(


### PR DESCRIPTION
This is the same as #79 except that the helper function is moved to `mlx/python/tests/test_optimizers.py` and the implementation of GD is removed for simplicity.

A helper function is added so that in we do not need to modify the test file manually every time a new optimizer is added. In current main branch: (`mlx/python/tests/test_optimizers.py`, line 20)
```python3
for optim in [opt.SGD(0.1), opt.Adam(0.1)]:
    ...
```

With the helper function `get_all_optimizers()`, this is modified to:
```python3
optimizers_dict = get_all_optimizers()
...
for optim_class in optimizers_dict.values():
    optim = optim_class(0.1)
    ...
```

Hence developers can simply run `mlx/python/tests/test_optimizers.py` to see whether new optimizers are implemented correctly and there will be no need to modify this test file manually.