### PR TITLE
Support for quantized matmul with w and w^T

### DIFF
--- a/benchmarks/python/comparative/bench_mlx.py
+++ b/benchmarks/python/comparative/bench_mlx.py
@@ -4,6 +4,7 @@ import argparse
 import math
 import os
 import time
+from functools import partial
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -59,13 +60,21 @@ def matmul(x, y):
     mx.eval(ys)
 
 
-def quant_matmul(x, w, s, b):
-    group_size = x.shape[-1] // s.shape[-1]
-    bits = 32 // (x.shape[-1] // w.shape[1])
+def _quant_matmul(x, w, s, b, group_size, bits):
     ys = []
     for i in range(10):
         ys.append(mx.quantized_matmul(x, w, s, b, group_size=group_size, bits=bits))
     mx.eval(ys)
+
+
+quant_matmul = {
+    "quant_matmul_64_2": partial(_quant_matmul, group_size=64, bits=2),
+    "quant_matmul_64_4": partial(_quant_matmul, group_size=64, bits=4),
+    "quant_matmul_64_8": partial(_quant_matmul, group_size=64, bits=8),
+    "quant_matmul_128_2": partial(_quant_matmul, group_size=128, bits=2),
+    "quant_matmul_128_4": partial(_quant_matmul, group_size=128, bits=4),
+    "quant_matmul_128_8": partial(_quant_matmul, group_size=128, bits=8),
+}
 
 
 def conv1d(x, y):
@@ -356,8 +365,8 @@ if __name__ == "__main__":
     elif args.benchmark == "matmul":
         print(bench(matmul, *xs))
 
-    elif args.benchmark == "quant_matmul":
-        print(bench(quant_matmul, *xs))
+    elif args.benchmark.startswith("quant_matmul"):
+        print(bench(quant_matmul[args.benchmark], *xs))
 
     elif args.benchmark == "linear":
         print(bench(linear, *xs))

--- a/benchmarks/python/comparative/bench_mlx.py
+++ b/benchmarks/python/comparative/bench_mlx.py
@@ -60,11 +60,11 @@ def matmul(x, y):
 
 
 def quant_matmul(x, w, s, b):
-    groups = x.shape[-1] // s.shape[-1]
-    width = 32 // (x.shape[-1] // w.shape[0])
+    group_size = x.shape[-1] // s.shape[-1]
+    bits = 32 // (x.shape[-1] // w.shape[1])
     ys = []
     for i in range(10):
-        ys.append(mx.quantized_matmul(x, w, s, b, groups=groups, width=width))
+        ys.append(mx.quantized_matmul(x, w, s, b, group_size=group_size, bits=bits))
     mx.eval(ys)
 
 

--- a/mlx/backend/accelerate/quantized.cpp
+++ b/mlx/backend/accelerate/quantized.cpp
@@ -77,7 +77,7 @@ void QuantizedMatmul::eval_cpu(const std::vector<array>& inputs, array& out) {
   auto& biases = inputs[3];
 
   bool condition =
-      (w.strides()[0] == 1 && x.flags().row_contiguous &&
+      (transpose_ && x.flags().row_contiguous && w.flags().row_contiguous &&
        scales.flags().row_contiguous && biases.flags().row_contiguous &&
        x.dtype() == float32 && bits_ == 4 && group_size_ == 64);
 
@@ -85,7 +85,7 @@ void QuantizedMatmul::eval_cpu(const std::vector<array>& inputs, array& out) {
     out.set_data(allocator::malloc_or_wait(out.nbytes()));
     int K = x.shape(-1);
     int M = x.size() / K;
-    int N = w.shape(1);
+    int N = out.shape(-1);
     _qmm_t_4_64(
         out.data<float>(),
         x.data<float>(),

--- a/mlx/backend/common/quantized.cpp
+++ b/mlx/backend/common/quantized.cpp
@@ -1,12 +1,61 @@
 // Copyright © 2023 Apple Inc.
 
 #include <cassert>
+#include <iostream>
 
+#include "mlx/backend/metal/copy.h"
 #include "mlx/primitives.h"
 
 namespace mlx::core {
 
 namespace {
+
+template <typename T, int bits, int group_size>
+void _qmm(
+    T* result,
+    const T* x,
+    const uint32_t* w,
+    const T* scales,
+    const T* biases,
+    int M,
+    int N,
+    int K) {
+  constexpr int bitmask = (1 << bits) - 1;
+  constexpr int pack_factor = 32 / bits;
+  constexpr int packs_in_group = group_size / pack_factor;
+  const int Ng = N / group_size;
+  const int Nw = N / pack_factor;
+
+  for (int m = 0; m < M; m++) {
+    const uint32_t* w_local = w;
+    const T* scales_local = scales;
+    const T* biases_local = biases;
+
+    std::fill(result, result + N, 0);
+
+    for (int k = 0; k < K; k++) {
+      T* result_local = result;
+      T xi = *x++;
+
+      for (int n = 0; n < N; n += group_size) {
+        T scale = *scales_local++;
+        T bias = *biases_local++;
+        for (int ng = 0; ng < packs_in_group; ng++) {
+          uint32_t wi = *w_local++;
+
+#pragma clang loop unroll(full)
+          for (int p = 0; p < pack_factor; p++) {
+            (*result_local++) +=
+                xi * (scale * static_cast<T>(wi & bitmask) + bias);
+            wi >>= bits;
+          }
+        }
+      }
+    }
+
+    result += N;
+  }
+}
 
 template <typename T, int bits, int group_size>
 void _qmm_t(
@@ -55,7 +104,7 @@ void _qmm_t(
 }
 
 template <typename T>
-void _qmm_t_dispatch_typed(
+void _qmm_dispatch_typed(
     T* result,
     const T* x,
     const uint32_t* w,
@@ -65,30 +114,55 @@ void _qmm_t_dispatch_typed(
     int N,
     int K,
     int group_size,
-    int bits) {
+    int bits,
+    bool transposed_w) {
   switch (bits) {
     case 2: {
       switch (group_size) {
         case 64:
-          return _qmm_t<T, 2, 64>(result, x, w, scales, biases, M, N, K);
+          if (transposed_w) {
+            return _qmm_t<T, 2, 64>(result, x, w, scales, biases, M, N, K);
+          } else {
+            return _qmm<T, 2, 64>(result, x, w, scales, biases, M, N, K);
+          }
         case 128:
-          return _qmm_t<T, 2, 128>(result, x, w, scales, biases, M, N, K);
+          if (transposed_w) {
+            return _qmm_t<T, 2, 128>(result, x, w, scales, biases, M, N, K);
+          } else {
+            return _qmm<T, 2, 128>(result, x, w, scales, biases, M, N, K);
+          }
       }
     }
     case 4: {
       switch (group_size) {
         case 64:
-          return _qmm_t<T, 4, 64>(result, x, w, scales, biases, M, N, K);
+          if (transposed_w) {
+            return _qmm_t<T, 4, 64>(result, x, w, scales, biases, M, N, K);
+          } else {
+            return _qmm<T, 4, 64>(result, x, w, scales, biases, M, N, K);
+          }
         case 128:
-          return _qmm_t<T, 4, 128>(result, x, w, scales, biases, M, N, K);
+          if (transposed_w) {
+            return _qmm_t<T, 4, 128>(result, x, w, scales, biases, M, N, K);
+          } else {
+            return _qmm<T, 4, 128>(result, x, w, scales, biases, M, N, K);
+          }
       }
     }
     case 8: {
       switch (group_size) {
         case 64:
-          return _qmm_t<T, 8, 64>(result, x, w, scales, biases, M, N, K);
+          if (transposed_w) {
+            return _qmm_t<T, 8, 64>(result, x, w, scales, biases, M, N, K);
+          } else {
+            return _qmm<T, 8, 64>(result, x, w, scales, biases, M, N, K);
+          }
         case 128:
-          return _qmm_t<T, 8, 128>(result, x, w, scales, biases, M, N, K);
+          if (transposed_w) {
+            return _qmm_t<T, 8, 128>(result, x, w, scales, biases, M, N, K);
+          } else {
+            return _qmm<T, 8, 128>(result, x, w, scales, biases, M, N, K);
+          }
       }
     }
   }
@@ -100,7 +174,7 @@ void _qmm_t_dispatch_typed(
   throw std::invalid_argument(msg.str());
 }
 
-void _qmm_t_dispatch(
+void _qmm_dispatch(
     array out,
     const array& x,
     const array& w,
@@ -110,11 +184,12 @@ void _qmm_t_dispatch(
     int group_size) {
   int K = x.shape(-1);
   int M = x.size() / K;
-  int N = w.shape(1);
+  int N = out.shape(-1);
+  bool transposed_w = w.strides().back() != 1;
 
   switch (x.dtype()) {
     case float32:
-      _qmm_t_dispatch_typed<float>(
+      _qmm_dispatch_typed<float>(
           out.data<float>(),
           x.data<float>(),
           w.data<uint32_t>(),
@@ -124,10 +199,11 @@ void _qmm_t_dispatch(
           N,
           K,
           bits,
-          group_size);
+          group_size,
+          transposed_w);
       break;
     case float16:
-      _qmm_t_dispatch_typed<float16_t>(
+      _qmm_dispatch_typed<float16_t>(
           out.data<float16_t>(),
           x.data<float16_t>(),
           w.data<uint32_t>(),
@@ -137,10 +213,11 @@ void _qmm_t_dispatch(
           N,
           K,
           bits,
-          group_size);
+          group_size,
+          transposed_w);
       break;
     case bfloat16:
-      _qmm_t_dispatch_typed<bfloat16_t>(
+      _qmm_dispatch_typed<bfloat16_t>(
           out.data<bfloat16_t>(),
           x.data<bfloat16_t>(),
           w.data<uint32_t>(),
@@ -150,7 +227,8 @@ void _qmm_t_dispatch(
           N,
           K,
           bits,
-          group_size);
+          group_size,
+          transposed_w);
       break;
     default:
       throw std::invalid_argument(
@@ -163,22 +241,41 @@ void _qmm_t_dispatch(
 void QuantizedMatmul::eval(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 4);
 
-  auto& x = inputs[0];
-  auto& w = inputs[1];
-  auto& scales = inputs[2];
-  auto& biases = inputs[3];
+  auto& x_pre = inputs[0];
+  auto& w_pre = inputs[1];
+  auto& scales_pre = inputs[2];
+  auto& biases_pre = inputs[3];
 
-  if (w.strides()[0] != 1) {
-    throw std::runtime_error("The quantized weight should be transposed");
+  auto check_transpose = [](const array& arr) {
+    auto stx = arr.strides()[arr.ndim() - 2];
+    auto sty = arr.strides()[arr.ndim() - 1];
+    if (stx == arr.shape(-1) && sty == 1) {
+      return std::make_tuple(false, arr);
+    } else if (stx == 1 && sty == arr.shape(-2)) {
+      return std::make_tuple(true, arr);
+    } else {
+      array arr_copy(arr.shape(), arr.dtype(), nullptr, {});
+      copy(arr, arr_copy, CopyType::General);
+      size_t stx = arr.shape(-1);
+      return std::make_tuple(false, arr_copy);
+    }
+  };
+
+  auto [x_transposed, x] = check_transpose(x_pre);
+  auto [w_transposed, w] = check_transpose(w_pre);
+  auto [scales_transposed, scales] = check_transpose(scales_pre);
+  auto [biases_transposed, biases] = check_transpose(biases_pre);
+
+  if (x_transposed) {
+    throw std::runtime_error("[quantized_matmul] x should be row contiguous.");
   }
-
-  if (!x.flags().row_contiguous || !scales.flags().row_contiguous ||
-      !biases.flags().row_contiguous) {
-    throw std::runtime_error("x, scales and biases should be row contiguous.");
+  if (w_transposed != scales_transposed || w_transposed != biases_transposed) {
+    throw std::runtime_error(
+        "[quantized_matmul] w, scales and biases should be transposed together.");
   }
 
   out.set_data(allocator::malloc_or_wait(out.nbytes()));
-  _qmm_t_dispatch(out, x, w, scales, biases, group_size_, bits_);
+  _qmm_dispatch(out, x, w, scales, biases, group_size_, bits_);
 }
 
 } // namespace mlx::core

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -43,8 +43,13 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
   auto [scales_transposed, scales_cols, scales] = check_transpose(scales_pre);
   auto [biases_transposed, biases_cols, biases] = check_transpose(biases_pre);
 
-  if (x_transposed || scales_transposed || biases_transposed) {
-    throw std::runtime_error("x, scales and biases should be row contiguous.");
+  // TODO: Change the following fatal errors to copies.
+  if (x_transposed) {
+    throw std::runtime_error("[quantized_matmul] x should be row contiguous.");
+  }
+  if (w_transposed != scales_transposed || w_transposed != biases_transposed) {
+    throw std::runtime_error(
+        "[quantized_matmul] w, scales and biases should be transposed together.");
   }
 
   int D = x.shape(-1);

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -2684,7 +2684,8 @@ array quantized_matmul(
     throw std::invalid_argument(
         "[quantized_matmul] The shapes of the weight and scales are "
         "not compatible. Make sure that if you are transposing `w` you "
-        "are also transposing `scales` and `biases`.");
+        "are also transposing `scales` and `biases` and that you are "
+        "using the correct `group_size` and `bits`.");
   }
 
   if (w_inner_dims != x_inner_dims) {

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -2621,7 +2621,8 @@ array quantized_matmul(
     int group_size /* = 64 */,
     int bits /* = 4 */,
     StreamOrDevice s /* = {} */) {
-  auto x = in_x;
+  auto dtype = promote_types(in_x.dtype(), scales.dtype());
+  auto x = astype(in_x, dtype, s);
 
   if (w.dtype() != uint32) {
     std::ostringstream msg;
@@ -2690,7 +2691,7 @@ array quantized_matmul(
       {x.shape(0), w_outer_dims},
       x.dtype(),
       std::make_unique<QuantizedMatmul>(to_stream(s), group_size, bits),
-      {x, w, scales, biases});
+      {x, w, astype(scales, dtype, s), astype(biases, dtype, s)});
 
   // If needed reshape x to the original batch shape
   if (original_shape.size() != 1) {

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -2695,7 +2695,7 @@ array quantized_matmul(
 
   // If needed reshape x to the original batch shape
   if (original_shape.size() != 1) {
-    original_shape.push_back(w.shape(1));
+    original_shape.push_back(w_outer_dims);
     out = reshape(out, original_shape, s);
   }
 

--- a/mlx/ops.h
+++ b/mlx/ops.h
@@ -1041,6 +1041,7 @@ array quantized_matmul(
     const array& w,
     const array& scales,
     const array& biases,
+    bool transpose = true,
     int group_size = 64,
     int bits = 4,
     StreamOrDevice s = {});

--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -1715,8 +1715,8 @@ std::vector<array> QuantizedMatmul::vjp(
       vjps.push_back(quantized_matmul(
           cotan,
           transpose(primals[1], {1, 0}, stream()),
-          primals[2],
-          primals[3],
+          transpose(primals[2], {1, 0}, stream()),
+          transpose(primals[3], {1, 0}, stream()),
           group_size_,
           bits_,
           stream()));
@@ -1725,7 +1725,7 @@ std::vector<array> QuantizedMatmul::vjp(
     // gradient wrt to w_q, scales or biases
     else {
       throw std::runtime_error(
-          "QuantizedMatmul::vjp cannot compute gradient wrt the quantized matrix.");
+          "QuantizedMatmul::vjp no gradient wrt the quantized matrix yet.");
     }
   }
   return vjps;
@@ -1735,7 +1735,7 @@ array QuantizedMatmul::jvp(
     const std::vector<array>& primals,
     const std::vector<array>& tangents,
     const std::vector<int>& argnums) {
-  throw std::runtime_error("QuantizedMatmul::vjp NYI");
+  throw std::runtime_error("QuantizedMatmul::jvp NYI");
 }
 
 bool QuantizedMatmul::is_equivalent(const Primitive& other) const {

--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -1706,7 +1706,29 @@ std::vector<array> QuantizedMatmul::vjp(
     const std::vector<array>& primals,
     const array& cotan,
     const std::vector<int>& argnums) {
-  throw std::runtime_error("QuantizedMatmul::vjp NYI");
+  std::vector<array> vjps;
+
+  // We rely on the fact that w is always 2D so transpose is simple
+  for (auto arg : argnums) {
+    // gradient wrt to x
+    if (arg == 0) {
+      vjps.push_back(quantized_matmul(
+          cotan,
+          transpose(primals[1], {1, 0}, stream()),
+          primals[2],
+          primals[3],
+          group_size_,
+          bits_,
+          stream()));
+    }
+
+    // gradient wrt to w_q, scales or biases
+    else {
+      throw std::runtime_error(
+          "QuantizedMatmul::vjp cannot compute gradient wrt the quantized matrix.");
+    }
+  }
+  return vjps;
 }
 
 array QuantizedMatmul::jvp(

--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -1714,9 +1714,10 @@ std::vector<array> QuantizedMatmul::vjp(
     if (arg == 0) {
       vjps.push_back(quantized_matmul(
           cotan,
-          transpose(primals[1], {1, 0}, stream()),
-          transpose(primals[2], {1, 0}, stream()),
-          transpose(primals[3], {1, 0}, stream()),
+          primals[1],
+          primals[2],
+          primals[3],
+          !transpose_,
           group_size_,
           bits_,
           stream()));

--- a/mlx/primitives.h
+++ b/mlx/primitives.h
@@ -1112,8 +1112,15 @@ class Power : public Primitive {
 
 class QuantizedMatmul : public Primitive {
  public:
-  explicit QuantizedMatmul(Stream stream, int group_size, int bits)
-      : Primitive(stream), group_size_(group_size), bits_(bits){};
+  explicit QuantizedMatmul(
+      Stream stream,
+      int group_size,
+      int bits,
+      bool transpose)
+      : Primitive(stream),
+        group_size_(group_size),
+        bits_(bits),
+        transpose_(transpose){};
 
   void eval_cpu(const std::vector<array>& inputs, array& out) override;
   void eval_gpu(const std::vector<array>& inputs, array& out) override;
@@ -1129,6 +1136,7 @@ class QuantizedMatmul : public Primitive {
  private:
   int group_size_;
   int bits_;
+  bool transpose_;
 
   void eval(const std::vector<array>& inputs, array& out);
 };

--- a/python/mlx/nn/layers/quantized.py
+++ b/python/mlx/nn/layers/quantized.py
@@ -82,8 +82,8 @@ class QuantizedLinear(Module):
         x = mx.quantized_matmul(
             x,
             self.weight.T,
-            scales=self.scales,
-            biases=self.biases,
+            scales=self.scales.T,
+            biases=self.biases.T,
             group_size=self.group_size,
             bits=self.bits,
         )

--- a/python/mlx/nn/layers/quantized.py
+++ b/python/mlx/nn/layers/quantized.py
@@ -81,9 +81,10 @@ class QuantizedLinear(Module):
     def __call__(self, x):
         x = mx.quantized_matmul(
             x,
-            self.weight.T,
-            scales=self.scales.T,
-            biases=self.biases.T,
+            self.weight,
+            scales=self.scales,
+            biases=self.biases,
+            transpose=True,
             group_size=self.group_size,
             bits=self.bits,
         )

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -3072,12 +3072,13 @@ void init_ops(py::module_& m) {
       py::pos_only(),
       "scales"_a,
       "biases"_a,
+      "transpose"_a = true,
       "group_size"_a = 64,
       "bits"_a = 4,
       py::kw_only(),
       "stream"_a = none,
       R"pbdoc(
-        quantized_matmul(x: array, w: array, scales: array, biases: array, /, group_size: int = 64, bits: int = 4, *, stream: Union[None, Stream, Device] = None) -> array
+        quantized_matmul(x: array, w: array, /, scales: array, biases: array, transpose: bool = True, group_size: int = 64, bits: int = 4, *, stream: Union[None, Stream, Device] = None) -> array
 
         Perform the matrix multiplication with the quantized matrix ``w``. The
         quantization uses one floating point scale and bias per ``group_size`` of
@@ -3089,6 +3090,9 @@ void init_ops(py::module_& m) {
           w (array): Quantized matrix packed in unsigned integers
           scales (array): The scales to use per ``group_size`` elements of ``w``
           biases (array): The biases to use per ``group_size`` elements of ``w``
+          transpose (bool, optional): Defines whether to multiply with the
+            transposed ``w`` or not, namelye whether we are performing
+            ``x @ w.T`` or ``x @ w``. (default: True)
           group_size (int, optional): The size of the group in ``w`` that
             shares a scale and bias. (default: 64)
           bits (int, optional): The number of bits occupied by each element in

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -3092,11 +3092,11 @@ void init_ops(py::module_& m) {
           biases (array): The biases to use per ``group_size`` elements of ``w``
           transpose (bool, optional): Defines whether to multiply with the
             transposed ``w`` or not, namelye whether we are performing
-            ``x @ w.T`` or ``x @ w``. (default: True)
+            ``x @ w.T`` or ``x @ w``. (default: ``True``)
           group_size (int, optional): The size of the group in ``w`` that
-            shares a scale and bias. (default: 64)
+            shares a scale and bias. (default: ``64``)
           bits (int, optional): The number of bits occupied by each element in
-            ``w``. (default: 4)
+            ``w``. (default: ``4``)
 
         Returns:
           result (array): The result of the multiplication of ``x`` with ``w``.
@@ -3150,9 +3150,9 @@ void init_ops(py::module_& m) {
         Args:
           w (array): Matrix to be quantized
           group_size (int, optional): The size of the group in ``w`` that shares a
-            scale and bias. (default: 64)
+            scale and bias. (default: ``64``)
           bits (int, optional): The number of bits occupied by each element of
-            ``w`` in the returned quantized matrix. (default: 4)
+            ``w`` in the returned quantized matrix. (default: ``4``)
 
         Returns:
           (tuple): A tuple containing
@@ -3191,9 +3191,9 @@ void init_ops(py::module_& m) {
           scales (array): The scales to use per ``group_size`` elements of ``w``
           biases (array): The biases to use per ``group_size`` elements of ``w``
           group_size (int, optional): The size of the group in ``w`` that shares a
-            scale and bias. (default: 64)
+            scale and bias. (default: ``64``)
           bits (int, optional): The number of bits occupied by each element in
-            ``w``. (default: 4)
+            ``w``. (default: ``4``)
 
         Returns:
           result (array): The dequantized version of ``w``

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -3091,7 +3091,7 @@ void init_ops(py::module_& m) {
           scales (array): The scales to use per ``group_size`` elements of ``w``
           biases (array): The biases to use per ``group_size`` elements of ``w``
           transpose (bool, optional): Defines whether to multiply with the
-            transposed ``w`` or not, namelye whether we are performing
+            transposed ``w`` or not, namely whether we are performing
             ``x @ w.T`` or ``x @ w``. (default: ``True``)
           group_size (int, optional): The size of the group in ``w`` that
             shares a scale and bias. (default: ``64``)


### PR DESCRIPTION
Add support for non-transposed quantized matmul which allows us to compute the gradients wrt to the input `x`.

This PR introduces an API/contract change to `quantized_matmul` which is that `w`, `scales` and `biases` should all be either transposed or not. It properly reports an error otherwise and in the extreme cases where an error can't be detected it unfortunately fails (this should be changed to a copy in the future).

For instance previously one would call `quantized_matmul` as follows:

```
y = mx.quantized_matmul(x, w_q.T, scales, biases)
```

but now that should be

```
# For x @ w.T
y = mx.quantized_matmul(x, w_q.T, scales.T, biases.T)
# For x @ w
y = mx.quantized_matmul(x, w_q, scales, biases)
```

Even though the quantized matrix-matrix kernels do require some love; in memory constrained environments like my M2 air Q-LoRA is ~50% faster than fp16 with memory to spare :-) (but only 4 LoRA layers for now). The following is about 12 minutes of training

```
python lora.py --model ../llms/mistral/mistral-7B-v0.1/ --lora-layers 4 --train
Loading pretrained model
Total parameters 1353.355M
Trainable parameters 0.426M
Loading datasets
Training
Iter 10: Train loss 2.492, It/sec 0.151, Tokens/sec 60.564
Iter 20: Train loss 2.394, It/sec 0.187, Tokens/sec 75.677
Iter 30: Train loss 2.424, It/sec 0.179, Tokens/sec 73.846
Iter 40: Train loss 2.388, It/sec 0.197, Tokens/sec 76.443
Iter 50: Train loss 2.215, It/sec 0.192, Tokens/sec 76.507
Iter 60: Train loss 2.010, It/sec 0.194, Tokens/sec 77.021
Iter 70: Train loss 1.955, It/sec 0.171, Tokens/sec 69.324
Iter 80: Train loss 1.921, It/sec 0.177, Tokens/sec 70.903
Iter 90: Train loss 1.856, It/sec 0.192, Tokens/sec 72.610
Iter 100: Train loss 1.847, It/sec 0.182, Tokens/sec 69.507
Iter 110: Train loss 1.703, It/sec 0.191, Tokens/sec 73.917
Iter 120: Train loss 1.676, It/sec 0.175, Tokens/sec 68.203
```

btw at around iteration 60 I started writing the PR hence the slight performance drop to 70 tok/s from 76.