### PR TITLE
implement-batch-norm-layer

### DIFF
--- a/docs/src/python/nn/layers.rst
+++ b/docs/src/python/nn/layers.rst
@@ -20,7 +20,7 @@ Layers
    Linear
    Conv1d
    Conv2d
-   BatchNorm1d
+   BatchNorm
    LayerNorm
    RMSNorm
    GroupNorm

--- a/docs/src/python/nn/layers.rst
+++ b/docs/src/python/nn/layers.rst
@@ -20,6 +20,7 @@ Layers
    Linear
    Conv1d
    Conv2d
+   BatchNorm1d
    LayerNorm
    RMSNorm
    GroupNorm

--- a/python/mlx/nn/layers/__init__.py
+++ b/python/mlx/nn/layers/__init__.py
@@ -36,9 +36,8 @@ from mlx.nn.layers.convolution import Conv1d, Conv2d
 from mlx.nn.layers.dropout import Dropout, Dropout2d
 from mlx.nn.layers.embedding import Embedding
 from mlx.nn.layers.linear import Linear
-from mlx.nn.layers.normalization import GroupNorm, LayerNorm, RMSNorm
-from mlx.nn.layers.positional_encoding import ALiBi, RoPE, SinusoidalPositionalEncoding
-from mlx.nn.layers.quantized import QuantizedLinear
+from mlx.nn.layers.normalization import BatchNorm, GroupNorm, LayerNorm, RMSNorm
+from mlx.nn.layers.positional_encoding import RoPE, SinusoidalPositionalEncoding
 from mlx.nn.layers.transformer import (
     MultiHeadAttention,
     TransformerEncoder,

--- a/python/mlx/nn/layers/__init__.py
+++ b/python/mlx/nn/layers/__init__.py
@@ -37,7 +37,8 @@ from mlx.nn.layers.dropout import Dropout, Dropout2d
 from mlx.nn.layers.embedding import Embedding
 from mlx.nn.layers.linear import Linear
 from mlx.nn.layers.normalization import BatchNorm, GroupNorm, LayerNorm, RMSNorm
-from mlx.nn.layers.positional_encoding import RoPE, SinusoidalPositionalEncoding
+from mlx.nn.layers.positional_encoding import ALiBi, RoPE, SinusoidalPositionalEncoding
+from mlx.nn.layers.quantized import QuantizedLinear
 from mlx.nn.layers.transformer import (
     MultiHeadAttention,
     TransformerEncoder,

--- a/python/mlx/nn/layers/dropout.py
+++ b/python/mlx/nn/layers/dropout.py
@@ -5,7 +5,7 @@ from mlx.nn.layers.base import Module
 
 
 class Dropout(Module):
-    """Randomly zero a portion of the elements during training.
+    r"""Randomly zero a portion of the elements during training.
 
     The remaining elements are multiplied with :math:`\frac{1}{1-p}` where
     :math:`p` is the probability of zeroing an element. This is done so the
@@ -36,15 +36,13 @@ class Dropout(Module):
 
 
 class Dropout2d(Module):
-    """Apply 2D channel-wise dropout during training.
+    r"""Apply 2D channel-wise dropout during training.
 
     Randomly zero out entire channels independently with probability :math:`p`.
     This layer expects the channels to be last, i.e. the input shape should be
-    ``NWHC`` or ``WHC`` where:
-        - ``N`` is the batch dimension
-        - ``H`` is the input image height
-        - ``W`` is the input image width
-        - ``C`` is the number of input channels
+    ``NWHC`` or ``WHC`` where:``N`` is the batch dimension,``H`` is the input
+    image height,``W`` is the input image width, and``C`` is the number of
+    input channels
 
     The remaining channels are scaled by :math:`\frac{1}{1-p}` to
     maintain the expected value of each element. Unlike traditional dropout,

--- a/python/mlx/nn/layers/normalization.py
+++ b/python/mlx/nn/layers/normalization.py
@@ -208,7 +208,7 @@ class BatchNorm(Module):
         >>> mx.random.seed(42)
         >>> input = mx.random.normal((5, 4), dtype=mx.float32)
         >>> # Batch norm
-        >>> bn = nn.BatchNorm1d(num_features=4, affine=True)
+        >>> bn = nn.BatchNorm(num_features=4, affine=True)
         >>> output = bn(x)
     """
 

--- a/python/mlx/nn/layers/normalization.py
+++ b/python/mlx/nn/layers/normalization.py
@@ -253,9 +253,9 @@ class BatchNorm(Module):
 
         num_dims = len(x.shape)
         dims_dict = {
-            2: ((1, self.num_features), (0,)),
-            3: ((1, self.num_features, 1), (0, 2)),
-            4: ((1, self.num_features, 1, 1), (0, 2, 3)),
+             2: ((1, self.num_features), (0,)),
+            3: ((1, 1, self.num_features), (0, 1)),
+            4: ((1, 1, 1, self.num_features), (0, 1, 2)),
         }
 
         if num_dims not in dims_dict:

--- a/python/mlx/nn/layers/normalization.py
+++ b/python/mlx/nn/layers/normalization.py
@@ -258,7 +258,7 @@ class BatchNorm1d(Module):
             means = mx.mean(x, axis=(0, 2), keepdims=True)
             var = mx.var(x, axis=(0, 2), keepdims=True)
 
-        if self.track_running_stats:
+        if self.track_running_stats and self.training:
             self.running_mean = (
                 1 - self.momentum
             ) * self.running_mean + self.momentum * means.squeeze()

--- a/python/mlx/nn/layers/normalization.py
+++ b/python/mlx/nn/layers/normalization.py
@@ -283,39 +283,3 @@ class BatchNorm1d(Module):
             means, var = self.running_mean, self.running_var
         x = (x - means) * mx.rsqrt(var + self.eps)
         return (self.weight * x + self.bias) if "weight" in self else x
-
-
-# import unittest
-# import numpy as np
-
-# class TestBatchNorm1d(unittest.TestCase):
-#     def setUp(self):
-#         self.bn = BatchNorm1d(10)
-
-#     def test_forward(self):
-#         x = mx.random.uniform(shape=(20, 10))
-#         y = self.bn(x)
-#         expedted =
-#         self.assertEqual(y.shape, x.shape)
-
-#     def test_running_stats(self):
-#         x = mx.random.uniform(shape=(20, 10))
-#         self.bn(x)
-#         self.assertNotEqual(mx.sum(self.bn.running_mean), 0)
-#         self.assertNotEqual(mx.sum(self.bn.running_var), 10)
-
-#     def test_eval_mode(self):
-#         x = mx.random.uniform(shape=(20, 10))
-#         self.bn(x)
-#         self.bn.training = False
-#         y = self.bn(x)
-#         self.assertEqual(y.shape, x.shape)
-
-#     def test_no_affine(self):
-#         bn = BatchNorm1d(10, affine=False)
-#         x = mx.random.uniform(shape=(20, 10))
-#         y = bn(x)
-#         self.assertEqual(y.shape, x.shape)
-
-# if __name__ == '__main__':
-#     unittest.main()

--- a/python/mlx/nn/layers/normalization.py
+++ b/python/mlx/nn/layers/normalization.py
@@ -182,14 +182,6 @@ class GroupNorm(Module):
         return (self.weight * x + self.bias) if "weight" in self else x
 
 
-# Copyright © 2023 Apple Inc.
-
-from typing import Tuple
-
-import mlx.core as mx
-from mlx.nn.layers.base import Module
-
-
 class BatchNorm1d(Module):
     r"""Applies Batch Normalization over a 2D or 3D input.
 
@@ -291,3 +283,39 @@ class BatchNorm1d(Module):
             means, var = self.running_mean, self.running_var
         x = (x - means) * mx.rsqrt(var + self.eps)
         return (self.weight * x + self.bias) if "weight" in self else x
+
+
+# import unittest
+# import numpy as np
+
+# class TestBatchNorm1d(unittest.TestCase):
+#     def setUp(self):
+#         self.bn = BatchNorm1d(10)
+
+#     def test_forward(self):
+#         x = mx.random.uniform(shape=(20, 10))
+#         y = self.bn(x)
+#         expedted =
+#         self.assertEqual(y.shape, x.shape)
+
+#     def test_running_stats(self):
+#         x = mx.random.uniform(shape=(20, 10))
+#         self.bn(x)
+#         self.assertNotEqual(mx.sum(self.bn.running_mean), 0)
+#         self.assertNotEqual(mx.sum(self.bn.running_var), 10)
+
+#     def test_eval_mode(self):
+#         x = mx.random.uniform(shape=(20, 10))
+#         self.bn(x)
+#         self.bn.training = False
+#         y = self.bn(x)
+#         self.assertEqual(y.shape, x.shape)
+
+#     def test_no_affine(self):
+#         bn = BatchNorm1d(10, affine=False)
+#         x = mx.random.uniform(shape=(20, 10))
+#         y = bn(x)
+#         self.assertEqual(y.shape, x.shape)
+
+# if __name__ == '__main__':
+#     unittest.main()

--- a/python/mlx/nn/layers/normalization.py
+++ b/python/mlx/nn/layers/normalization.py
@@ -203,7 +203,13 @@ class BatchNorm1d(Module):
         affine (bool, optional): If True, learn an affine transform to apply after the normalization. Default is True.
 
     Examples:
-        -> TODO: Add examples.
+        >>> import mlx.core as mx
+        >>> import mlx.nn as nn
+        >>> mx.random.seed(42)
+        >>> input = mx.random.normal((5, 4), dtype=mx.float32)
+        >>> # Batch norm
+        >>> bn = nn.BatchNorm1d(num_features=4, affine=True)
+        >>> output = bn(x)
     """
 
     def __init__(

--- a/python/mlx/nn/layers/normalization.py
+++ b/python/mlx/nn/layers/normalization.py
@@ -99,7 +99,7 @@ class GroupNorm(Module):
     where :math:`\gamma` and :math:`\beta` are learned per feature dimension
     parameters initialized at 1 and 0 respectively. However, the mean and
     variance are computed over the spatial dimensions and each group of
-    features. In particular, the input is split into num_groups accross the
+    features. In particular, the input is split into num_groups across the
     feature dimension.
 
     The feature dimension is assumed to be the last dimension and the dimensions

--- a/python/mlx/nn/layers/normalization.py
+++ b/python/mlx/nn/layers/normalization.py
@@ -196,6 +196,9 @@ class BatchNorm(Module):
 
     [1]: https://arxiv.org/abs/1502.03167
 
+    The input tensor shape is specified as (N, C) or (N, C, L), representing the batch size (N), the number of features or channels (C), and optionally, the sequence length (L). The output tensor maintains the same shape as the input, adhering to (N, C) or (N, C, L).
+    For three-dimensional tensors, the shape is denoted as (N, C, H, W), where N signifies the batch size, C represents the number of channels, H corresponds to the height, and W denotes the width.
+
     Args:
         num_features (int): The feature dimension of the input to normalize over.
         eps (float, optional): A small additive constant for numerical stability. Default is 1e-5.

--- a/python/mlx/nn/layers/normalization.py
+++ b/python/mlx/nn/layers/normalization.py
@@ -234,8 +234,8 @@ class BatchNorm(Module):
             self.bias = mx.zeros((num_features,))
 
         if self.track_running_stats:
-            self.running_mean = mx.zeros((num_features,))
-            self.running_var = mx.ones((num_features,))
+            self._running_mean = mx.zeros((num_features,))
+            self._running_var = mx.ones((num_features,))
 
     def _extra_repr(self):
         return f"{self.num_features}, eps={self.eps}, momentum={self.momentum}, affine={'weight' in self}, track_running_stats={self.track_running_stats}"

--- a/python/mlx/nn/layers/normalization.py
+++ b/python/mlx/nn/layers/normalization.py
@@ -227,7 +227,7 @@ class BatchNorm(Module):
         self.momentum = momentum
         self.affine = affine
         self.track_running_stats = track_running_stats
-        self.dims_expanded = False
+        self._dims_expanded = False
 
         if self.affine:
             self.weight = mx.ones((num_features,))
@@ -268,7 +268,7 @@ class BatchNorm(Module):
             self.running_mean = mx.expand_dims(self.running_mean, self.reduction_axes)
             self.running_var = mx.expand_dims(self.running_var, self.reduction_axes)
 
-        self.dims_expanded = True
+        self._dims_expanded = True
 
     def _calc_stats(self, x: mx.array) -> Tuple[mx.array, mx.array]:
         """
@@ -304,7 +304,7 @@ class BatchNorm(Module):
             mx.array: Output tensor.
         """
 
-        if not self.dims_expanded:
+        if not self._dims_expanded:
             self._check_and_expand_dims(x)
 
         if self.training or not self.track_running_stats:

--- a/python/mlx/nn/layers/normalization.py
+++ b/python/mlx/nn/layers/normalization.py
@@ -181,7 +181,7 @@ class GroupNorm(Module):
         x = group_norm(x)
         return (self.weight * x + self.bias) if "weight" in self else x
 
-   
+
 class BatchNorm(Module):
     r"""Applies Batch Normalization over a 2D or 3D input.
 
@@ -211,7 +211,7 @@ class BatchNorm(Module):
         >>> bn = nn.BatchNorm1d(num_features=4, affine=True)
         >>> output = bn(x)
     """
-    
+
     def __init__(
         self,
         num_features: int,
@@ -239,7 +239,7 @@ class BatchNorm(Module):
 
     def _extra_repr(self):
         return f"{self.num_features}, eps={self.eps}, momentum={self.momentum}, affine={'weight' in self}, track_running_stats={self.track_running_stats}"
-    
+
     def _check_and_expand_dims(self, x: mx.array):
         """
         Check if the input is a 2D or 3D tensor and expand the weight, bias, running mean, and running variance accordingly.
@@ -247,7 +247,7 @@ class BatchNorm(Module):
         Args:
             x (mx.array): Input tensor.
         """
-        
+
         num_dims = len(x.shape)
         dims_dict = {
             2: ((1, self.num_features), (0,)),
@@ -259,17 +259,16 @@ class BatchNorm(Module):
             raise ValueError(f"expected num_dims to be 2, 3, or 4 (got {num_dims})")
 
         shape, self.reduction_axes = dims_dict[num_dims]
-        
+
         if self.affine:
             self.weight = mx.expand_dims(self.weight, self.reduction_axes)
             self.bias = mx.expand_dims(self.bias, self.reduction_axes)
-        
+
         if self.track_running_stats:
             self.running_mean = mx.expand_dims(self.running_mean, self.reduction_axes)
             self.running_var = mx.expand_dims(self.running_var, self.reduction_axes)
-        
-        self.dims_expanded = True
 
+        self.dims_expanded = True
 
     def _calc_stats(self, x: mx.array) -> Tuple[mx.array, mx.array]:
         """
@@ -304,7 +303,7 @@ class BatchNorm(Module):
         Returns:
             mx.array: Output tensor.
         """
-        
+
         if not self.dims_expanded:
             self._check_and_expand_dims(x)
 

--- a/python/mlx/nn/losses.py
+++ b/python/mlx/nn/losses.py
@@ -286,7 +286,7 @@ def _reduce(loss: mx.array, reduction: str = "none"):
 def hinge_loss(
     inputs: mx.array, targets: mx.array, reduction: str = "none"
 ) -> mx.array:
-    """
+    r"""
     Computes the hinge loss between inputs and targets.
 
     .. math::
@@ -311,7 +311,7 @@ def hinge_loss(
 def huber_loss(
     inputs: mx.array, targets: mx.array, delta: float = 1.0, reduction: str = "none"
 ) -> mx.array:
-    """
+    r"""
     Computes the Huber loss between inputs and targets.
 
     .. math::
@@ -345,7 +345,7 @@ def huber_loss(
 def log_cosh_loss(
     inputs: mx.array, targets: mx.array, reduction: str = "none"
 ) -> mx.array:
-    """
+    r"""
     Computes the log cosh loss between inputs and targets.
 
     Logcosh acts like L2 loss for small errors, ensuring stable gradients,

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -325,7 +325,7 @@ class TestNN(mlx_tests.MLXTestCase):
         x = mx.random.normal((5, 4), dtype=mx.float32)
 
         # Batch norm
-        bn = nn.BatchNorm1d(num_features=4, affine=True)
+        bn = nn.BatchNorm(num_features=4, affine=True)
         self.assertTrue(mx.allclose(bn.running_mean, mx.zeros_like(bn.running_mean)))
         self.assertTrue(mx.allclose(bn.running_var, mx.ones_like(bn.running_var)))
         y = bn(x)
@@ -362,7 +362,7 @@ class TestNN(mlx_tests.MLXTestCase):
         self.assertTrue(np.allclose(y, expected_y, atol=1e-5))
 
         # test_no_affine
-        bn = nn.BatchNorm1d(num_features=4, affine=False)
+        bn = nn.BatchNorm(num_features=4, affine=False)
         y = bn(x)
         expected_y = mx.array(
             [
@@ -381,7 +381,7 @@ class TestNN(mlx_tests.MLXTestCase):
         x = mx.random.normal((2, 4, 3), dtype=mx.float32)
 
         # Batch norm
-        bn = nn.BatchNorm1d(num_features=4, affine=True)
+        bn = nn.BatchNorm(num_features=4, affine=True)
         self.assertTrue(mx.allclose(bn.running_mean, mx.zeros_like(bn.running_mean)))
         self.assertTrue(mx.allclose(bn.running_var, mx.ones_like(bn.running_var)))
         y = bn(x)

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -320,6 +320,62 @@ class TestNN(mlx_tests.MLXTestCase):
         self.assertTrue(np.allclose(means, 3 * np.ones_like(means), atol=1e-6))
         self.assertTrue(np.allclose(var, 4 * np.ones_like(var), atol=1e-6))
 
+    def test_batch_norm(self):
+        mx.random.seed(42)
+        x = mx.random.normal((5, 4), dtype=mx.float32)
+
+        # Batch norm
+        bn = nn.BatchNorm1d(num_features=4, affine=True)
+        self.assertTrue(mx.allclose(bn.running_mean, mx.zeros_like(bn.running_mean)))
+        self.assertTrue(mx.allclose(bn.running_var, mx.ones_like(bn.running_var)))
+        y = bn(x)
+        expected_y = mx.array(
+            [
+                [-0.439520, 1.647328, -0.955515, 1.966031],
+                [-1.726690, -1.449826, -0.234026, -0.723364],
+                [0.938414, -0.349603, -0.354470, -0.175369],
+                [0.305006, 0.234914, -0.393017, -0.459385],
+                [0.922789, -0.082813, 1.937028, -0.607913],
+            ],
+        )
+        expected_mean = mx.array([0.008929, 0.005680, -0.016092, 0.027778])
+        expected_var = mx.array([0.928435, 1.00455, 1.04117, 0.94258])
+        self.assertTrue(x.shape == y.shape)
+        self.assertTrue(np.allclose(y, expected_y, atol=1e-5))
+        self.assertTrue(np.allclose(bn.running_mean, expected_mean, atol=1e-5))
+        self.assertTrue(np.allclose(bn.running_var, expected_var, atol=1e-5))
+
+        # test eval mode
+        bn.eval()
+        y = bn(x)
+        expected_y = mx.array(
+            [
+                [-0.15984, 1.73159, -1.25456, 1.57891],
+                [-0.872193, -1.4281, -0.414439, -0.228678],
+                [0.602743, -0.30566, -0.554687, 0.139639],
+                [0.252199, 0.29066, -0.599572, -0.0512532],
+                [0.594096, -0.0334829, 2.11359, -0.151081],
+            ]
+        )
+
+        self.assertTrue(x.shape == y.shape)
+        self.assertTrue(np.allclose(y, expected_y, atol=1e-5))
+
+        # test_no_affine
+        bn = nn.BatchNorm1d(num_features=4, affine=False)
+        y = bn(x)
+        expected_y = mx.array(
+            [
+                [-0.439520, 1.647328, -0.955515, 1.966031],
+                [-1.726690, -1.449826, -0.234026, -0.723364],
+                [0.938414, -0.349603, -0.354470, -0.175369],
+                [0.305006, 0.234914, -0.393017, -0.459385],
+                [0.922789, -0.082813, 1.937028, -0.607913],
+            ]
+        )
+        self.assertTrue(x.shape == y.shape)
+        self.assertTrue(np.allclose(y, expected_y, atol=1e-5))
+
     def test_conv1d(self):
         N = 5
         L = 12

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -413,7 +413,7 @@ class TestNN(mlx_tests.MLXTestCase):
         expected_var = mx.array([[[0.968415, 1.05322, 0.96913, 0.932305, 0.967224]]])
         self.assertTrue(np.allclose(bn._running_mean, expected_mean, atol=1e-5))
         self.assertTrue(np.allclose(bn._running_var, expected_var, atol=1e-5))
-        
+
         x = mx.random.normal((N, L, C, L, C), dtype=mx.float32)
         with self.assertRaises(ValueError):
             y = bn(x)

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -376,6 +376,40 @@ class TestNN(mlx_tests.MLXTestCase):
         self.assertTrue(x.shape == y.shape)
         self.assertTrue(np.allclose(y, expected_y, atol=1e-5))
 
+        # test with 3D input
+        mx.random.seed(42)
+        x = mx.random.normal((2, 4, 3), dtype=mx.float32)
+
+        # Batch norm
+        bn = nn.BatchNorm1d(num_features=4, affine=True)
+        self.assertTrue(mx.allclose(bn.running_mean, mx.zeros_like(bn.running_mean)))
+        self.assertTrue(mx.allclose(bn.running_var, mx.ones_like(bn.running_var)))
+        y = bn(x)
+        self.assertTrue(x.shape == y.shape)
+        expected_y = mx.array(
+            [
+                [
+                    [-0.285056, -0.657241, 0.584881],
+                    [1.079424, 0.795527, 0.163417],
+                    [-0.351929, 0.669030, 1.713490],
+                    [-0.679080, -1.467115, 1.077580],
+                ],
+                [
+                    [-0.091968, -1.362007, 1.811391],
+                    [-1.654407, -1.017945, 0.633983],
+                    [-1.309168, 0.148356, -0.869779],
+                    [-0.742132, 1.037774, 0.772974],
+                ],
+            ]
+        )
+        self.assertTrue(np.allclose(y, expected_y, atol=1e-5))
+        expected_mean = mx.array(
+            [[[0.0362097], [0.0360611], [0.0166926], [-0.0111884]]]
+        )
+        expected_var = mx.array([[[1.07218], [0.992639], [1.01724], [1.16217]]])
+        self.assertTrue(np.allclose(bn.running_mean, expected_mean, atol=1e-5))
+        self.assertTrue(np.allclose(bn.running_var, expected_var, atol=1e-5))
+
     def test_conv1d(self):
         N = 5
         L = 12

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -374,7 +374,7 @@ class TestNN(mlx_tests.MLXTestCase):
             ]
         )
         self.assertTrue(x.shape == y.shape)
-        self.assertTrue(np.allclose(y, expected_y, atol=1e-5))
+        self.assertTrue(mx.allclose(y, expected_y, atol=1e-5))
 
         # test with 3D input
         mx.random.seed(42)
@@ -418,58 +418,44 @@ class TestNN(mlx_tests.MLXTestCase):
             y = bn(x)
 
     def test_batch_norm_stats(self):
-        batch_size = 4
-        num_features = 32
-        num_channels = 32
-        h = 28
-        w = 28
-        num_iterations = 100
+        batch_size = 2
+        num_features = 4
+        h = 3
+        w = 3
         momentum = 0.1
 
         batch_norm = nn.BatchNorm(num_features)
 
         batch_norm.train()
-        running_mean = np.array(batch_norm._running_mean.tolist())
-        running_var = np.array(batch_norm._running_var.tolist())
+        running_mean = np.array(batch_norm._running_mean)
+        running_var = np.array(batch_norm._running_var)
 
-        data = mx.random.normal((batch_size * num_features,)).reshape(
-            (batch_size, num_features)
-        )
+        data = mx.random.normal((batch_size, num_features))
 
-        for _ in range(num_iterations):
-            normalized_data = batch_norm(data)
-            means = np.mean(data.tolist(), axis=0)
-            variances = np.var(data.tolist(), axis=0)
-            running_mean = (1 - momentum) * running_mean + momentum * means
-            running_var = (1 - momentum) * running_var + momentum * variances
-            assert np.allclose(batch_norm._running_mean, running_mean, atol=1e-5)
-            assert np.allclose(batch_norm._running_var, running_var, atol=1e-5)
-            data = normalized_data
+        normalized_data = batch_norm(data)
+        np_data = np.array(data)
+        means = np.mean(np_data, axis=0)
+        variances = np.var(np_data, axis=0)
+        running_mean = (1 - momentum) * running_mean + momentum * means
+        running_var = (1 - momentum) * running_var + momentum * variances
+        self.assertTrue(np.allclose(batch_norm._running_mean, running_mean, atol=1e-5))
+        self.assertTrue(np.allclose(batch_norm._running_var, running_var, atol=1e-5))
 
-        batch_norm = nn.BatchNorm(num_channels)
+        batch_norm = nn.BatchNorm(num_features)
 
         batch_norm.train()
-        running_mean = np.array(batch_norm._running_mean.tolist()).reshape(
-            1, 1, 1, num_channels
-        )
-        running_var = np.array(batch_norm._running_var.tolist()).reshape(
-            1, 1, 1, num_channels
-        )
-        data = mx.random.normal((batch_size, h, w, num_channels))
+        running_mean = np.array(batch_norm._running_mean)
+        running_var = np.array(batch_norm._running_var)
+        data = mx.random.normal((batch_size, h, w, num_features))
 
-        for _ in range(num_iterations):
-            normalized_data = batch_norm(data)
-            means = np.mean(data.tolist(), axis=(0, 1, 2)).reshape(
-                1, 1, 1, num_channels
-            )
-            variances = np.var(data.tolist(), axis=(0, 1, 2)).reshape(
-                1, 1, 1, num_channels
-            )
-            running_mean = (1 - momentum) * running_mean + momentum * means
-            running_var = (1 - momentum) * running_var + momentum * variances
-            assert np.allclose(batch_norm._running_mean, running_mean, atol=1e-5)
-            assert np.allclose(batch_norm._running_var, running_var, atol=1e-5)
-            data = normalized_data
+        normalized_data = batch_norm(data)
+        np_data = np.array(data)
+        means = np.mean(np_data, axis=(0, 1, 2))
+        variances = np.var(np_data, axis=(0, 1, 2))
+        running_mean = (1 - momentum) * running_mean + momentum * means
+        running_var = (1 - momentum) * running_var + momentum * variances
+        self.assertTrue(np.allclose(batch_norm._running_mean, running_mean, atol=1e-5))
+        self.assertTrue(np.allclose(batch_norm._running_var, running_var, atol=1e-5))
 
     def test_conv1d(self):
         N = 5

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -3,7 +3,6 @@
 import os
 import tempfile
 import unittest
-from unittest.mock import Mock, patch
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -342,9 +341,9 @@ class TestNN(mlx_tests.MLXTestCase):
         expected_mean = mx.array([0.008929, 0.005680, -0.016092, 0.027778])
         expected_var = mx.array([0.928435, 1.00455, 1.04117, 0.94258])
         self.assertTrue(x.shape == y.shape)
-        self.assertTrue(np.allclose(y, expected_y, atol=1e-5))
-        self.assertTrue(np.allclose(bn._running_mean, expected_mean, atol=1e-5))
-        self.assertTrue(np.allclose(bn._running_var, expected_var, atol=1e-5))
+        self.assertTrue(mx.allclose(y, expected_y, atol=1e-5))
+        self.assertTrue(mx.allclose(bn._running_mean, expected_mean, atol=1e-5))
+        self.assertTrue(mx.allclose(bn._running_var, expected_var, atol=1e-5))
 
         # test eval mode
         bn.eval()
@@ -360,7 +359,7 @@ class TestNN(mlx_tests.MLXTestCase):
         )
 
         self.assertTrue(x.shape == y.shape)
-        self.assertTrue(np.allclose(y, expected_y, atol=1e-5))
+        self.assertTrue(mx.allclose(y, expected_y, atol=1e-5))
 
         # test_no_affine
         bn = nn.BatchNorm(num_features=4, affine=False)
@@ -406,13 +405,13 @@ class TestNN(mlx_tests.MLXTestCase):
                 ],
             ]
         )
-        self.assertTrue(np.allclose(y, expected_y, atol=1e-5))
+        self.assertTrue(mx.allclose(y, expected_y, atol=1e-5))
         expected_mean = mx.array(
             [[[0.00207845, -5.3259e-05, 0.04755, -0.0697296, 0.0236228]]]
         )
         expected_var = mx.array([[[0.968415, 1.05322, 0.96913, 0.932305, 0.967224]]])
-        self.assertTrue(np.allclose(bn._running_mean, expected_mean, atol=1e-5))
-        self.assertTrue(np.allclose(bn._running_var, expected_var, atol=1e-5))
+        self.assertTrue(mx.allclose(bn._running_mean, expected_mean, atol=1e-5))
+        self.assertTrue(mx.allclose(bn._running_var, expected_var, atol=1e-5))
 
         x = mx.random.normal((N, L, C, L, C), dtype=mx.float32)
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Proposed changes


### Description
This pull request introduces implementation of Batch Normalization, following the specifications outlined in the paper [Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift](https://arxiv.org/abs/1502.03167).

### Changes Made
- Added a new class `BatchNorm1d` that extends the `Module` class.
- The implementation includes the forward pass logic for Batch Normalization.
- Options for configurable parameters such as `eps` (numerical stability constant), `momentum` (for running mean and variance updates), and `affine` (whether to include learnable affine parameters).
- Provided examples in the documentation to demonstrate how to use the `BatchNorm1d` module with and without learnable parameters.

### Usage
```python
import mlx.core as mx
import mlx.nn as nn

# With Learnable Parameters
m = nn.BatchNorm1d(100)
# Without Learnable Parameters
m = nn.BatchNorm1d(4, affine=False)
input = mx.random.normal(20, 4)
output = m(input)
```

### Notes
- The implementation ensures compatibility with mlx conventions and practices.

Please review and provide feedback.
## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
