### PR TITLE
Fix failing test for log cosh loss

### DIFF
--- a/python/mlx/nn/layers/dropout.py
+++ b/python/mlx/nn/layers/dropout.py
@@ -88,5 +88,3 @@ class Dropout2d(Module):
 
         mask = mx.random.bernoulli(p=self._p_1, shape=mask_shape)
         return (1 / self._p_1) * mask * x
-
-

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -597,7 +597,7 @@ class TestNN(mlx_tests.MLXTestCase):
         inputs = mx.ones((2, 4))
         targets = mx.zeros((2, 4))
         loss = nn.losses.log_cosh_loss(inputs, targets, reduction="mean")
-        self.assertEqual(loss, 0.433781)
+        self.assertAlmostEqual(loss.item(), 0.433781, places=6)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Proposed changes
The value of loss precisely is 0.4337807297706604, due to which it causing failure in assert statement with 0.433781. So, I changed `assertEqual` with `assertAlmostEqual`

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
