### PR TITLE
Add type hint for Module

### DIFF
--- a/python/mlx/nn/layers/base.py
+++ b/python/mlx/nn/layers/base.py
@@ -54,6 +54,8 @@ class Module(dict):
         mx.eval(model.parameters())
     """
 
+    __call__: Callable
+
     def __init__(self):
         """Should be called by the subclasses of ``Module``."""
         self._no_grad = set()


### PR DESCRIPTION
## Proposed changes

For some of the activations, we define them using a decorator of a class. Like ReLU:

```python
@_make_activation_module(relu)
class ReLU(Module):
    r"""Applies the Rectified Linear Unit.
        Simply ``mx.maximum(x, 0)``.

    See :func:`relu`, for the functional equivalent.
    """
```

When we use `ReLU`:

```python
import mlx.core as mx
from mlx import nn
a = mx.array(-1)
b = nn.ReLU()(a)
print(b)
```
pyright will report a warning complaining that it is not callable.

This PR adds a hint on the module.

## Reference

- https://peps.python.org/pep-0526/#class-and-instance-variable-annotations

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
