### PR TITLE
Fix data_types.rst uint64 documentation

### DIFF
--- a/docs/src/python/data_types.rst
+++ b/docs/src/python/data_types.rst
@@ -29,9 +29,9 @@ The default floating point type is ``float32`` and the default integer type is
    * - ``uint32``
      - 4 
      - 32-bit unsigned integer 
-   * - ``uint32``
+   * - ``uint64``
      - 8 
-     - 32-bit unsigned integer 
+     - 64-bit unsigned integer 
    * - ``int8``
      - 1 
      - 8-bit signed integer 


### PR DESCRIPTION
uint64 correctly says 8 bytes, but the description is copy pasta from uint32.

## Proposed changes

Please include a description of the problem or feature this PR is addressing. If there is a corresponding issue, include the issue #.

## Checklist

Put an `x` in the boxes that apply.

- [X] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [NA - documentation update] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [NA - documentation update] I have added tests that prove my fix is effective or that my feature works
- [NA - documentation update] I have updated the necessary documentation (if needed)
