### PR TITLE
fix type cast error in item() for bfloat16

### DIFF
--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -64,7 +64,7 @@ auto to_scalar(array& a) {
     case float32:
       return py::cast(a.item<float>(retain_graph));
     case bfloat16:
-      return py::cast(static_cast<float>(a.item<float16_t>(retain_graph)));
+      return py::cast(static_cast<float>(a.item<bfloat16_t>(retain_graph)));
     case complex64:
       return py::cast(a.item<std::complex<float>>(retain_graph));
   }

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -102,6 +102,9 @@ class TestArray(mlx_tests.MLXTestCase):
         self.assertEqual(x.item(), 1)
         self.assertTrue(isinstance(x.item(), int))
 
+        x = mx.array(1, mx.bfloat16)
+        self.assertEqual(x.item(), 1.0)
+
         x = mx.array(1.0)
         self.assertEqual(x.size, 1)
         self.assertEqual(x.ndim, 0)


### PR DESCRIPTION
## Proposed changes

So previously for `item()` for `bfloat16` is buggy... for example:
```
y = mx.array(1.0).astype(mx.bfloat16)
print(f"{y.item()=}")
# would print out 1.875
```

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
