### PR TITLE
Add Makefile for python related development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+.PHONY: install
+install:
+	# Build and install it using pip:
+	env CMAKE_BUILD_PARALLEL_LEVEL="" pip install .
+
+.PHONY: dev
+dev:
+	# Build and install an editable install:
+	env CMAKE_BUILD_PARALLEL_LEVEL="" pip install -e .
+
+.PHONY: test
+test:
+	# Install and run all the tests
+	pip install ".[testing]"
+	python -m unittest discover python/tests
+
+.PHONY: stub
+	# Install stubs to enable auto completions and type checking from your IDE:
+stub:
+	pip install ".[dev]"
+	python setup.py generate_stubs

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ test:
 	python -m unittest discover python/tests
 
 .PHONY: stub
-	# Install stubs to enable auto completions and type checking from your IDE:
 stub:
+	# Install stubs to enable auto completions and type checking from your IDE:
 	pip install ".[dev]"
 	python setup.py generate_stubs

--- a/docs/src/install.rst
+++ b/docs/src/install.rst
@@ -74,11 +74,24 @@ Then simply build and install it using pip:
 
    env CMAKE_BUILD_PARALLEL_LEVEL="" pip install .
 
+or
+
+.. code-block:: shell
+
+  make install
+
 For developing use an editable install:
 
 .. code-block:: shell
 
   env CMAKE_BUILD_PARALLEL_LEVEL="" pip install -e .
+
+
+or
+
+.. code-block:: shell
+
+  make dev
 
 To make sure the install is working run the tests with:
 
@@ -87,12 +100,26 @@ To make sure the install is working run the tests with:
   pip install ".[testing]"
   python -m unittest discover python/tests
 
+or
+
+.. code-block:: shell
+
+  make test
+
 Optional: Install stubs to enable auto completions and type checking from your IDE:
 
 .. code-block:: shell
 
   pip install ".[dev]"
   python setup.py generate_stubs
+
+
+or
+
+.. code-block:: shell
+
+  make stub
+
 
 C++ API
 ^^^^^^^


### PR DESCRIPTION
## Proposed changes

Add a Makefile for python related development. We do not have to type in all the commands from time to time.

Doc change preview:

<img width="862" alt="image" src="https://github.com/ml-explore/mlx/assets/2911134/119014a0-b4af-4972-a963-bcf2484b7ea6">


## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
