### PR TITLE
Fix saving for non-contiguous arrays

### DIFF
--- a/mlx/io/load.cpp
+++ b/mlx/io/load.cpp
@@ -50,9 +50,14 @@ void save(std::shared_ptr<io::Writer> out_stream, array a, bool retain_graph) {
     throw std::invalid_argument("[save] cannot serialize an empty array");
   }
 
-  if (!a.flags().contiguous) {
+  if (!(a.flags().row_contiguous || a.flags().col_contiguous)) {
+    a = reshape(flatten(a), a.shape());
+    a.eval(retain_graph);
+  }
+  // Check once more in-case the above ops change
+  if (!(a.flags().row_contiguous || a.flags().col_contiguous)) {
     throw std::invalid_argument(
-        "[save] cannot serialize a non-contiguous array");
+        "[save] can only serialize row or col contiguous arrays");
   }
 
   ////////////////////////////////////////////////////////

--- a/python/tests/test_load.py
+++ b/python/tests/test_load.py
@@ -178,6 +178,29 @@ class TestLoad(mlx_tests.MLXTestCase):
                     for k, v in load_arr_mlx_npy.items():
                         self.assertTrue(np.array_equal(save_arrs_npy[k], v))
 
+    def test_non_contiguous(self):
+        if not os.path.isdir(self.test_dir):
+            os.mkdir(self.test_dir)
+
+        a = mx.broadcast_to(mx.array([1, 2]), [4, 2])
+
+        save_file = os.path.join(self.test_dir, "a.npy")
+        mx.save(save_file, a)
+        aload = mx.load(save_file)
+        self.assertTrue(mx.array_equal(a, aload))
+
+        save_file = os.path.join(self.test_dir, "a.safetensors")
+        mx.save_safetensors(save_file, {"a": a})
+        aload = mx.load(save_file)["a"]
+        self.assertTrue(mx.array_equal(a, aload))
+
+        # safetensors only works with row contiguous
+        # make sure col contiguous is handled properly
+        a = mx.arange(4).reshape(2, 2).T
+        mx.save_safetensors(save_file, {"a": a})
+        aload = mx.load(save_file)["a"]
+        self.assertTrue(mx.array_equal(a, aload))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Proposed changes

- Put arrays in row-major if they are not row or col contiguous before we save them for numpy
- Put arrays in row-major if they are not row contiguous before we save them for safetensors (which only supports row-major)
- Adds tests for these cases

Closes #369 