### PR TITLE
fail early if readinto attribute does not exist when trying to load file

### DIFF
--- a/python/src/load.cpp
+++ b/python/src/load.cpp
@@ -26,7 +26,7 @@ using namespace mlx::core;
 ///////////////////////////////////////////////////////////////////////////////
 
 bool is_istream_object(const py::object& file) {
-  return py::hasattr(file, "read") && py::hasattr(file, "seek") &&
+  return py::hasattr(file, "readinto") && py::hasattr(file, "seek") &&
       py::hasattr(file, "tell") && py::hasattr(file, "closed");
 }
 


### PR DESCRIPTION
## Proposed changes

Fixes a small bug when attempting to load a file from python missing the `readinto` func. Now it catches early and avoids attempting to cast to PyFileReader

The following would throw an error of unknown attribute as `readinto` does not exist in text mode
```python
import mlx.core as mx
mx.load(open("./temp.npy"))
```

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
