### PR TITLE
Rearrange Python functions and classes in a logical order

### DIFF
--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -12,6 +12,10 @@ MLX was developed with contributions from the following individuals:
 - Justin Deschenaux: Sine, Cosine, arange, randint, truncated normal, bernoulli, lion optimizer, Dropout2d, linear and logistic regression python example.
 - Diogo Da Cruz: Added tri, tril, triu and safetensor support
 
+<a href="https://github.com/ml-explore/mlx/graphs/contributors">
+  <img class="dark-light" src="https://contrib.rocks/image?repo=ml-explore/mlx&anon=0&columns=20&max=100&r=true" />
+</a>
+
 # Third-Party Software
 
 MLX leverages several third-party software, listed here together with

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ contributors](ACKNOWLEDGMENTS.md#Individual-Contributors). If you contribute
 to MLX and wish to be acknowledged, please add your name to the list in your
 pull request.
 
+<a href="https://github.com/ml-explore/mlx/graphs/contributors">
+  <img class="dark-light" src="https://contrib.rocks/image?repo=ml-explore/mlx&anon=0&columns=20&max=100&r=true" />
+</a>
+
 ## Citing MLX
 
 The MLX software suite was initially developed with equal contribution by Awni

--- a/README.md
+++ b/README.md
@@ -88,10 +88,6 @@ contributors](ACKNOWLEDGMENTS.md#Individual-Contributors). If you contribute
 to MLX and wish to be acknowledged, please add your name to the list in your
 pull request.
 
-<a href="https://github.com/ml-explore/mlx/graphs/contributors">
-  <img class="dark-light" src="https://contrib.rocks/image?repo=ml-explore/mlx&anon=0&columns=20&max=100&r=true" />
-</a>
-
 ## Citing MLX
 
 The MLX software suite was initially developed with equal contribution by Awni

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ information on building from source, and running tests.
 
 We are grateful for all of [our
 contributors](ACKNOWLEDGMENTS.md#Individual-Contributors). If you contribute
-to MLX and wish to be acknowledged, please add your name to to the list in your
+to MLX and wish to be acknowledged, please add your name to the list in your
 pull request.
 
 ## Citing MLX

--- a/benchmarks/numpy/single_ops.py
+++ b/benchmarks/numpy/single_ops.py
@@ -10,15 +10,15 @@ def time_add():
     time_fn(np.add, a, b)
 
 
+def time_exp():
+    a = np.random.randn(1000, 100).astype(np.float32)
+    time_fn(np.exp, a)
+
+
 def time_matmul():
     a = np.random.rand(1000, 500).astype(np.float32)
     b = np.random.rand(500, 1000).astype(np.float32)
     time_fn(np.matmul, a, b)
-
-
-def time_exp():
-    a = np.random.randn(1000, 100).astype(np.float32)
-    time_fn(np.exp, a)
 
 
 def time_take():

--- a/benchmarks/python/batch_matmul_bench.py
+++ b/benchmarks/python/batch_matmul_bench.py
@@ -6,8 +6,8 @@ import mlx.core as mx
 from time_utils import time_fn
 
 B = 8
-T = 1024
 D = 512
+T = 1024
 
 
 def time_batch_matmul():

--- a/benchmarks/python/blas/bench_gemv.py
+++ b/benchmarks/python/blas/bench_gemv.py
@@ -10,28 +10,14 @@ import mlx.core as mx
 import numpy as np
 import torch
 
-results_dir = "./results"
-
-if not os.path.isdir(results_dir):
-    os.mkdir(results_dir)
-
-device_name = subprocess.check_output(["sysctl", "-n", "machdep.cpu.brand_string"])
-device_name = device_name.decode("utf-8").strip("\n")
-
-N_warmup = 5
 N_iter_bench = 50
 N_iter_func = 20
-
-out_vec_sizes = [128, 512, 2048, 4096]
-in_vec_sizes = [128, 512, 2048, 4096]
-
+N_warmup = 5
 benchmark_vector_lens = []
-benchmark_vector_lens += [(i + 1) * 4096 for i in range(8)][::2]
-benchmark_vector_lens += [(i + 1) * 4095 for i in range(8)][::2]
-benchmark_vector_lens += [(i + 1) * 4097 for i in range(8)][::2]
-benchmark_vector_lens += [64, 128, 512, 1024, 2048, 11008, 32000]
-
-benchmark_vector_lens.sort()
+device_name = subprocess.check_output(["sysctl", "-n", "machdep.cpu.brand_string"])
+in_vec_sizes = [128, 512, 2048, 4096]
+out_vec_sizes = [128, 512, 2048, 4096]
+results_dir = "./results"
 
 
 def bench(f, m, v):
@@ -44,44 +30,6 @@ def bench(f, m, v):
         f(m, v)
     e = time.perf_counter_ns()
     return (e - s) * 1e-9
-
-
-def gemv_mlx(m, v):
-    ys = []
-    for i in range(N_iter_func):
-        y = m @ v
-        ys.append(y)
-    mx.eval(ys)
-    return ys
-
-
-def gemv_t_mlx(m, v):
-    ys = []
-    for i in range(N_iter_func):
-        y = v @ m
-        ys.append(y)
-    mx.eval(ys)
-    return ys
-
-
-@torch.no_grad()
-def gemv_torch(m, v):
-    ys = []
-    for i in range(N_iter_func):
-        y = m @ v
-        ys.append(y)
-    torch.mps.synchronize()
-    return ys
-
-
-@torch.no_grad()
-def gemv_t_torch(m, v):
-    ys = []
-    for i in range(N_iter_func):
-        y = v @ m
-        ys.append(y)
-    torch.mps.synchronize()
-    return ys
 
 
 def bench_lens(in_vec_len, out_vec_len, np_dtype, transpose=False):
@@ -119,18 +67,6 @@ def bench_lens(in_vec_len, out_vec_len, np_dtype, transpose=False):
         )
 
     return time_mlx, time_torch
-
-
-def get_gflop_count(in_vec_len, out_vec_len):
-    return float(2.0 * N_iter_bench * N_iter_func * in_vec_len * out_vec_len) / float(
-        1024**3
-    )
-
-
-def get_gbyte_size(in_vec_len, out_vec_len, np_dtype):
-    n_elem = in_vec_len * out_vec_len + in_vec_len + out_vec_len
-    item_size = 4 if np_dtype == np.float32 else 2
-    return float(N_iter_bench * N_iter_func * n_elem * item_size) / float(1024**3)
 
 
 def bench_with_in_len(ax, in_vec_len, out_vector_lens, dtype, tranpose):
@@ -193,6 +129,68 @@ def bench_with_out_len(ax, out_vec_len, in_vector_lens, dtype, tranpose):
     ax.set_title(title)
     ax.set(xlabel="in_vector_len", ylabel="Performance (GB/s)")
     ax.legend()
+
+
+def gemv_mlx(m, v):
+    ys = []
+    for i in range(N_iter_func):
+        y = m @ v
+        ys.append(y)
+    mx.eval(ys)
+    return ys
+
+
+def gemv_t_mlx(m, v):
+    ys = []
+    for i in range(N_iter_func):
+        y = v @ m
+        ys.append(y)
+    mx.eval(ys)
+    return ys
+
+
+@torch.no_grad()
+def gemv_t_torch(m, v):
+    ys = []
+    for i in range(N_iter_func):
+        y = v @ m
+        ys.append(y)
+    torch.mps.synchronize()
+    return ys
+
+
+@torch.no_grad()
+def gemv_torch(m, v):
+    ys = []
+    for i in range(N_iter_func):
+        y = m @ v
+        ys.append(y)
+    torch.mps.synchronize()
+    return ys
+
+
+def get_gbyte_size(in_vec_len, out_vec_len, np_dtype):
+    n_elem = in_vec_len * out_vec_len + in_vec_len + out_vec_len
+    item_size = 4 if np_dtype == np.float32 else 2
+    return float(N_iter_bench * N_iter_func * n_elem * item_size) / float(1024**3)
+
+
+def get_gflop_count(in_vec_len, out_vec_len):
+    return float(2.0 * N_iter_bench * N_iter_func * in_vec_len * out_vec_len) / float(
+        1024**3
+    )
+
+
+device_name = device_name.decode("utf-8").strip("\n")
+
+if not os.path.isdir(results_dir):
+    os.mkdir(results_dir)
+benchmark_vector_lens += [(i + 1) * 4096 for i in range(8)][::2]
+benchmark_vector_lens += [(i + 1) * 4095 for i in range(8)][::2]
+benchmark_vector_lens += [(i + 1) * 4097 for i in range(8)][::2]
+benchmark_vector_lens += [64, 128, 512, 1024, 2048, 11008, 32000]
+
+benchmark_vector_lens.sort()
 
 
 for transpose in (False, True):

--- a/benchmarks/python/comparative/bench_mlx.py
+++ b/benchmarks/python/comparative/bench_mlx.py
@@ -9,30 +9,6 @@ import mlx.core as mx
 import mlx.nn as nn
 
 
-def int_or_list(x):
-    try:
-        return int(x)
-    except ValueError:
-        return [int(xi) for xi in x.split(",")]
-
-
-def none_or_list(x):
-    if x == "":
-        return None
-    else:
-        return [int(xi) for xi in x.split(",")]
-
-
-def dtype_from_str(x):
-    if x == "":
-        return mx.float32
-    else:
-        dt = getattr(mx, x)
-        if not isinstance(dt, mx.Dtype):
-            raise ValueError(f"{x} is not an mlx dtype")
-        return dt
-
-
 def bench(f, *args):
     for i in range(10):
         f(*args)
@@ -44,27 +20,23 @@ def bench(f, *args):
     return e - s
 
 
-def matmul_square(x):
-    y = x
-    for i in range(10):
-        y = y @ x
+def binary(op, x, y):
+    for i in range(100):
+        y = getattr(mx, op)(x, y)
     mx.eval(y)
-    return y
 
 
-def matmul(x, y):
+def celu(x):
+    y = x
+    for i in range(100):
+        y = nn.celu(y)
+    mx.eval(y)
+
+
+def concatenate(axis, x, y):
     ys = []
     for i in range(10):
-        ys.append(x @ y)
-    mx.eval(ys)
-
-
-def quant_matmul(x, w, s, b):
-    groups = x.shape[-1] // s.shape[-1]
-    width = 32 // (x.shape[-1] // w.shape[0])
-    ys = []
-    for i in range(10):
-        ys.append(mx.quantized_matmul(x, w, s, b, groups=groups, width=width))
+        ys.append(mx.concatenate([x, y], axis=axis))
     mx.eval(ys)
 
 
@@ -82,120 +54,6 @@ def conv2d(x, y):
     mx.eval(ys)
 
 
-def binary(op, x, y):
-    for i in range(100):
-        y = getattr(mx, op)(x, y)
-    mx.eval(y)
-
-
-def reduction(op, axis, x):
-    ys = []
-    for i in range(100):
-        ys.append(getattr(mx, op)(x, axis=axis))
-    mx.eval(ys)
-
-
-def softmax(axis, x):
-    ys = []
-    for i in range(100):
-        ex = mx.exp(x - mx.max(x, axis=axis, keepdims=True))
-        y = ex / mx.sum(ex, axis=axis, keepdims=True)
-        ys.append(y)
-    mx.eval(ys)
-
-
-def softmax_fused(axis, x):
-    ys = []
-    for i in range(100):
-        y = mx.softmax(x, axis=axis)
-        ys.append(y)
-    mx.eval(ys)
-
-
-def relu(x):
-    y = x
-    for i in range(100):
-        y = nn.relu(y)
-    mx.eval(y)
-
-
-def leaky_relu(x: mx.array):
-    y = x
-    for i in range(100):
-        y = nn.leaky_relu(y)
-    mx.eval(y)
-
-
-def prelu(x: mx.array):
-    y = x
-    for i in range(100):
-        y = nn.prelu(y, mx.ones(1))
-    mx.eval(y)
-
-
-def softplus(x: mx.array):
-    y = x
-    for i in range(100):
-        y = nn.softplus(y)
-    mx.eval(y)
-
-
-def mish(x: mx.array):
-    y = x
-    for i in range(100):
-        y = nn.mish(y)
-    mx.eval(y)
-
-
-def leaky_relu(x):
-    y = x
-    for i in range(100):
-        y = nn.leaky_relu(y)
-    mx.eval(y)
-
-
-def elu(x):
-    y = x
-    for i in range(100):
-        y = nn.elu(y)
-    mx.eval(y)
-
-
-def relu6(x):
-    y = x
-    for i in range(100):
-        y = nn.relu6(y)
-    mx.eval(y)
-
-
-def softplus(x):
-    y = x
-    for i in range(100):
-        y = nn.softplus(y)
-    mx.eval(y)
-
-
-def celu(x):
-    y = x
-    for i in range(100):
-        y = nn.celu(y)
-    mx.eval(y)
-
-
-def log_sigmoid(x):
-    y = x
-    for i in range(100):
-        y = nn.log_sigmoid(y)
-    mx.eval(y)
-
-
-def scalar_mult(x):
-    y = x
-    for i in range(100):
-        y = y * (1.0 / (1 + i))
-    mx.eval(y)
-
-
 def cross_entropy(targets, x):
     ys = []
     for i in range(100):
@@ -206,11 +64,49 @@ def cross_entropy(targets, x):
     mx.eval(ys)
 
 
-def logsumexp(axis, x):
+def cumsum(axis, x):
     ys = []
-    for i in range(100):
-        ys.append(mx.logsumexp(x, axis=axis))
+    for i in range(10):
+        ys.append(mx.cumsum(x, axis))
     mx.eval(ys)
+
+
+def dtype_from_str(x):
+    if x == "":
+        return mx.float32
+    else:
+        dt = getattr(mx, x)
+        if not isinstance(dt, mx.Dtype):
+            raise ValueError(f"{x} is not an mlx dtype")
+        return dt
+
+
+def elu(x):
+    y = x
+    for i in range(100):
+        y = nn.elu(y)
+    mx.eval(y)
+
+
+def int_or_list(x):
+    try:
+        return int(x)
+    except ValueError:
+        return [int(xi) for xi in x.split(",")]
+
+
+def leaky_relu(x: mx.array):
+    y = x
+    for i in range(100):
+        y = nn.leaky_relu(y)
+    mx.eval(y)
+
+
+def leaky_relu(x):
+    y = x
+    for i in range(100):
+        y = nn.leaky_relu(y)
+    mx.eval(y)
 
 
 def linear(w, b, x):
@@ -218,6 +114,86 @@ def linear(w, b, x):
     for i in range(10):
         ys.append(x @ mx.transpose(w, (1, 0)) + b)
     mx.eval(ys)
+
+
+def log_sigmoid(x):
+    y = x
+    for i in range(100):
+        y = nn.log_sigmoid(y)
+    mx.eval(y)
+
+
+def logsumexp(axis, x):
+    ys = []
+    for i in range(100):
+        ys.append(mx.logsumexp(x, axis=axis))
+    mx.eval(ys)
+
+
+def matmul(x, y):
+    ys = []
+    for i in range(10):
+        ys.append(x @ y)
+    mx.eval(ys)
+
+
+def matmul_square(x):
+    y = x
+    for i in range(10):
+        y = y @ x
+    mx.eval(y)
+    return y
+
+
+def mish(x: mx.array):
+    y = x
+    for i in range(100):
+        y = nn.mish(y)
+    mx.eval(y)
+
+
+def none_or_list(x):
+    if x == "":
+        return None
+    else:
+        return [int(xi) for xi in x.split(",")]
+
+
+def prelu(x: mx.array):
+    y = x
+    for i in range(100):
+        y = nn.prelu(y, mx.ones(1))
+    mx.eval(y)
+
+
+def quant_matmul(x, w, s, b):
+    groups = x.shape[-1] // s.shape[-1]
+    width = 32 // (x.shape[-1] // w.shape[0])
+    ys = []
+    for i in range(10):
+        ys.append(mx.quantized_matmul(x, w, s, b, groups=groups, width=width))
+    mx.eval(ys)
+
+
+def reduction(op, axis, x):
+    ys = []
+    for i in range(100):
+        ys.append(getattr(mx, op)(x, axis=axis))
+    mx.eval(ys)
+
+
+def relu(x):
+    y = x
+    for i in range(100):
+        y = nn.relu(y)
+    mx.eval(y)
+
+
+def relu6(x):
+    y = x
+    for i in range(100):
+        y = nn.relu6(y)
+    mx.eval(y)
 
 
 def rope(x):
@@ -241,32 +217,55 @@ def rope(x):
     mx.eval(ys)
 
 
-def concatenate(axis, x, y):
+def scalar_mult(x):
+    y = x
+    for i in range(100):
+        y = y * (1.0 / (1 + i))
+    mx.eval(y)
+
+
+def selu(x):
+    y = x
+    for i in range(100):
+        y = nn.selu(x)
+    mx.eval(y)
+
+
+def softmax(axis, x):
     ys = []
-    for i in range(10):
-        ys.append(mx.concatenate([x, y], axis=axis))
+    for i in range(100):
+        ex = mx.exp(x - mx.max(x, axis=axis, keepdims=True))
+        y = ex / mx.sum(ex, axis=axis, keepdims=True)
+        ys.append(y)
     mx.eval(ys)
 
 
-def cumsum(axis, x):
+def softmax_fused(axis, x):
     ys = []
-    for i in range(10):
-        ys.append(mx.cumsum(x, axis))
+    for i in range(100):
+        y = mx.softmax(x, axis=axis)
+        ys.append(y)
     mx.eval(ys)
+
+
+def softplus(x: mx.array):
+    y = x
+    for i in range(100):
+        y = nn.softplus(y)
+    mx.eval(y)
+
+
+def softplus(x):
+    y = x
+    for i in range(100):
+        y = nn.softplus(y)
+    mx.eval(y)
 
 
 def sort(axis, x):
     ys = []
     for i in range(10):
         ys.append(mx.sort(x, axis))
-    mx.eval(ys)
-
-
-def topk(axis, x):
-    k = x.shape[axis] // 3
-    ys = []
-    for i in range(10):
-        ys.append(mx.topk(x, k, axis))
     mx.eval(ys)
 
 
@@ -277,11 +276,12 @@ def step_function(x):
     mx.eval(y)
 
 
-def selu(x):
-    y = x
-    for i in range(100):
-        y = nn.selu(x)
-    mx.eval(y)
+def topk(axis, x):
+    k = x.shape[axis] // 3
+    ys = []
+    for i in range(10):
+        ys.append(mx.topk(x, k, axis))
+    mx.eval(ys)
 
 
 if __name__ == "__main__":

--- a/benchmarks/python/comparative/compare.py
+++ b/benchmarks/python/comparative/compare.py
@@ -11,14 +11,6 @@ BENCH_MLX = Path(__file__).parent / "bench_mlx.py"
 BENCH_TORCH = Path(__file__).parent / "bench_torch.py"
 
 
-def run_or_raise(*args, **kwargs):
-    try:
-        result = run(*args, capture_output=True, **kwargs)
-        return float(result.stdout)
-    except ValueError:
-        raise ValueError(f"stdout: {result.stdout}\nstderr: {result.stderr}")
-
-
 def compare(args):
     t_mlx = run_or_raise(["python", BENCH_MLX] + args)
     t_torch = run_or_raise(["python", BENCH_TORCH] + args)
@@ -31,15 +23,6 @@ def compare_mlx_dtypes(args, dt1, dt2):
     t_mlx_dt2 = run_or_raise(["python", BENCH_MLX] + args + ["--dtype", dt2])
 
     print((t_mlx_dt2 - t_mlx_dt1) / t_mlx_dt2, " ".join(args), sep="\t")
-
-
-def make_regex_search(regexes):
-    compiled_regexes = list(map(re.compile, regexes))
-
-    def search(x):
-        return (c.search(x) is not None for c in compiled_regexes)
-
-    return search
 
 
 def make_predicate(positive_filter, negative_filter):
@@ -59,6 +42,23 @@ def make_predicate(positive_filter, negative_filter):
         return positive_filter(x) and negative_filter(x)
 
     return predicate
+
+
+def make_regex_search(regexes):
+    compiled_regexes = list(map(re.compile, regexes))
+
+    def search(x):
+        return (c.search(x) is not None for c in compiled_regexes)
+
+    return search
+
+
+def run_or_raise(*args, **kwargs):
+    try:
+        result = run(*args, capture_output=True, **kwargs)
+        return float(result.stdout)
+    except ValueError:
+        raise ValueError(f"stdout: {result.stdout}\nstderr: {result.stderr}")
 
 
 if __name__ == "__main__":

--- a/benchmarks/python/llama_torch_bench.py
+++ b/benchmarks/python/llama_torch_bench.py
@@ -8,11 +8,6 @@ import torch.mps
 import torch.nn as nn
 
 
-def sync_if_needed(x):
-    if x.device != torch.device("cpu"):
-        torch.mps.synchronize()
-
-
 class RoPE(nn.Module):
     def __init__(self, dims: int, traditional: bool = False):
         super().__init__()
@@ -176,6 +171,11 @@ def measure(model, x, cache):
     sync_if_needed(x)
     end = time.time()
     return (end - start) * 1000 / 5
+
+
+def sync_if_needed(x):
+    if x.device != torch.device("cpu"):
+        torch.mps.synchronize()
 
 
 if __name__ == "__main__":

--- a/benchmarks/python/single_ops.py
+++ b/benchmarks/python/single_ops.py
@@ -37,6 +37,18 @@ def time_add():
     time_fn(mid_slice_add, a, b)
 
 
+def time_exp():
+    a = mx.random.uniform(shape=(1000, 100))
+    mx.eval(a)
+    time_fn(mx.exp, a)
+
+
+def time_logsumexp():
+    a = mx.random.uniform(shape=(64, 10, 10000))
+    mx.eval(a)
+    time_fn(mx.logsumexp, a, axis=-1)
+
+
 def time_matmul():
     a = mx.random.uniform(shape=(1024, 1024))
     b = mx.random.uniform(shape=(1024, 1024))
@@ -56,16 +68,14 @@ def time_negative():
     time_fn(negative, a)
 
 
-def time_exp():
-    a = mx.random.uniform(shape=(1000, 100))
-    mx.eval(a)
-    time_fn(mx.exp, a)
+def time_reshape_transposed():
+    x = mx.random.uniform(shape=(256, 256, 128))
+    mx.eval(x)
 
+    def reshape_transposed():
+        return mx.reshape(mx.transpose(x, (1, 0, 2)), (-1,))
 
-def time_logsumexp():
-    a = mx.random.uniform(shape=(64, 10, 10000))
-    mx.eval(a)
-    time_fn(mx.logsumexp, a, axis=-1)
+    time_fn(reshape_transposed)
 
 
 def time_take():
@@ -78,16 +88,6 @@ def time_take():
         return [mx.take(a, idx, 0) for idx in ids]
 
     time_fn(random_take)
-
-
-def time_reshape_transposed():
-    x = mx.random.uniform(shape=(256, 256, 128))
-    mx.eval(x)
-
-    def reshape_transposed():
-        return mx.reshape(mx.transpose(x, (1, 0, 2)), (-1,))
-
-    time_fn(reshape_transposed)
 
 
 if __name__ == "__main__":

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -5,14 +5,9 @@
 import os
 import subprocess
 
-# -- Project information -----------------------------------------------------
-
-project = "MLX"
-copyright = "2023, MLX Contributors"
 author = "MLX Contributors"
-version = "0.0.6"
-release = "0.0.6"
-
+autosummary_generate = True
+copyright = "2023, MLX Contributors"
 # -- General configuration ---------------------------------------------------
 
 extensions = [
@@ -21,36 +16,32 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
 ]
-
-python_use_unqualified_type_names = True
-autosummary_generate = True
-
-intersphinx_mapping = {
-    "https://docs.python.org/3": None,
-    "https://numpy.org/doc/stable/": None,
-}
-
-templates_path = ["_templates"]
-html_static_path = ["_static"]
-source_suffix = ".rst"
-master_doc = "index"
 highlight_language = "python"
-pygments_style = "sphinx"
-
+html_logo = "_static/mlx_logo.png"
+html_static_path = ["_static"]
 # -- Options for HTML output -------------------------------------------------
 
 html_theme = "sphinx_book_theme"
-
 html_theme_options = {
     "show_toc_level": 2,
     "repository_url": "https://github.com/ml-explore/mlx",
     "use_repository_button": True,
     "navigation_with_keys": False,
 }
-
-html_logo = "_static/mlx_logo.png"
-
-
 # -- Options for HTMLHelp output ---------------------------------------------
 
 htmlhelp_basename = "mlx_doc"
+intersphinx_mapping = {
+    "https://docs.python.org/3": None,
+    "https://numpy.org/doc/stable/": None,
+}
+master_doc = "index"
+# -- Project information -----------------------------------------------------
+
+project = "MLX"
+pygments_style = "sphinx"
+python_use_unqualified_type_names = True
+release = "0.0.6"
+source_suffix = ".rst"
+templates_path = ["_templates"]
+version = "0.0.6"

--- a/examples/python/linear_regression.py
+++ b/examples/python/linear_regression.py
@@ -4,23 +4,12 @@ import time
 
 import mlx.core as mx
 
-num_features = 100
-num_examples = 1_000
-num_iters = 10_000
 lr = 0.01
-
-# True parameters
-w_star = mx.random.normal((num_features,))
-
-# Input examples (design matrix)
-X = mx.random.normal((num_examples, num_features))
-
-# Noisy labels
-eps = 1e-2 * mx.random.normal((num_examples,))
-y = X @ w_star + eps
-
-# Initialize random parameters
-w = 1e-2 * mx.random.normal((num_features,))
+num_examples = 1_000
+num_features = 100
+num_iters = 10_000
+tic = time.time()
+toc = time.time()
 
 
 def loss_fn(w):
@@ -28,17 +17,22 @@ def loss_fn(w):
 
 
 grad_fn = mx.grad(loss_fn)
-
-tic = time.time()
+# Input examples (design matrix)
+X = mx.random.normal((num_examples, num_features))
+# Noisy labels
+eps = 1e-2 * mx.random.normal((num_examples,))
+error_norm = mx.sum(mx.square(w - w_star)).item() ** 0.5
+loss = loss_fn(w)
+throughput = num_iters / (toc - tic)
+# Initialize random parameters
+w = 1e-2 * mx.random.normal((num_features,))
+# True parameters
+w_star = mx.random.normal((num_features,))
+y = X @ w_star + eps
 for _ in range(num_iters):
     grad = grad_fn(w)
     w = w - lr * grad
     mx.eval(w)
-toc = time.time()
-
-loss = loss_fn(w)
-error_norm = mx.sum(mx.square(w - w_star)).item() ** 0.5
-throughput = num_iters / (toc - tic)
 
 print(
     f"Loss {loss.item():.5f}, |w-w*| = {error_norm:.5f}, "

--- a/examples/python/logistic_regression.py
+++ b/examples/python/logistic_regression.py
@@ -4,23 +4,12 @@ import time
 
 import mlx.core as mx
 
-num_features = 100
-num_examples = 1_000
-num_iters = 10_000
 lr = 0.1
-
-# True parameters
-w_star = mx.random.normal((num_features,))
-
-# Input examples
-X = mx.random.normal((num_examples, num_features))
-
-# Labels
-y = (X @ w_star) > 0
-
-
-# Initialize random parameters
-w = 1e-2 * mx.random.normal((num_features,))
+num_examples = 1_000
+num_features = 100
+num_iters = 10_000
+tic = time.time()
+toc = time.time()
 
 
 def loss_fn(w):
@@ -29,20 +18,22 @@ def loss_fn(w):
 
 
 grad_fn = mx.grad(loss_fn)
-
-tic = time.time()
+# Input examples
+X = mx.random.normal((num_examples, num_features))
+acc = mx.mean(final_preds == y)
+final_preds = (X @ w) > 0
+loss = loss_fn(w)
+throughput = num_iters / (toc - tic)
+# Initialize random parameters
+w = 1e-2 * mx.random.normal((num_features,))
+# True parameters
+w_star = mx.random.normal((num_features,))
+# Labels
+y = (X @ w_star) > 0
 for _ in range(num_iters):
     grad = grad_fn(w)
     w = w - lr * grad
     mx.eval(w)
-
-toc = time.time()
-
-loss = loss_fn(w)
-final_preds = (X @ w) > 0
-acc = mx.mean(final_preds == y)
-
-throughput = num_iters / (toc - tic)
 print(
     f"Loss {loss.item():.5f}, Accuracy {acc.item():.5f} "
     f"Throughput {throughput:.5f} (it/s)"

--- a/python/mlx/nn/layers/activations.py
+++ b/python/mlx/nn/layers/activations.py
@@ -15,79 +15,6 @@ def _make_activation_module(f):
     return decorator
 
 
-def sigmoid(x):
-    r"""Applies the element-wise function:
-
-    .. math::
-        \text{Sigmoid}(x) = \sigma(x) = \frac{1}{1 + \exp(-x)}
-    """
-    return mx.sigmoid(x)
-
-
-def relu(x):
-    r"""Applies the Rectified Linear Unit.
-
-    Simply ``mx.maximum(x, 0)``.
-    """
-    return mx.maximum(x, 0)
-
-
-def leaky_relu(x, negative_slope=0.01):
-    r"""Applies the Leaky Rectified Linear Unit.
-
-    Simply ``mx.maximum(negative_slope * x, x)``.
-    """
-    return mx.maximum(negative_slope * x, x)
-
-
-def log_softmax(x, axis=-1):
-    r"""Applies the Log Softmax function.
-
-    Applies :math:`x + \log \sum_i e^{x_i}` element wise.
-    """
-    return x - mx.logsumexp(x, axis=axis, keepdims=True)
-
-
-def elu(x, alpha=1.0):
-    r"""Applies the Exponential Linear Unit.
-
-    Simply ``mx.where(x > 0, x, alpha * (mx.exp(x) - 1))``.
-    """
-    return mx.where(x > 0, x, alpha * (mx.exp(x) - 1))
-
-
-def relu6(x):
-    r"""Applies the Rectified Linear Unit 6.
-
-    Applies :math:`\min(\max(x, 0), 6)` element wise.
-    """
-    return mx.minimum(mx.maximum(x, 0), 6.0)
-
-
-def softmax(x, axis=-1):
-    r"""Applies the Softmax function.
-
-    Applies :math:`\frac{e^{x_i}}{\sum_j e^{x_j}}` element wise.
-    """
-    return mx.softmax(x, axis=axis)
-
-
-def softplus(x):
-    r"""Applies the Softplus function.
-
-    Applies :math:`\log(1 + \exp(x))` element wise.
-    """
-    return mx.logaddexp(x, 0)
-
-
-def softsign(x):
-    r"""Applies the Softsign function.
-
-    Applies :math:`\frac{x}{1 + |x|}` element wise.
-    """
-    return mx.divide(x, 1 + mx.abs(x))
-
-
 def celu(x, alpha=1.0):
     r"""Applies the Continuously Differentiable Exponential Linear Unit.
 
@@ -97,21 +24,12 @@ def celu(x, alpha=1.0):
     return mx.maximum(x, 0.0) + alpha * (mx.exp(mx.minimum(x, 0.0) / alpha) - 1)
 
 
-def silu(x):
-    r"""Applies the Sigmoid Linear Unit. Also known as Swish.
+def elu(x, alpha=1.0):
+    r"""Applies the Exponential Linear Unit.
 
-    Applies :math:`x \sigma(x)` element wise, where :math:`\sigma(\cdot)` is
-    the logistic sigmoid.
+    Simply ``mx.where(x > 0, x, alpha * (mx.exp(x) - 1))``.
     """
-    return x * mx.sigmoid(x)
-
-
-def log_sigmoid(x):
-    r"""Applies the Log Sigmoid function.
-
-    Applies :math:`\log(\sigma(x)) = -\log(1 + e^{-x})` element wise.
-    """
-    return -softplus(-x)
+    return mx.where(x > 0, x, alpha * (mx.exp(x) - 1))
 
 
 def gelu(x):
@@ -162,14 +80,136 @@ def gelu_fast_approx(x):
     return x * mx.sigmoid(1.773 * x)
 
 
-@_make_activation_module
-class Sigmoid(Module):
-    r"""Applies the sigmoid function, element-wise.
+def hardswish(x):
+    r"""Applies the hardswish function, element-wise.
+
+    .. math::
+        \text{Hardswish}(x) = x * \min(\max(x + 3, 0), 6) / 6
+    """
+    max_x_3 = mx.maximum(x + 3, 0)
+    return x * mx.minimum(max_x_3, 6) / 6
+
+
+def leaky_relu(x, negative_slope=0.01):
+    r"""Applies the Leaky Rectified Linear Unit.
+
+    Simply ``mx.maximum(negative_slope * x, x)``.
+    """
+    return mx.maximum(negative_slope * x, x)
+
+
+def log_sigmoid(x):
+    r"""Applies the Log Sigmoid function.
+
+    Applies :math:`\log(\sigma(x)) = -\log(1 + e^{-x})` element wise.
+    """
+    return -softplus(-x)
+
+
+def log_softmax(x, axis=-1):
+    r"""Applies the Log Softmax function.
+
+    Applies :math:`x + \log \sum_i e^{x_i}` element wise.
+    """
+    return x - mx.logsumexp(x, axis=axis, keepdims=True)
+
+
+def mish(x: mx.array) -> mx.array:
+    r"""Applies the Mish function, element-wise.
+    Mish: A Self Regularized Non-Monotonic Neural Activation Function.
+
+    Reference: https://arxiv.org/abs/1908.08681
+
+    .. math::
+        \text{Mish}(x) = x * \text{Tanh}(\text{Softplus}(x))
+
+    """
+    return x * mx.tanh(softplus(x))
+
+
+def prelu(x: mx.array, alpha: mx.array) -> mx.array:
+    r"""Applies the element-wise parametric ReLU.
+
+    .. math::
+        \text{PReLU}(x) = \max(0,x) + a * \min(0,x)
+
+    where :math:`a` is an array.
+    """
+    return mx.maximum(0, x) + alpha * mx.minimum(0, x)
+
+
+def relu(x):
+    r"""Applies the Rectified Linear Unit.
+
+    Simply ``mx.maximum(x, 0)``.
+    """
+    return mx.maximum(x, 0)
+
+
+def relu6(x):
+    r"""Applies the Rectified Linear Unit 6.
+
+    Applies :math:`\min(\max(x, 0), 6)` element wise.
+    """
+    return mx.minimum(mx.maximum(x, 0), 6.0)
+
+
+def selu(x):
+    r"""Applies the Scaled Exponential Linear Unit.
+
+    .. math::
+        \text{selu}(x) = \begin{cases}
+        \lambda x & \text{if } x > 0 \\
+        \lambda \alpha (\exp(x) - 1) & \text{if } x \leq 0
+        \end{cases}
+
+    where :math:`\lambda = 1.0507` and :math:`\alpha = 1.67326`.
+
+    See also :func:`elu`.
+    """
+    return elu(x, 1.67326) * 1.0507
+
+
+def sigmoid(x):
+    r"""Applies the element-wise function:
 
     .. math::
         \text{Sigmoid}(x) = \sigma(x) = \frac{1}{1 + \exp(-x)}
     """
-    pass
+    return mx.sigmoid(x)
+
+
+def silu(x):
+    r"""Applies the Sigmoid Linear Unit. Also known as Swish.
+
+    Applies :math:`x \sigma(x)` element wise, where :math:`\sigma(\cdot)` is
+    the logistic sigmoid.
+    """
+    return x * mx.sigmoid(x)
+
+
+def softmax(x, axis=-1):
+    r"""Applies the Softmax function.
+
+    Applies :math:`\frac{e^{x_i}}{\sum_j e^{x_j}}` element wise.
+    """
+    return mx.softmax(x, axis=axis)
+
+
+def softplus(x):
+    r"""Applies the Softplus function.
+
+    Applies :math:`\log(1 + \exp(x))` element wise.
+    """
+    return mx.logaddexp(x, 0)
+
+
+def softsign(x):
+    r"""Applies the Softsign function.
+
+    Applies :math:`\frac{x}{1 + |x|}` element wise.
+    """
+    return mx.divide(x, 1 + mx.abs(x))
 
 
 def step(x: mx.array, threshold: float = 0.0):
@@ -191,54 +231,22 @@ def step(x: mx.array, threshold: float = 0.0):
     return mx.where(x > threshold, 1, 0)
 
 
-def selu(x):
-    r"""Applies the Scaled Exponential Linear Unit.
+def tanh(x):
+    """Applies the hyperbolic tangent function.
+
+    Simply ``mx.tanh(x)``.
+    """
+    return mx.tanh(x)
+
+
+@_make_activation_module
+class Sigmoid(Module):
+    r"""Applies the sigmoid function, element-wise.
 
     .. math::
-        \text{selu}(x) = \begin{cases}
-        \lambda x & \text{if } x > 0 \\
-        \lambda \alpha (\exp(x) - 1) & \text{if } x \leq 0
-        \end{cases}
-
-    where :math:`\lambda = 1.0507` and :math:`\alpha = 1.67326`.
-
-    See also :func:`elu`.
+        \text{Sigmoid}(x) = \sigma(x) = \frac{1}{1 + \exp(-x)}
     """
-    return elu(x, 1.67326) * 1.0507
-
-
-def prelu(x: mx.array, alpha: mx.array) -> mx.array:
-    r"""Applies the element-wise parametric ReLU.
-
-    .. math::
-        \text{PReLU}(x) = \max(0,x) + a * \min(0,x)
-
-    where :math:`a` is an array.
-    """
-    return mx.maximum(0, x) + alpha * mx.minimum(0, x)
-
-
-def mish(x: mx.array) -> mx.array:
-    r"""Applies the Mish function, element-wise.
-    Mish: A Self Regularized Non-Monotonic Neural Activation Function.
-
-    Reference: https://arxiv.org/abs/1908.08681
-
-    .. math::
-        \text{Mish}(x) = x * \text{Tanh}(\text{Softplus}(x))
-
-    """
-    return x * mx.tanh(softplus(x))
-
-
-def hardswish(x):
-    r"""Applies the hardswish function, element-wise.
-
-    .. math::
-        \text{Hardswish}(x) = x * \min(\max(x + 3, 0), 6) / 6
-    """
-    max_x_3 = mx.maximum(x + 3, 0)
-    return x * mx.minimum(max_x_3, 6) / 6
+    pass
 
 
 @_make_activation_module(mish)
@@ -440,14 +448,6 @@ class GELU(Module):
 
     def __call__(self, x):
         return self._act(x)
-
-
-def tanh(x):
-    """Applies the hyperbolic tangent function.
-
-    Simply ``mx.tanh(x)``.
-    """
-    return mx.tanh(x)
 
 
 @_make_activation_module(tanh)

--- a/python/mlx/nn/losses.py
+++ b/python/mlx/nn/losses.py
@@ -6,6 +6,44 @@ import mlx.core as mx
 from mlx.nn.layers.base import Module
 
 
+def _reduce(loss: mx.array, reduction: str = "none"):
+    if reduction == "mean":
+        return mx.mean(loss)
+    elif reduction == "sum":
+        return mx.sum(loss)
+    elif reduction == "none":
+        return loss
+    else:
+        raise ValueError("Invalid reduction. Must be 'none', 'mean', or 'sum'.")
+
+
+def binary_cross_entropy(
+    logits: mx.array, targets: mx.array, reduction: str = "none"
+) -> mx.array:
+    """
+    Computes the binary cross entropy loss.
+
+    Args:
+        logits (array): The unnormalized (pre-sigmoid) predicted logits.
+        targets (array): The binary target values in {0, 1}.
+        reduction (str, optional): Specifies the reduction to apply to the output:
+          ``'none'`` | ``'mean'`` | ``'sum'``. Default: ``'none'``.
+
+    Returns:
+        array: The computed binary cross entropy loss.
+    Examples:
+        >>> import mlx.core as mx
+        >>> import mlx.nn as nn
+        >>> inputs = mx.array([0.105361, 0.223144, 1.20397, 0.916291])
+        >>> targets = mx.array([0, 0, 1, 1])
+        >>> loss = nn.losses.binary_cross_entropy(inputs, targets, "mean")
+        >>> loss
+        array([0.612192], dtype=float32)
+    """
+    loss = mx.logaddexp(0.0, logits) - targets * logits
+    return _reduce(loss, reduction)
+
+
 def cross_entropy(
     logits: mx.array,
     targets: mx.array,
@@ -60,30 +98,89 @@ def cross_entropy(
     return _reduce(loss, reduction)
 
 
-def binary_cross_entropy(
-    logits: mx.array, targets: mx.array, reduction: str = "none"
+def hinge_loss(
+    inputs: mx.array, targets: mx.array, reduction: str = "none"
 ) -> mx.array:
-    """
-    Computes the binary cross entropy loss.
+    r"""
+    Computes the hinge loss between inputs and targets.
+
+    .. math::
+
+       \text{hinge}(y, y_{\text{pred}}) = \max(0, 1 - y \cdot y_{\text{pred}})
+
 
     Args:
-        logits (array): The unnormalized (pre-sigmoid) predicted logits.
-        targets (array): The binary target values in {0, 1}.
+        inputs (array): The predicted values.
+        targets (array): The target values. They should be -1 or 1.
         reduction (str, optional): Specifies the reduction to apply to the output:
           ``'none'`` | ``'mean'`` | ``'sum'``. Default: ``'none'``.
 
     Returns:
-        array: The computed binary cross entropy loss.
-    Examples:
-        >>> import mlx.core as mx
-        >>> import mlx.nn as nn
-        >>> inputs = mx.array([0.105361, 0.223144, 1.20397, 0.916291])
-        >>> targets = mx.array([0, 0, 1, 1])
-        >>> loss = nn.losses.binary_cross_entropy(inputs, targets, "mean")
-        >>> loss
-        array([0.612192], dtype=float32)
+        array: The computed hinge loss.
     """
-    loss = mx.logaddexp(0.0, logits) - targets * logits
+    loss = mx.maximum(1 - inputs * targets, 0)
+
+    return _reduce(loss, reduction)
+
+
+def huber_loss(
+    inputs: mx.array, targets: mx.array, delta: float = 1.0, reduction: str = "none"
+) -> mx.array:
+    r"""
+    Computes the Huber loss between inputs and targets.
+
+    .. math::
+
+        L_{\delta}(a) =
+        \left\{ \begin{array}{ll}
+            \frac{1}{2} a^2 & \text{for } |a| \leq \delta, \\
+            \delta \left( |a| - \frac{1}{2} \delta \right) & \text{otherwise.}
+        \end{array} \right.
+
+    Args:
+        inputs (array): The predicted values.
+        targets (array): The target values.
+        delta (float, optional): The threshold at which to change between L1 and L2 loss.
+          Default: ``1.0``.
+        reduction (str, optional): Specifies the reduction to apply to the output:
+          ``'none'`` | ``'mean'`` | ``'sum'``. Default: ``'none'``.
+
+    Returns:
+        array: The computed Huber loss.
+    """
+    errors = inputs - targets
+    abs_errors = mx.abs(errors)
+    quadratic = mx.minimum(abs_errors, delta)
+    linear = abs_errors - quadratic
+    loss = 0.5 * quadratic**2 + delta * linear
+
+    return _reduce(loss, reduction)
+
+
+def kl_div_loss(
+    inputs: mx.array, targets: mx.array, axis: int = -1, reduction: str = "none"
+) -> mx.array:
+    """
+    Computes the Kullback-Leibler divergence loss.
+
+    Computes the following when ``reduction == 'none'``:
+
+    .. code-block:: python
+
+        mx.exp(targets) * (targets - inputs).sum(axis)
+
+    Args:
+        inputs (array): Log probabilities for the predicted distribution.
+        targets (array): Log probabilities for the target distribution.
+        axis (int, optional): The distribution axis. Default: ``-1``.
+        reduction (str, optional): Specifies the reduction to apply to the output:
+          ``'none'`` | ``'mean'`` | ``'sum'``. Default: ``'none'``.
+
+    Returns:
+        array: The computed Kullback-Leibler divergence loss.
+    """
+    loss = mx.sum(mx.exp(targets) * (targets - inputs), axis)
+
     return _reduce(loss, reduction)
 
 
@@ -108,6 +205,38 @@ def l1_loss(
             f"targets shape {targets.shape}."
         )
     loss = mx.abs(predictions - targets)
+
+    return _reduce(loss, reduction)
+
+
+def log_cosh_loss(
+    inputs: mx.array, targets: mx.array, reduction: str = "none"
+) -> mx.array:
+    r"""
+    Computes the log cosh loss between inputs and targets.
+
+    Logcosh acts like L2 loss for small errors, ensuring stable gradients,
+    and like the L1 loss for large errors, reducing sensitivity to outliers. This
+    dual behavior offers a balanced, robust approach for regression tasks.
+
+    .. math::
+
+       \text{logcosh}(y_{\text{true}}, y_{\text{pred}}) =
+            \frac{1}{n} \sum_{i=1}^{n}
+            \log(\cosh(y_{\text{pred}}^{(i)} - y_{\text{true}}^{(i)}))
+
+
+    Args:
+        inputs (array): The predicted values.
+        targets (array): The target values.
+        reduction (str, optional): Specifies the reduction to apply to the output:
+          ``'none'`` | ``'mean'`` | ``'sum'``. Default: ``'none'``.
+
+    Returns:
+        array: The computed log cosh loss.
+    """
+    errors = inputs - targets
+    loss = mx.logaddexp(errors, -errors) - math.log(2)
 
     return _reduce(loss, reduction)
 
@@ -154,33 +283,6 @@ def nll_loss(
         array: The computed NLL loss.
     """
     loss = -mx.take_along_axis(inputs, targets[..., None], axis).squeeze(-1)
-
-    return _reduce(loss, reduction)
-
-
-def kl_div_loss(
-    inputs: mx.array, targets: mx.array, axis: int = -1, reduction: str = "none"
-) -> mx.array:
-    """
-    Computes the Kullback-Leibler divergence loss.
-
-    Computes the following when ``reduction == 'none'``:
-
-    .. code-block:: python
-
-        mx.exp(targets) * (targets - inputs).sum(axis)
-
-    Args:
-        inputs (array): Log probabilities for the predicted distribution.
-        targets (array): Log probabilities for the target distribution.
-        axis (int, optional): The distribution axis. Default: ``-1``.
-        reduction (str, optional): Specifies the reduction to apply to the output:
-          ``'none'`` | ``'mean'`` | ``'sum'``. Default: ``'none'``.
-
-    Returns:
-        array: The computed Kullback-Leibler divergence loss.
-    """
-    loss = mx.sum(mx.exp(targets) * (targets - inputs), axis)
 
     return _reduce(loss, reduction)
 
@@ -269,106 +371,4 @@ def triplet_loss(
         + margin,
         0,
     )
-    return _reduce(loss, reduction)
-
-
-def _reduce(loss: mx.array, reduction: str = "none"):
-    if reduction == "mean":
-        return mx.mean(loss)
-    elif reduction == "sum":
-        return mx.sum(loss)
-    elif reduction == "none":
-        return loss
-    else:
-        raise ValueError("Invalid reduction. Must be 'none', 'mean', or 'sum'.")
-
-
-def hinge_loss(
-    inputs: mx.array, targets: mx.array, reduction: str = "none"
-) -> mx.array:
-    r"""
-    Computes the hinge loss between inputs and targets.
-
-    .. math::
-
-       \text{hinge}(y, y_{\text{pred}}) = \max(0, 1 - y \cdot y_{\text{pred}})
-
-
-    Args:
-        inputs (array): The predicted values.
-        targets (array): The target values. They should be -1 or 1.
-        reduction (str, optional): Specifies the reduction to apply to the output:
-          ``'none'`` | ``'mean'`` | ``'sum'``. Default: ``'none'``.
-
-    Returns:
-        array: The computed hinge loss.
-    """
-    loss = mx.maximum(1 - inputs * targets, 0)
-
-    return _reduce(loss, reduction)
-
-
-def huber_loss(
-    inputs: mx.array, targets: mx.array, delta: float = 1.0, reduction: str = "none"
-) -> mx.array:
-    r"""
-    Computes the Huber loss between inputs and targets.
-
-    .. math::
-
-        L_{\delta}(a) =
-        \left\{ \begin{array}{ll}
-            \frac{1}{2} a^2 & \text{for } |a| \leq \delta, \\
-            \delta \left( |a| - \frac{1}{2} \delta \right) & \text{otherwise.}
-        \end{array} \right.
-
-    Args:
-        inputs (array): The predicted values.
-        targets (array): The target values.
-        delta (float, optional): The threshold at which to change between L1 and L2 loss.
-          Default: ``1.0``.
-        reduction (str, optional): Specifies the reduction to apply to the output:
-          ``'none'`` | ``'mean'`` | ``'sum'``. Default: ``'none'``.
-
-    Returns:
-        array: The computed Huber loss.
-    """
-    errors = inputs - targets
-    abs_errors = mx.abs(errors)
-    quadratic = mx.minimum(abs_errors, delta)
-    linear = abs_errors - quadratic
-    loss = 0.5 * quadratic**2 + delta * linear
-
-    return _reduce(loss, reduction)
-
-
-def log_cosh_loss(
-    inputs: mx.array, targets: mx.array, reduction: str = "none"
-) -> mx.array:
-    r"""
-    Computes the log cosh loss between inputs and targets.
-
-    Logcosh acts like L2 loss for small errors, ensuring stable gradients,
-    and like the L1 loss for large errors, reducing sensitivity to outliers. This
-    dual behavior offers a balanced, robust approach for regression tasks.
-
-    .. math::
-
-       \text{logcosh}(y_{\text{true}}, y_{\text{pred}}) =
-            \frac{1}{n} \sum_{i=1}^{n}
-            \log(\cosh(y_{\text{pred}}^{(i)} - y_{\text{true}}^{(i)}))
-
-
-    Args:
-        inputs (array): The predicted values.
-        targets (array): The target values.
-        reduction (str, optional): Specifies the reduction to apply to the output:
-          ``'none'`` | ``'mean'`` | ``'sum'``. Default: ``'none'``.
-
-    Returns:
-        array: The computed log cosh loss.
-    """
-    errors = inputs - targets
-    loss = mx.logaddexp(errors, -errors) - math.log(2)
-
     return _reduce(loss, reduction)

--- a/python/mlx/optimizers.py
+++ b/python/mlx/optimizers.py
@@ -345,6 +345,62 @@ class Adam(Optimizer):
         return parameter - lr * m / (mx.sqrt(v) + eps)
 
 
+class Lion(Optimizer):
+    r"""Implementation of the Lion optimizer [1].
+
+    Since updates are computed through the sign operation, they tend to
+    have larger norm than for other optimizers such as SGD and Adam.
+    We recommend a learning rate that is 3-10x smaller than AdamW and a
+    weight decay 3-10x larger than AdamW to maintain the strength
+    (lr * wd). Our Lion implementation follows the original paper. In
+    detail,
+
+    [1]: Chen, X. Symbolic Discovery of Optimization Algorithms. arXiv
+    preprint arXiv:2302.06675.
+
+    .. math::
+
+        c_{t + 1} &= \beta_1 m_t + (1 - \beta_1) g_t
+        m_{t + 1} &= \beta_2 m_t + (1 - \beta_2) g_t
+        w_{t + 1} &= w_t - \eta (\text{sign}(c_t) + \lambda w_t)
+
+    Args:
+        learning_rate (float): The learning rate :math:`\eta`.
+        betas (Tuple[float, float], optional): The coefficients
+          :math:`(\beta_1, \beta_2)` used for computing the gradient
+          momentum and update direction. Default: ``(0.9, 0.99)``
+        weight_decay (float, optional): The weight decay :math:`\lambda`. Default: ``0.0``
+    """
+
+    def __init__(
+        self,
+        learning_rate: float,
+        betas: List[float] = [0.9, 0.99],
+        weight_decay: float = 0.0,
+    ):
+        super().__init__()
+
+        self.learning_rate = learning_rate
+        self.betas = betas
+        self.weight_decay = weight_decay
+
+    def apply_single(
+        self, gradient: mx.array, parameter: mx.array, state: OptimizerState
+    ):
+        """Performs the Lion parameter update and stores :math:`m`
+        in the optimizer state."""
+        lr = self.learning_rate
+        b1, b2 = self.betas
+        weight_decay = self.weight_decay
+
+        m = state.get("m", gradient)
+        c = b1 * m + (1 - b1) * gradient
+        state["m"] = b2 * m + (1 - b2) * gradient
+        if weight_decay > 0:
+            parameter = (1 - lr * weight_decay) * parameter
+        return parameter - lr * mx.sign(c)
+
+
 class AdamW(Adam):
     r"""Implementation of the AdamW optimizer [1].
 
@@ -442,59 +498,3 @@ class Adamax(Adam):
         state["v"] = v
 
         return parameter - lr * m / (v + eps)
-
-
-class Lion(Optimizer):
-    r"""Implementation of the Lion optimizer [1].
-
-    Since updates are computed through the sign operation, they tend to
-    have larger norm than for other optimizers such as SGD and Adam.
-    We recommend a learning rate that is 3-10x smaller than AdamW and a
-    weight decay 3-10x larger than AdamW to maintain the strength
-    (lr * wd). Our Lion implementation follows the original paper. In
-    detail,
-
-    [1]: Chen, X. Symbolic Discovery of Optimization Algorithms. arXiv
-    preprint arXiv:2302.06675.
-
-    .. math::
-
-        c_{t + 1} &= \beta_1 m_t + (1 - \beta_1) g_t
-        m_{t + 1} &= \beta_2 m_t + (1 - \beta_2) g_t
-        w_{t + 1} &= w_t - \eta (\text{sign}(c_t) + \lambda w_t)
-
-    Args:
-        learning_rate (float): The learning rate :math:`\eta`.
-        betas (Tuple[float, float], optional): The coefficients
-          :math:`(\beta_1, \beta_2)` used for computing the gradient
-          momentum and update direction. Default: ``(0.9, 0.99)``
-        weight_decay (float, optional): The weight decay :math:`\lambda`. Default: ``0.0``
-    """
-
-    def __init__(
-        self,
-        learning_rate: float,
-        betas: List[float] = [0.9, 0.99],
-        weight_decay: float = 0.0,
-    ):
-        super().__init__()
-
-        self.learning_rate = learning_rate
-        self.betas = betas
-        self.weight_decay = weight_decay
-
-    def apply_single(
-        self, gradient: mx.array, parameter: mx.array, state: OptimizerState
-    ):
-        """Performs the Lion parameter update and stores :math:`m`
-        in the optimizer state."""
-        lr = self.learning_rate
-        b1, b2 = self.betas
-        weight_decay = self.weight_decay
-
-        m = state.get("m", gradient)
-        c = b1 * m + (1 - b1) * gradient
-        state["m"] = b2 * m + (1 - b2) * gradient
-        if weight_decay > 0:
-            parameter = (1 - lr * weight_decay) * parameter
-        return parameter - lr * mx.sign(c)

--- a/python/mlx/utils.py
+++ b/python/mlx/utils.py
@@ -3,6 +3,50 @@
 from collections import defaultdict
 
 
+def tree_flatten(tree, prefix="", is_leaf=None):
+    """Flattens a python tree to a list of key, value tuples.
+
+    The keys are using the dot notation to define trees of arbitrary depth and
+    complexity.
+
+    .. code-block:: python
+
+        from mlx.utils import tree_flatten
+
+        print(tree_flatten([[[0]]]))
+        # [("0.0.0", 0)]
+
+        print(tree_flatten([[[0]]], ".hello"))
+        # [("hello.0.0.0", 0)]
+
+    .. note::
+       Dictionaries should have keys that are valid python identifiers.
+
+    Args:
+        tree (Any): The python tree to be flattened.
+        prefix (str): A prefix to use for the keys. The first character is
+            always discarded.
+        is_leaf (Callable): An optional callable that returns True if the
+            passed object is considered a leaf or False otherwise.
+
+    Returns:
+        List[Tuple[str, Any]]: The flat representation of the python tree.
+    """
+    flat_tree = []
+
+    if is_leaf is None or not is_leaf(tree):
+        if isinstance(tree, (list, tuple)):
+            for i, t in enumerate(tree):
+                flat_tree.extend(tree_flatten(t, f"{prefix}.{i}", is_leaf))
+            return flat_tree
+        if isinstance(tree, dict):
+            for k, t in tree.items():
+                flat_tree.extend(tree_flatten(t, f"{prefix}.{k}", is_leaf))
+            return flat_tree
+
+    return [(prefix[1:], tree)]
+
+
 def tree_map(fn, tree, *rest, is_leaf=None):
     """Applies ``fn`` to the leaves of the python tree ``tree`` and
     returns a new collection with the results.
@@ -52,50 +96,6 @@ def tree_map(fn, tree, *rest, is_leaf=None):
         }
     else:
         return fn(tree, *rest)
-
-
-def tree_flatten(tree, prefix="", is_leaf=None):
-    """Flattens a python tree to a list of key, value tuples.
-
-    The keys are using the dot notation to define trees of arbitrary depth and
-    complexity.
-
-    .. code-block:: python
-
-        from mlx.utils import tree_flatten
-
-        print(tree_flatten([[[0]]]))
-        # [("0.0.0", 0)]
-
-        print(tree_flatten([[[0]]], ".hello"))
-        # [("hello.0.0.0", 0)]
-
-    .. note::
-       Dictionaries should have keys that are valid python identifiers.
-
-    Args:
-        tree (Any): The python tree to be flattened.
-        prefix (str): A prefix to use for the keys. The first character is
-            always discarded.
-        is_leaf (Callable): An optional callable that returns True if the
-            passed object is considered a leaf or False otherwise.
-
-    Returns:
-        List[Tuple[str, Any]]: The flat representation of the python tree.
-    """
-    flat_tree = []
-
-    if is_leaf is None or not is_leaf(tree):
-        if isinstance(tree, (list, tuple)):
-            for i, t in enumerate(tree):
-                flat_tree.extend(tree_flatten(t, f"{prefix}.{i}", is_leaf))
-            return flat_tree
-        if isinstance(tree, dict):
-            for k, t in tree.items():
-                flat_tree.extend(tree_flatten(t, f"{prefix}.{k}", is_leaf))
-            return flat_tree
-
-    return [(prefix[1:], tree)]
 
 
 def tree_unflatten(tree):

--- a/python/tests/test_bf16.py
+++ b/python/tests/test_bf16.py
@@ -122,7 +122,6 @@ class TestBF16(mlx_tests.MLXTestCase):
 
         for op in ("min", "max"):
             with self.subTest(op=op):
-
                 for axes in (0, 1, 2, (0, 1), (0, 2), (1, 2), (0, 1, 2)):
                     with self.subTest(axes=axes):
                         np_args = (x.astype(np.float32),)

--- a/python/tests/test_blas.py
+++ b/python/tests/test_blas.py
@@ -80,7 +80,6 @@ class TestBlas(mlx_tests.MLXTestCase):
             np_dtype = getattr(np, dtype)
 
             for B, M, N, K in shapes:
-
                 with self.subTest(tranpose="nn"):
                     shape_a = (B, M, K)
                     shape_b = (B, K, N)
@@ -151,7 +150,6 @@ class TestBlas(mlx_tests.MLXTestCase):
         self.assertTrue(np.allclose(d_mlx, d_npy, atol=1e-6))
 
     def test_matmul_dtypes(self):
-
         for dt in self.dtypes:
             a_npy = np.random.normal(0.0, 1.0 / 256, (16, 16, 16)).astype(
                 getattr(np, dt)

--- a/python/tests/test_load.py
+++ b/python/tests/test_load.py
@@ -34,7 +34,6 @@ class TestLoad(mlx_tests.MLXTestCase):
         cls.test_dir_fid.cleanup()
 
     def test_save_and_load(self):
-
         if not os.path.isdir(self.test_dir):
             os.mkdir(self.test_dir)
 
@@ -92,7 +91,6 @@ class TestLoad(mlx_tests.MLXTestCase):
                         )
 
     def test_save_and_load_fs(self):
-
         if not os.path.isdir(self.test_dir):
             os.mkdir(self.test_dir)
 
@@ -165,7 +163,6 @@ class TestLoad(mlx_tests.MLXTestCase):
                     (save_file_npy_uncomp, save_file_mlx_uncomp),
                     (save_file_npy_comp, save_file_mlx_comp),
                 ):
-
                     # Load array saved by mlx as mlx array
                     load_arr_mlx_mlx = mx.load(save_file_mlx)
                     for k, v in load_arr_mlx_mlx.items():

--- a/python/tests/test_optimizers.py
+++ b/python/tests/test_optimizers.py
@@ -9,18 +9,6 @@ import mlx.utils
 import mlx_tests
 
 
-def get_all_optimizers():
-    classes = dict()
-    for name, obj in inspect.getmembers(opt):
-        if inspect.isclass(obj):
-            if obj.__name__ not in ["OptimizerState", "Optimizer"]:
-                classes[name] = obj
-    return classes
-
-
-optimizers_dict = get_all_optimizers()
-
-
 class TestOptimizers(mlx_tests.MLXTestCase):
     def test_optimizers(self):
         params = {
@@ -38,6 +26,18 @@ class TestOptimizers(mlx_tests.MLXTestCase):
             )
             all_equal = all(v for _, v in mlx.utils.tree_flatten(equal_shape))
             self.assertTrue(all_equal)
+
+
+def get_all_optimizers():
+    classes = dict()
+    for name, obj in inspect.getmembers(opt):
+        if inspect.isclass(obj):
+            if obj.__name__ not in ["OptimizerState", "Optimizer"]:
+                classes[name] = obj
+    return classes
+
+
+optimizers_dict = get_all_optimizers()
 
 
 if __name__ == "__main__":

--- a/python/tests/test_reduce.py
+++ b/python/tests/test_reduce.py
@@ -65,7 +65,6 @@ class TestReduce(mlx_tests.MLXTestCase):
 
                 for op in ("sum", "prod", "min", "max"):
                     with self.subTest(op=op):
-
                         np_op = getattr(np, op)
                         mlx_op = getattr(mx, op)
 
@@ -96,7 +95,6 @@ class TestReduce(mlx_tests.MLXTestCase):
         ]
         for dtype in dtypes:
             with self.subTest(dtype=dtype):
-
                 data = np.random.rand(10, 12, 13).astype(getattr(np, dtype))
                 x = mx.array(data)
                 for op in ["argmin", "argmax"]:

--- a/setup.py
+++ b/setup.py
@@ -13,26 +13,6 @@ from setuptools import Command, Extension, find_namespace_packages, setup
 from setuptools.command.build_ext import build_ext
 
 
-def get_version(version):
-    if "PYPI_RELEASE" not in os.environ:
-        today = datetime.date.today()
-        version = f"{version}.dev{today.year}{today.month}{today.day}"
-
-        if "DEV_RELEASE" not in os.environ:
-            git_hash = (
-                run(
-                    "git rev-parse --short HEAD".split(),
-                    capture_output=True,
-                    check=True,
-                )
-                .stdout.strip()
-                .decode()
-            )
-            version = f"{version}+{git_hash}"
-
-    return version
-
-
 # A CMakeExtension needs a sourcedir instead of a file list.
 # The name must be the _single_ output extension from the CMake build.
 # If you need multiple extensions, see scikit-build.
@@ -148,6 +128,26 @@ class GenerateStubs(Command):
             ]
         )
         subprocess.run(["rm", "python/mlx/core/__init__.pyi''"])
+
+
+def get_version(version):
+    if "PYPI_RELEASE" not in os.environ:
+        today = datetime.date.today()
+        version = f"{version}.dev{today.year}{today.month}{today.day}"
+
+        if "DEV_RELEASE" not in os.environ:
+            git_hash = (
+                run(
+                    "git rev-parse --short HEAD".split(),
+                    capture_output=True,
+                    check=True,
+                )
+                .stdout.strip()
+                .decode()
+            )
+            version = f"{version}+{git_hash}"
+
+    return version
 
 
 # Read the content of README.md


### PR DESCRIPTION
## Proposed changes

I have sorted all the Python functions and classes alphabetically/logically for better readability. I am developing a pre-commit hook that will automatically arrange function/classes. This is the repo link https://github.com/NripeshN/fsort. I have not included it in the `pre-commit.yaml` file yet cause it is still a little broken and I still have to make some manual changes before this PR. 

## Checklist

Put an `x` in the boxes that apply.

- [ ] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
