### PR TITLE
Docs update

### DIFF
--- a/docs/src/unified_memory.rst
+++ b/docs/src/unified_memory.rst
@@ -6,7 +6,7 @@ Unified Memory
 .. currentmodule:: mlx.core
 
 Apple silicon has a unified memory architecture. The CPU and GPU have direct
-access to the same memory pool. MLX is designed to take advantage that.
+access to the same memory pool. MLX is designed to take advantage of that.
 
 Concretely, when you make an array in MLX you don't have to specify its location:
 


### PR DESCRIPTION
Just fixes a small typo I noticed while reviewing the docs. I tried running Sphinx locally to verify the change but kept getting this error even without my change:
```
Running Sphinx v6.2.1
WARNING: The pre-Sphinx 1.0 'intersphinx_mapping' format is deprecated and will be removed in Sphinx 8. Update to the current format as described in the documentation. Hint: "intersphinx_mapping = {'<name>': ('https://docs.python.org/3', None)}".https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping
WARNING: The pre-Sphinx 1.0 'intersphinx_mapping' format is deprecated and will be removed in Sphinx 8. Update to the current format as described in the documentation. Hint: "intersphinx_mapping = {'<name>': ('https://numpy.org/doc/stable/', None)}".https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping
[autosummary] generating autosummary for: cpp/ops.rst, dev/extensions.rst, examples/linear_regression.rst, examples/llama-inference.rst, examples/mlp.rst, index.rst, install.rst, python/array.rst, python/data_types.rst, python/devices_and_streams.rst, ..., python/nn.rst, python/nn/module.rst, python/ops.rst, python/optimizers.rst, python/random.rst, python/transforms.rst, python/tree_utils.rst, quick_start.rst, unified_memory.rst, using_streams.rst

Extension error (sphinx.ext.autosummary):
Handler <function process_generate_options at 0x103abc550> for event 'builder-inited' threw an exception (exception: no module named mlx.core)
make: *** [html] Error 2
```

Seems like the change is small enough that not re-creating the html locally would be fine