### PR TITLE
move all ObjC (via metal-cpp) interaction until post static initializers

### DIFF
--- a/mlx/backend/metal/allocator.cpp
+++ b/mlx/backend/metal/allocator.cpp
@@ -29,6 +29,7 @@ BufferCache::BufferCache(MTL::Device* device)
     : device_(device), head_(nullptr), tail_(nullptr), pool_size_(0) {}
 
 BufferCache::~BufferCache() {
+  auto thread_pool = metal::new_scoped_memory_pool();
   clear();
 }
 
@@ -152,6 +153,8 @@ MetalAllocator::MetalAllocator()
       gc_limit_(0.95 * device_->recommendedMaxWorkingSetSize()) {}
 
 Buffer MetalAllocator::malloc(size_t size, bool allow_swap /* = false */) {
+  auto thread_pool = metal::new_scoped_memory_pool();
+
   // Align up memory
   if (size > vm_page_size) {
     size = vm_page_size * ((size + vm_page_size - 1) / vm_page_size);

--- a/mlx/backend/metal/allocator.cpp
+++ b/mlx/backend/metal/allocator.cpp
@@ -153,8 +153,6 @@ MetalAllocator::MetalAllocator()
       gc_limit_(0.95 * device_->recommendedMaxWorkingSetSize()) {}
 
 Buffer MetalAllocator::malloc(size_t size, bool allow_swap /* = false */) {
-  auto thread_pool = metal::new_scoped_memory_pool();
-
   // Align up memory
   if (size > vm_page_size) {
     size = vm_page_size * ((size + vm_page_size - 1) / vm_page_size);
@@ -168,6 +166,8 @@ Buffer MetalAllocator::malloc(size_t size, bool allow_swap /* = false */) {
     if (!allow_swap && device_->currentAllocatedSize() + size >= block_limit_) {
       return Buffer{nullptr};
     }
+
+    auto thread_pool = metal::new_scoped_memory_pool();
 
     // If we have a lot of memory pressure, check if we can reclaim some memory
     // from the cache

--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -292,12 +292,9 @@ Device& device(mlx::core::Device) {
 
 std::shared_ptr<void> new_scoped_memory_pool() {
   auto dtor = [](void* ptr) {
-    //      printf("free autoreleasepool %p\n", ptr);
     static_cast<NS::AutoreleasePool*>(ptr)->release();
   };
-  auto pool = NS::AutoreleasePool::alloc()->init();
-  //    printf("new autoreleasepool %p\n", x);
-  return std::shared_ptr<void>(pool, dtor);
+  return std::shared_ptr<void>(NS::AutoreleasePool::alloc()->init(), dtor);
 }
 
 void new_stream(Stream stream) {

--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -138,6 +138,8 @@ Device::~Device() {
 }
 
 void Device::new_queue(int index) {
+  auto thread_pool = metal::new_scoped_memory_pool();
+  
   // Multiple threads can ask the device for queues
   // We lock this as a critical section for safety
   const std::lock_guard<std::mutex> lock(mtx_);

--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -19,9 +19,6 @@ namespace mlx::core::metal {
 
 namespace {
 
-// Catch things related to the main-thread static variables
-// static std::shared_ptr<void> global_memory_pool = new_scoped_memory_pool();
-
 // TODO nicer way to set this or possibly expose as an environment variable
 static constexpr int MAX_BUFFERS_PER_QUEUE = 12;
 

--- a/mlx/scheduler.h
+++ b/mlx/scheduler.h
@@ -50,8 +50,10 @@ struct StreamThread {
       // pool scoped to the task
       auto thread_pool = metal::new_scoped_memory_pool();
 
-      // cannot initialize on thread start because metal-cpp static initializers
-      // may not have run yet
+      // thread_fn may be called from a static initializer and we cannot
+      // call metal-cpp until all static initializers have completed. waiting
+      // for a task to arrive means that user code is running so metal-cpp
+      // can safely be called.
       if (!initialized) {
         initialized = true;
         metal::new_stream(stream);

--- a/mlx/scheduler.h
+++ b/mlx/scheduler.h
@@ -47,8 +47,6 @@ struct StreamThread {
         task = std::move(q.front());
         q.pop();
       }
-      // pool scoped to the task
-      auto thread_pool = metal::new_scoped_memory_pool();
 
       // thread_fn may be called from a static initializer and we cannot
       // call metal-cpp until all static initializers have completed. waiting
@@ -58,6 +56,7 @@ struct StreamThread {
         initialized = true;
         metal::new_stream(stream);
       }
+
       task();
     }
   }


### PR DESCRIPTION
- metal-cpp relies on static initializers to cache class and selector pointers
- code in mlx was using metal-cpp to set up NSAutoreleasePools during its own static init time
- but this code was silently failing as the class and selector pointers from metal-cpp were still nil

- defer the creation of NSAutoreleasePools until after static init time

This fix ensures that autorelease pools are in place where needed.  This is manually verified via:

```
OBJC_DEBUG_MISSING_POOLS=YES ./tests/tests -d |& grep MISSING | wc -l
```

There were 6 leaks before the change and 6 leaks after.  Manual inspection of these leaks shows that they are from Metal doing `dispatch_async()` to a queue that does not have an autoreleasepool (outside the mlx codebase).  As far as I can tell the 6 leaks are independent of the amount of work done -- it is a static 6.

## Proposed changes

I ran into trouble while running some Xcode from XCTest that calls mlx.  In particular this:

```
static std::shared_ptr<void> global_memory_pool = new_scoped_memory_pool();
```

is called under XCTestMain — xctest is loading my code as a dynamic library and the static initializers in it are firing after XCTestMain.  This creates a nested NSAutoreleasePool (fine) that is torn down (released) when the static initializer finalizes.  This happens as the process is shutting down, which is after the NSAutoreleasePool in XCTestMain has been torn down which triggers an abort() because the nesting is incorrect.

In addition to that problem, I also observe that this NSAutoreleasePool would simply catch all top level objects and abandon them, e.g. when called from python.  This silences warnings from OBJC_DEBUG_MISSING_POOLS but doesn't actually address the issue.

While debugging this I noticed that the new_scoped_memory_pool() (the C++ side of things creating these) was often failing to create the NSAutoreleasePools.  It turns out that was also being called from static initializers and the metal-cpp static initializers had not run.  They have to run to initialize the class and selector pointers (NSPrivate.h):

```
#define _NS_PRIVATE_DEF_CLS(symbol) void* s_k##symbol _NS_PRIVATE_VISIBILITY = _NS_PRIVATE_OBJC_LOOKUP_CLASS(symbol)
```

```
namespace NS
{
namespace Private
{
namespace Class
    {
    _NS_PRIVATE_DEF_CLS(NSArray);   
    _NS_PRIVATE_DEF_CLS(NSAutoreleasePool);
```

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
