### PR TITLE
Add information for dropout probability

### DIFF
--- a/python/mlx/nn/layers/dropout.py
+++ b/python/mlx/nn/layers/dropout.py
@@ -19,7 +19,7 @@ class Dropout(Module):
         super().__init__()
 
         if p < 0 or p >= 1:
-            raise ValueError("The dropout probability should be in [0, 1)")
+            raise ValueError("The dropout probability {p} is not in [0, 1)")
 
         self._p_1 = 1 - p
 
@@ -62,7 +62,7 @@ class Dropout2d(Module):
         super().__init__()
 
         if p < 0 or p >= 1:
-            raise ValueError("The dropout probability should be in [0, 1)")
+            raise ValueError(f"The dropout probability {p} is not in [0, 1)")
 
         self._p_1 = 1 - p
 


### PR DESCRIPTION
## Proposed changes

When passing a wrong dropout probability, no information about the value is printed. This PR will print the wrong value to help debug.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
