### PR TITLE
support arange for bfloat16

### DIFF
--- a/mlx/backend/metal/primitives.cpp
+++ b/mlx/backend/metal/primitives.cpp
@@ -215,7 +215,8 @@ void Arange::eval_gpu(const std::vector<array>& inputs, array& out) {
       arange_set_scalars<float>(start_, start_ + step_, compute_encoder);
       break;
     case bfloat16:
-      throw std::runtime_error("[Arange::eval_gpu] Does not support bfloat16");
+      arange_set_scalars<bfloat16_t>(start_, start_ + step_, compute_encoder);
+      break;
     case complex64:
       throw std::runtime_error("[Arange::eval_gpu] Does not support complex64");
   }

--- a/tests/creations_tests.cpp
+++ b/tests/creations_tests.cpp
@@ -18,6 +18,12 @@ TEST_CASE("test arange") {
     x = arange(10, float32);
     CHECK_EQ(x.dtype(), float32);
 
+    x = arange(10, float16);
+    CHECK_EQ(x.dtype(), float16);
+
+    x = arange(10, bfloat16);
+    CHECK_EQ(x.dtype(), bfloat16);
+
     x = arange(10.0, int32);
     CHECK_EQ(x.dtype(), int32);
 
@@ -105,6 +111,15 @@ TEST_CASE("test arange") {
 
     x = arange(0.0, 5.0, 1.5, int32);
     CHECK(array_equal(x, array({0, 1, 2, 3})).item<bool>());
+
+    x = arange(0.0, 5.0, 1.0, float16);
+    CHECK(array_equal(x, array({0, 1, 2, 3, 4}, float16)).item<bool>());
+
+    x = arange(0.0, 5.0, 1.0, bfloat16);
+    CHECK(array_equal(x, array({0, 1, 2, 3, 4}, bfloat16)).item<bool>());
+
+    x = arange(0.0, 5.0, 1.5, bfloat16);
+    CHECK(array_equal(x, array({0., 1.5, 3., 4.5}, bfloat16)).item<bool>());
   }
 }
 


### PR DESCRIPTION
## Proposed changes

While playing around with the bfloat16 dtype I got: 

```
mx.arange(0, 1, dtype=mx.bfloat16)
libc++abi: terminating due to uncaught exception of type std::runtime_error: [Arange::eval_gpu] Does not support bfloat16
```

After looking into the implementation, I did not find a reason why this is not implemented. Simple tests seem to work fine. 

If there are any reasons why bfloat16 should not be supported, I suggest we should at least add a comment why that is the case. But maybe there was a reason in the past and it was just forgotten to implement `arange`. 

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
