### PR TITLE
Add `base` kwarg to RoPE

### DIFF
--- a/mlx/array.h
+++ b/mlx/array.h
@@ -154,8 +154,8 @@ class array {
     };
 
    private:
-    int idx;
     const array& arr;
+    int idx;
   };
 
   ArrayIterator begin() const {

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -463,6 +463,21 @@ class TestNN(mlx_tests.MLXTestCase):
             mx.array([0.8651, -0.3034, 0.0000, 0.3752]),
         )
 
+    def test_rope(self):
+        for kwargs in [{}, {"traditional": False}, {"base": 10000}]:
+            rope = nn.RoPE(4, **kwargs)
+            shape = (1, 3, 4)
+            x = mx.random.uniform(shape=shape)
+            y = rope(x)
+            self.assertTrue(y.shape, shape)
+            self.assertTrue(y.dtype, mx.float32)
+
+            y = rope(x, offset=3)
+            self.assertTrue(y.shape, shape)
+
+            y = rope(x.astype(mx.float16))
+            self.assertTrue(y.dtype, mx.float16)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Proposed changes

It's common to configure this parameter in the RopE encodings, so this makes it configurable

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
