### PR TITLE
fix: tidy pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,12 @@
+## Proposed changes
 
-Before submitting this PR, check the [contribution guidelines](CONTRIBUTING.md).
+Please include a description of the problem or feature this PR is addressing.
 
-Make sure your code is formatted: `pre-commit run --all-files`.
+## Checklist
+
+Put an `x` in the boxes that apply.
+
+- [ ] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
+- [ ] I have run `pre-commit run --all-files` to format my code
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have updated the necessary documentation (if needed)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,12 @@
 ## Proposed changes
 
-Please include a description of the problem or feature this PR is addressing.
+Please include a description of the problem or feature this PR is addressing. If there is a corresponding issue, include the issue #.
 
 ## Checklist
 
 Put an `x` in the boxes that apply.
 
 - [ ] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
-- [ ] I have run `pre-commit run --all-files` to format my code
+- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] I have updated the necessary documentation (if needed)


### PR DESCRIPTION
This fixes the template which redirects to https://github.com/ml-explore/mlx/blob/main/.github/CONTRIBUTING.md instead of https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md

Also adds a checklist to help, lemme know if anything needs to be tweaked.