### PR TITLE
Memory allocation

### DIFF
--- a/mlx/allocator.h
+++ b/mlx/allocator.h
@@ -39,7 +39,7 @@ Buffer malloc_or_wait(size_t size);
 class Allocator {
   /** Abstract base class for a memory allocator. */
  public:
-  virtual Buffer malloc(size_t size) = 0;
+  virtual Buffer malloc(size_t size, bool allow_swap = false) = 0;
   virtual void free(Buffer buffer) = 0;
 
   Allocator() = default;
@@ -55,7 +55,7 @@ Allocator& allocator();
 class CommonAllocator : public Allocator {
   /** A general CPU allocator. */
  public:
-  virtual Buffer malloc(size_t size) override;
+  virtual Buffer malloc(size_t size, bool allow_swap = false) override;
   virtual void free(Buffer buffer) override;
 
  private:

--- a/mlx/backend/metal/allocator.cpp
+++ b/mlx/backend/metal/allocator.cpp
@@ -23,41 +23,152 @@ void* Buffer::raw_ptr() {
 
 namespace metal {
 
+namespace {
+
+BufferCache::BufferCache(MTL::Device* device)
+    : device_(device), head_(nullptr), tail_(nullptr), pool_size_(0) {}
+
+BufferCache::~BufferCache() {
+  clear();
+}
+
+void BufferCache::clear() {
+  std::lock_guard<std::mutex> lk(cache_mutex_);
+  for (auto& [size, holder] : buffer_pool_) {
+    if (holder->buf)
+      holder->buf->release();
+    delete holder;
+  }
+  buffer_pool_.clear();
+  pool_size_ = 0;
+  head_ = nullptr;
+  tail_ = nullptr;
+}
+
+MTL::Buffer* BufferCache::reuse_from_cache(size_t size) {
+  std::lock_guard<std::mutex> lk(cache_mutex_);
+
+  // Find the closest buffer in pool
+  MTL::Buffer* pbuf = nullptr;
+
+  // Make sure we use > 50% of the available memory
+  if (auto it = buffer_pool_.lower_bound(size);
+      it != buffer_pool_.end() && it->first < 2 * size) {
+    // Collect from the cache
+    pbuf = it->second->buf;
+    // Remove from cache
+    remove_from_list(it->second);
+    delete it->second;
+    it = buffer_pool_.erase(it);
+  }
+
+  if (pbuf) {
+    pool_size_ -= pbuf->length();
+  }
+
+  return pbuf;
+}
+
+void BufferCache::recycle_to_cache(MTL::Buffer* buf) {
+  std::lock_guard<std::mutex> lk(cache_mutex_);
+
+  // Add to cache
+  if (buf) {
+    BufferHolder* bh = new BufferHolder(buf);
+    add_at_head(bh);
+    pool_size_ += buf->length();
+    buffer_pool_.insert({buf->length(), bh});
+  }
+}
+
+void BufferCache::release_cached_buffers(size_t min_bytes_to_free) {
+  if (min_bytes_to_free >= 0.9 * pool_size_) {
+    clear();
+  } else {
+    std::lock_guard<std::mutex> lk(cache_mutex_);
+    size_t total_bytes_freed = 0;
+    while (tail_ && (total_bytes_freed < min_bytes_to_free)) {
+      if (tail_->buf) {
+        total_bytes_freed += tail_->buf->length();
+        tail_->buf->release();
+        tail_->buf = nullptr;
+      }
+      remove_from_list(tail_);
+    }
+    pool_size_ -= total_bytes_freed;
+  }
+}
+
+void BufferCache::add_at_head(BufferCache::BufferHolder* to_add) {
+  if (!to_add)
+    return;
+
+  if (!head_) {
+    head_ = to_add;
+    tail_ = to_add;
+  } else {
+    head_->prev = to_add;
+    to_add->next = head_;
+    head_ = to_add;
+  }
+}
+
+void BufferCache::remove_from_list(BufferCache::BufferHolder* to_remove) {
+  if (!to_remove)
+    return;
+
+  // If in the middle
+  if (to_remove->prev && to_remove->next) {
+    to_remove->prev->next = to_remove->next;
+    to_remove->next->prev = to_remove->prev;
+  } else if (to_remove->prev && to_remove == tail_) { // If tail
+    tail_ = to_remove->prev;
+    tail_->next = nullptr;
+  } else if (to_remove == head_ && to_remove->next) { // If head
+    head_ = to_remove->next;
+    head_->prev = nullptr;
+  } else if (to_remove == head_ && to_remove == tail_) { // If only element
+    head_ = nullptr;
+    tail_ = nullptr;
+  }
+
+  to_remove->prev = nullptr;
+  to_remove->next = nullptr;
+}
+
+} // namespace
+
 MetalAllocator::MetalAllocator()
     : device_(device(mlx::core::Device::gpu).mtl_device()),
+      buffer_cache_(device_),
       peak_allocated_size_(0),
       block_limit_(device_->recommendedMaxWorkingSetSize()) {}
 
 Buffer MetalAllocator::malloc(size_t size, bool allow_swap /* = false */) {
   // Align up memory
-  /// if (size > vm_page_size) {
-  //  size = vm_page_size * ((size + vm_page_size - 1) / vm_page_size);
-  //}
+  if (size > vm_page_size) {
+    size = vm_page_size * ((size + vm_page_size - 1) / vm_page_size);
+  }
 
-  //  MTL::Buffer* buf = buffer_cache_.reuse_from_cache(size);
+  MTL::Buffer* buf = buffer_cache_.reuse_from_cache(size);
 
   // Prepare to allocate new memory as needed
-  //  if (!buf) {
-  // If we have memory pressure, first check if we can reclaim some memory
-  // from the cache
-  //    if (auto new_size = device_->currentAllocatedSize() + size; new_size >=
-  //    block_limit_) {
-  //      buffer_cache_.clear();
-  //      buffer_cache_.release_cached_buffers(
-  //          std::max(new_size - block_limit_, size));
-  //    }
+  if (!buf) {
+    // If there is still too much memory pressure, fail (likely causes a wait).
+    if (auto new_size = device_->currentAllocatedSize() + size;
+        new_size >= block_limit_) {
+      buffer_cache_.clear();
+    }
 
-  // If there is still too much memory pressure, fail (likely causes a wait).
-  // size + allocated (to avoid going over the limit)
-  if (!allow_swap && device_->currentAllocatedSize() + size >= block_limit_) {
-    return Buffer{nullptr};
+    if (device_->currentAllocatedSize() >= block_limit_) {
+      return Buffer{nullptr};
+    }
+
+    // Allocate new buffer if needed
+    size_t res_opt = MTL::ResourceStorageModeShared;
+    res_opt |= MTL::ResourceHazardTrackingModeTracked;
+    buf = device_->newBuffer(size, res_opt);
   }
-  //  }
-
-  // Allocate new buffer if needed
-  size_t res_opt = MTL::ResourceStorageModeShared;
-  res_opt |= MTL::ResourceHazardTrackingModeTracked;
-  auto buf = device_->newBuffer(size, res_opt);
 
   peak_allocated_size_ =
       std::max(peak_allocated_size_, device_->currentAllocatedSize());
@@ -66,7 +177,8 @@ Buffer MetalAllocator::malloc(size_t size, bool allow_swap /* = false */) {
 }
 
 void MetalAllocator::free(Buffer buffer) {
-  static_cast<MTL::Buffer*>(buffer.ptr())->release();
+  auto buf = static_cast<MTL::Buffer*>(buffer.ptr());
+  buffer_cache_.recycle_to_cache(buf);
 }
 
 MetalAllocator& allocator() {

--- a/mlx/backend/metal/allocator.cpp
+++ b/mlx/backend/metal/allocator.cpp
@@ -81,24 +81,6 @@ void BufferCache::recycle_to_cache(MTL::Buffer* buf) {
   }
 }
 
-void BufferCache::release_cached_buffers(size_t min_bytes_to_free) {
-  if (min_bytes_to_free >= 0.9 * pool_size_) {
-    clear();
-  } else {
-    std::lock_guard<std::mutex> lk(cache_mutex_);
-    size_t total_bytes_freed = 0;
-    while (tail_ && (total_bytes_freed < min_bytes_to_free)) {
-      if (tail_->buf) {
-        total_bytes_freed += tail_->buf->length();
-        tail_->buf->release();
-        tail_->buf = nullptr;
-      }
-      remove_from_list(tail_);
-    }
-    pool_size_ -= total_bytes_freed;
-  }
-}
-
 void BufferCache::add_at_head(BufferCache::BufferHolder* to_add) {
   if (!to_add)
     return;

--- a/mlx/backend/metal/allocator.cpp
+++ b/mlx/backend/metal/allocator.cpp
@@ -51,7 +51,7 @@ MTL::Buffer* BufferCache::reuse_from_cache(size_t size) {
   // Find the closest buffer in pool
   MTL::Buffer* pbuf = nullptr;
 
-  // Make sure we use > 50% of the available memory
+  // Make sure we use most of the available memory
   if (auto it = buffer_pool_.lower_bound(size); it != buffer_pool_.end() &&
       it->first < std::min(2 * size, size + vm_page_size)) {
     // Collect from the cache

--- a/mlx/backend/metal/allocator.cpp
+++ b/mlx/backend/metal/allocator.cpp
@@ -1,5 +1,6 @@
 // Copyright © 2023 Apple Inc.
 
+#include <iostream>
 #include "mlx/backend/metal/allocator.h"
 #include "mlx/backend/metal/metal.h"
 
@@ -23,155 +24,40 @@ void* Buffer::raw_ptr() {
 
 namespace metal {
 
-namespace {
-
-BufferCache::BufferCache(MTL::Device* device)
-    : device_(device), head_(nullptr), tail_(nullptr), pool_size_(0) {}
-
-BufferCache::~BufferCache() {
-  clear();
-}
-
-void BufferCache::clear() {
-  std::lock_guard<std::mutex> lk(cache_mutex_);
-  for (auto& [size, holder] : buffer_pool_) {
-    if (holder->buf)
-      holder->buf->release();
-    delete holder;
-  }
-  buffer_pool_.clear();
-  pool_size_ = 0;
-  head_ = nullptr;
-  tail_ = nullptr;
-}
-
-MTL::Buffer* BufferCache::reuse_from_cache(size_t size) {
-  std::lock_guard<std::mutex> lk(cache_mutex_);
-
-  // Find the closest buffer in pool
-  MTL::Buffer* pbuf = nullptr;
-
-  // Make sure we use > 50% of the available memory
-  if (auto it = buffer_pool_.lower_bound(size);
-      it != buffer_pool_.end() && it->first < 2 * size) {
-    // Collect from the cache
-    pbuf = it->second->buf;
-    // Remove from cache
-    remove_from_list(it->second);
-    delete it->second;
-    it = buffer_pool_.erase(it);
-  }
-
-  if (pbuf) {
-    pool_size_ -= pbuf->length();
-  }
-
-  return pbuf;
-}
-
-void BufferCache::recycle_to_cache(MTL::Buffer* buf) {
-  std::lock_guard<std::mutex> lk(cache_mutex_);
-
-  // Add to cache
-  if (buf) {
-    BufferHolder* bh = new BufferHolder(buf);
-    add_at_head(bh);
-    pool_size_ += buf->length();
-    buffer_pool_.insert({buf->length(), bh});
-  }
-}
-
-void BufferCache::release_cached_buffers(size_t min_bytes_to_free) {
-  if (min_bytes_to_free >= 0.9 * pool_size_) {
-    clear();
-  } else {
-    std::lock_guard<std::mutex> lk(cache_mutex_);
-    size_t total_bytes_freed = 0;
-    while (tail_ && (total_bytes_freed < min_bytes_to_free)) {
-      if (tail_->buf) {
-        total_bytes_freed += tail_->buf->length();
-        tail_->buf->release();
-        tail_->buf = nullptr;
-      }
-      remove_from_list(tail_);
-    }
-    pool_size_ -= total_bytes_freed;
-  }
-}
-
-void BufferCache::add_at_head(BufferCache::BufferHolder* to_add) {
-  if (!to_add)
-    return;
-
-  if (!head_) {
-    head_ = to_add;
-    tail_ = to_add;
-  } else {
-    head_->prev = to_add;
-    to_add->next = head_;
-    head_ = to_add;
-  }
-}
-
-void BufferCache::remove_from_list(BufferCache::BufferHolder* to_remove) {
-  if (!to_remove)
-    return;
-
-  // If in the middle
-  if (to_remove->prev && to_remove->next) {
-    to_remove->prev->next = to_remove->next;
-    to_remove->next->prev = to_remove->prev;
-  } else if (to_remove->prev && to_remove == tail_) { // If tail
-    tail_ = to_remove->prev;
-    tail_->next = nullptr;
-  } else if (to_remove == head_ && to_remove->next) { // If head
-    head_ = to_remove->next;
-    head_->prev = nullptr;
-  } else if (to_remove == head_ && to_remove == tail_) { // If only element
-    head_ = nullptr;
-    tail_ = nullptr;
-  }
-
-  to_remove->prev = nullptr;
-  to_remove->next = nullptr;
-}
-
-} // namespace
-
 MetalAllocator::MetalAllocator()
     : device_(device(mlx::core::Device::gpu).mtl_device()),
-      buffer_cache_(device_),
       peak_allocated_size_(0),
-      block_limit_(1.5 * device_->recommendedMaxWorkingSetSize()) {}
+      block_limit_(device_->recommendedMaxWorkingSetSize()) {}
 
-Buffer MetalAllocator::malloc(size_t size) {
+Buffer MetalAllocator::malloc(size_t size, bool allow_swap /* = false */) {
   // Align up memory
-  if (size > vm_page_size) {
-    size = vm_page_size * ((size + vm_page_size - 1) / vm_page_size);
-  }
+  ///if (size > vm_page_size) {
+  //  size = vm_page_size * ((size + vm_page_size - 1) / vm_page_size);
+  //}
 
-  MTL::Buffer* buf = buffer_cache_.reuse_from_cache(size);
+//  MTL::Buffer* buf = buffer_cache_.reuse_from_cache(size);
 
   // Prepare to allocate new memory as needed
-  if (!buf) {
-    // First check if the cache is big but nothing fits, garbage collect
-    // if so
-    // TODO maybe block limit and gc limit should be different
-    if (buffer_cache_.size() >= block_limit_) {
-      buffer_cache_.release_cached_buffers(
-          std::max(buffer_cache_.size() - block_limit_, size));
-    }
+//  if (!buf) {
+    // If we have memory pressure, first check if we can reclaim some memory
+    // from the cache
+//    if (auto new_size = device_->currentAllocatedSize() + size; new_size >= block_limit_) {
+//      buffer_cache_.clear();
+//      buffer_cache_.release_cached_buffers(
+//          std::max(new_size - block_limit_, size));
+//    }
 
     // If there is still too much memory pressure, fail (likely causes a wait).
-    if (device_->currentAllocatedSize() >= block_limit_) {
+    // size + allocated (to avoid going over the limit)
+    if (!allow_swap && device_->currentAllocatedSize() + size >= block_limit_) {
       return Buffer{nullptr};
     }
+//  }
 
     // Allocate new buffer if needed
     size_t res_opt = MTL::ResourceStorageModeShared;
     res_opt |= MTL::ResourceHazardTrackingModeTracked;
-    buf = device_->newBuffer(size, res_opt);
-  }
+    auto buf = device_->newBuffer(size, res_opt);
 
   peak_allocated_size_ =
       std::max(peak_allocated_size_, device_->currentAllocatedSize());
@@ -180,8 +66,7 @@ Buffer MetalAllocator::malloc(size_t size) {
 }
 
 void MetalAllocator::free(Buffer buffer) {
-  auto buf = static_cast<MTL::Buffer*>(buffer.ptr());
-  buffer_cache_.recycle_to_cache(buf);
+  static_cast<MTL::Buffer*>(buffer.ptr())->release();
 }
 
 MetalAllocator& allocator() {

--- a/mlx/backend/metal/allocator.cpp
+++ b/mlx/backend/metal/allocator.cpp
@@ -1,6 +1,5 @@
 // Copyright © 2023 Apple Inc.
 
-#include <iostream>
 #include "mlx/backend/metal/allocator.h"
 #include "mlx/backend/metal/metal.h"
 
@@ -31,33 +30,34 @@ MetalAllocator::MetalAllocator()
 
 Buffer MetalAllocator::malloc(size_t size, bool allow_swap /* = false */) {
   // Align up memory
-  ///if (size > vm_page_size) {
+  /// if (size > vm_page_size) {
   //  size = vm_page_size * ((size + vm_page_size - 1) / vm_page_size);
   //}
 
-//  MTL::Buffer* buf = buffer_cache_.reuse_from_cache(size);
+  //  MTL::Buffer* buf = buffer_cache_.reuse_from_cache(size);
 
   // Prepare to allocate new memory as needed
-//  if (!buf) {
-    // If we have memory pressure, first check if we can reclaim some memory
-    // from the cache
-//    if (auto new_size = device_->currentAllocatedSize() + size; new_size >= block_limit_) {
-//      buffer_cache_.clear();
-//      buffer_cache_.release_cached_buffers(
-//          std::max(new_size - block_limit_, size));
-//    }
+  //  if (!buf) {
+  // If we have memory pressure, first check if we can reclaim some memory
+  // from the cache
+  //    if (auto new_size = device_->currentAllocatedSize() + size; new_size >=
+  //    block_limit_) {
+  //      buffer_cache_.clear();
+  //      buffer_cache_.release_cached_buffers(
+  //          std::max(new_size - block_limit_, size));
+  //    }
 
-    // If there is still too much memory pressure, fail (likely causes a wait).
-    // size + allocated (to avoid going over the limit)
-    if (!allow_swap && device_->currentAllocatedSize() + size >= block_limit_) {
-      return Buffer{nullptr};
-    }
-//  }
+  // If there is still too much memory pressure, fail (likely causes a wait).
+  // size + allocated (to avoid going over the limit)
+  if (!allow_swap && device_->currentAllocatedSize() + size >= block_limit_) {
+    return Buffer{nullptr};
+  }
+  //  }
 
-    // Allocate new buffer if needed
-    size_t res_opt = MTL::ResourceStorageModeShared;
-    res_opt |= MTL::ResourceHazardTrackingModeTracked;
-    auto buf = device_->newBuffer(size, res_opt);
+  // Allocate new buffer if needed
+  size_t res_opt = MTL::ResourceStorageModeShared;
+  res_opt |= MTL::ResourceHazardTrackingModeTracked;
+  auto buf = device_->newBuffer(size, res_opt);
 
   peak_allocated_size_ =
       std::max(peak_allocated_size_, device_->currentAllocatedSize());

--- a/mlx/backend/metal/allocator.cpp
+++ b/mlx/backend/metal/allocator.cpp
@@ -52,10 +52,14 @@ MTL::Buffer* BufferCache::reuse_from_cache(size_t size) {
   MTL::Buffer* pbuf = nullptr;
 
   // Make sure we use most of the available memory
-  if (auto it = buffer_pool_.lower_bound(size); it != buffer_pool_.end() &&
-      it->first < std::min(2 * size, size + vm_page_size)) {
+  auto it = buffer_pool_.lower_bound(size);
+
+  // Make sure we use most of the available memory
+  while (!pbuf && it != buffer_pool_.end() &&
+         it->first < std::min(2 * size, size + 2 * vm_page_size)) {
     // Collect from the cache
     pbuf = it->second->buf;
+
     // Remove from cache
     remove_from_list(it->second);
     delete it->second;
@@ -81,6 +85,25 @@ void BufferCache::recycle_to_cache(MTL::Buffer* buf) {
   }
 }
 
+void BufferCache::release_cached_buffers(size_t min_bytes_to_free) {
+  if (min_bytes_to_free >= 0.9 * pool_size_) {
+    clear();
+  } else {
+    std::lock_guard<std::mutex> lk(cache_mutex_);
+    size_t total_bytes_freed = 0;
+
+    while (tail_ && (total_bytes_freed < min_bytes_to_free)) {
+      if (tail_->buf) {
+        total_bytes_freed += tail_->buf->length();
+        tail_->buf->release();
+        tail_->buf = nullptr;
+      }
+      remove_from_list(tail_);
+    }
+    pool_size_ -= total_bytes_freed;
+  }
+}
+
 void BufferCache::add_at_head(BufferCache::BufferHolder* to_add) {
   if (!to_add)
     return;
@@ -96,8 +119,9 @@ void BufferCache::add_at_head(BufferCache::BufferHolder* to_add) {
 }
 
 void BufferCache::remove_from_list(BufferCache::BufferHolder* to_remove) {
-  if (!to_remove)
+  if (!to_remove) {
     return;
+  }
 
   // If in the middle
   if (to_remove->prev && to_remove->next) {
@@ -124,7 +148,8 @@ MetalAllocator::MetalAllocator()
     : device_(device(mlx::core::Device::gpu).mtl_device()),
       buffer_cache_(device_),
       peak_allocated_size_(0),
-      block_limit_(device_->recommendedMaxWorkingSetSize()) {}
+      block_limit_(device_->recommendedMaxWorkingSetSize()),
+      gc_limit_(0.95 * device_->recommendedMaxWorkingSetSize()) {}
 
 Buffer MetalAllocator::malloc(size_t size, bool allow_swap /* = false */) {
   // Align up memory
@@ -136,15 +161,17 @@ Buffer MetalAllocator::malloc(size_t size, bool allow_swap /* = false */) {
   MTL::Buffer* buf = buffer_cache_.reuse_from_cache(size);
 
   if (!buf) {
-    // If we have memory pressure, first check if we can reclaim some memory
-    // from the cache
-    if (device_->currentAllocatedSize() + size >= block_limit_) {
-      buffer_cache_.clear();
-    }
-
-    // If there is still too much memory pressure, fail (likely causes a wait).
+    // If there is too much memory pressure, fail (likely causes a wait).
     if (!allow_swap && device_->currentAllocatedSize() + size >= block_limit_) {
       return Buffer{nullptr};
+    }
+
+    // If we have a lot of memory pressure, check if we can reclaim some memory
+    // from the cache
+    if (device_->currentAllocatedSize() + size >= gc_limit_) {
+      size_t min_bytes_to_free =
+          size + device_->currentAllocatedSize() - gc_limit_;
+      buffer_cache_.release_cached_buffers(min_bytes_to_free);
     }
 
     // Allocate new buffer if needed

--- a/mlx/backend/metal/allocator.cpp
+++ b/mlx/backend/metal/allocator.cpp
@@ -148,7 +148,7 @@ MetalAllocator::MetalAllocator()
     : device_(device(mlx::core::Device::gpu).mtl_device()),
       buffer_cache_(device_),
       peak_allocated_size_(0),
-      block_limit_(device_->recommendedMaxWorkingSetSize()),
+      block_limit_(1.5 * device_->recommendedMaxWorkingSetSize()),
       gc_limit_(0.95 * device_->recommendedMaxWorkingSetSize()) {}
 
 Buffer MetalAllocator::malloc(size_t size, bool allow_swap /* = false */) {

--- a/mlx/backend/metal/allocator.h
+++ b/mlx/backend/metal/allocator.h
@@ -23,7 +23,6 @@ class BufferCache {
 
   MTL::Buffer* reuse_from_cache(size_t size);
   void recycle_to_cache(MTL::Buffer* buf);
-  void release_cached_buffers(size_t min_bytes_to_free);
 
  private:
   struct BufferHolder {

--- a/mlx/backend/metal/allocator.h
+++ b/mlx/backend/metal/allocator.h
@@ -13,6 +13,42 @@ namespace mlx::core::metal {
 
 using allocator::Buffer;
 
+namespace {
+
+class BufferCache {
+ public:
+  BufferCache(MTL::Device* device);
+  ~BufferCache();
+  void clear();
+
+  MTL::Buffer* reuse_from_cache(size_t size);
+  void recycle_to_cache(MTL::Buffer* buf);
+  void release_cached_buffers(size_t min_bytes_to_free);
+
+ private:
+  struct BufferHolder {
+   public:
+    BufferHolder(MTL::Buffer* buf_) : buf(buf_), prev(nullptr), next(nullptr) {}
+
+    BufferHolder* prev;
+    BufferHolder* next;
+    MTL::Buffer* buf;
+  };
+
+  void add_at_head(BufferHolder* to_add);
+  void remove_from_list(BufferHolder* to_remove);
+
+  MTL::Device* device_;
+  std::mutex cache_mutex_;
+
+  std::multimap<size_t, BufferHolder*> buffer_pool_;
+  BufferHolder* head_;
+  BufferHolder* tail_;
+  size_t pool_size_;
+};
+
+} // namespace
+
 class MetalAllocator : public allocator::Allocator {
   /** Allocator for Metal GPUs. */
  public:
@@ -23,6 +59,9 @@ class MetalAllocator : public allocator::Allocator {
   MTL::Device* device_;
   MetalAllocator();
   friend MetalAllocator& allocator();
+
+  // Caching allocator
+  BufferCache buffer_cache_;
 
   // Allocation stats
   size_t peak_allocated_size_;

--- a/mlx/backend/metal/allocator.h
+++ b/mlx/backend/metal/allocator.h
@@ -13,60 +13,16 @@ namespace mlx::core::metal {
 
 using allocator::Buffer;
 
-namespace {
-
-class BufferCache {
- public:
-  BufferCache(MTL::Device* device);
-  ~BufferCache();
-  void clear();
-
-  MTL::Buffer* reuse_from_cache(size_t size);
-  void recycle_to_cache(MTL::Buffer* buf);
-  void release_cached_buffers(size_t min_bytes_to_free);
-
-  // Returnt he size in bytes of cached memory
-  size_t size() {
-    return pool_size_;
-  }
-
- private:
-  struct BufferHolder {
-   public:
-    BufferHolder(MTL::Buffer* buf_) : buf(buf_), prev(nullptr), next(nullptr) {}
-
-    BufferHolder* prev;
-    BufferHolder* next;
-    MTL::Buffer* buf;
-  };
-
-  void add_at_head(BufferHolder* to_add);
-  void remove_from_list(BufferHolder* to_remove);
-
-  MTL::Device* device_;
-  std::mutex cache_mutex_;
-
-  std::multimap<size_t, BufferHolder*> buffer_pool_;
-  BufferHolder* head_;
-  BufferHolder* tail_;
-  size_t pool_size_;
-};
-
-} // namespace
-
 class MetalAllocator : public allocator::Allocator {
   /** Allocator for Metal GPUs. */
  public:
-  virtual Buffer malloc(size_t size) override;
+  virtual Buffer malloc(size_t size, bool allow_swap = false) override;
   virtual void free(Buffer buffer) override;
 
  private:
   MTL::Device* device_;
   MetalAllocator();
   friend MetalAllocator& allocator();
-
-  // Caching allocator
-  BufferCache buffer_cache_;
 
   // Allocation stats
   size_t peak_allocated_size_;

--- a/mlx/backend/metal/allocator.h
+++ b/mlx/backend/metal/allocator.h
@@ -23,10 +23,11 @@ class BufferCache {
 
   MTL::Buffer* reuse_from_cache(size_t size);
   void recycle_to_cache(MTL::Buffer* buf);
-  size_t release_cached_buffers(size_t min_bytes_to_free);
+  void release_cached_buffers(size_t min_bytes_to_free);
 
-  bool can_garbage_collect() {
-    return pool_size_ > 0 && device_->currentAllocatedSize() > gc_limit_;
+  // Returnt he size in bytes of cached memory
+  size_t size() {
+    return pool_size_;
   }
 
  private:
@@ -49,7 +50,6 @@ class BufferCache {
   BufferHolder* head_;
   BufferHolder* tail_;
   size_t pool_size_;
-  size_t gc_limit_;
 };
 
 } // namespace

--- a/mlx/backend/metal/allocator.h
+++ b/mlx/backend/metal/allocator.h
@@ -23,6 +23,7 @@ class BufferCache {
 
   MTL::Buffer* reuse_from_cache(size_t size);
   void recycle_to_cache(MTL::Buffer* buf);
+  void release_cached_buffers(size_t min_bytes_to_free);
 
  private:
   struct BufferHolder {
@@ -65,6 +66,7 @@ class MetalAllocator : public allocator::Allocator {
   // Allocation stats
   size_t peak_allocated_size_;
   size_t block_limit_;
+  size_t gc_limit_;
 };
 
 MetalAllocator& allocator();


### PR DESCRIPTION
## Proposed changes

This changes a few problems I observed in our memory allocator.

1. In some cases the cache is really full but nothing fits. Instead of trying to clear the cache, the allocator waits and in some extreme cases even fails when there is memory technically "available" but it's held by the cache. (If there are no scheduled jobs, nothing in the cache fits, we don't clear the cache, we just fail).

2. Change the cache fit policy to be a little stricter. It used to require the block to be less than twice the size. Now it requires `min(2 * size, size + vm_page_size)`. The `vm_page_size` is somewhat arbitrary but I think it's much better policy. Can save a lot of memory and when you get to big sizes, typically missing allocator the cache isn't such a huge deal as we fall back to allocating a new bugger.

3. Add a force swap parameter to the `malloc`. Once there are no more jobs to wait for, instead of just breaking the allocator will swap to the CPU. This makes it possible to do large model conversions for example.

4. Decrease the wait limit. I notice we often swap even at `1.5 * recommendedSize` (probably related to the amount of wired memory and other apps running). I cranked it down to just `recommendedSize`. That + the force allocate seems to work just as well in the cases I tested.

I will add some benchmarks before we decide to merge this. But want to solicit comments in parallel.
 
## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
