### PR TITLE
fixes for building with swiftpm

### DIFF
--- a/mlx/backend/common/default_primitives.cpp
+++ b/mlx/backend/common/default_primitives.cpp
@@ -1,6 +1,6 @@
 // Copyright © 2023 Apple Inc.
 
-#include <cblas.h>
+#include <VecLib/cblas.h>
 
 #include "mlx/array.h"
 #include "mlx/backend/common/copy.h"


### PR DESCRIPTION
- clbas is part of veclib (compile failure)
- add SWIFTPM_BUNDLE #define to allow loading the metallib from a swiftpm resource bundle

## Proposed changes

This has two changes needed for building with swiftpm:

- include of <cblas.h> failed, should be <VecLib/cblas.h>
- added -DSWIFTPM_BUNDLE=... to provide a way for the metallib to be loaded from a swiftpm resource bundle

The latter would normally be done via swift code like this:

```
let defaultLibrary = try device.makeDefaultLibrary(bundle: Bundle.module)
```

where `Bundle.module` has logic to find the resource bundle.  mlx loads the metallib implicitly so this has to be done in that path.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
