### PR TITLE
support python mlx.array creation from list of mlx.array's

### DIFF
--- a/mlx/dtype.h
+++ b/mlx/dtype.h
@@ -39,7 +39,7 @@ struct Dtype {
   };
 
   Val val;
-  uint8_t size;
+  const uint8_t size;
   constexpr explicit Dtype(Val val, uint8_t size) : val(val), size(size){};
   constexpr operator Val() const {
     return val;

--- a/mlx/dtype.h
+++ b/mlx/dtype.h
@@ -39,7 +39,7 @@ struct Dtype {
   };
 
   Val val;
-  const uint8_t size;
+  uint8_t size;
   constexpr explicit Dtype(Val val, uint8_t size) : val(val), size(size){};
   constexpr operator Val() const {
     return val;

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -714,6 +714,7 @@ array stack(
   }
   return concatenate(new_arrays, axis, s);
 }
+
 array stack(const std::vector<array>& arrays, StreamOrDevice s /* = {} */) {
   return stack(arrays, 0, s);
 }

--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -157,7 +157,7 @@ Dtype validate_shape(
     } else if (py::isinstance<array>(l)) {
       all_python_primitive_elements = false;
       auto arr = py::cast<array>(l);
-      if (arr.shape().size() + idx + 1 == shape.size() &&
+      if (arr.ndim() + idx + 1 == shape.size() &&
           std::equal(
               arr.shape().cbegin(),
               arr.shape().cend(),

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -231,6 +231,7 @@ class TestArray(mlx_tests.MLXTestCase):
             mx.int64,
             mx.float16,
             mx.float32,
+            mx.bfloat16,
             mx.complex64,
         ]
         for x_t, y_t in permutations(dtypes, 2):


### PR DESCRIPTION
## Proposed changes

Adds support for python mlx.array create from list of mlx.array's. Trying to tackle [issue 287](https://github.com/ml-explore/mlx/issues/287).

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
