### PR TITLE
Move the matmul type check in the op

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -1948,11 +1948,11 @@ array matmul(
   }
   // Type promotion
   auto out_type = promote_types(a.dtype(), b.dtype());
-  if (!is_floating_point(out_type)) {
+  if (!is_floating_point(out_type) || is_complex(out_type)) {
     std::ostringstream msg;
-    msg << "[matmul] Only floating point types are supported but " << a.dtype()
-        << " and " << b.dtype() << " were provided which results"
-        << " in " << out_type << ", which is not a floating point type.";
+    msg << "[matmul] Only real floating point types are supported but "
+        << a.dtype() << " and " << b.dtype() << " were provided which results"
+        << " in " << out_type << ", which is not a real floating point type.";
     throw std::invalid_argument(msg.str());
   }
   if (a.dtype() != out_type) {

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -1948,6 +1948,13 @@ array matmul(
   }
   // Type promotion
   auto out_type = promote_types(a.dtype(), b.dtype());
+  if (!is_floating_point(out_type)) {
+    std::ostringstream msg;
+    msg << "[matmul] Only floating point types are supported but " << a.dtype()
+        << " and " << b.dtype() << " were provided which results"
+        << " in " << out_type << ", which is not a floating point type.";
+    throw std::invalid_argument(msg.str());
+  }
   if (a.dtype() != out_type) {
     a = astype(a, out_type, s);
   }


### PR DESCRIPTION
Pointed out by #376. Matmul is not checking that the `out_dtype` is a floating point type and fails hard during eval rather than softly during graph creation.