### PR TITLE
Add move and swap axis, and vmap for slice, concat, and gather

### DIFF
--- a/docs/src/python/ops.rst
+++ b/docs/src/python/ops.rst
@@ -61,6 +61,7 @@ Operations
    mean
    min
    minimum
+   moveaxis
    multiply
    negative
    ones
@@ -87,6 +88,7 @@ Operations
    stop_gradient
    subtract
    sum
+   swapaxes
    take
    take_along_axis
    tan

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -677,6 +677,53 @@ array pad(
       s);
 }
 
+array moveaxis(
+    const array& a,
+    int source,
+    int destination,
+    StreamOrDevice s /* = {} */) {
+  auto check_ax = [&a](int ax) {
+    auto ndim = static_cast<int>(a.ndim());
+    if (ax < -ndim || ax >= ndim) {
+      std::ostringstream msg;
+      msg << "[moveaxis] Invalid axis " << ax << " for array with " << ndim
+          << " dimensions.";
+      throw std::out_of_range(msg.str());
+    }
+    return ax < 0 ? ax + ndim : ax;
+  };
+  source = check_ax(source);
+  destination = check_ax(destination);
+  std::vector<int> reorder(a.ndim());
+  std::iota(reorder.begin(), reorder.end(), 0);
+  reorder.erase(reorder.begin() + source);
+  reorder.insert(reorder.begin() + destination, source);
+  return transpose(a, reorder, s);
+}
+
+array swapaxes(
+    const array& a,
+    int axis1,
+    int axis2,
+    StreamOrDevice s /* = {} */) {
+  auto check_ax = [&a](int ax) {
+    auto ndim = static_cast<int>(a.ndim());
+    if (ax < -ndim || ax >= ndim) {
+      std::ostringstream msg;
+      msg << "[swapaxes] Invalid axis " << ax << " for array with " << ndim
+          << " dimensions.";
+      throw std::out_of_range(msg.str());
+    }
+    return ax < 0 ? ax + ndim : ax;
+  };
+  axis1 = check_ax(axis1);
+  axis2 = check_ax(axis2);
+  std::vector<int> reorder(a.ndim());
+  std::iota(reorder.begin(), reorder.end(), 0);
+  std::swap(reorder[axis1], reorder[axis2]);
+  return transpose(a, reorder, s);
+}
+
 array transpose(
     const array& a,
     std::vector<int> axes,

--- a/mlx/ops.h
+++ b/mlx/ops.h
@@ -183,6 +183,16 @@ inline array transpose(
   return transpose(a, std::vector<int>(axes), s);
 }
 
+/** Swap two axes of an array. */
+array swapaxes(const array& a, int axis1, int axis2, StreamOrDevice s = {});
+
+/** Move an axis of an array. */
+array moveaxis(
+    const array& a,
+    int source,
+    int destination,
+    StreamOrDevice s = {});
+
 /** Pad an array with a constant value */
 array pad(
     const array& a,

--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -2,7 +2,6 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
-#include <iostream> // TODO
 #include <numeric>
 #include <sstream>
 #include <stdexcept>

--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -863,6 +863,22 @@ void init_array(py::module_& m) {
           "stream"_a = none,
           "See :func:`any`.")
       .def(
+          "moveaxis",
+          &moveaxis,
+          "source"_a,
+          "destination"_a,
+          py::kw_only(),
+          "stream"_a = none,
+          "See :func:`moveaxis`.")
+      .def(
+          "swapaxes",
+          &swapaxes,
+          "axis1"_a,
+          "axis2"_a,
+          py::kw_only(),
+          "stream"_a = none,
+          "See :func:`moveaxis`.")
+      .def(
           "transpose",
           [](const array& a, py::args axes, StreamOrDevice s) {
             if (axes.size() > 0) {

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -1592,6 +1592,50 @@ void init_ops(py::module_& m) {
             array: The ceil of ``a``.
       )pbdoc");
   m.def(
+      "moveaxis",
+      &moveaxis,
+      "a"_a,
+      py::pos_only(),
+      "source"_a,
+      "destiantion"_a,
+      py::kw_only(),
+      "stream"_a = none,
+      R"pbdoc(
+        moveaxis(a: array, /, source: int, destination: int, *, stream: Union[None, Stream, Device] = None) -> array
+
+        Move an axis to a new position.
+
+        Args:
+            a (array): Input array.
+            source (int): Specifies the source axis.
+            destination (int): Specifies the destination axis.
+
+        Returns:
+            array: The array with the axis moved.
+      )pbdoc");
+  m.def(
+      "swapaxes",
+      &swapaxes,
+      "a"_a,
+      py::pos_only(),
+      "axis1"_a,
+      "axis2"_a,
+      py::kw_only(),
+      "stream"_a = none,
+      R"pbdoc(
+        swapaxes(a: array, /, axis1 : int, axis2: int, *, stream: Union[None, Stream, Device] = None) -> array
+
+        Swap two axes of an array.
+
+        Args:
+            a (array): Input array.
+            axis1 (int): Specifies the first axis.
+            axis2 (int): Specifies the second axis.
+
+        Returns:
+            array: The array with swapped axes.
+      )pbdoc");
+  m.def(
       "transpose",
       [](const array& a,
          const std::optional<std::vector<int>>& axes,

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -375,6 +375,13 @@ class TestOps(mlx_tests.MLXTestCase):
 
         self.assertListEqual(mx.transpose(x, axes=(0, 2, 1)).tolist(), expected)
 
+    def test_move_swap_axes(self):
+        x = mx.zeros((2, 3, 4))
+        self.assertEqual(mx.moveaxis(x, 0, 2).shape, [3, 4, 2])
+        self.assertEqual(x.moveaxis(0, 2).shape, [3, 4, 2])
+        self.assertEqual(mx.swapaxes(x, 0, 2).shape, [4, 3, 2])
+        self.assertEqual(x.swapaxes(0, 2).shape, [4, 3, 2])
+
     def test_sum(self):
         x = mx.array(
             [

--- a/python/tests/test_vmap.py
+++ b/python/tests/test_vmap.py
@@ -163,6 +163,61 @@ class TestVmap(mlx_tests.MLXTestCase):
         self.assertTrue(mx.array_equal(out["a"].T, expected["a"]))
         self.assertTrue(mx.array_equal(out["b"], expected["b"]))
 
+    def test_vmap_indexing(self):
+        x = mx.arange(16).reshape(2, 2, 2, 2)
+        inds = mx.array([[0, 1, 0], [1, 1, 0]])
+
+        out = mx.vmap(lambda x, y: x[y], in_axes=(0, 0))(x, inds)
+        expected = mx.array(
+            [
+                [[[0, 1], [2, 3]], [[4, 5], [6, 7]], [[0, 1], [2, 3]]],
+                [[[12, 13], [14, 15]], [[12, 13], [14, 15]], [[8, 9], [10, 11]]],
+            ]
+        )
+        self.assertTrue(mx.array_equal(out, expected))
+
+        out = mx.vmap(lambda x, y: x[y], in_axes=(0, None))(x, inds)
+        expected = mx.array(
+            [
+                [
+                    [[[0, 1], [2, 3]], [[4, 5], [6, 7]], [[0, 1], [2, 3]]],
+                    [[[4, 5], [6, 7]], [[4, 5], [6, 7]], [[0, 1], [2, 3]]],
+                ],
+                [
+                    [[[8, 9], [10, 11]], [[12, 13], [14, 15]], [[8, 9], [10, 11]]],
+                    [[[12, 13], [14, 15]], [[12, 13], [14, 15]], [[8, 9], [10, 11]]],
+                ],
+            ]
+        )
+        self.assertTrue(mx.array_equal(out, expected))
+
+        out = mx.vmap(lambda x, y: x[y], in_axes=(None, 0))(x, inds)
+        expected = mx.array(
+            [
+                [
+                    [[[0, 1], [2, 3]], [[4, 5], [6, 7]]],
+                    [[[8, 9], [10, 11]], [[12, 13], [14, 15]]],
+                    [[[0, 1], [2, 3]], [[4, 5], [6, 7]]],
+                ],
+                [
+                    [[[8, 9], [10, 11]], [[12, 13], [14, 15]]],
+                    [[[8, 9], [10, 11]], [[12, 13], [14, 15]]],
+                    [[[0, 1], [2, 3]], [[4, 5], [6, 7]]],
+                ],
+            ]
+        )
+        self.assertTrue(mx.array_equal(out, expected))
+
+        inds2 = mx.array([[0, 1, 0], [0, 1, 0]])
+        out = mx.vmap(lambda x, y, z: x[y, z], in_axes=(None, 0, 0))(x, inds, inds2)
+        expected = mx.array(
+            [
+                [[[0, 1], [2, 3]], [[12, 13], [14, 15]], [[0, 1], [2, 3]]],
+                [[[8, 9], [10, 11]], [[12, 13], [14, 15]], [[0, 1], [2, 3]]],
+            ]
+        )
+        self.assertTrue(mx.array_equal(out, expected))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/ops_tests.cpp
+++ b/tests/ops_tests.cpp
@@ -1,6 +1,6 @@
 // Copyright © 2023 Apple Inc.
-
 #include <cmath>
+#include <iostream> // TODO
 #include <numeric>
 
 #include "doctest/doctest.h"
@@ -203,6 +203,46 @@ TEST_CASE("test split") {
   CHECK(array_equal(out[1], array({})).item<bool>());
   CHECK(array_equal(out[2], array({1})).item<bool>());
   CHECK(array_equal(out[3], array({2, 3, 4})).item<bool>());
+}
+
+TEST_CASE("test swap and move axes") {
+  // Test swapaxes
+  array a(0.0);
+  CHECK_THROWS(swapaxes(a, 0, 0));
+
+  a = zeros({2});
+  CHECK_THROWS(swapaxes(a, 0, 1));
+  CHECK_EQ(swapaxes(a, 0, 0).shape(), std::vector<int>{2});
+  CHECK_EQ(swapaxes(a, -1, -1).shape(), std::vector<int>{2});
+
+  a = zeros({2, 3, 4});
+  CHECK_THROWS(swapaxes(a, 0, -4));
+  CHECK_THROWS(swapaxes(a, 0, 3));
+  CHECK_THROWS(swapaxes(a, 3, 0));
+  CHECK_THROWS(swapaxes(a, -4, 0));
+  CHECK_EQ(swapaxes(a, 0, 2).shape(), std::vector<int>{4, 3, 2});
+  CHECK_EQ(swapaxes(a, 0, 1).shape(), std::vector<int>{3, 2, 4});
+  CHECK_EQ(swapaxes(a, 0, -1).shape(), std::vector<int>{4, 3, 2});
+  CHECK_EQ(swapaxes(a, -2, 2).shape(), std::vector<int>{2, 4, 3});
+
+  // Test moveaxis
+  a = array(0.0);
+  CHECK_THROWS(moveaxis(a, 0, 0));
+
+  a = zeros({2});
+  CHECK_THROWS(moveaxis(a, 0, 1));
+  CHECK_EQ(moveaxis(a, 0, 0).shape(), std::vector<int>{2});
+  CHECK_EQ(moveaxis(a, -1, -1).shape(), std::vector<int>{2});
+
+  a = zeros({2, 3, 4});
+  CHECK_THROWS(moveaxis(a, 0, -4));
+  CHECK_THROWS(moveaxis(a, 0, 3));
+  CHECK_THROWS(moveaxis(a, 3, 0));
+  CHECK_THROWS(moveaxis(a, -4, 0));
+  CHECK_EQ(moveaxis(a, 0, 2).shape(), std::vector<int>{3, 4, 2});
+  CHECK_EQ(moveaxis(a, 0, 1).shape(), std::vector<int>{3, 2, 4});
+  CHECK_EQ(moveaxis(a, 0, -1).shape(), std::vector<int>{3, 4, 2});
+  CHECK_EQ(moveaxis(a, -2, 2).shape(), std::vector<int>{2, 4, 3});
 }
 
 TEST_CASE("test transpose") {

--- a/tests/ops_tests.cpp
+++ b/tests/ops_tests.cpp
@@ -1,6 +1,5 @@
 // Copyright © 2023 Apple Inc.
 #include <cmath>
-#include <iostream> // TODO
 #include <numeric>
 
 #include "doctest/doctest.h"

--- a/tests/vmap_tests.cpp
+++ b/tests/vmap_tests.cpp
@@ -275,7 +275,6 @@ TEST_CASE("test vmap concatenate") {
   auto y = reshape(arange(4), {2, 2});
   auto out = vmap(fun)({x, y})[0];
   auto expected = reshape(array({0, 1, 0, 1, 2, 3, 2, 3}), {2, 4});
-  std::cout << out.shape() << std::endl;
   CHECK(array_equal(out, expected).item<bool>());
   out = vmap(fun, {1, 1})({x, y})[0];
   expected = reshape(array({0, 2, 0, 2, 1, 3, 1, 3}), {2, 4});

--- a/tests/vmap_tests.cpp
+++ b/tests/vmap_tests.cpp
@@ -1,6 +1,5 @@
 // Copyright © 2023 Apple Inc.
 
-#include <iostream>
 #include "doctest/doctest.h"
 
 #include "mlx/mlx.h"

--- a/tests/vmap_tests.cpp
+++ b/tests/vmap_tests.cpp
@@ -1,5 +1,6 @@
 // Copyright © 2023 Apple Inc.
 
+#include <iostream>
 #include "doctest/doctest.h"
 
 #include "mlx/mlx.h"
@@ -246,5 +247,107 @@ TEST_CASE("test vmap creation ops") {
     out = vmap(fun, 1, 1)(x);
     expected = array({1, 2, 3, 1, 2, 3}, {2, 3});
     CHECK(array_equal(out, expected).item<bool>());
+  }
+}
+
+TEST_CASE("test vmap slice") {
+  {
+    auto fun = [](array in) { return slice(in, {4}, {8}, {2}); };
+    auto x = reshape(arange(16), {2, 8});
+    auto out = vmap(fun)(x);
+    auto expected = reshape(array({4, 6, 12, 14}), {2, 2});
+    CHECK(array_equal(out, expected).item<bool>());
+  }
+
+  {
+    auto fun = [](array in) { return slice(in, {0, 1}, {2, 3}); };
+    auto x = reshape(arange(12), {2, 2, 3});
+    auto out = vmap(fun, 1, 0)(x);
+    auto expected = reshape(array({1, 2, 7, 8, 4, 5, 10, 11}), {2, 2, 2});
+    CHECK(array_equal(out, expected).item<bool>());
+  }
+}
+
+TEST_CASE("test vmap concatenate") {
+  auto fun = [](std::vector<array> inputs) {
+    return std::vector<array>{concatenate(inputs, 0)};
+  };
+  auto x = reshape(arange(4), {2, 2});
+  auto y = reshape(arange(4), {2, 2});
+  auto out = vmap(fun)({x, y})[0];
+  auto expected = reshape(array({0, 1, 0, 1, 2, 3, 2, 3}), {2, 4});
+  std::cout << out.shape() << std::endl;
+  CHECK(array_equal(out, expected).item<bool>());
+  out = vmap(fun, {1, 1})({x, y})[0];
+  expected = reshape(array({0, 2, 0, 2, 1, 3, 1, 3}), {2, 4});
+  CHECK(array_equal(out, expected).item<bool>());
+  out = vmap(fun, {0, 1})({x, y})[0];
+  expected = reshape(array({0, 1, 0, 2, 2, 3, 1, 3}), {2, 4});
+  CHECK(array_equal(out, expected).item<bool>());
+}
+
+TEST_CASE("test vmap gather") {
+  {
+    auto fun = [](std::vector<array> inputs) {
+      auto src = inputs[0];
+      auto indices = inputs[1];
+      std::vector<int> slice_sizes = {1, 2, 2};
+      auto out = squeeze(gather(src, indices, 0, slice_sizes), 2);
+      return std::vector<array>{out};
+    };
+    auto x = zeros({2, 2, 2, 2});
+    auto y = array({0, 1, 0, 0, 1, 0}, {2, 3});
+    auto out = vmap(fun, {0, -1})({x, y})[0];
+    CHECK_EQ(out.shape(), std::vector<int>{2, 2, 3, 2, 2});
+    out = vmap(fun, {0, -1}, {3})({x, y})[0];
+    CHECK_EQ(out.shape(), std::vector<int>{2, 3, 2, 2, 2});
+  }
+
+  {
+    auto fun = [](std::vector<array> inputs) {
+      auto src = inputs[0];
+      auto indices = inputs[1];
+      std::vector<int> slice_sizes = {1, 2, 2};
+      auto out = squeeze(gather(src, indices, 0, slice_sizes), 1);
+      return std::vector<array>{out};
+    };
+    auto x = zeros({2, 2, 2, 2});
+    auto y = array({0, 1, 0, 0, 1, 0}, {2, 3});
+    auto out = vmap(fun, {0, 0})({x, y})[0];
+    CHECK_EQ(out.shape(), std::vector<int>{2, 3, 2, 2});
+  }
+
+  {
+    auto fun = [](std::vector<array> inputs) {
+      auto src = inputs[0];
+      auto indices = inputs[1];
+      std::vector<int> slice_sizes = {1, 2, 2, 2};
+      auto out = squeeze(gather(src, indices, 0, slice_sizes), 1);
+      return std::vector<array>{out};
+    };
+    auto x = zeros({2, 2, 2, 2});
+    auto y = array({0, 1, 0, 0, 1, 0}, {2, 3});
+
+    auto out = vmap(fun, {-1, 0})({x, y})[0];
+    CHECK_EQ(out.shape(), std::vector<int>{2, 3, 2, 2, 2});
+  }
+
+  {
+    auto fun = [](std::vector<array> inputs) {
+      auto src = inputs[0];
+      auto indices = std::vector<array>(inputs.begin() + 1, inputs.end());
+      std::vector<int> slice_sizes = {1, 1, 2, 2};
+      auto out = squeeze(gather(src, indices, {0, 1}, slice_sizes), {1, 2});
+      return std::vector<array>{out};
+    };
+    auto x = zeros({2, 2, 2, 2});
+    auto y = array({0, 1, 0, 0, 1, 0}, {2, 3});
+    auto z = array({0, 1, 0, 0, 1, 0}, {2, 3});
+    auto out = vmap(fun, {-1, 0, 0})({x, y, z})[0];
+    CHECK_EQ(out.shape(), std::vector<int>{2, 3, 2, 2});
+
+    z = array({0, 1, 0, 0, 1, 0}, {3, 2});
+    out = vmap(fun, {-1, 0, 1})({x, y, z})[0];
+    CHECK_EQ(out.shape(), std::vector<int>{2, 3, 2, 2});
   }
 }


### PR DESCRIPTION
## Proposed changes

Add two ops:
- `mx.moveaxis`
- `mx.swapaxes`

Add three missing vmaps:
- Concatenate
- Slice
- Gather