### PR TITLE
GGUF: Avoid dequantization when format is compatible 

### DIFF
--- a/mlx/io/CMakeLists.txt
+++ b/mlx/io/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(
   ${CMAKE_CURRENT_SOURCE_DIR}/load.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/safetensor.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/gguf.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/gguf_quants.cpp
 )
 
 MESSAGE(STATUS "Downloading json")

--- a/mlx/io/gguf.cpp
+++ b/mlx/io/gguf.cpp
@@ -240,7 +240,7 @@ void extract_q4_1_data(
     // 16 weights in lower bits
     for (int64_t j = 0; j < 16; ++j) {
       uint8_t x = (block_data[j + 4] & 0x0F);
-      if (j % 2 == 0) {
+      if (j % 2 != 0) {
         x <<= 4;
       }
       weigths[i * 16 + j / 2] += x;
@@ -248,7 +248,7 @@ void extract_q4_1_data(
     // 16 weights in higher bits
     for (int64_t j = 0; j < 16; ++j) {
       uint8_t x = (block_data[j + 4] >> 4);
-      if (j % 2 == 0) {
+      if (j % 2 != 0) {
         x <<= 4;
       }
       weigths[i * 16 + 8 + j / 2] += x;

--- a/mlx/io/gguf.cpp
+++ b/mlx/io/gguf.cpp
@@ -205,6 +205,16 @@ std::unordered_map<std::string, MetaData> load_metadata(gguf_ctx* ctx) {
 std::unordered_map<std::string, array> load_arrays(gguf_ctx* ctx) {
   std::unordered_map<std::string, array> array_map;
   gguf_tensor tensor;
+
+  auto check_insert = [](auto inserted) {
+    if (!inserted.second) {
+      std::ostringstream msg;
+      msg << "[load_gguf] Duplicate parameter name " << inserted.first->second
+          << " this can happend when loading quantized tensors.";
+      throw std::runtime_error(msg.str());
+    }
+  };
+
   while (gguf_get_tensor(ctx, &tensor)) {
     if (tensor.type == GGUF_TYPE_Q4_0 || tensor.type == GGUF_TYPE_Q4_1 ||
         tensor.type == GGUF_TYPE_Q8_0) {

--- a/mlx/io/gguf.cpp
+++ b/mlx/io/gguf.cpp
@@ -241,7 +241,8 @@ void extract_q4_1_data(
     biases[i] = *((float16_t*)block_data + 1);
     // First 16 weights are in the lower bits
     for (int64_t j = 0; j < 16; ++j) {
-      uint8_t x = (block_data[j + 4] & 0x0F);  // j+4 to skip scale and biases bytes.
+      uint8_t x =
+          (block_data[j + 4] & 0x0F); // j+4 to skip scale and biases bytes.
       if (j % 2 != 0) {
         x <<= 4;
       }
@@ -279,6 +280,75 @@ void extract_q4_1_data(
 
 std::unordered_map<std::string, array> load_arrays(gguf_ctx* ctx) {
   std::unordered_map<std::string, array> array_map;
+=======
+// Extracts (weight, scales, biases) from Q8_0 tensors.
+// Data layout is: |16 bit scale|32 x 8bit weights|.
+void extract_q8_0_data(
+    std::unordered_map<std::string, array>* a,
+    const gguf_tensor& tensor) {
+  std::string name = std::string(tensor.name, tensor.namelen);
+  const std::vector<int> shape = get_shape(tensor);
+  const uint64_t weights_per_byte = 1;
+  const uint64_t weights_per_block = 32;
+  if (shape[shape.size() - 1] % weights_per_block != 0) {
+    std::ostringstream msg;
+    msg << "[load_gguf] tensor " << name
+        << "has incompatible last dim shape: " << shape[shape.size() - 1];
+    throw std::runtime_error(msg.str());
+  }
+  const uint64_t bytes_per_block = 34; // 2 bytes scale, 32x1 byte weights
+  const uint64_t num_blocks = tensor.num_weights / weights_per_block;
+  allocator::Buffer weights_buffer =
+      allocator::malloc(tensor.num_weights / weights_per_byte);
+  allocator::Buffer scales_buffer = allocator::malloc(num_blocks * 2);
+  allocator::Buffer biases_buffer = allocator::malloc(num_blocks * 2);
+  auto data = (uint8_t*)tensor.weights_data;
+  auto weigths = (int8_t*)weights_buffer.raw_ptr();
+  auto scales = (float16_t*)scales_buffer.raw_ptr();
+  auto biases = (float16_t*)biases_buffer.raw_ptr();
+  for (int64_t i = 0; i < num_blocks; i++) {
+    uint8_t* block_data = data + i * bytes_per_block;
+    scales[i] = *((float16_t*)block_data);
+    biases[i] = -128 * scales[i];
+    for (int64_t j = 0; j < weights_per_block; ++j) {
+      uint8_t x = block_data[j + 2]; // j+2 to skip the scale bytes.
+      // Original data is in int8_t, so we add a bias of -128 and invert the
+      // first bit.
+      x ^= 1 << 7;
+      weigths[i * weights_per_block + j] = x;
+    }
+  }
+  std::vector<int> weights_shape = shape;
+  weights_shape[shape.size() - 1] =
+      weights_shape[shape.size() - 1] / weights_per_byte / 4;
+  a->insert({name, array(weights_buffer, weights_shape, uint32)});
+
+  const std::string weight_suffix = ".weight";
+  const std::string name_prefix =
+      name.substr(0, name.length() - weight_suffix.length());
+  std::vector<int> scale_bias_shape = shape;
+  scale_bias_shape[shape.size() - 1] =
+      scale_bias_shape[shape.size() - 1] / weights_per_block;
+
+  const std::string scales_name =
+      (std::ostringstream() << name_prefix << ".scales").str();
+  a->insert({scales_name, array(scales_buffer, scale_bias_shape, float16)});
+
+  const std::string biases_name =
+      (std::ostringstream() << name_prefix << ".biases").str();
+  a->insert({biases_name, array(biases_buffer, scale_bias_shape, float16)});
+}
+
+std::unordered_map<std::string, array> load_gguf(
+    const std::string& file,
+    StreamOrDevice s) {
+  std::unordered_map<std::string, array> result;
+  gguf_ctx* ctx = gguf_open(file.c_str());
+  if (!ctx) {
+    throw std::runtime_error("[load_gguf] gguf_init failed");
+  }
+  gguf_skip_key_values_section(ctx);
+>>>>>>> ffa86a8 (Don't dequantize q8_0)
   gguf_tensor tensor;
   while (gguf_get_tensor(ctx, &tensor)) {
     std::string name = std::string(tensor.name, tensor.namelen);
@@ -291,6 +361,8 @@ std::unordered_map<std::string, array> load_arrays(gguf_ctx* ctx) {
       extract_q4_0_data(&result, tensor);
     } else if (ends_with_weight && tensor.type == GGUF_TYPE_Q4_1) {
       extract_q4_1_data(&result, tensor);
+    } else if (ends_with_weight && tensor.type == GGUF_TYPE_Q8_0) {
+      extract_q8_0_data(&result, tensor);
     } else {
       const auto& [data, dtype] = extract_tensor_data(&tensor);
       array loaded_array = array(data, get_shape(tensor), dtype);

--- a/mlx/io/gguf.cpp
+++ b/mlx/io/gguf.cpp
@@ -1,17 +1,10 @@
-// Copyright © 2023 Apple Inc.
+// Copyright © 2023-2024 Apple Inc.
 
 #include <cstdint>
 #include <cstring>
 #include <numeric>
 
-#include "mlx/io.h"
-#include "mlx/primitives.h"
-#include "mlx/transforms.h"
-#include "mlx/utils.h"
-
-extern "C" {
-#include <gguflib.h>
-}
+#include <mlx/io/gguf.h>
 
 namespace mlx::core {
 
@@ -209,146 +202,8 @@ std::unordered_map<std::string, MetaData> load_metadata(gguf_ctx* ctx) {
   return metadata;
 }
 
-// Extracts (weight, scales, biases) from Q4_1 tensors.
-// Data layout is: |16 bit scale|32 x 4bit weights|.
-void extract_q4_1_data(
-    std::unordered_map<std::string, array>* a,
-    const gguf_tensor& tensor) {
-  std::string name = std::string(tensor.name, tensor.namelen);
-  const std::vector<int> shape = get_shape(tensor);
-  const uint64_t weights_per_byte = 2;
-  const uint64_t weights_per_block = 32;
-  if (shape[shape.size() - 1] % weights_per_block != 0) {
-    std::ostringstream msg;
-    msg << "[load_gguf] tensor " << name
-        << "has incompatible last dim shape: " << shape[shape.size() - 1];
-    throw std::runtime_error(msg.str());
-  }
-  const uint64_t bytes_per_block =
-      20; // 2 bytes scale, 2 bytes bias, 32x0.5 byte weights
-  const uint64_t num_blocks = tensor.num_weights / weights_per_block;
-  allocator::Buffer weights_buffer =
-      allocator::malloc(tensor.num_weights / weights_per_byte);
-  allocator::Buffer scales_buffer = allocator::malloc(num_blocks * 2);
-  allocator::Buffer biases_buffer = allocator::malloc(num_blocks * 2);
-  auto data = (uint8_t*)tensor.weights_data;
-  auto weigths = (uint8_t*)weights_buffer.raw_ptr();
-  auto scales = (float16_t*)scales_buffer.raw_ptr();
-  auto biases = (float16_t*)biases_buffer.raw_ptr();
-  for (int64_t i = 0; i < num_blocks; i++) {
-    uint8_t* block_data = data + i * bytes_per_block;
-    scales[i] = *((float16_t*)block_data);
-    biases[i] = *((float16_t*)block_data + 1);
-    // First 16 weights are in the lower bits
-    for (int64_t j = 0; j < 16; ++j) {
-      uint8_t x =
-          (block_data[j + 4] & 0x0F); // j+4 to skip scale and biases bytes.
-      if (j % 2 != 0) {
-        x <<= 4;
-      }
-      weigths[i * 16 + j / 2] += x;
-    }
-    // Last 16 weights are in the higher bits
-    for (int64_t j = 0; j < 16; ++j) {
-      uint8_t x = (block_data[j + 4] >> 4);
-      if (j % 2 != 0) {
-        x <<= 4;
-      }
-      weigths[i * 16 + 8 + j / 2] += x;
-    }
-  }
-  std::vector<int> weights_shape = shape;
-  weights_shape[shape.size() - 1] =
-      weights_shape[shape.size() - 1] / weights_per_byte / 4;
-  a->insert({name, array(weights_buffer, weights_shape, uint32)});
-
-  const std::string weight_suffix = ".weight";
-  const std::string name_prefix =
-      name.substr(0, name.length() - weight_suffix.length());
-  std::vector<int> scale_bias_shape = shape;
-  scale_bias_shape[shape.size() - 1] =
-      scale_bias_shape[shape.size() - 1] / weights_per_block;
-
-  const std::string scales_name =
-      (std::ostringstream() << name_prefix << ".scales").str();
-  a->insert({scales_name, array(scales_buffer, scale_bias_shape, float16)});
-
-  const std::string biases_name =
-      (std::ostringstream() << name_prefix << ".biases").str();
-  a->insert({biases_name, array(biases_buffer, scale_bias_shape, float16)});
-}
-
 std::unordered_map<std::string, array> load_arrays(gguf_ctx* ctx) {
   std::unordered_map<std::string, array> array_map;
-=======
-// Extracts (weight, scales, biases) from Q8_0 tensors.
-// Data layout is: |16 bit scale|32 x 8bit weights|.
-void extract_q8_0_data(
-    std::unordered_map<std::string, array>* a,
-    const gguf_tensor& tensor) {
-  std::string name = std::string(tensor.name, tensor.namelen);
-  const std::vector<int> shape = get_shape(tensor);
-  const uint64_t weights_per_byte = 1;
-  const uint64_t weights_per_block = 32;
-  if (shape[shape.size() - 1] % weights_per_block != 0) {
-    std::ostringstream msg;
-    msg << "[load_gguf] tensor " << name
-        << "has incompatible last dim shape: " << shape[shape.size() - 1];
-    throw std::runtime_error(msg.str());
-  }
-  const uint64_t bytes_per_block = 34; // 2 bytes scale, 32x1 byte weights
-  const uint64_t num_blocks = tensor.num_weights / weights_per_block;
-  allocator::Buffer weights_buffer =
-      allocator::malloc(tensor.num_weights / weights_per_byte);
-  allocator::Buffer scales_buffer = allocator::malloc(num_blocks * 2);
-  allocator::Buffer biases_buffer = allocator::malloc(num_blocks * 2);
-  auto data = (uint8_t*)tensor.weights_data;
-  auto weigths = (int8_t*)weights_buffer.raw_ptr();
-  auto scales = (float16_t*)scales_buffer.raw_ptr();
-  auto biases = (float16_t*)biases_buffer.raw_ptr();
-  for (int64_t i = 0; i < num_blocks; i++) {
-    uint8_t* block_data = data + i * bytes_per_block;
-    scales[i] = *((float16_t*)block_data);
-    biases[i] = -128 * scales[i];
-    for (int64_t j = 0; j < weights_per_block; ++j) {
-      uint8_t x = block_data[j + 2]; // j+2 to skip the scale bytes.
-      // Original data is in int8_t, so we add a bias of -128 and invert the
-      // first bit.
-      x ^= 1 << 7;
-      weigths[i * weights_per_block + j] = x;
-    }
-  }
-  std::vector<int> weights_shape = shape;
-  weights_shape[shape.size() - 1] =
-      weights_shape[shape.size() - 1] / weights_per_byte / 4;
-  a->insert({name, array(weights_buffer, weights_shape, uint32)});
-
-  const std::string weight_suffix = ".weight";
-  const std::string name_prefix =
-      name.substr(0, name.length() - weight_suffix.length());
-  std::vector<int> scale_bias_shape = shape;
-  scale_bias_shape[shape.size() - 1] =
-      scale_bias_shape[shape.size() - 1] / weights_per_block;
-
-  const std::string scales_name =
-      (std::ostringstream() << name_prefix << ".scales").str();
-  a->insert({scales_name, array(scales_buffer, scale_bias_shape, float16)});
-
-  const std::string biases_name =
-      (std::ostringstream() << name_prefix << ".biases").str();
-  a->insert({biases_name, array(biases_buffer, scale_bias_shape, float16)});
-}
-
-std::unordered_map<std::string, array> load_gguf(
-    const std::string& file,
-    StreamOrDevice s) {
-  std::unordered_map<std::string, array> result;
-  gguf_ctx* ctx = gguf_open(file.c_str());
-  if (!ctx) {
-    throw std::runtime_error("[load_gguf] gguf_init failed");
-  }
-  gguf_skip_key_values_section(ctx);
->>>>>>> ffa86a8 (Don't dequantize q8_0)
   gguf_tensor tensor;
   while (gguf_get_tensor(ctx, &tensor)) {
     std::string name = std::string(tensor.name, tensor.namelen);
@@ -358,15 +213,15 @@ std::unordered_map<std::string, array> load_gguf(
         (name.compare(name.length() - weight_len, weight_len, weight_suffix) ==
          0);
     if (ends_with_weight && tensor.type == GGUF_TYPE_Q4_0) {
-      extract_q4_0_data(&result, tensor);
+      extract_q4_0_data(&array_map, tensor);
     } else if (ends_with_weight && tensor.type == GGUF_TYPE_Q4_1) {
-      extract_q4_1_data(&result, tensor);
+      extract_q4_1_data(&array_map, tensor);
     } else if (ends_with_weight && tensor.type == GGUF_TYPE_Q8_0) {
-      extract_q8_0_data(&result, tensor);
+      extract_q8_0_data(&array_map, tensor);
     } else {
       const auto& [data, dtype] = extract_tensor_data(&tensor);
       array loaded_array = array(data, get_shape(tensor), dtype);
-      result.insert({name, loaded_array});
+      array_map.insert({name, loaded_array});
     }
   }
   return array_map;

--- a/mlx/io/gguf.cpp
+++ b/mlx/io/gguf.cpp
@@ -206,19 +206,12 @@ std::unordered_map<std::string, array> load_arrays(gguf_ctx* ctx) {
   std::unordered_map<std::string, array> array_map;
   gguf_tensor tensor;
   while (gguf_get_tensor(ctx, &tensor)) {
-    std::string name = std::string(tensor.name, tensor.namelen);
-    const std::string weight_suffix = ".weight";
-    const size_t weight_len = weight_suffix.length();
-    const bool ends_with_weight = (name.length() > weight_len) &&
-        (name.compare(name.length() - weight_len, weight_len, weight_suffix) ==
-         0);
-    if (ends_with_weight && tensor.type == GGUF_TYPE_Q4_0) {
-      extract_q4_0_data(&array_map, tensor);
-    } else if (ends_with_weight && tensor.type == GGUF_TYPE_Q4_1) {
-      extract_q4_1_data(&array_map, tensor);
-    } else if (ends_with_weight && tensor.type == GGUF_TYPE_Q8_0) {
-      extract_q8_0_data(&array_map, tensor);
+    if (tensor.type == GGUF_TYPE_Q4_0 || tensor.type == GGUF_TYPE_Q4_1 ||
+        tensor.type == GGUF_TYPE_Q8_0) {
+      gguf_load_quantized(array_map, tensor);
     } else {
+      std::string name = std::string(tensor.name, tensor.namelen);
+
       const auto& [data, dtype] = extract_tensor_data(&tensor);
       array loaded_array = array(data, get_shape(tensor), dtype);
       array_map.insert({name, loaded_array});

--- a/mlx/io/gguf.h
+++ b/mlx/io/gguf.h
@@ -1,0 +1,26 @@
+// Copyright © 2023-2024 Apple Inc.
+#pragma once
+
+#include "mlx/io.h"
+#include "mlx/primitives.h"
+#include "mlx/transforms.h"
+#include "mlx/utils.h"
+
+extern "C" {
+#include <gguflib.h>
+}
+
+namespace mlx::core {
+
+std::vector<int> get_shape(const gguf_tensor& tensor);
+void extract_q4_0_data(
+    std::unordered_map<std::string, array>* a,
+    const gguf_tensor& tensor);
+void extract_q4_1_data(
+    std::unordered_map<std::string, array>* a,
+    const gguf_tensor& tensor);
+void extract_q8_0_data(
+    std::unordered_map<std::string, array>* a,
+    const gguf_tensor& tensor);
+
+} // namespace mlx::core

--- a/mlx/io/gguf.h
+++ b/mlx/io/gguf.h
@@ -13,14 +13,8 @@ extern "C" {
 namespace mlx::core {
 
 std::vector<int> get_shape(const gguf_tensor& tensor);
-void extract_q4_0_data(
-    std::unordered_map<std::string, array>* a,
-    const gguf_tensor& tensor);
-void extract_q4_1_data(
-    std::unordered_map<std::string, array>* a,
-    const gguf_tensor& tensor);
-void extract_q8_0_data(
-    std::unordered_map<std::string, array>* a,
+void gguf_load_quantized(
+    std::unordered_map<std::string, array>& a,
     const gguf_tensor& tensor);
 
 } // namespace mlx::core

--- a/mlx/io/gguf_quants.cpp
+++ b/mlx/io/gguf_quants.cpp
@@ -1,0 +1,204 @@
+// Copyright © 2023-2024 Apple Inc.
+
+#include <cstdint>
+#include <cstring>
+
+#include <mlx/io/gguf.h>
+
+namespace mlx::core {
+
+// Extracts (weight, scales, biases) from Q4_0 tensors.
+// Data layout is: |16 bit scale|32 x 4bit weights|.
+void extract_q4_0_data(
+    std::unordered_map<std::string, array>* a,
+    const gguf_tensor& tensor) {
+  std::string name = std::string(tensor.name, tensor.namelen);
+  const std::vector<int> shape = get_shape(tensor);
+  const uint64_t weights_per_byte = 2;
+  const uint64_t weights_per_block = 32;
+  if (shape[shape.size() - 1] % weights_per_block != 0) {
+    std::ostringstream msg;
+    msg << "[load_gguf] tensor " << name
+        << "has incompatible last dim shape: " << shape[shape.size() - 1];
+    throw std::runtime_error(msg.str());
+  }
+  const uint64_t bytes_per_block = 18; // 2 bytes scale, 32x0.5 byte weights
+  const uint64_t num_blocks = tensor.num_weights / weights_per_block;
+  allocator::Buffer weights_buffer =
+      allocator::malloc(tensor.num_weights / weights_per_byte);
+  allocator::Buffer scales_buffer = allocator::malloc(num_blocks * 2);
+  allocator::Buffer biases_buffer = allocator::malloc(num_blocks * 2);
+  auto data = (uint8_t*)tensor.weights_data;
+  auto weigths = (uint8_t*)weights_buffer.raw_ptr();
+  auto scales = (float16_t*)scales_buffer.raw_ptr();
+  auto biases = (float16_t*)biases_buffer.raw_ptr();
+  for (int64_t i = 0; i < num_blocks; i++) {
+    uint8_t* block_data = data + i * bytes_per_block;
+    scales[i] = *((float16_t*)block_data);
+    biases[i] = -8 * scales[i];
+    // First 16 weights are in the lower bits
+    for (int64_t j = 0; j < 16; ++j) {
+      uint8_t x = (block_data[j + 2] & 0x0F); // j+2 to skip scale bytes.
+      if (j % 2 != 0) {
+        x <<= 4;
+      }
+      weigths[i * 16 + j / 2] += x;
+    }
+    // Last 16 weights are in the higher bits
+    for (int64_t j = 0; j < 16; ++j) {
+      uint8_t x = (block_data[j + 2] >> 4);
+      if (j % 2 != 0) {
+        x <<= 4;
+      }
+      weigths[i * 16 + 8 + j / 2] += x;
+    }
+  }
+  std::vector<int> weights_shape = shape;
+  weights_shape[shape.size() - 1] =
+      weights_shape[shape.size() - 1] / weights_per_byte / 4;
+  a->insert({name, array(weights_buffer, weights_shape, uint32)});
+
+  const std::string weight_suffix = ".weight";
+  const std::string name_prefix =
+      name.substr(0, name.length() - weight_suffix.length());
+  std::vector<int> scale_bias_shape = shape;
+  scale_bias_shape[shape.size() - 1] =
+      scale_bias_shape[shape.size() - 1] / weights_per_block;
+
+  const std::string scales_name =
+      (std::ostringstream() << name_prefix << ".scales").str();
+  a->insert({scales_name, array(scales_buffer, scale_bias_shape, float16)});
+
+  const std::string biases_name =
+      (std::ostringstream() << name_prefix << ".biases").str();
+  a->insert({biases_name, array(biases_buffer, scale_bias_shape, float16)});
+}
+
+// Extracts (weight, scales, biases) from Q4_1 tensors.
+// Data layout is: |16 bit scale|32 x 4bit weights|.
+void extract_q4_1_data(
+    std::unordered_map<std::string, array>* a,
+    const gguf_tensor& tensor) {
+  std::string name = std::string(tensor.name, tensor.namelen);
+  const std::vector<int> shape = get_shape(tensor);
+  const uint64_t weights_per_byte = 2;
+  const uint64_t weights_per_block = 32;
+  if (shape[shape.size() - 1] % weights_per_block != 0) {
+    std::ostringstream msg;
+    msg << "[load_gguf] tensor " << name
+        << "has incompatible last dim shape: " << shape[shape.size() - 1];
+    throw std::runtime_error(msg.str());
+  }
+  const uint64_t bytes_per_block =
+      20; // 2 bytes scale, 2 bytes bias, 32x0.5 byte weights
+  const uint64_t num_blocks = tensor.num_weights / weights_per_block;
+  allocator::Buffer weights_buffer =
+      allocator::malloc(tensor.num_weights / weights_per_byte);
+  allocator::Buffer scales_buffer = allocator::malloc(num_blocks * 2);
+  allocator::Buffer biases_buffer = allocator::malloc(num_blocks * 2);
+  auto data = (uint8_t*)tensor.weights_data;
+  auto weigths = (uint8_t*)weights_buffer.raw_ptr();
+  auto scales = (float16_t*)scales_buffer.raw_ptr();
+  auto biases = (float16_t*)biases_buffer.raw_ptr();
+  for (int64_t i = 0; i < num_blocks; i++) {
+    uint8_t* block_data = data + i * bytes_per_block;
+    scales[i] = *((float16_t*)block_data);
+    biases[i] = *((float16_t*)block_data + 1);
+    // First 16 weights are in the lower bits
+    for (int64_t j = 0; j < 16; ++j) {
+      uint8_t x =
+          (block_data[j + 4] & 0x0F); // j+4 to skip scale and biases bytes.
+      if (j % 2 != 0) {
+        x <<= 4;
+      }
+      weigths[i * 16 + j / 2] += x;
+    }
+    // Last 16 weights are in the higher bits
+    for (int64_t j = 0; j < 16; ++j) {
+      uint8_t x = (block_data[j + 4] >> 4);
+      if (j % 2 != 0) {
+        x <<= 4;
+      }
+      weigths[i * 16 + 8 + j / 2] += x;
+    }
+  }
+  std::vector<int> weights_shape = shape;
+  weights_shape[shape.size() - 1] =
+      weights_shape[shape.size() - 1] / weights_per_byte / 4;
+  a->insert({name, array(weights_buffer, weights_shape, uint32)});
+
+  const std::string weight_suffix = ".weight";
+  const std::string name_prefix =
+      name.substr(0, name.length() - weight_suffix.length());
+  std::vector<int> scale_bias_shape = shape;
+  scale_bias_shape[shape.size() - 1] =
+      scale_bias_shape[shape.size() - 1] / weights_per_block;
+
+  const std::string scales_name =
+      (std::ostringstream() << name_prefix << ".scales").str();
+  a->insert({scales_name, array(scales_buffer, scale_bias_shape, float16)});
+
+  const std::string biases_name =
+      (std::ostringstream() << name_prefix << ".biases").str();
+  a->insert({biases_name, array(biases_buffer, scale_bias_shape, float16)});
+}
+
+// Extracts (weight, scales, biases) from Q8_0 tensors.
+// Data layout is: |16 bit scale|32 x 8bit weights|.
+void extract_q8_0_data(
+    std::unordered_map<std::string, array>* a,
+    const gguf_tensor& tensor) {
+  std::string name = std::string(tensor.name, tensor.namelen);
+  const std::vector<int> shape = get_shape(tensor);
+  const uint64_t weights_per_byte = 1;
+  const uint64_t weights_per_block = 32;
+  if (shape[shape.size() - 1] % weights_per_block != 0) {
+    std::ostringstream msg;
+    msg << "[load_gguf] tensor " << name
+        << "has incompatible last dim shape: " << shape[shape.size() - 1];
+    throw std::runtime_error(msg.str());
+  }
+  const uint64_t bytes_per_block = 34; // 2 bytes scale, 32x1 byte weights
+  const uint64_t num_blocks = tensor.num_weights / weights_per_block;
+  allocator::Buffer weights_buffer =
+      allocator::malloc(tensor.num_weights / weights_per_byte);
+  allocator::Buffer scales_buffer = allocator::malloc(num_blocks * 2);
+  allocator::Buffer biases_buffer = allocator::malloc(num_blocks * 2);
+  auto data = (uint8_t*)tensor.weights_data;
+  auto weigths = (int8_t*)weights_buffer.raw_ptr();
+  auto scales = (float16_t*)scales_buffer.raw_ptr();
+  auto biases = (float16_t*)biases_buffer.raw_ptr();
+  for (int64_t i = 0; i < num_blocks; i++) {
+    uint8_t* block_data = data + i * bytes_per_block;
+    scales[i] = *((float16_t*)block_data);
+    biases[i] = -128 * scales[i];
+    for (int64_t j = 0; j < weights_per_block; ++j) {
+      uint8_t x = block_data[j + 2]; // j+2 to skip the scale bytes.
+      // Original data is in int8_t, so we add a bias of -128 and invert the
+      // first bit.
+      x ^= 1 << 7;
+      weigths[i * weights_per_block + j] = x;
+    }
+  }
+  std::vector<int> weights_shape = shape;
+  weights_shape[shape.size() - 1] =
+      weights_shape[shape.size() - 1] / weights_per_byte / 4;
+  a->insert({name, array(weights_buffer, weights_shape, uint32)});
+
+  const std::string weight_suffix = ".weight";
+  const std::string name_prefix =
+      name.substr(0, name.length() - weight_suffix.length());
+  std::vector<int> scale_bias_shape = shape;
+  scale_bias_shape[shape.size() - 1] =
+      scale_bias_shape[shape.size() - 1] / weights_per_block;
+
+  const std::string scales_name =
+      (std::ostringstream() << name_prefix << ".scales").str();
+  a->insert({scales_name, array(scales_buffer, scale_bias_shape, float16)});
+
+  const std::string biases_name =
+      (std::ostringstream() << name_prefix << ".biases").str();
+  a->insert({biases_name, array(biases_buffer, scale_bias_shape, float16)});
+}
+
+} // namespace mlx::core

--- a/mlx/io/gguf_quants.cpp
+++ b/mlx/io/gguf_quants.cpp
@@ -7,168 +7,82 @@
 
 namespace mlx::core {
 
+void unpack_32_4(uint8_t* data, int8_t* dst) {
+  for (int64_t j = 0; j < 16; ++j) {
+    uint8_t x = (data[j + 2] & 0x0F); // j+2 to skip scale bytes.
+    if (j % 2 != 0) {
+      x <<= 4;
+    }
+    dst[j / 2] += x;
+  }
+  // Last 16 weights are in the higher bits
+  for (int64_t j = 0; j < 16; ++j) {
+    uint8_t x = (data[j + 2] >> 4);
+    if (j % 2 != 0) {
+      x <<= 4;
+    }
+    dst[8 + j / 2] += x;
+  }
+}
+
 // Extracts (weight, scales, biases) from Q4_0 tensors.
 // Data layout is: |16 bit scale|32 x 4bit weights|.
 void extract_q4_0_data(
-    std::unordered_map<std::string, array>& a,
-    const gguf_tensor& tensor) {
-  std::string name = std::string(tensor.name, tensor.namelen);
-  const std::vector<int> shape = get_shape(tensor);
-  const uint64_t weights_per_byte = 2;
-  const uint64_t weights_per_block = 32;
-  if (shape[shape.size() - 1] % weights_per_block != 0) {
-    std::ostringstream msg;
-    msg << "[load_gguf] tensor " << name
-        << "has incompatible last dim shape: " << shape[shape.size() - 1];
-    throw std::runtime_error(msg.str());
-  }
+    const gguf_tensor& tensor,
+    array& weights_arr,
+    array& scales_arr,
+    array& biases_arr) {
   const uint64_t bytes_per_block = 18; // 2 bytes scale, 32x0.5 byte weights
-  const uint64_t num_blocks = tensor.num_weights / weights_per_block;
-  allocator::Buffer weights_buffer =
-      allocator::malloc(tensor.num_weights / weights_per_byte);
-  allocator::Buffer scales_buffer = allocator::malloc(num_blocks * 2);
-  allocator::Buffer biases_buffer = allocator::malloc(num_blocks * 2);
-  auto data = (uint8_t*)tensor.weights_data;
-  auto weigths = (uint8_t*)weights_buffer.raw_ptr();
-  auto scales = (float16_t*)scales_buffer.raw_ptr();
-  auto biases = (float16_t*)biases_buffer.raw_ptr();
-  for (int64_t i = 0; i < num_blocks; i++) {
-    uint8_t* block_data = data + i * bytes_per_block;
-    scales[i] = *((float16_t*)block_data);
+  auto data = static_cast<uint8_t*>(tensor.weights_data);
+  auto weights = weights_arr.data<int8_t>();
+  auto scales = scales_arr.data<float16_t>();
+  auto biases = biases_arr.data<float16_t>();
+  for (int64_t i = 0; i < scales_arr.size(); i++) {
+    scales[i] = *((float16_t*)data);
     biases[i] = -8 * scales[i];
-    // First 16 weights are in the lower bits
-    for (int64_t j = 0; j < 16; ++j) {
-      uint8_t x = (block_data[j + 2] & 0x0F); // j+2 to skip scale bytes.
-      if (j % 2 != 0) {
-        x <<= 4;
-      }
-      weigths[i * 16 + j / 2] += x;
-    }
-    // Last 16 weights are in the higher bits
-    for (int64_t j = 0; j < 16; ++j) {
-      uint8_t x = (block_data[j + 2] >> 4);
-      if (j % 2 != 0) {
-        x <<= 4;
-      }
-      weigths[i * 16 + 8 + j / 2] += x;
-    }
+    unpack_32_4(data, weights);
+    weights += 16;
+    data += bytes_per_block;
   }
-  std::vector<int> weights_shape = shape;
-  weights_shape[shape.size() - 1] =
-      weights_shape[shape.size() - 1] / weights_per_byte / 4;
-  a.insert({name, array(weights_buffer, weights_shape, uint32)});
-
-  const std::string weight_suffix = ".weight";
-  const std::string name_prefix =
-      name.substr(0, name.length() - weight_suffix.length());
-  std::vector<int> scale_bias_shape = shape;
-  scale_bias_shape[shape.size() - 1] =
-      scale_bias_shape[shape.size() - 1] / weights_per_block;
-
-  const std::string scales_name =
-      (std::ostringstream() << name_prefix << ".scales").str();
-  a.insert({scales_name, array(scales_buffer, scale_bias_shape, float16)});
-
-  const std::string biases_name =
-      (std::ostringstream() << name_prefix << ".biases").str();
-  a.insert({biases_name, array(biases_buffer, scale_bias_shape, float16)});
 }
 
 // Extracts (weight, scales, biases) from Q4_1 tensors.
-// Data layout is: |16 bit scale|32 x 4bit weights|.
+// Data layout is: |16 bit scale|16 bit bias|32 x 4bit weights|.
 void extract_q4_1_data(
-    std::unordered_map<std::string, array>& a,
-    const gguf_tensor& tensor) {
-  std::string name = std::string(tensor.name, tensor.namelen);
-  const std::vector<int> shape = get_shape(tensor);
-  const uint64_t weights_per_byte = 2;
-  const uint64_t weights_per_block = 32;
-  if (shape[shape.size() - 1] % weights_per_block != 0) {
-    std::ostringstream msg;
-    msg << "[load_gguf] tensor " << name
-        << "has incompatible last dim shape: " << shape[shape.size() - 1];
-    throw std::runtime_error(msg.str());
-  }
+    const gguf_tensor& tensor,
+    array& weights_arr,
+    array& scales_arr,
+    array& biases_arr) {
   const uint64_t bytes_per_block =
       20; // 2 bytes scale, 2 bytes bias, 32x0.5 byte weights
-  const uint64_t num_blocks = tensor.num_weights / weights_per_block;
-  allocator::Buffer weights_buffer =
-      allocator::malloc(tensor.num_weights / weights_per_byte);
-  allocator::Buffer scales_buffer = allocator::malloc(num_blocks * 2);
-  allocator::Buffer biases_buffer = allocator::malloc(num_blocks * 2);
-  auto data = (uint8_t*)tensor.weights_data;
-  auto weigths = (uint8_t*)weights_buffer.raw_ptr();
-  auto scales = (float16_t*)scales_buffer.raw_ptr();
-  auto biases = (float16_t*)biases_buffer.raw_ptr();
-  for (int64_t i = 0; i < num_blocks; i++) {
-    uint8_t* block_data = data + i * bytes_per_block;
-    scales[i] = *((float16_t*)block_data);
-    biases[i] = *((float16_t*)block_data + 1);
-    // First 16 weights are in the lower bits
-    for (int64_t j = 0; j < 16; ++j) {
-      uint8_t x =
-          (block_data[j + 4] & 0x0F); // j+4 to skip scale and biases bytes.
-      if (j % 2 != 0) {
-        x <<= 4;
-      }
-      weigths[i * 16 + j / 2] += x;
-    }
-    // Last 16 weights are in the higher bits
-    for (int64_t j = 0; j < 16; ++j) {
-      uint8_t x = (block_data[j + 4] >> 4);
-      if (j % 2 != 0) {
-        x <<= 4;
-      }
-      weigths[i * 16 + 8 + j / 2] += x;
-    }
+  auto data = static_cast<uint8_t*>(tensor.weights_data);
+  auto weights = weights_arr.data<int8_t>();
+  auto scales = scales_arr.data<float16_t>();
+  auto biases = biases_arr.data<float16_t>();
+  for (int64_t i = 0; i < scales_arr.size(); i++) {
+    scales[i] = *((float16_t*)data);
+    biases[i] = *((float16_t*)(data) + 1);
+    unpack_32_4(data, weights);
+    weights += 16;
+    data += bytes_per_block;
   }
-  std::vector<int> weights_shape = shape;
-  weights_shape[shape.size() - 1] =
-      weights_shape[shape.size() - 1] / weights_per_byte / 4;
-  a.insert({name, array(weights_buffer, weights_shape, uint32)});
-
-  const std::string weight_suffix = ".weight";
-  const std::string name_prefix =
-      name.substr(0, name.length() - weight_suffix.length());
-  std::vector<int> scale_bias_shape = shape;
-  scale_bias_shape[shape.size() - 1] =
-      scale_bias_shape[shape.size() - 1] / weights_per_block;
-
-  const std::string scales_name =
-      (std::ostringstream() << name_prefix << ".scales").str();
-  a.insert({scales_name, array(scales_buffer, scale_bias_shape, float16)});
-
-  const std::string biases_name =
-      (std::ostringstream() << name_prefix << ".biases").str();
-  a.insert({biases_name, array(biases_buffer, scale_bias_shape, float16)});
 }
 
 // Extracts (weight, scales, biases) from Q8_0 tensors.
 // Data layout is: |16 bit scale|32 x 8bit weights|.
 void extract_q8_0_data(
-    std::unordered_map<std::string, array>& a,
-    const gguf_tensor& tensor) {
-  std::string name = std::string(tensor.name, tensor.namelen);
-  const std::vector<int> shape = get_shape(tensor);
-  const uint64_t weights_per_byte = 1;
+    const gguf_tensor& tensor,
+    array& weights_arr,
+    array& scales_arr,
+    array& biases_arr) {
+
   const uint64_t weights_per_block = 32;
-  if (shape[shape.size() - 1] % weights_per_block != 0) {
-    std::ostringstream msg;
-    msg << "[load_gguf] tensor " << name
-        << "has incompatible last dim shape: " << shape[shape.size() - 1];
-    throw std::runtime_error(msg.str());
-  }
   const uint64_t bytes_per_block = 34; // 2 bytes scale, 32x1 byte weights
-  const uint64_t num_blocks = tensor.num_weights / weights_per_block;
-  allocator::Buffer weights_buffer =
-      allocator::malloc(tensor.num_weights / weights_per_byte);
-  allocator::Buffer scales_buffer = allocator::malloc(num_blocks * 2);
-  allocator::Buffer biases_buffer = allocator::malloc(num_blocks * 2);
-  auto data = (uint8_t*)tensor.weights_data;
-  auto weigths = (int8_t*)weights_buffer.raw_ptr();
-  auto scales = (float16_t*)scales_buffer.raw_ptr();
-  auto biases = (float16_t*)biases_buffer.raw_ptr();
-  for (int64_t i = 0; i < num_blocks; i++) {
+  auto data = static_cast<uint8_t*>(tensor.weights_data);
+  auto weights = weights_arr.data<int8_t>();
+  auto scales = scales_arr.data<float16_t>();
+  auto biases = biases_arr.data<float16_t>();
+  for (int64_t i = 0; i < scales_arr.size(); i++) {
     uint8_t* block_data = data + i * bytes_per_block;
     scales[i] = *((float16_t*)block_data);
     biases[i] = -128 * scales[i];
@@ -177,40 +91,61 @@ void extract_q8_0_data(
       // Original data is in int8_t, so we add a bias of -128 and invert the
       // first bit.
       x ^= 1 << 7;
-      weigths[i * weights_per_block + j] = x;
+      weights[i * weights_per_block + j] = x;
     }
   }
-  std::vector<int> weights_shape = shape;
-  weights_shape[shape.size() - 1] =
-      weights_shape[shape.size() - 1] / weights_per_byte / 4;
-  a.insert({name, array(weights_buffer, weights_shape, uint32)});
-
-  const std::string weight_suffix = ".weight";
-  const std::string name_prefix =
-      name.substr(0, name.length() - weight_suffix.length());
-  std::vector<int> scale_bias_shape = shape;
-  scale_bias_shape[shape.size() - 1] =
-      scale_bias_shape[shape.size() - 1] / weights_per_block;
-
-  const std::string scales_name =
-      (std::ostringstream() << name_prefix << ".scales").str();
-  a.insert({scales_name, array(scales_buffer, scale_bias_shape, float16)});
-
-  const std::string biases_name =
-      (std::ostringstream() << name_prefix << ".biases").str();
-  a.insert({biases_name, array(biases_buffer, scale_bias_shape, float16)});
 }
 
 void gguf_load_quantized(
     std::unordered_map<std::string, array>& a,
     const gguf_tensor& tensor) {
-  if (tensor.type == GGUF_TYPE_Q4_0) {
-    extract_q4_0_data(a, tensor);
-  } else if (tensor.type == GGUF_TYPE_Q4_1) {
-    extract_q4_1_data(a, tensor);
-  } else if (tensor.type == GGUF_TYPE_Q8_0) {
-    extract_q8_0_data(a, tensor);
+
+  uint64_t weights_per_byte;
+  if (tensor.type == GGUF_TYPE_Q4_0 || tensor.type == GGUF_TYPE_Q4_1) {
+    weights_per_byte = 2;
+  } else { // tensor.type == GGUF_TYPE_Q8_0
+    weights_per_byte = 1;
   }
+
+  std::string name = std::string(tensor.name, tensor.namelen);
+  std::vector<int> shape = get_shape(tensor);
+  const uint64_t weights_per_block = 32;
+  if (shape[shape.size() - 1] % weights_per_block != 0) {
+    std::ostringstream msg;
+    msg << "[load_gguf] tensor " << name
+        << "has incompatible last dim shape: " << shape[shape.size() - 1];
+    throw std::runtime_error(msg.str());
+  }
+  const uint64_t num_blocks = tensor.num_weights / weights_per_block;
+
+  std::vector<int> weights_shape = shape;
+  weights_shape.back() /= (weights_per_byte * 4);
+
+  array weights(std::move(weights_shape), uint32, nullptr, {});
+  weights.set_data(allocator::malloc(weights.nbytes()));
+
+  // For scales and bias
+  shape[shape.size() - 1] = shape[shape.size() - 1] / weights_per_block;
+  array scales(shape, float16, nullptr, {});
+  array biases(std::move(shape), float16, nullptr, {});
+  scales.set_data(allocator::malloc(scales.nbytes()));
+  biases.set_data(allocator::malloc(biases.nbytes()));
+
+
+  if (tensor.type == GGUF_TYPE_Q4_0) {
+    extract_q4_0_data(tensor, weights, scales, biases);
+  } else if (tensor.type == GGUF_TYPE_Q4_1) {
+    extract_q4_1_data(tensor, weights, scales, biases);
+  } else if (tensor.type == GGUF_TYPE_Q8_0) {
+    extract_q8_0_data(tensor, weights, scales, biases);
+  }
+
+  a.insert({name, weights});
+  const std::string weight_suffix = ".weight";
+  const std::string name_prefix =
+      name.substr(0, name.length() - weight_suffix.length());
+  a.insert({name_prefix + ".scales", scales});
+  a.insert({name_prefix + ".biases", biases});
 }
 
 } // namespace mlx::core

--- a/mlx/io/gguf_quants.cpp
+++ b/mlx/io/gguf_quants.cpp
@@ -10,7 +10,7 @@ namespace mlx::core {
 // Extracts (weight, scales, biases) from Q4_0 tensors.
 // Data layout is: |16 bit scale|32 x 4bit weights|.
 void extract_q4_0_data(
-    std::unordered_map<std::string, array>* a,
+    std::unordered_map<std::string, array>& a,
     const gguf_tensor& tensor) {
   std::string name = std::string(tensor.name, tensor.namelen);
   const std::vector<int> shape = get_shape(tensor);
@@ -56,7 +56,7 @@ void extract_q4_0_data(
   std::vector<int> weights_shape = shape;
   weights_shape[shape.size() - 1] =
       weights_shape[shape.size() - 1] / weights_per_byte / 4;
-  a->insert({name, array(weights_buffer, weights_shape, uint32)});
+  a.insert({name, array(weights_buffer, weights_shape, uint32)});
 
   const std::string weight_suffix = ".weight";
   const std::string name_prefix =
@@ -67,17 +67,17 @@ void extract_q4_0_data(
 
   const std::string scales_name =
       (std::ostringstream() << name_prefix << ".scales").str();
-  a->insert({scales_name, array(scales_buffer, scale_bias_shape, float16)});
+  a.insert({scales_name, array(scales_buffer, scale_bias_shape, float16)});
 
   const std::string biases_name =
       (std::ostringstream() << name_prefix << ".biases").str();
-  a->insert({biases_name, array(biases_buffer, scale_bias_shape, float16)});
+  a.insert({biases_name, array(biases_buffer, scale_bias_shape, float16)});
 }
 
 // Extracts (weight, scales, biases) from Q4_1 tensors.
 // Data layout is: |16 bit scale|32 x 4bit weights|.
 void extract_q4_1_data(
-    std::unordered_map<std::string, array>* a,
+    std::unordered_map<std::string, array>& a,
     const gguf_tensor& tensor) {
   std::string name = std::string(tensor.name, tensor.namelen);
   const std::vector<int> shape = get_shape(tensor);
@@ -125,7 +125,7 @@ void extract_q4_1_data(
   std::vector<int> weights_shape = shape;
   weights_shape[shape.size() - 1] =
       weights_shape[shape.size() - 1] / weights_per_byte / 4;
-  a->insert({name, array(weights_buffer, weights_shape, uint32)});
+  a.insert({name, array(weights_buffer, weights_shape, uint32)});
 
   const std::string weight_suffix = ".weight";
   const std::string name_prefix =
@@ -136,17 +136,17 @@ void extract_q4_1_data(
 
   const std::string scales_name =
       (std::ostringstream() << name_prefix << ".scales").str();
-  a->insert({scales_name, array(scales_buffer, scale_bias_shape, float16)});
+  a.insert({scales_name, array(scales_buffer, scale_bias_shape, float16)});
 
   const std::string biases_name =
       (std::ostringstream() << name_prefix << ".biases").str();
-  a->insert({biases_name, array(biases_buffer, scale_bias_shape, float16)});
+  a.insert({biases_name, array(biases_buffer, scale_bias_shape, float16)});
 }
 
 // Extracts (weight, scales, biases) from Q8_0 tensors.
 // Data layout is: |16 bit scale|32 x 8bit weights|.
 void extract_q8_0_data(
-    std::unordered_map<std::string, array>* a,
+    std::unordered_map<std::string, array>& a,
     const gguf_tensor& tensor) {
   std::string name = std::string(tensor.name, tensor.namelen);
   const std::vector<int> shape = get_shape(tensor);
@@ -183,7 +183,7 @@ void extract_q8_0_data(
   std::vector<int> weights_shape = shape;
   weights_shape[shape.size() - 1] =
       weights_shape[shape.size() - 1] / weights_per_byte / 4;
-  a->insert({name, array(weights_buffer, weights_shape, uint32)});
+  a.insert({name, array(weights_buffer, weights_shape, uint32)});
 
   const std::string weight_suffix = ".weight";
   const std::string name_prefix =
@@ -194,11 +194,23 @@ void extract_q8_0_data(
 
   const std::string scales_name =
       (std::ostringstream() << name_prefix << ".scales").str();
-  a->insert({scales_name, array(scales_buffer, scale_bias_shape, float16)});
+  a.insert({scales_name, array(scales_buffer, scale_bias_shape, float16)});
 
   const std::string biases_name =
       (std::ostringstream() << name_prefix << ".biases").str();
-  a->insert({biases_name, array(biases_buffer, scale_bias_shape, float16)});
+  a.insert({biases_name, array(biases_buffer, scale_bias_shape, float16)});
+}
+
+void gguf_load_quantized(
+    std::unordered_map<std::string, array>& a,
+    const gguf_tensor& tensor) {
+  if (tensor.type == GGUF_TYPE_Q4_0) {
+    extract_q4_0_data(a, tensor);
+  } else if (tensor.type == GGUF_TYPE_Q4_1) {
+    extract_q4_1_data(a, tensor);
+  } else if (tensor.type == GGUF_TYPE_Q8_0) {
+    extract_q8_0_data(a, tensor);
+  }
 }
 
 } // namespace mlx::core

--- a/tests/metal_tests.cpp
+++ b/tests/metal_tests.cpp
@@ -500,7 +500,6 @@ TEST_CASE("test metal enable/disable cache") {
     auto buf = a.malloc(size, false);
     auto buf_ptr = static_cast<MTL::Buffer*>(buf.ptr());
     unsigned char first_byte = *reinterpret_cast<unsigned char*>(buf_ptr);
-    printf("first byte: %d\n", first_byte);
 
     // Release a
     a.free(buf);
@@ -508,7 +507,6 @@ TEST_CASE("test metal enable/disable cache") {
     // If release successfully, the first byte should be different from the
     // first byte before release
     unsigned char new_first_byte = *reinterpret_cast<unsigned char*>(buf_ptr);
-    printf("new first byte: %d\n", new_first_byte);
 
     CHECK_NE(new_first_byte, first_byte);
   }


### PR DESCRIPTION
## Proposed changes

This is a follow up for https://github.com/ml-explore/mlx/pull/350

To avoid casting to `float16`, we should unpack quantized GGUF weights to `weight, scales, biases` tensors.

Q4_1 seems like the format that more closely aligns with MLX (blocks of 32 weights with 4 bits each, and scales, and biases in fp16). Main difference is the order of the data layout.

### Manual tests

(We should add unit tests)

I tested this with this file: https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/discussions/3

```python
>>> import mlx.core as mx
>>> weights = mx.load("models/tinyllama-1.1b-chat-v1.0.Q4_1.gguf")
>>> mx.dequantize(weights["blk.9.attn_v.weight"], weights["blk.9.attn_v.scales"], weights["blk.9.attn_v.biases"], group_size=32)
array([[-0.0247803, -0.0568848, 0.0233154, ..., 0.00634766, 0.0279541, -0.0109253],
       [0.00671387, 0.00671387, -0.0137939, ..., -0.012207, -0.00642395, 0.0224609],
       [-0.014328, -0.018158, 0.00860596, ..., -0.0187988, -0.00262451, 0.011261],
       ...,
       [-0.00126648, 0.00540161, -0.0246124, ..., 0.000305176, 0.0160828, 0.00424194],
       [-0.00265503, -0.0170441, 0.026123, ..., 0.000640869, 0.0118408, 0.00439453],
       [0.000457764, 0.00430298, -0.0264893, ..., -0.000137329, -0.0105896, 0.00769043]], dtype=float16)
```

Expected (first 3 values of the first 3 rows and last 3 rows match):

```bash
./gguf-tools inspect-tensor ~/dev/github/mlx-examples/llms/tiny_llama_gguf/models/tinyllama-1.1b-chat-v1.0.Q4_1.gguf blk.9.attn_v.weight  | grep "\[" -A1 -B 1 | head
[
        -0.024796, -0.056885, 0.023338, 0.007294,
--
],
[
        0.006714, 0.006714, -0.013794, 0.006714,
--
],
[
        -0.014326, -0.018150, 0.008619, 0.000971,

$ ./gguf-tools inspect-tensor ~/dev/github/mlx-examples/llms/tiny_llama_gguf/models/tinyllama-1.1b-chat-v1.0.Q4_1.gguf blk.9.attn_v.weight  | grep "\[" -A1 -B 1 | tail
[
        -0.001266, 0.005405, -0.024618, 0.002069,
--
],
[
        -0.002651, -0.017040, 0.026127, -0.006248,
--
],
[
        0.000454, 0.004303, -0.026489, 0.000454,
```

I'm not sure if it would be best to leave some of the logic in gguflib

cc @awni , @antirez

Similarly, I have validated the outputs for Q4_0 and Q8_0. Both are centered at zero, instead of having custom biases per block:

```python
>>> weights = mx.load("models/tinyllama-1.1b-chat-v1.0.Q8_0.gguf")
>>> mx.dequantize(weights["blk.9.attn_v.weight"], weights["blk.9.attn_v.scales"], weights["blk.9.attn_v.biases"], group_size=32, bits=8)
array([[-0.0232849, -0.0568848, 0.0215149, ..., 0.00668335, 0.0278931, -0.0121918],
       [0.00675964, 0.0071106, -0.0128555, ..., -0.0129166, -0.00584412, 0.0224609],
       [-0.0155487, -0.0179138, 0.0100098, ..., -0.0185089, -0.00192261, 0.0109558],
       ...,
       [-0.00198364, 0.00683594, -0.0250854, ..., 0.000549316, 0.0149536, 0.00579834],
       [-0.00306702, -0.0159912, 0.026062, ..., 0.000274658, 0.0116882, 0.00415039],
       [0, 0.00540161, -0.0265808, ..., -0.00114441, -0.0119324, 0.00898743]], dtype=float16)
>>> weights = mx.load("models/tinyllama-1.1b-chat-v1.0.Q4_0.gguf")
>>> mx.dequantize(weights["blk.9.attn_v.weight"], weights["blk.9.attn_v.scales"], weights["blk.9.attn_v.biases"], group_size=32, bits=4)
array([[-0.0213318, -0.0568848, 0.0213623, ..., 0.00460815, 0.0276489, -0.0138245],
       [0.00805664, 0.00805664, -0.0134277, ..., -0.0140381, -0.00561523, 0.0224609],
       [-0.0167236, -0.0167236, 0.00836182, ..., -0.0187988, -0.00234985, 0.0117493],
       ...,
       [-0.00349426, 0.00698853, -0.0244598, ..., 0, 0.0131836, 0.00439453],
       [-0.003479, -0.017395, 0.024353, ..., 0, 0.0123596, 0.00411987],
       [0, 0.00390625, -0.0273438, ..., 0, -0.01297, 0.00778198]], dtype=float16)
```


## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
