### PR TITLE
Use compiled black as the pre-commit formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,8 @@ repos:
     rev: v14.0.6
     hooks:
     -   id: clang-format
--   repo: https://github.com/psf/black
+# Using this mirror lets us use mypyc-compiled black, which is about 2x faster
+-   repo: https://github.com/psf/black-pre-commit-mirror
     rev: 22.10.0
     hooks:
     -   id: black


### PR DESCRIPTION
The black offical repo [recommends](https://black.readthedocs.io/en/stable/integrations/source_version_control.html) us to use https://github.com/psf/black-pre-commit-mirror as the pre-commit hooks, which will work about **2x as fast** as using the hooks in the original repository (https://github.com/psf/black).