### PR TITLE
Pooling layers

### DIFF
--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -11,7 +11,7 @@ MLX was developed with contributions from the following individuals:
 - Juarez Bochi: Fixed bug in cross attention.
 - Justin Deschenaux: Sine, Cosine, arange, randint, truncated normal, bernoulli, lion optimizer, Dropout2d, linear and logistic regression python example.
 - Diogo Da Cruz: Added `tri`, `tril`, `triu`, `tensordot`, `inner`, `outer`, `tile` and safetensor support
-- Gabrijel Boduljak: Added `mlx.core.linalg`, implemented `norm` method and `InstanceNorm` layer.
+- Gabrijel Boduljak: Added `mlx.core.linalg`, implemented `norm` method and `InstanceNorm` layer. Implemented ``MaxPool1d``, ``MaxPool2d``, ``AvgPool1d``, ``AvgPool2d``.
 
 <a href="https://github.com/ml-explore/mlx/graphs/contributors">
   <img class="dark-light" src="https://contrib.rocks/image?repo=ml-explore/mlx&anon=0&columns=20&max=100&r=true" />

--- a/docs/src/python/nn/layers.rst
+++ b/docs/src/python/nn/layers.rst
@@ -8,7 +8,8 @@ Layers
 .. autosummary::
    :toctree: _autosummary
    :template: nn-module-template.rst
-
+   AvgPool1d
+   AvgPool2d
    ALiBi
    BatchNorm
    Conv1d
@@ -22,6 +23,8 @@ Layers
    InstanceNorm
    LayerNorm
    Linear
+   MaxPool1d
+   MaxPool2d
    Mish
    MultiHeadAttention
    PReLU

--- a/docs/src/python/nn/layers.rst
+++ b/docs/src/python/nn/layers.rst
@@ -8,9 +8,9 @@ Layers
 .. autosummary::
    :toctree: _autosummary
    :template: nn-module-template.rst
+   ALiBi
    AvgPool1d
    AvgPool2d
-   ALiBi
    BatchNorm
    Conv1d
    Conv2d

--- a/docs/src/python/nn/layers.rst
+++ b/docs/src/python/nn/layers.rst
@@ -8,6 +8,7 @@ Layers
 .. autosummary::
    :toctree: _autosummary
    :template: nn-module-template.rst
+
    ALiBi
    AvgPool1d
    AvgPool2d

--- a/python/mlx/nn/layers/__init__.py
+++ b/python/mlx/nn/layers/__init__.py
@@ -58,6 +58,7 @@ from mlx.nn.layers.normalization import (
     LayerNorm,
     RMSNorm,
 )
+from mlx.nn.layers.pooling import AvgPool1d, AvgPool2d, MaxPool1d, MaxPool2d
 from mlx.nn.layers.positional_encoding import ALiBi, RoPE, SinusoidalPositionalEncoding
 from mlx.nn.layers.quantized import QuantizedLinear
 from mlx.nn.layers.transformer import (

--- a/python/mlx/nn/layers/pooling.py
+++ b/python/mlx/nn/layers/pooling.py
@@ -1,0 +1,400 @@
+# Copyright © 2023 Apple Inc.
+
+
+from typing import Callable, List, Optional, Tuple, Union
+
+import mlx.core as mx
+from mlx.nn.layers.base import Module
+
+
+class PoolBase(Module):
+    def __init__(
+        self,
+        kernel_size: Union[int, Tuple[int, int]],
+        stride: Optional[Union[int, Tuple[int, int]]] = None,
+        padding: Union[int, Tuple[int, int]] = 0,
+    ):
+        super().__init__()
+        self.kernel_size = kernel_size
+        self.stride = stride if stride != None else kernel_size
+        self.padding = padding
+
+    def _get_padding(self, features_sizes: List[int]) -> List[Tuple[int, int]]:
+        if isinstance(self.padding, int):
+            return (
+                [(0, 0)]
+                + [(self.padding, self.padding)] * len(features_sizes)
+                + [(0, 0)]
+            )
+        if len(self.padding) != len(features_sizes):
+            raise ValueError(
+                "the number of provided padding values must match the number of feature axes"
+            )
+        return [(0, 0)] + [(p, p) for p in self.padding] + [(0, 0)]
+
+    def _get_stride(self, features_sizes: List[int]) -> List[int]:
+        if isinstance(self.stride, int):
+            return [self.stride] * len(features_sizes)
+        if len(self.stride) != len(features_sizes):
+            raise ValueError(
+                "the number of provided strides must match the number of feature axes"
+            )
+        return self.stride
+
+    def _get_kernel_size(self, features_sizes: List[int]) -> List[int]:
+        if isinstance(self.kernel_size, int):
+            return [self.kernel_size] * len(features_sizes)
+        if len(self.kernel_size) != len(features_sizes):
+            raise ValueError("kernel_size must match the number of feature axes")
+        return self.kernel_size
+
+    def _get_row_contiguous_strides(self, a: mx.array) -> List[int]:
+        return list(
+            reversed(mx.cumprod(mx.array([1] + list(reversed(a.shape))))[:-1].tolist())
+        )
+
+    def _pad(
+        self, a: mx.array, features_sizes: List[int], padding_value: float
+    ) -> mx.array:
+        return mx.pad(a, self._get_padding(features_sizes), padding_value)
+
+    def _extra_repr(self):
+        return (
+            f"{self.kernel_size}, " f"stride={self.stride}, " f"padding={self.padding}"
+        )
+
+
+class Pool1d(PoolBase):
+    def __init__(
+        self, kernel_size: int, stride: Optional[int] = None, padding: Optional[int] = 0
+    ):
+        super().__init__(kernel_size, stride, padding)
+
+    def __call__(
+        self,
+        a: mx.array,
+        pooling_operator: Callable[[mx.array, List[int]], mx.array],
+        padding_value: float,
+    ) -> mx.array:
+        if a.ndim != 3:
+            raise ValueError("[pooling] the input must be three-dimensional.")
+        # Pad if necessary
+        if self.padding != 0:
+            _, input_feature_size, _ = a.shape
+            a = self._pad(a, [input_feature_size], padding_value)
+        # Assumes a.shape = (batch_size, sequence_length, num_channels)
+        [batch_size, sequence_length, num_channels] = a.shape
+        [
+            batch_stride,
+            sequence_length_stride,
+            channels_stride,
+        ] = self._get_row_contiguous_strides(a)
+        [kernel_size] = self._get_kernel_size([sequence_length])
+        [pool_stride] = self._get_stride([sequence_length])
+        # Compute windows : [batch_size, output_dim, kernel_size, num_channels]
+        windows = mx.as_strided(
+            a,
+            shape=(
+                batch_size,
+                (sequence_length - kernel_size) // pool_stride + 1,
+                kernel_size,
+                num_channels,
+            ),
+            strides=(
+                batch_stride,
+                pool_stride * sequence_length_stride,
+                sequence_length_stride,
+                channels_stride,
+            ),
+        )
+        # Reduce over windows
+        return pooling_operator(windows, 2)
+
+
+class Pool2d(PoolBase):
+    def __init__(
+        self,
+        kernel_size: Union[int, Tuple[int, int]],
+        stride: Optional[Union[int, Tuple[int, int]]] = None,
+        padding: Optional[Union[int, Tuple[int, int]]] = 0,
+    ):
+        super().__init__(kernel_size, stride, padding)
+
+    def __call__(
+        self,
+        a: mx.array,
+        pooling_operator: Callable[[mx.array, List[int]], mx.array],
+        padding_value: float,
+    ) -> mx.array:
+        if a.ndim != 4:
+            raise ValueError("[pooling] the input must be four-dimensional.")
+        # Pad if necessary
+        if self.padding != 0:
+            _, input_height, input_width, _ = a.shape
+            a = self._pad(a, [input_height, input_width], padding_value)
+        # Assumes a.shape = (batch_size, height, width, num_channels)
+        [batch_size, height, width, num_channels] = a.shape
+        [
+            batch_stride,
+            height_stride,
+            width_stride,
+            channels_stride,
+        ] = self._get_row_contiguous_strides(a)
+        [kernel_height, kernel_width] = self._get_kernel_size([height, width])
+        [pool_height_stride, pool_width_stride] = self._get_stride([height, width])
+        # Compute windows : [batch_size, output_height, output_width, kernel_height, kernel_width, num_channels]
+        windows = mx.as_strided(
+            a,
+            shape=(
+                batch_size,
+                (height - kernel_height) // pool_height_stride + 1,
+                (width - kernel_width) // pool_width_stride + 1,
+                kernel_height,
+                kernel_width,
+                num_channels,
+            ),
+            strides=(
+                batch_stride,
+                pool_height_stride * height_stride,
+                pool_width_stride * width_stride,
+                height_stride,
+                width_stride,
+                channels_stride,
+            ),
+        )
+        # Reduce over windows
+        return pooling_operator(windows, (3, 4))
+
+
+class MaxPool1d(Pool1d):
+    r"""Applies a 1-dimensional max pooling.
+
+    The channels are expected to be last i.e. the input shape should be :math:`(N, L, C)` where:
+        - ``N`` is the batch dimension
+        - ``L`` is the sequence length
+        - ``C`` is the number of input channels
+
+    Assuming :attr:`kernel_size` is :math:`kL`, the output is a tensor of shape :math:`(N, L_{out}, C)`, given by:
+        .. math::
+            \text{out}(N_i, k, C_j) = \max_{m=0, \ldots, kL - 1}
+                    \text{input}(N_i, \text{stride} \times k + m, C_j),
+    where :math:`L_{out} = \left\lfloor \frac{L + 2 \times \text{padding} - \text{kernel_size}}{\text{stride}}\right\rfloor + 1`.
+
+    Args:
+        kernel_size (int): The size of the pooling window kernel.
+        stride (int, optional): The stride of the pooling window.
+            Default: :attr:`kernel_size`.
+        padding (int, optional): How many positions to 0-pad the input with. The padding amount is applied to both sides of the feature axis.
+            Default: 0.
+
+    Shape:
+        - Input: :math:`(N, L, C)`.
+        - Output: :math:`(N, L_{out}, C)`.
+
+    Examples:
+        >>> import mlx.core as mx
+        >>> import mlx.nn.layers as nn
+        >>> x = mx.array([[[0, 1, 2],
+                           [3, 4, 5],
+                           [6, 7, 8],
+                           [9, 10, 11]],
+                          [[12, 13, 14],
+                           [15, 16, 17],
+                           [18, 19, 20],
+                           [21, 22, 23]]])
+        >>> pool = nn.MaxPool1d(kernel_size=2, stride=2)
+        >>> pool(x)
+    """
+
+    def __init__(
+        self, kernel_size: int, stride: Optional[int] = None, padding: Optional[int] = 0
+    ):
+        super().__init__(kernel_size, stride, padding)
+
+    def __call__(self, a: mx.array) -> mx.array:
+        return super().__call__(a, mx.max, float("-inf"))
+
+
+class AvgPool1d(Pool1d):
+    r"""Applies a 1-dimensional average pooling.
+
+    The channels are expected to be last i.e. the input shape should be :math:`(N, L, C)` where:
+        - ``N`` is the batch dimension
+        - ``L`` is the sequence length
+        - ``C`` is the number of input channels
+
+    Assuming :attr:`kernel_size` is :math:`kL`, the output is a tensor of shape :math:`(N, L_{out}, C)`, given by:
+        .. math::
+            \text{out}(N_i, k, C_j) = \frac{1}{kL} \sum_{m=0, \ldots, kL - 1}
+                    \text{input}(N_i, \text{stride} \times k + m, C_j),
+    where :math:`L_{out} = \left\lfloor \frac{L + 2 \times \text{padding} - \text{kernel_size}}{\text{stride}}\right\rfloor + 1`.
+
+    Args:
+        kernel_size (int): The size of the pooling window kernel.
+        stride (int, optional): The stride of the pooling window.
+            Default: :attr:`kernel_size`.
+        padding (int, optional): How many positions to pad the input with. The padding value is ``float("-inf")`` and it is applied to both sides of the sequence length axis.
+            Padded values are included in the average pooling calculation.
+            Default: 0.
+
+    Shape:
+        - Input: :math:`(N, L, C)`.
+        - Output: :math:`(N, L_{out}, C)`.
+
+    Examples:
+        >>> import mlx.core as mx
+        >>> import mlx.nn.layers as nn
+        >>> x = mx.array([[[0, 1, 2],
+                           [3, 4, 5],
+                           [6, 7, 8],
+                           [9, 10, 11]],
+                          [[12, 13, 14],
+                           [15, 16, 17],
+                           [18, 19, 20],
+                           [21, 22, 23]]])
+        >>> pool = nn.AvgPool1d(kernel_size=2, stride=2)
+        >>> pool(x)
+    """
+
+    def __init__(
+        self, kernel_size: int, stride: Optional[int] = None, padding: Optional[int] = 0
+    ):
+        super().__init__(kernel_size, stride, padding)
+
+    def __call__(self, a: mx.array) -> mx.array:
+        return super().__call__(a, mx.mean, 0)
+
+
+class MaxPool2d(Pool2d):
+    r"""Applies a 2-dimensional max pooling.
+
+    The channels are expected to be last i.e. the input shape should be :math:`(N, H, W, C)` where:
+        - ``N`` is the batch dimension
+        - ``H`` is the input image height
+        - ``W`` is the input image width
+        - ``C`` is the number of input channels
+
+    Assuming :attr:`kernel_size` is :math:`(kH, kW)`, the output is a tensor of shape :math:`(N, H_{out}, W_{out}, C)`, given by:
+
+    .. math::
+        \begin{aligned}
+            \text{out}(N_i, h, w, C_j) ={} & \max_{m=0, \ldots, kH-1} \max_{n=0, \ldots, kW-1} \\
+                                    & \text{input}(N_i, \text{stride[0]} \times h + m,
+                                                \text{stride[1]} \times w + n, C_j),
+        \end{aligned}
+    where :math:`H_{out} = \left\lfloor\frac{H + 2 * \text{padding[0]} - \text{kernel_size[0]}}{\text{stride[0]}}\right\rfloor + 1`,
+    :math:`W_{out} = \left\lfloor\frac{W + 2 * \text{padding[1]} - \text{kernel_size[1]}}{\text{stride[1]}}\right\rfloor + 1`.
+
+    The parameters :attr:`kernel_size`, :attr:`stride`, :attr:`padding`, can either be:
+        - a single ``int`` -- in which case the same value is used for both the height and width axis;
+        - a ``tuple`` of two ``int`` s -- in which case, the first `int` is used for the height axis, the second `int` for the width axis.
+
+    Args:
+        kernel_size (int, tuple(int, int)): The size of the pooling window.
+        stride (int, tuple(int, int), optional): The stride of the window. Default: :attr:`kernel_size`.
+        padding (int, tuple(int, int), optional): The padding amount on both sides of the height and width axis. Default: 0.
+
+    Shape:
+        - Input: :math:`(N, H, W, C)`.
+        - Output: :math:`(N, H_{out}, W_{out}, C)`.
+
+    Examples: 
+        >>> import mlx.core as mx
+        >>> import mlx.nn.layers as nn
+        >>> x = mx.array([[[[0, 1],
+                            [2, 3],
+                            [4, 5],
+                            [6, 7]],
+                           [[8, 9],
+                            [10, 11],
+                            [12, 13],
+                            [14, 15]],
+                           [[16, 17],
+                            [18, 19],
+                            [20, 21],
+                            [22, 23]],
+                           [[24, 25],
+                            [26, 27],
+                            [28, 29],
+                            [30, 31]]]])
+        >>> pool = nn.MaxPool2d(kernel_size=2, stride=2)
+        >>> pool(x)
+    """
+
+    def __init__(
+        self,
+        kernel_size: Union[int, Tuple[int, int]],
+        stride: Optional[Union[int, Tuple[int, int]]] = None,
+        padding: Optional[Union[int, Tuple[int, int]]] = 0,
+    ):
+        super().__init__(kernel_size, stride, padding)
+
+    def __call__(self, a: mx.array) -> mx.array:
+        return super().__call__(a, mx.max, float("-inf"))
+
+
+class AvgPool2d(Pool2d):
+    r"""Applies a 2-dimensional average pooling.
+
+    The channels are expected to be last i.e. the input shape should be :math:`(N, H, W, C)` where:
+        - ``N`` is the batch dimension
+        - ``H`` is the input image height
+        - ``W`` is the input image width
+        - ``C`` is the number of input channels
+
+    Assuming :attr:`kernel_size` is :math:`(kH, kW)`, the output is a tensor of shape :math:`(N, H_{out}, W_{out}, C)`, given by:
+
+    .. math::
+        \begin{aligned}
+            \text{out}(N_i, h, w, C_j) = \frac{1} {kH \times kW} & \sum_{m=0, \ldots, kH-1} \sum_{n=0, \ldots, kW-1} \\
+                                        & \text{input}(N_i, \text{stride[0]} \times h + m, \text{stride[1]} \times w + n, C_j)
+        \end{aligned}
+    where :math:`H_{out} = \left\lfloor\frac{H + 2 * \text{padding[0]} - \text{kernel_size[0]}}{\text{stride[0]}}\right\rfloor + 1`,
+    :math:`W_{out} = \left\lfloor\frac{W + 2 * \text{padding[1]} - \text{kernel_size[1]}}{\text{stride[1]}}\right\rfloor + 1`.
+
+    The parameters :attr:`kernel_size`, :attr:`stride`, :attr:`padding`, can either be:
+        - a single ``int`` -- in which case the same value is used for both the height and width axis;
+        - a ``tuple`` of two ``int`` s -- in which case, the first `int` is used for the height axis, the second `int` for the width axis.
+
+    Args:
+        kernel_size (int, tuple(int, int)): The size of the pooling window.
+        stride (int, tuple(int, int), optional): The stride of the window. Default: :attr:`kernel_size`.
+        padding (int, tuple(int, int), optional): The padding amount on both sides of the height and width axis. The padding value is ``float("-inf")`` and it is applied to both sides of the height axis and the width axis. Padded values are included in the average pooling calculation. Default: 0.
+
+    Shape:
+        - Input: :math:`(N, H, W, C)`.
+        - Output: :math:`(N, H_{out}, W_{out}, C)`.
+
+    Examples: 
+        >>> import mlx.core as mx
+        >>> import mlx.nn.layers as nn
+        >>> x = mx.array([[[[0, 1],
+                            [2, 3],
+                            [4, 5],
+                            [6, 7]],
+                           [[8, 9],
+                            [10, 11],
+                            [12, 13],
+                            [14, 15]],
+                           [[16, 17],
+                            [18, 19],
+                            [20, 21],
+                            [22, 23]],
+                           [[24, 25],
+                            [26, 27],
+                            [28, 29],
+                            [30, 31]]]])
+        >>> pool = nn.AvgPool2d(kernel_size=2, stride=2)
+        >>> pool(x)    
+    """
+
+    def __init__(
+        self,
+        kernel_size: Union[int, Tuple[int, int]],
+        stride: Optional[Union[int, Tuple[int, int]]] = None,
+        padding: Optional[Union[int, Tuple[int, int]]] = 0,
+    ):
+        super().__init__(kernel_size, stride, padding)
+
+    def __call__(self, a: mx.array) -> mx.array:
+        return super().__call__(a, mx.mean, 0)

--- a/python/mlx/nn/layers/pooling.py
+++ b/python/mlx/nn/layers/pooling.py
@@ -138,9 +138,11 @@ class MaxPool1d(_Pool1d):
     Assuming an input of shape :math:`(N, L, C)` and ``kernel_size`` is
     :math:`k`, the output is a tensor of shape :math:`(N, L_{out}, C)`, given
     by:
+
         .. math::
-            \text{out}(N_i, k, C_j) = \max_{m=0, \ldots, k - 1}
-                    \text{input}(N_i, \text{stride} \times k + m, C_j),
+            \text{out}(N_i, t, C_j) = \max_{m=0, \ldots, k - 1}
+                    \text{input}(N_i, \text{stride} \times t + m, C_j),
+
     where :math:`L_{out} = \left\lfloor \frac{L + 2 \times \text{padding} -
     \text{kernel_size}}{\text{stride}}\right\rfloor + 1`.
 
@@ -175,9 +177,11 @@ class AvgPool1d(_Pool1d):
     Assuming an input of shape :math:`(N, L, C)` and ``kernel_size`` is
     :math:`k`, the output is a tensor of shape :math:`(N, L_{out}, C)`, given
     by:
+
         .. math::
-            \text{out}(N_i, k, C_j) = \frac{1}{k} \sum_{m=0, \ldots, k - 1}
-                    \text{input}(N_i, \text{stride} \times k + m, C_j),
+            \text{out}(N_i, t, C_j) = \frac{1}{k} \sum_{m=0, \ldots, k - 1}
+                    \text{input}(N_i, \text{stride} \times t + m, C_j),
+
     where :math:`L_{out} = \left\lfloor \frac{L + 2 \times \text{padding} -
     \text{kernel_size}}{\text{stride}}\right\rfloor + 1`.
 
@@ -219,10 +223,12 @@ class MaxPool2d(_Pool2d):
                                     & \text{input}(N_i, \text{stride[0]} \times h + m,
                                                 \text{stride[1]} \times w + n, C_j),
         \end{aligned}
+
     where :math:`H_{out} = \left\lfloor\frac{H + 2 * \text{padding[0]} - \text{kernel_size[0]}}{\text{stride[0]}}\right\rfloor + 1`,
     :math:`W_{out} = \left\lfloor\frac{W + 2 * \text{padding[1]} - \text{kernel_size[1]}}{\text{stride[1]}}\right\rfloor + 1`.
 
     The parameters ``kernel_size``, ``stride``, ``padding``, can either be:
+
         - a single ``int`` -- in which case the same value is used for both the
           height and width axis;
         - a ``tuple`` of two ``int`` s -- in which case, the first ``int`` is
@@ -236,7 +242,7 @@ class MaxPool2d(_Pool2d):
             padding to apply to the input. The padding is applied on both sides
             of the height and width axis. Default: ``0``.
 
-    Examples: 
+    Examples:
         >>> import mlx.core as mx
         >>> import mlx.nn.layers as nn
         >>> x = mx.random.normal(shape=(8, 32, 32, 4))
@@ -266,10 +272,12 @@ class AvgPool2d(_Pool2d):
                                     & \text{input}(N_i, \text{stride[0]} \times h + m,
                                                 \text{stride[1]} \times w + n, C_j),
         \end{aligned}
+
     where :math:`H_{out} = \left\lfloor\frac{H + 2 * \text{padding[0]} - \text{kernel_size[0]}}{\text{stride[0]}}\right\rfloor + 1`,
     :math:`W_{out} = \left\lfloor\frac{W + 2 * \text{padding[1]} - \text{kernel_size[1]}}{\text{stride[1]}}\right\rfloor + 1`.
 
     The parameters ``kernel_size``, ``stride``, ``padding``, can either be:
+
         - a single ``int`` -- in which case the same value is used for both the
           height and width axis;
         - a ``tuple`` of two ``int`` s -- in which case, the first ``int`` is
@@ -283,7 +291,7 @@ class AvgPool2d(_Pool2d):
             padding to apply to the input. The padding is applied on both sides
             of the height and width axis. Default: ``0``.
 
-    Examples: 
+    Examples:
         >>> import mlx.core as mx
         >>> import mlx.nn.layers as nn
         >>> x = mx.random.normal(shape=(8, 32, 32, 4))

--- a/python/mlx/nn/layers/pooling.py
+++ b/python/mlx/nn/layers/pooling.py
@@ -232,7 +232,7 @@ class MaxPool2d(_Pool2d):
         - a single ``int`` -- in which case the same value is used for both the
           height and width axis;
         - a ``tuple`` of two ``int`` s -- in which case, the first ``int`` is
-          used for the height axis, the second `int` for the width axis.
+          used for the height axis, the second ``int`` for the width axis.
 
     Args:
         kernel_size (int or tuple(int, int)): The size of the pooling window.
@@ -281,7 +281,7 @@ class AvgPool2d(_Pool2d):
         - a single ``int`` -- in which case the same value is used for both the
           height and width axis;
         - a ``tuple`` of two ``int`` s -- in which case, the first ``int`` is
-          used for the height axis, the second `int` for the width axis.
+          used for the height axis, the second ``int`` for the width axis.
 
     Args:
         kernel_size (int or tuple(int, int)): The size of the pooling window.

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -905,6 +905,347 @@ class TestLayers(mlx_tests.MLXTestCase):
         self.assertTrue(y.shape, x.shape)
         self.assertTrue(y.dtype, mx.float16)
 
+    def test_pooling(self):
+        # Test 1d pooling
+        x = mx.array(
+            [
+                [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9, 10, 11]],
+                [[12, 13, 14], [15, 16, 17], [18, 19, 20], [21, 22, 23]],
+            ]
+        )
+        expected_max_pool_output_no_padding_stride_1 = [
+            [[3.0, 4.0, 5.0], [6.0, 7.0, 8.0], [9.0, 10.0, 11.0]],
+            [[15.0, 16.0, 17.0], [18.0, 19.0, 20.0], [21.0, 22.0, 23.0]],
+        ]
+        expected_max_pool_output_no_padding_stride_2 = [
+            [[3.0, 4.0, 5.0], [9.0, 10.0, 11.0]],
+            [[15.0, 16.0, 17.0], [21.0, 22.0, 23.0]],
+        ]
+        expected_max_pool_output_padding_1_stride_2 = [
+            [[0.0, 1.0, 2.0], [6.0, 7.0, 8.0], [9.0, 10.0, 11.0]],
+            [[12.0, 13.0, 14.0], [18.0, 19.0, 20.0], [21.0, 22.0, 23.0]],
+        ]
+        expected_max_pool_output_padding_1_stride_2_kernel_3 = [
+            [[3.0, 4.0, 5.0], [9.0, 10.0, 11.0]],
+            [[15.0, 16.0, 17.0], [21.0, 22.0, 23.0]],
+        ]
+        expected_avg_pool_output_no_padding_stride_1 = [
+            [
+                [1.5000, 2.5000, 3.5000],
+                [4.5000, 5.5000, 6.5000],
+                [7.5000, 8.5000, 9.5000],
+            ],
+            [
+                [13.5000, 14.5000, 15.5000],
+                [16.5000, 17.5000, 18.5000],
+                [19.5000, 20.5000, 21.5000],
+            ],
+        ]
+        expected_avg_pool_output_no_padding_stride_2 = [
+            [[1.5000, 2.5000, 3.5000], [7.5000, 8.5000, 9.5000]],
+            [[13.5000, 14.5000, 15.5000], [19.5000, 20.5000, 21.5000]],
+        ]
+        expected_avg_pool_output_padding_1_stride_2 = [
+            [
+                [0.0000, 0.5000, 1.0000],
+                [4.5000, 5.5000, 6.5000],
+                [4.5000, 5.0000, 5.5000],
+            ],
+            [
+                [6.0000, 6.5000, 7.0000],
+                [16.5000, 17.5000, 18.5000],
+                [10.5000, 11.0000, 11.5000],
+            ],
+        ]
+        expected_avg_pool_output_padding_1_kernel_3 = [
+            [[1, 1.66667, 2.33333], [6, 7, 8]],
+            [[9, 9.66667, 10.3333], [18, 19, 20]],
+        ]
+        self.assertTrue(
+            np.array_equal(
+                nn.MaxPool1d(kernel_size=2, stride=1, padding=0)(x),
+                expected_max_pool_output_no_padding_stride_1,
+            )
+        )
+        self.assertTrue(
+            np.array_equal(
+                nn.MaxPool1d(kernel_size=2, stride=2, padding=0)(x),
+                expected_max_pool_output_no_padding_stride_2,
+            )
+        )
+        self.assertTrue(
+            np.array_equal(
+                nn.MaxPool1d(kernel_size=2, stride=2, padding=1)(x),
+                expected_max_pool_output_padding_1_stride_2,
+            )
+        )
+        self.assertTrue(
+            np.array_equal(
+                nn.MaxPool1d(kernel_size=3, stride=2, padding=1)(x),
+                expected_max_pool_output_padding_1_stride_2_kernel_3,
+            )
+        )
+        self.assertTrue(
+            np.allclose(
+                nn.AvgPool1d(kernel_size=2, stride=1, padding=0)(x),
+                expected_avg_pool_output_no_padding_stride_1,
+            )
+        )
+        self.assertTrue(
+            np.allclose(
+                nn.AvgPool1d(kernel_size=2, stride=2, padding=0)(x),
+                expected_avg_pool_output_no_padding_stride_2,
+            )
+        )
+        self.assertTrue(
+            np.allclose(
+                nn.AvgPool1d(kernel_size=2, stride=2, padding=1)(x),
+                expected_avg_pool_output_padding_1_stride_2,
+            )
+        )
+        self.assertTrue(
+            np.allclose(
+                nn.AvgPool1d(kernel_size=3, stride=2, padding=1)(x),
+                expected_avg_pool_output_padding_1_kernel_3,
+            )
+        )
+        # Test 2d pooling
+        x = mx.array(
+            [
+                [
+                    [[0, 16], [1, 17], [2, 18], [3, 19]],
+                    [[4, 20], [5, 21], [6, 22], [7, 23]],
+                    [[8, 24], [9, 25], [10, 26], [11, 27]],
+                    [[12, 28], [13, 29], [14, 30], [15, 31]],
+                ]
+            ]
+        )
+        expected_max_pool_output_no_padding_stride_1 = [
+            [
+                [[5, 21], [6, 22], [7, 23]],
+                [[9, 25], [10, 26], [11, 27]],
+                [[13, 29], [14, 30], [15, 31]],
+            ]
+        ]
+        expected_max_pool_output_no_padding_stride_2 = [
+            [[[5, 21], [7, 23]], [[13, 29], [15, 31]]]
+        ]
+        expected_max_pool_output_padding_1 = [
+            [
+                [[0, 16], [2, 18], [3, 19]],
+                [[8, 24], [10, 26], [11, 27]],
+                [[12, 28], [14, 30], [15, 31]],
+            ]
+        ]
+        expected_mean_pool_output_no_padding_stride_1 = [
+            [
+                [[2.5000, 18.5000], [3.5000, 19.5000], [4.5000, 20.5000]],
+                [[6.5000, 22.5000], [7.5000, 23.5000], [8.5000, 24.5000]],
+                [[10.5000, 26.5000], [11.5000, 27.5000], [12.5000, 28.5000]],
+            ]
+        ]
+        expected_mean_pool_output_no_padding_stride_2 = [
+            [
+                [[2.5000, 18.5000], [4.5000, 20.5000]],
+                [[10.5000, 26.5000], [12.5000, 28.5000]],
+            ]
+        ]
+        expected_mean_pool_output_padding_1 = [
+            [
+                [[0.0000, 4.0000], [0.7500, 8.7500], [0.7500, 4.7500]],
+                [[3.0000, 11.0000], [7.5000, 23.5000], [4.5000, 12.5000]],
+                [[3.0000, 7.0000], [6.7500, 14.7500], [3.7500, 7.7500]],
+            ]
+        ]
+        self.assertTrue(
+            np.array_equal(
+                nn.MaxPool2d(kernel_size=2, stride=1, padding=0)(x),
+                expected_max_pool_output_no_padding_stride_1,
+            )
+        )
+        self.assertTrue(
+            np.array_equal(
+                nn.MaxPool2d(kernel_size=2, stride=2, padding=0)(x),
+                expected_max_pool_output_no_padding_stride_2,
+            )
+        )
+        self.assertTrue(
+            np.array_equal(
+                nn.MaxPool2d(kernel_size=2, stride=2, padding=1)(x),
+                expected_max_pool_output_padding_1,
+            )
+        )
+        # Average pooling
+        self.assertTrue(
+            np.allclose(
+                nn.AvgPool2d(kernel_size=2, stride=1, padding=0)(x),
+                expected_mean_pool_output_no_padding_stride_1,
+            )
+        )
+        self.assertTrue(
+            np.array_equal(
+                nn.AvgPool2d(kernel_size=2, stride=2, padding=0)(x),
+                expected_mean_pool_output_no_padding_stride_2,
+            )
+        )
+        self.assertTrue(
+            np.array_equal(
+                nn.AvgPool2d(kernel_size=2, stride=2, padding=1)(x),
+                expected_mean_pool_output_padding_1,
+            )
+        )
+        # Test multiple batches
+        x = mx.array(
+            [
+                [
+                    [[0, 1], [2, 3], [4, 5], [6, 7]],
+                    [[8, 9], [10, 11], [12, 13], [14, 15]],
+                    [[16, 17], [18, 19], [20, 21], [22, 23]],
+                    [[24, 25], [26, 27], [28, 29], [30, 31]],
+                ],
+                [
+                    [[32, 33], [34, 35], [36, 37], [38, 39]],
+                    [[40, 41], [42, 43], [44, 45], [46, 47]],
+                    [[48, 49], [50, 51], [52, 53], [54, 55]],
+                    [[56, 57], [58, 59], [60, 61], [62, 63]],
+                ],
+            ]
+        )
+        expected_max_pool_output = [
+            [[[10.0, 11.0], [14.0, 15.0]], [[26.0, 27.0], [30.0, 31.0]]],
+            [[[42.0, 43.0], [46.0, 47.0]], [[58.0, 59.0], [62.0, 63.0]]],
+        ]
+        expected_avg_pool_output = [
+            [[[2.22222, 2.66667], [5.33333, 6]], [[11.3333, 12], [20, 21]]],
+            [[[16.4444, 16.8889], [26.6667, 27.3333]], [[32.6667, 33.3333], [52, 53]]],
+        ]
+        self.assertTrue(
+            np.array_equal(
+                nn.MaxPool2d(kernel_size=3, stride=2, padding=1)(x),
+                expected_max_pool_output,
+            )
+        )
+        self.assertTrue(
+            np.allclose(
+                nn.AvgPool2d(kernel_size=3, stride=2, padding=1)(x),
+                expected_avg_pool_output,
+            )
+        )
+        # Test irregular kernel (2, 4), stride (3, 1) and padding (1, 2)
+        x = mx.array(
+            [
+                [
+                    [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9, 10, 11]],
+                    [[12, 13, 14], [15, 16, 17], [18, 19, 20], [21, 22, 23]],
+                    [[24, 25, 26], [27, 28, 29], [30, 31, 32], [33, 34, 35]],
+                    [[36, 37, 38], [39, 40, 41], [42, 43, 44], [45, 46, 47]],
+                ],
+                [
+                    [[48, 49, 50], [51, 52, 53], [54, 55, 56], [57, 58, 59]],
+                    [[60, 61, 62], [63, 64, 65], [66, 67, 68], [69, 70, 71]],
+                    [[72, 73, 74], [75, 76, 77], [78, 79, 80], [81, 82, 83]],
+                    [[84, 85, 86], [87, 88, 89], [90, 91, 92], [93, 94, 95]],
+                ],
+            ]
+        )
+        expected_irregular_max_pool_output = [
+            [
+                [
+                    [3.0, 4.0, 5.0],
+                    [6.0, 7.0, 8.0],
+                    [9.0, 10.0, 11.0],
+                    [9.0, 10.0, 11.0],
+                    [9.0, 10.0, 11.0],
+                ],
+                [
+                    [39.0, 40.0, 41.0],
+                    [42.0, 43.0, 44.0],
+                    [45.0, 46.0, 47.0],
+                    [45.0, 46.0, 47.0],
+                    [45.0, 46.0, 47.0],
+                ],
+            ],
+            [
+                [
+                    [51.0, 52.0, 53.0],
+                    [54.0, 55.0, 56.0],
+                    [57.0, 58.0, 59.0],
+                    [57.0, 58.0, 59.0],
+                    [57.0, 58.0, 59.0],
+                ],
+                [
+                    [87.0, 88.0, 89.0],
+                    [90.0, 91.0, 92.0],
+                    [93.0, 94.0, 95.0],
+                    [93.0, 94.0, 95.0],
+                    [93.0, 94.0, 95.0],
+                ],
+            ],
+        ]
+        expected_irregular_average_pool_output = [
+            [
+                [
+                    [0.3750, 0.6250, 0.8750],
+                    [1.1250, 1.5000, 1.8750],
+                    [2.2500, 2.7500, 3.2500],
+                    [2.2500, 2.6250, 3.0000],
+                    [1.8750, 2.1250, 2.3750],
+                ],
+                [
+                    [15.7500, 16.2500, 16.7500],
+                    [24.7500, 25.5000, 26.2500],
+                    [34.5000, 35.5000, 36.5000],
+                    [27.0000, 27.7500, 28.5000],
+                    [18.7500, 19.2500, 19.7500],
+                ],
+            ],
+            [
+                [
+                    [12.3750, 12.6250, 12.8750],
+                    [19.1250, 19.5000, 19.8750],
+                    [26.2500, 26.7500, 27.2500],
+                    [20.2500, 20.6250, 21.0000],
+                    [13.8750, 14.1250, 14.3750],
+                ],
+                [
+                    [39.7500, 40.2500, 40.7500],
+                    [60.7500, 61.5000, 62.2500],
+                    [82.5000, 83.5000, 84.5000],
+                    [63.0000, 63.7500, 64.5000],
+                    [42.7500, 43.2500, 43.7500],
+                ],
+            ],
+        ]
+        self.assertTrue(
+            np.array_equal(
+                nn.MaxPool2d(kernel_size=(2, 4), stride=(3, 1), padding=(1, 2))(x),
+                expected_irregular_max_pool_output,
+            )
+        )
+        self.assertTrue(
+            np.allclose(
+                nn.AvgPool2d(kernel_size=(2, 4), stride=(3, 1), padding=(1, 2))(x),
+                expected_irregular_average_pool_output,
+            )
+        )
+        # Test repr
+        self.assertTrue(
+            str(nn.MaxPool1d(kernel_size=3, padding=2))
+            == "MaxPool1d(3, stride=3, padding=2)"
+        )
+        self.assertTrue(
+            str(nn.AvgPool1d(kernel_size=2, stride=3))
+            == "AvgPool1d(2, stride=3, padding=0)"
+        )
+        self.assertTrue(
+            str(nn.MaxPool2d(kernel_size=3, stride=2, padding=1))
+            == "MaxPool2d(3, stride=2, padding=1)"
+        )
+        self.assertTrue(
+            str(nn.AvgPool2d(kernel_size=(1, 2), stride=2, padding=(1, 2)))
+            == "AvgPool2d((1, 2), stride=2, padding=(1, 2))"
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -1229,21 +1229,21 @@ class TestLayers(mlx_tests.MLXTestCase):
             )
         )
         # Test repr
-        self.assertTrue(
-            str(nn.MaxPool1d(kernel_size=3, padding=2))
-            == "MaxPool1d(3, stride=3, padding=2)"
+        self.assertEqual(
+            str(nn.MaxPool1d(kernel_size=3, padding=2)),
+            "MaxPool1d(kernel_size=(3,), stride=(3,), padding=(2,))",
         )
-        self.assertTrue(
-            str(nn.AvgPool1d(kernel_size=2, stride=3))
-            == "AvgPool1d(2, stride=3, padding=0)"
+        self.assertEqual(
+            str(nn.AvgPool1d(kernel_size=2, stride=3)),
+            "AvgPool1d(kernel_size=(2,), stride=(3,), padding=(0,))",
         )
-        self.assertTrue(
-            str(nn.MaxPool2d(kernel_size=3, stride=2, padding=1))
-            == "MaxPool2d(3, stride=2, padding=1)"
+        self.assertEqual(
+            str(nn.MaxPool2d(kernel_size=3, stride=2, padding=1)),
+            "MaxPool2d(kernel_size=(3, 3), stride=(2, 2), padding=(1, 1))",
         )
-        self.assertTrue(
-            str(nn.AvgPool2d(kernel_size=(1, 2), stride=2, padding=(1, 2)))
-            == "AvgPool2d((1, 2), stride=2, padding=(1, 2))"
+        self.assertEqual(
+            str(nn.AvgPool2d(kernel_size=(1, 2), stride=2, padding=(1, 2))),
+            "AvgPool2d(kernel_size=(1, 2), stride=(2, 2), padding=(1, 2))",
         )
 
 


### PR DESCRIPTION
## Proposed changes

Added ``MaxPool`` and ``AvgPool``  layers. MaxPool and AvgPool layers were requested in [this issue](https://github.com/ml-explore/mlx/issues/25). In this PR, I propose implementing the requested pooling operations by firstly computing sliding windows and subsequently reducing them. More precisely, we can use ``as_strided`` to compute pooling sliding windows. Then, we can simply reduce over appropriate axes to implement the desired pooling operation.

**Concerns**: My only concern is performance. Ideally, we should call optimized backend kernels for pooling operations. There are ``MPSCNNPoolingAverageNode`` and ``MPSCNNPoolingMaxNode``. Similarly, there is ``BNNSFilterCreateLayerPooling`` in Accelerate. Alternatively, we could implement a kernel for window reduction.

Closes https://github.com/ml-explore/mlx/issues/25.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
