### PR TITLE
make positional_encoding align with transformer's implementation

### DIFF
--- a/python/mlx/nn/layers/positional_encoding.py
+++ b/python/mlx/nn/layers/positional_encoding.py
@@ -96,7 +96,7 @@ class RoPE(Module):
         dtype=mx.float32,
     ):
         D = D // 2
-        positions = mx.arange(offset, N, dtype=dtype) * scale
+        positions = mx.arange(offset, N, dtype=dtype) / scale
         freqs = mx.exp(-mx.arange(0.0, D, dtype=dtype) * (math.log(base) / D))
         theta = mx.reshape(positions, (-1, 1)) * mx.reshape(freqs, (1, -1))
         return mx.cos(theta), mx.sin(theta)


### PR DESCRIPTION
## Proposed changes

Notice that currently, in order to scale rope linearly, we have to pass a scaling factor of 1/self.config.rope_scaling["factor"] to make it work if we use the transformer configuration. I'm just wondering if we can align with the transformer config to update the position scaling implementation.

This is a PR just for demo purposes. The change would align with the transformer's implementation(https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py#L168-L169), but please feel free to close it if it doesn't fit the purpose.

## Checklist

Put an `x` in the boxes that apply.

- [ ] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
