### PR TITLE
Fix the implementation of the Bilinear layer

### DIFF
--- a/python/mlx/nn/layers/linear.py
+++ b/python/mlx/nn/layers/linear.py
@@ -122,13 +122,13 @@ class Bilinear(Module):
         out, in2, in1 = self.weight.shape
         xshape = x1.shape[:-1]
         x1 = x1.reshape(-1, in1)
-        x2 = x2.reshape(-1, in2)
+        x2 = x2.reshape(-1, 1, in2)
 
         # Perform the bilinear transformation
-        w = self.weight.reshape(in2 * out, in1)
+        w = self.weight.reshape(out * in2, in1)
         y = x1 @ w.T
         y = y.reshape(-1, out, in2).swapaxes(-2, -1)
-        y = x2[:, None, :] @ y
+        y = x2 @ y
         y = y.squeeze(1)
 
         # Reset the shape

--- a/python/mlx/nn/layers/linear.py
+++ b/python/mlx/nn/layers/linear.py
@@ -101,7 +101,7 @@ class Bilinear(Module):
         self.weight = mx.random.uniform(
             low=-scale,
             high=scale,
-            shape=(1, output_dims, input1_dims, input2_dims),
+            shape=(output_dims, input2_dims, input1_dims),
         )
         if bias:
             self.bias = mx.random.uniform(
@@ -111,16 +111,31 @@ class Bilinear(Module):
             )
 
     def _extra_repr(self) -> str:
+        out, in2, in1 = self.weight.shape
         return (
-            f"input1_dims={self.weight.shape[2]}, input2_dims={self.weight.shape[3]}, "
-            f"output_dims={self.weight.shape[1]}, bias={'bias' in self}"
+            f"input1_dims={in1}, input2_dims={in2}, output_dims={out}, "
+            f"bias={'bias' in self}"
         )
 
     def __call__(self, x1: mx.array, x2: mx.array) -> mx.array:
-        x1 = mx.expand_dims(x1, axis=(-2, -3))
-        x2 = mx.expand_dims(x2, axis=(-2))
-        y = mx.squeeze(x1 @ self.weight, -2).swapaxes(-1, -2)
-        y = mx.squeeze(x2 @ y, -2)
+        # Normalize shapes
+        out, in2, in1 = self.weight.shape
+        xshape = x1.shape[:-1]
+        x1 = x1.reshape(-1, in1)
+        x2 = x2.reshape(-1, in2)
+
+        # Perform the bilinear transformation
+        w = self.weight.reshape(in2 * out, in1)
+        y = x1 @ w.T
+        y = y.reshape(-1, out, in2).swapaxes(-2, -1)
+        y = x2[:, None, :] @ y
+        y = y.squeeze(1)
+
+        # Reset the shape
+        y = y.reshape(*xshape, out)
+
+        # Apply the bias
         if "bias" in self:
             y = y + self.bias
+
         return y


### PR DESCRIPTION
The current implementation causes an unnecessary huge copy of `x1` in the first matmul (it copies it `output_dims` times). This fixes it by changing the order of the dims in the weight so it can be done without any copy at all.

The outputs are identical provided one transposes the weight from one to the other. Even for modest sizes of `128` it gives a 20x speedup on my M2 air, measured using the following:

```python
import mlx.nn as nn
import mlx.core as mx
def bench(f, *args):
    ys = []
    for i in range(10):
        ys.append(f(*args))
    mx.eval(ys)

m = nn.Bilinear(128, 128, 128)
x = mx.random.normal((64, 128))
y = mx.random.normal((64, 128))
get_ipython().run_line_magic('timeit', 'bench(m, x, y)')
```

Before
```
49.8 ms ± 493 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

Now
```
2.52 ms ± 6.54 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```