### PR TITLE
Lazy metal_device_ initialization

### DIFF
--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -17,8 +17,6 @@ namespace fs = std::filesystem;
 
 namespace mlx::core::metal {
 
-static Device metal_device_;
-
 namespace {
 
 // TODO nicer way to set this or possibly expose as an environment variable
@@ -240,6 +238,7 @@ MTL::ComputePipelineState* Device::get_kernel(
 }
 
 Device& device(mlx::core::Device) {
+  static Device metal_device_;
   return metal_device_;
 }
 


### PR DESCRIPTION
This ensures it is defined when the Scheduler needs it.

## Proposed changes

Lazy metal_device_ initialization: moving metal_device_ to local static variable instead of global one.
This ensures proper initialization order (in certain instances, Scheduler might need metal_device_, but if global static might not be initialized yet).

## Checklist

Put an `x` in the boxes that apply.

- [X ] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ X] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ X] I have added tests that prove my fix is effective or that my feature works
- [ X] I have updated the necessary documentation (if needed)
