### PR TITLE
Update cpp tests for numerical tolerance

### DIFF
--- a/tests/autograd_tests.cpp
+++ b/tests/autograd_tests.cpp
@@ -238,11 +238,11 @@ TEST_CASE("test grad") {
     auto x = array(1.);
     auto expfn = [](array input) { return exp(input); };
     auto dfdx = grad(expfn);
-    CHECK_EQ(dfdx(x).item<float>(), std::exp(1.0f));
+    CHECK_EQ(dfdx(x).item<float>(), doctest::Approx(std::exp(1.0f)));
     auto d2fdx2 = grad(grad(expfn));
-    CHECK_EQ(d2fdx2(x).item<float>(), std::exp(1.0f));
+    CHECK_EQ(d2fdx2(x).item<float>(), doctest::Approx(std::exp(1.0f)));
     auto d3fdx3 = grad(grad(grad(expfn)));
-    CHECK_EQ(d3fdx3(x).item<float>(), std::exp(1.0f));
+    CHECK_EQ(d3fdx3(x).item<float>(), doctest::Approx(std::exp(1.0f)));
   }
 
   {
@@ -393,7 +393,7 @@ TEST_CASE("test op vjps") {
   // Test exp
   {
     auto out = vjp([](array in) { return exp(in); }, array(1.0f), array(2.0f));
-    CHECK_EQ(out.second.item<float>(), 2.0f * std::exp(1.0f));
+    CHECK_EQ(out.second.item<float>(), doctest::Approx(2.0f * std::exp(1.0f)));
   }
 
   // Test sin

--- a/tests/ops_tests.cpp
+++ b/tests/ops_tests.cpp
@@ -929,7 +929,7 @@ TEST_CASE("test arithmetic unary ops") {
 
     // Input is irregularly strided
     x = broadcast_to(array(1.0f), {2, 2, 2});
-    CHECK(array_equal(exp(x), full({2, 2, 2}, std::exp(1.0f))).item<bool>());
+    CHECK(allclose(exp(x), full({2, 2, 2}, std::exp(1.0f))).item<bool>());
 
     x = split(array({0.0f, 1.0f, 2.0f, 3.0f}, {2, 2}), 2, 1)[0];
     auto expected = array({std::exp(0.0f), std::exp(2.0f)}, {2, 1});
@@ -2016,7 +2016,7 @@ TEST_CASE("test power") {
   CHECK_EQ((array(false) ^ array(true)).item<bool>(), false);
 
   auto x = array(2.0f);
-  CHECK_EQ((x ^ 0.5).item<float>(), std::pow(2.0f, 0.5f));
+  CHECK_EQ((x ^ 0.5).item<float>(), doctest::Approx(std::pow(2.0f, 0.5f)));
   CHECK_EQ((x ^ 2.0f).item<float>(), 4.0f);
 
   CHECK(std::isnan((array(-1.0f) ^ 0.5).item<float>()));


### PR DESCRIPTION
## Proposed changes

Update cpp test that use `std::exp` or `std::pow` that were throwing errors due to numerical tolerance. (Found when exploring issue #396 )

## Checklist

Put an `x` in the boxes that apply.

- [`x`] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [`x`] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [`x`] I have added tests that prove my fix is effective or that my feature works
- [`x`] I have updated the necessary documentation (if needed)
