### PR TITLE
Implement RNN, GRU, LSTM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,6 +275,9 @@ workflows:
           context: pr-approval
       - mac_build_and_test:
           requires: [ hold ]
+          matrix:
+            parameters:
+              xcode_version: ["15.0.0", "15.2.0"]
       - linux_build_and_test:
           requires: [ hold ]
   nightly_build:

--- a/docs/src/python/nn/layers.rst
+++ b/docs/src/python/nn/layers.rst
@@ -21,9 +21,11 @@ Layers
    Embedding
    GELU
    GroupNorm
+   GRU
    InstanceNorm
    LayerNorm
    Linear
+   LSTM
    MaxPool1d
    MaxPool2d
    Mish
@@ -32,6 +34,7 @@ Layers
    QuantizedLinear
    RMSNorm
    ReLU
+   RNN
    RoPE
    SELU
    Sequential

--- a/python/mlx/nn/layers/__init__.py
+++ b/python/mlx/nn/layers/__init__.py
@@ -62,6 +62,7 @@ from mlx.nn.layers.normalization import (
 from mlx.nn.layers.pooling import AvgPool1d, AvgPool2d, MaxPool1d, MaxPool2d
 from mlx.nn.layers.positional_encoding import ALiBi, RoPE, SinusoidalPositionalEncoding
 from mlx.nn.layers.quantized import QuantizedLinear
+from mlx.nn.layers.recurrent import GRU, LSTM, RNN
 from mlx.nn.layers.transformer import (
     MultiHeadAttention,
     Transformer,

--- a/python/mlx/nn/layers/recurrent.py
+++ b/python/mlx/nn/layers/recurrent.py
@@ -1,46 +1,52 @@
 import math
+from typing import Callable, Optional
 
 import mlx.core as mx
+from mlx.nn.layers.activations import tanh
 from mlx.nn.layers.base import Module
 
 
 class RNN(Module):
-    r"""Apply one Elman recurrent units to a sequence of
-    shape ``NLD`` or ``LD``, where:
-        - ``N`` is the optional batch dimension
-        - ``L`` is the sequence length
-        - ``D`` is the input's feature dimension
+    r"""An Elman recurrent layer.
 
-    Concretely, for each element along the sequence length axis, compute:
+    The input is a sequence of shape ``NLD`` or ``LD`` where:
+
+    * ``N`` is the optional batch dimension
+    * ``L`` is the sequence length
+    * ``D`` is the input's feature dimension
+
+    Concretely, for each element along the sequence length axis, this
+    layer applies the function:
 
     .. math::
 
-        h_{t + 1} = \text{tanh} (W_{ih}x_t + b_{ih} + W_{hh}h_t + b_{hh})
+        h_{t + 1} = \text{tanh} (W_{ih}x_t + W_{hh}h_t + b)
 
-    The hidden state :math:`h` has shape ``NH`` or ``H``, depending
+    The hidden state :math:`h` has shape ``NH`` or ``H``, depending on
     whether the input is batched or not. Returns the hidden state at each
     time step, of shape ``NLH`` or ``LH``.
 
-
     Args:
-        input_size (int): Dimension of the input :math:`x`
-        hidden_size (int): Dimension of the hidden state :math:`h`
-        nonlinearity (callable): Non-linearity to use. Default: `mx.tanh`.
-        bias (bool): Whether to use biases or not. Default: `True`.
+        input_size (int): Dimension of the input, ``D``.
+        hidden_size (int): Dimension of the hidden state, ``H``.
+        bias (bool, optional): Whether to use a bias. Default: ``True``.
+        nonlinearity (callable, optional): Non-linearity to use. If ``None``,
+            then func:`tanh` is used. Default: ``None``.
     """
 
     def __init__(
         self,
         input_size: int,
         hidden_size: int,
-        nonlinearity: callable = mx.tanh,
         bias: bool = True,
+        nonlinearity: Optional[Callable] = None,
     ):
         super().__init__()
 
-        if not callable(nonlinearity):
+        self.nonlinearity = nonlinearity or tanh
+        if not callable(self.nonlinearity):
             raise ValueError(
-                f"Nonlinearity must be callable. Current value: {nonlinearity}"
+                f"Nonlinearity must be callable. Current value: {nonlinearity}."
             )
 
         scale = 1.0 / math.sqrt(hidden_size)
@@ -51,28 +57,31 @@ class RNN(Module):
         self.Whh = mx.random.uniform(
             low=-scale, high=scale, shape=(hidden_size, hidden_size)
         )
-        self.bh = (
+        self.bias = (
             mx.random.uniform(low=-scale, high=scale, shape=(hidden_size,))
             if bias
             else None
         )
-        self.nonlinearity = nonlinearity
 
     def _extra_repr(self):
-        return f"input_dims={self.Wxh.shape[0]}, hidden_size={self.hidden_size}, nonlinearity={self.nonlinearity}, bias={self.bh is not None}"
+        return (
+            f"input_dims={self.Wxh.shape[0]}, "
+            f"hidden_size={self.hidden_size}, "
+            f"nonlinearity={self.nonlinearity}, bias={self.bias is not None}"
+        )
 
     def __call__(self, x, hidden=None):
-        x_proj = x @ self.Wxh
+        if self.bias is not None:
+            x = mx.addmm(self.bias, x, self.Wxh)
+        else:
+            x = x @ self.Wxh
 
-        if self.bh is not None:
-            x_proj += x_proj
-
-        if hidden is None:
-            hidden = mx.zeros(shape=(self.hidden_size,))
         all_hidden = []
-
         for idx in range(x.shape[-2]):
-            hidden = x_proj[..., idx, :] + hidden @ self.Whh
+            if hidden is not None:
+                hidden = x[..., idx, :] + hidden @ self.Whh
+            else:
+                hidden = x[..., idx, :]
             hidden = self.nonlinearity(hidden)
             all_hidden.append(hidden)
 
@@ -80,29 +89,33 @@ class RNN(Module):
 
 
 class GRU(Module):
-    r"""Apply one GRU recurrent unit to a sequence of shape
-    ``NLD`` or ``LD``, where:
-        - ``N`` is the optional batch dimension
-        - ``L`` is the sequence length
-        - ``D`` is the input's feature dimension
+    r"""A gated recurrent unit (GRU) RNN layer.
 
-    Concretely, for each element of the sequence, computes:
+    The input has shape ``NLD`` or ``LD`` where:
+
+    * ``N`` is the optional batch dimension
+    * ``L`` is the sequence length
+    * ``D`` is the input's feature dimension
+
+    Concretely, for each element of the sequence, this layer computes:
 
     .. math::
 
-        r_t = \sigma (W_{xr}x_t + b_{xr} + W_{hr}h_t + b_{hr})
-        z_t = \sigma (W_{xz}x_t + b_{xz} + W_{hz}h_t + b_{hz})
-        n_t = \text{tanh}(W_{xn}x_t + b_{xn} + r_t \odot (W_{hn}h_t + b_{hn}))
-        h_{t + 1} = (1 - z_t) \odot n_t + z_t \odot h_t
+        \begin{align*}
+        r_t &= \sigma (W_{xr}x_t + W_{hr}h_t + b_{r}) \\
+        z_t &= \sigma (W_{xz}x_t + W_{hz}h_t + b_{z}) \\
+        n_t &= \text{tanh}(W_{xn}x_t + b_{n} + r_t \odot (W_{hn}h_t + b_{hn})) \\
+        h_{t + 1} &= (1 - z_t) \odot n_t + z_t \odot h_t
+        \end{align*}
 
-    The hidden state :math:`h` has shape ``NH`` or ``H``, depending
+    The hidden state :math:`h` has shape ``NH`` or ``H`` depending on
     whether the input is batched or not. Returns the hidden state at each
-    time step, of shape ``NLH`` or ``LH``.
+    time step of shape ``NLH`` or ``LH``.
 
     Args:
-        input_size (int): Dimension of the input :math:`x`
-        hidden_size (int): Dimension of the hidden state :math:`h`
-        bias (bool): Whether to use biases or not. Default: `True`.
+        input_size (int): Dimension of the input, ``D``.
+        hidden_size (int): Dimension of the hidden state, ``H``.
+        bias (bool): Whether to use biases or not. Default: ``True``.
     """
 
     def __init__(
@@ -133,16 +146,19 @@ class GRU(Module):
         )
 
     def _extra_repr(self):
-        return f"input_dims={self.Wx.shape[0]}, hidden_size={self.hidden_size}, bias={self.b is not None}"
+        return (
+            f"input_dims={self.Wx.shape[0]}, "
+            f"hidden_size={self.hidden_size}, bias={self.b is not None}"
+        )
 
     def __call__(self, x, hidden=None):
-        x_proj = x @ self.Wx
-
         if self.b is not None:
-            x_proj += self.b
+            x = mx.addmm(self.b, x, self.Wx)
+        else:
+            x = x @ self.Wx
 
-        x_proj_rz = x_proj[..., : -self.hidden_size]
-        x_proj_n = x_proj[..., -self.hidden_size :]
+        x_rz = x[..., : -self.hidden_size]
+        x_n = x[..., -self.hidden_size :]
 
         all_hidden = []
 
@@ -158,12 +174,12 @@ class GRU(Module):
                 h_proj_n += self.bhn
 
             # Note bias in r, z, n is added through x already
-            rz = x_proj_rz[..., idx, :] + h_proj_rz
+            rz = x_rz[..., idx, :] + h_proj_rz
             rz = mx.sigmoid(rz)
 
             r, z = mx.split(rz, 2, axis=-1)
 
-            n_x = x_proj_n[..., idx, :]
+            n_x = x_n[..., idx, :]
 
             n = n_x + r * h_proj_n
             n = mx.tanh(n)
@@ -175,31 +191,36 @@ class GRU(Module):
 
 
 class LSTM(Module):
-    r"""Apply one LSTM recurrent unit to a sequence of
-    shape ``NLD`` or ``LD``, where:
-        - ``N`` is the optional batch dimension
-        - ``L`` is the sequence length
-        - ``D`` is the input's feature dimension
+    r"""An LSTM recurrent layer.
 
-    Concretely, for each element of the sequence, computes:
+    The input has shape ``NLD`` or ``LD`` where:
+
+    * ``N`` is the optional batch dimension
+    * ``L`` is the sequence length
+    * ``D`` is the input's feature dimension
+
+    Concretely, for each element of the sequence, this layer computes:
 
     .. math::
-        i_t = \sigma (W_{xi}x_t + b_{xi} + W_{hi}h_t + b_{hi})
-        f_t = \sigma (W_{xf}x_t + b_{xf} + W_{hf}h_t + b_{hf})
-        g_t = \text{tanh} (W_{xg}x_t + b_{xg} + W_{hg}h_t + b_{hg})
-        o_t = \sigma (W_{xo}x_t + b_{xo} + W_{ho}h_t + b_{ho})
-        c_{t + 1} = f_t \odot c_t + i_t \odot g_t
-        h_{t + 1} = o_t \text{tanh}(c_{t + 1})
+        \begin{align*}
+        i_t &= \sigma (W_{xi}x_t + W_{hi}h_t + b_{i}) \\
+        f_t &= \sigma (W_{xf}x_t + W_{hf}h_t + b_{f}) \\
+        g_t &= \text{tanh} (W_{xg}x_t + W_{hg}h_t + b_{g}) \\
+        o_t &= \sigma (W_{xo}x_t + W_{ho}h_t + b_{o}) \\
+        c_{t + 1} &= f_t \odot c_t + i_t \odot g_t \\
+        h_{t + 1} &= o_t \text{tanh}(c_{t + 1})
+        \end{align*}
 
     The hidden state :math:`h` and cell state :math:`c` have shape ``NH``
-    or ``H``, depending whether the input is batched or not. Returns two
-    arrays: the hidden state and the cell state at each time step, both
-    of shape ``NLH`` or ``LH``.
+    or ``H``, depending on whether the input is batched or not.
+
+    The layer returns two arrays, the hidden state and the cell state at
+    each time step, both of shape ``NLH`` or ``LH``.
 
     Args:
-        input_size (int): Dimension of the input :math:`x`
-        hidden_size (int): Dimension of the hidden state :math:`h`
-        bias (bool): Whether to use biases or not. Default: `True`.
+        input_size (int): Dimension of the input, ``D``.
+        hidden_size (int): Dimension of the hidden state, ``H``.
+        bias (bool): Whether to use biases or not. Default: ``True``.
     """
 
     def __init__(
@@ -218,20 +239,23 @@ class LSTM(Module):
         self.Wh = mx.random.uniform(
             low=-scale, high=scale, shape=(hidden_size, 4 * hidden_size)
         )
-        self.b = (
+        self.bias = (
             mx.random.uniform(low=-scale, high=scale, shape=(4 * hidden_size,))
             if bias
             else None
         )
 
     def _extra_repr(self):
-        return f"input_dims={self.Wx.shape[0]}, hidden_size={self.hidden_size}, bias={self.b is not None}"
+        return (
+            f"input_dims={self.Wx.shape[0]}, "
+            f"hidden_size={self.hidden_size}, bias={self.bias is not None}"
+        )
 
     def __call__(self, x, hidden=None, cell=None):
-        x_proj = x @ self.Wx
-
-        if self.b is not None:
-            x_proj += self.b
+        if self.bias is not None:
+            x = mx.addmm(self.bias, x, self.Wx)
+        else:
+            x = x @ self.Wx
 
         if hidden is None:
             hidden = mx.zeros(shape=(self.hidden_size,))
@@ -245,7 +269,7 @@ class LSTM(Module):
         for idx in range(x.shape[-2]):
             h_proj = hidden @ self.Wh
 
-            ifgo = x_proj[..., idx, :] + h_proj
+            ifgo = x[..., idx, :] + h_proj
             i, f, g, o = mx.split(ifgo, 4, axis=-1)
 
             i = mx.sigmoid(i)

--- a/python/mlx/nn/layers/recurrent.py
+++ b/python/mlx/nn/layers/recurrent.py
@@ -1,0 +1,262 @@
+import math
+
+import mlx.core as mx
+from mlx.nn.layers.base import Module
+
+
+def _weight_init(input_size: int, hidden_size: int):
+    scale = 1.0 / math.sqrt(hidden_size)
+    return mx.random.uniform(low=-scale, high=scale, shape=(input_size, hidden_size))
+
+
+def _bias_init(hidden_size: int, use_bias: bool):
+    if not use_bias:
+        return None
+
+    scale = 1.0 / math.sqrt(hidden_size)
+    return mx.random.uniform(low=-scale, high=scale, shape=(hidden_size,))
+
+
+class RNN(Module):
+    r"""Apply one Elman recurrent units to a sequence of
+    shape ``NLD`` or ``LD``, where:
+        - ``N`` is the optional batch dimension
+        - ``L`` is the sequence length
+        - ``D`` is the input's feature dimension
+
+    Concretely, for each element along the sequence length axis, compute:
+
+    .. math::
+
+        h_{t + 1} = \text{tanh} (W_{ih}x_t + b_{ih} + W_{hh}h_t + b_{hh})
+
+    The hidden state :math:`h` has shape ``NH`` or ``H``, depending
+    whether the input is batched or not. Returns the hidden state at each
+    time step, of shape ``NLH`` or ``LH``.
+
+
+    Args:
+        input_size (int): Dimension of the input :math:`x`
+        hidden_size (int): Dimension of the hidden state :math:`h`
+        nonlinearity (callable): Non-linearity to use. Default: `mx.tanh`.
+        bias (bool): Whether to use biases or not. Default: `True`.
+    """
+
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int,
+        nonlinearity: callable = mx.tanh,
+        bias: bool = True,
+    ):
+        super().__init__()
+
+        if not callable(nonlinearity):
+            raise ValueError(
+                f"Nonlinearity must be callable. Current value: {nonlinearity}"
+            )
+
+        self.Wxh = _weight_init(input_size, hidden_size)
+        self.Whh = _weight_init(hidden_size, hidden_size)
+        self.bh = _bias_init(hidden_size, bias)
+        self.nonlinearity = nonlinearity
+
+    def _extra_repr(self):
+        return f"input_dims={self.Wxh.shape[0]}, hidden_size={self.Wxh.shape[-1]}, nonlinearity={self.nonlinearity}, bias={self.bh is not None}"
+
+    def __call__(self, x):
+        x_proj = x @ self.Wxh
+
+        if self.bh is not None:
+            x_proj += x_proj
+
+        curr_hidden = mx.zeros(shape=(self.Whh.shape[-1],))
+        all_hidden = []
+
+        for idx in range(x.shape[-2]):
+            curr_hidden = x_proj[..., idx, :] + curr_hidden @ self.Whh
+            curr_hidden = self.nonlinearity(curr_hidden)
+            all_hidden.append(curr_hidden)
+
+        return mx.stack(all_hidden, axis=-2)
+
+
+class GRU(Module):
+    r"""Apply one GRU recurrent unit to a sequence of shape
+    ``NLD`` or ``LD``, where:
+        - ``N`` is the optional batch dimension
+        - ``L`` is the sequence length
+        - ``D`` is the input's feature dimension
+
+    Concretely, for each element of the sequence, computes:
+
+    .. math::
+
+        r_t = \sigma (W_{xr}x_t + b_{xr} + W_{hr}h_t + b_{hr})
+        z_t = \sigma (W_{xz}x_t + b_{xz} + W_{hz}h_t + b_{hz})
+        n_t = \text{tanh}(W_{xn}x_t + b_{xn} + r_t \odot (W_{hn}h_t + b_{hn}))
+        h_{t + 1} = (1 - z_t) \odot n_t + z_t \odot h_t
+
+    The hidden state :math:`h` has shape ``NH`` or ``H``, depending
+    whether the input is batched or not. Returns the hidden state at each
+    time step, of shape ``NLH`` or ``LH``.
+
+    Args:
+        input_size (int): Dimension of the input :math:`x`
+        hidden_size (int): Dimension of the hidden state :math:`h`
+        bias (bool): Whether to use biases or not. Default: `True`.
+    """
+
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int,
+        bias: bool = True,
+    ):
+        super().__init__()
+        self.bias = bias
+        # r
+        self.Wxr = _weight_init(input_size, hidden_size)
+        self.Whr = _weight_init(hidden_size, hidden_size)
+        self.br = _bias_init(hidden_size, bias)
+        # n
+        self.Wxn = _weight_init(input_size, hidden_size)
+        self.Whn = _weight_init(hidden_size, hidden_size)
+        self.bn = _bias_init(hidden_size, bias)
+        self.bhn = _bias_init(hidden_size, bias)
+        # z
+        self.Wxz = _weight_init(input_size, hidden_size)
+        self.Whz = _weight_init(hidden_size, hidden_size)
+        self.bz = _bias_init(hidden_size, bias)
+
+    def _extra_repr(self):
+        return f"input_dims={self.Wxr.shape[0]}, hidden_size={self.Wxr.shape[-1]}, bias={self.bias}"
+
+    def __call__(self, x):
+        x_proj_r = x @ self.Wxr
+        x_proj_n = x @ self.Wxn
+        x_proj_z = x @ self.Wxz
+
+        if self.bias:
+            x_proj_r += self.br
+            x_proj_n += self.bn
+            x_proj_z += self.bz
+
+        all_hidden = []
+        curr_hidden = mx.zeros(shape=(self.Whr.shape[0],))
+
+        for idx in range(x.shape[-2]):
+            r = x_proj_r[..., idx, :] + curr_hidden @ self.Whr
+            r = mx.sigmoid(r)
+
+            z = x_proj_z[..., idx, :] + curr_hidden @ self.Whz
+            z = mx.sigmoid(z)
+
+            n_x = x_proj_n[..., idx, :]
+
+            n_h = curr_hidden @ self.Whn
+            if self.bias:
+                n_h += self.bhn
+
+            n = n_x + r * n_h
+            n = mx.tanh(n)
+
+            curr_hidden = (1 - z) * n + z * curr_hidden
+            all_hidden.append(curr_hidden)
+
+        return mx.stack(all_hidden, axis=-2)
+
+
+class LSTM(Module):
+    r"""Apply one LSTM recurrent unit to a sequence of
+    shape ``NLD`` or ``LD``, where:
+        - ``N`` is the optional batch dimension
+        - ``L`` is the sequence length
+        - ``D`` is the input's feature dimension
+
+    Concretely, for each element of the sequence, computes:
+
+    .. math::
+        i_t = \sigma (W_{xi}x_t + b_{xi} + W_{hi}h_t + b_{hi})
+        f_t = \sigma (W_{xf}x_t + b_{xf} + W_{hf}h_t + b_{hf})
+        g_t = \text{tanh} (W_{xg}x_t + b_{xg} + W_{hg}h_t + b_{hg})
+        o_t = \sigma (W_{xo}x_t + b_{xo} + W_{ho}h_t + b_{ho})
+        c_{t + 1} = f_t \odot c_t + i_t \odot g_t
+        h_{t + 1} = o_t \text{tanh}(c_{t + 1})
+
+    The hidden state :math:`h` and cell state :math:`c` have shape ``NH``
+    or ``H``, depending whether the input is batched or not. Returns two
+    arrays: the hidden state and the cell state at each time step, both
+    of shape ``NLH`` or ``LH``.
+
+    Args:
+        input_size (int): Dimension of the input :math:`x`
+        hidden_size (int): Dimension of the hidden state :math:`h`
+        bias (bool): Whether to use biases or not. Default: `True`.
+    """
+
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int,
+        bias: bool = True,
+    ):
+        super().__init__()
+        self.bias = bias
+        # i
+        self.Wxi = _weight_init(input_size, hidden_size)
+        self.Whi = _weight_init(hidden_size, hidden_size)
+        self.bi = _bias_init(hidden_size, bias)
+        # f
+        self.Wxf = _weight_init(input_size, hidden_size)
+        self.Whf = _weight_init(hidden_size, hidden_size)
+        self.bf = _bias_init(hidden_size, bias)
+        # g
+        self.Wxg = _weight_init(input_size, hidden_size)
+        self.Whg = _weight_init(hidden_size, hidden_size)
+        self.bg = _bias_init(hidden_size, bias)
+        # o
+        self.Wxo = _weight_init(input_size, hidden_size)
+        self.Who = _weight_init(hidden_size, hidden_size)
+        self.bo = _bias_init(hidden_size, bias)
+
+    def _extra_repr(self):
+        return f"input_dims={self.Wxi.shape[0]}, hidden_size={self.Whi.shape[0]}, bias={self.bias}"
+
+    def __call__(self, x):
+        x_proj_i = x @ self.Wxi
+        x_proj_f = x @ self.Wxf
+        x_proj_g = x @ self.Wxg
+        x_proj_o = x @ self.Wxo
+
+        if self.bias:
+            x_proj_i += self.bi
+            x_proj_f += self.bf
+            x_proj_g += self.bg
+            x_proj_o += self.bo
+
+        all_hidden = []
+        all_cell = []
+        curr_hidden = mx.zeros(shape=(self.Whi.shape[0],))
+        curr_cell = mx.zeros(shape=(self.Whi.shape[0],))
+
+        for idx in range(x.shape[-2]):
+            i = x_proj_i[..., idx, :] + curr_hidden @ self.Whi
+            i = mx.sigmoid(i)
+
+            f = x_proj_f[..., idx, :] + curr_hidden @ self.Whf
+            f = mx.sigmoid(f)
+
+            g = x_proj_g[..., idx, :] + curr_hidden @ self.Whg
+            g = mx.tanh(g)
+
+            o = x_proj_o[..., idx, :] + curr_hidden @ self.Who
+            o = mx.sigmoid(o)
+
+            curr_cell = f * curr_cell + i * g
+            curr_hidden = o * mx.tanh(curr_cell)
+
+            all_cell.append(curr_cell)
+            all_hidden.append(curr_hidden)
+
+        return mx.stack(all_hidden, axis=-2), mx.stack(all_cell, axis=-2)

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -1504,6 +1504,9 @@ class TestLayers(mlx_tests.MLXTestCase):
         h_out = layer(inp)
         self.assertEqual(h_out.shape, (44, 12))
 
+        h_out = layer(inp, hidden=h_out[-1, :])
+        self.assertEqual(h_out.shape, (44, 12))
+
     def test_gru(self):
         layer = nn.GRU(5, 12, bias=True)
         inp = mx.random.normal((2, 25, 5))
@@ -1511,8 +1514,14 @@ class TestLayers(mlx_tests.MLXTestCase):
         h_out = layer(inp)
         self.assertEqual(h_out.shape, (2, 25, 12))
 
+        h_out = layer(inp, hidden=h_out[:, -1, :])
+        self.assertEqual(h_out.shape, (2, 25, 12))
+
         inp = mx.random.normal((44, 5))
         h_out = layer(inp)
+        self.assertEqual(h_out.shape, (44, 12))
+
+        h_out = layer(inp, h_out[-1, :])
         self.assertEqual(h_out.shape, (44, 12))
 
     def test_lstm(self):
@@ -1523,8 +1532,17 @@ class TestLayers(mlx_tests.MLXTestCase):
         self.assertEqual(h_out.shape, (2, 25, 12))
         self.assertEqual(c_out.shape, (2, 25, 12))
 
+        h_out, c_out = layer(inp, hidden=h_out[:, -1, :], cell=c_out[:, -1, :])
+        self.assertEqual(h_out.shape, (2, 25, 12))
+        self.assertEqual(c_out.shape, (2, 25, 12))
+
         inp = mx.random.normal((44, 5))
         h_out, c_out = layer(inp)
+        self.assertEqual(h_out.shape, (44, 12))
+        self.assertEqual(c_out.shape, (44, 12))
+
+        inp = mx.random.normal((44, 5))
+        h_out, c_out = layer(inp, hidden=h_out[-1, :], cell=c_out[-1, :])
         self.assertEqual(h_out.shape, (44, 12))
         self.assertEqual(c_out.shape, (44, 12))
 

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -1480,6 +1480,54 @@ class TestLayers(mlx_tests.MLXTestCase):
             "AvgPool2d(kernel_size=(1, 2), stride=(2, 2), padding=(1, 2))",
         )
 
+    def test_rnn(self):
+        layer = nn.RNN(input_size=5, hidden_size=12, bias=True)
+        inp = mx.random.normal((2, 25, 5))
+
+        h_out = layer(inp)
+        self.assertEqual(h_out.shape, (2, 25, 12))
+
+        layer = nn.RNN(
+            5,
+            12,
+            bias=False,
+            nonlinearity=lambda x: mx.maximum(0, x),
+        )
+
+        h_out = layer(inp)
+        self.assertEqual(h_out.shape, (2, 25, 12))
+
+        with self.assertRaises(ValueError):
+            nn.RNN(5, 12, nonlinearity="tanh")
+
+        inp = mx.random.normal((44, 5))
+        h_out = layer(inp)
+        self.assertEqual(h_out.shape, (44, 12))
+
+    def test_gru(self):
+        layer = nn.GRU(5, 12, bias=True)
+        inp = mx.random.normal((2, 25, 5))
+
+        h_out = layer(inp)
+        self.assertEqual(h_out.shape, (2, 25, 12))
+
+        inp = mx.random.normal((44, 5))
+        h_out = layer(inp)
+        self.assertEqual(h_out.shape, (44, 12))
+
+    def test_lstm(self):
+        layer = nn.LSTM(5, 12)
+        inp = mx.random.normal((2, 25, 5))
+
+        h_out, c_out = layer(inp)
+        self.assertEqual(h_out.shape, (2, 25, 12))
+        self.assertEqual(c_out.shape, (2, 25, 12))
+
+        inp = mx.random.normal((44, 5))
+        h_out, c_out = layer(inp)
+        self.assertEqual(h_out.shape, (44, 12))
+        self.assertEqual(c_out.shape, (44, 12))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -1416,7 +1416,7 @@ class TestOps(mlx_tests.MLXTestCase):
         # Sliced inputs
         y = mx.random.uniform(shape=(8, 4))
         out = mx.softmax(y[:, 0:2], axis=-1)
-        self.assertAlmostEqual(out.sum().item(), 8.0)
+        self.assertAlmostEqual(out.sum().item(), 8.0, 5)
 
     def test_concatenate(self):
         a_npy = np.random.randn(32, 32, 32)


### PR DESCRIPTION
## Proposed changes

Implement recurrent cells and layers (Elman RNN, GRU, LSTM) in Python. Ultimately, it would probably be more efficient to implement in metal for parallelization (esp. for multi-layer and bi-directional), but in the meantime I think it is worth having a simple, be it only for benchmarking.

I have tested the implementations on small character-level language models.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
