### PR TITLE
add numeric type hierarchy and issubdtype as well as a set_dtype meth…

### DIFF
--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -58,6 +58,7 @@ are the CPU and GPU.
    :maxdepth: 1
 
    python/array
+   python/data_types
    python/devices_and_streams
    python/ops
    python/random

--- a/docs/src/python/array.rst
+++ b/docs/src/python/array.rst
@@ -19,8 +19,6 @@ Array
     array.ndim
     array.shape
     array.size
-    Dtype
-    DtypeCategory
     array.abs
     array.all
     array.any

--- a/docs/src/python/array.rst
+++ b/docs/src/python/array.rst
@@ -20,6 +20,7 @@ Array
     array.shape
     array.size
     Dtype
+    DtypeCategory
     array.abs
     array.all
     array.any
@@ -32,7 +33,6 @@ Array
     array.cumsum
     array.diag
     array.diagonal
-    array.dtype
     array.exp
     array.flatten
     array.log

--- a/docs/src/python/data_types.rst
+++ b/docs/src/python/data_types.rst
@@ -55,6 +55,12 @@ The default floating point type is ``float32`` and the default integer type is
      - 8 
      - 64-bit complex float
 
+
+The full reference for the :obj:`Dtype` class is below.
+
+.. autoclass:: Dtype
+   :members:
+
 Categories
 ----------
 

--- a/docs/src/python/data_types.rst
+++ b/docs/src/python/data_types.rst
@@ -56,14 +56,13 @@ The default floating point type is ``float32`` and the default integer type is
      - 64-bit complex float
 
 
-The full reference for the :obj:`Dtype` class is below.
+Data type are aranged in a hierarchy. See the :obj:`DtypeCategory` object
+documentation for more information. Use :func:`issubdtype` to determine if one
+``dtype`` (or category) is a subtype of another category.
 
-.. autoclass:: Dtype
-   :members:
+.. autosummary::
+   :toctree: _autosummary
 
-Categories
-----------
-
-The hierarchy below shows supported values for :obj:`DtypeCategory`.
-
-.. autoclass:: DtypeCategory
+   Dtype
+   DtypeCategory
+   issubdtype

--- a/docs/src/python/data_types.rst
+++ b/docs/src/python/data_types.rst
@@ -1,7 +1,5 @@
 .. _data_types:
 
-:orphan:
-
 Data Types
 ==========
 
@@ -56,3 +54,10 @@ The default floating point type is ``float32`` and the default integer type is
    * - ``complex64``
      - 8 
      - 64-bit complex float
+
+Categories
+----------
+
+The hierarchy below shows supported values for :obj:`DtypeCategory`.
+
+.. autoclass:: DtypeCategory

--- a/docs/src/python/nn/module.rst
+++ b/docs/src/python/nn/module.rst
@@ -30,6 +30,7 @@ Module
       Module.named_modules
       Module.parameters
       Module.save_weights
+      Module.set_dtype
       Module.train
       Module.trainable_parameters
       Module.unfreeze

--- a/docs/src/python/ops.rst
+++ b/docs/src/python/ops.rst
@@ -64,7 +64,6 @@ Operations
    isclose
    isinf
    isnan
-   issubdtype
    isneginf
    isposinf
    less

--- a/docs/src/python/ops.rst
+++ b/docs/src/python/ops.rst
@@ -62,10 +62,11 @@ Operations
    identity
    inner
    isclose
-   isnan
-   isposinf
-   isneginf
    isinf
+   isnan
+   issubdtype
+   isneginf
+   isposinf
    less
    less_equal
    linspace

--- a/mlx/backend/accelerate/primitives.cpp
+++ b/mlx/backend/accelerate/primitives.cpp
@@ -301,7 +301,7 @@ void Exp::eval_cpu(const std::vector<array>& inputs, array& out) {
     set_unary_output_data(in, out);
     auto size = in.data_size();
     vvexpf(out.data<float>(), in.data<float>(), reinterpret_cast<int*>(&size));
-  } else if (is_floating_point(out.dtype())) {
+  } else if (issubdtype(out.dtype(), inexact)) {
     unary_fp(in, out, [](auto x) { return std::exp(x); });
   } else {
     throw std::invalid_argument(
@@ -355,7 +355,7 @@ void Log1p::eval_cpu(const std::vector<array>& inputs, array& out) {
     auto size = in.data_size();
     vvlog1pf(
         out.data<float>(), in.data<float>(), reinterpret_cast<int*>(&size));
-  } else if (is_floating_point(out.dtype())) {
+  } else if (issubdtype(out.dtype(), inexact)) {
     unary_fp(in, out, [](auto x) { return std::log1p(x); });
   } else {
     throw std::invalid_argument(

--- a/mlx/backend/common/binary.cpp
+++ b/mlx/backend/common/binary.cpp
@@ -179,18 +179,16 @@ void LogAddExp::eval(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 2);
   auto& a = inputs[0];
   auto& b = inputs[1];
-  if (is_floating_point(out.dtype())) {
-    if (out.dtype() == float32) {
-      binary_op<float>(a, b, out, detail::LogAddExp());
-    } else if (out.dtype() == float16) {
-      binary_op<float16_t>(a, b, out, detail::LogAddExp());
-    } else if (out.dtype() == bfloat16) {
-      binary_op<bfloat16_t>(a, b, out, detail::LogAddExp());
-    } else {
-      std::ostringstream err;
-      err << "[logaddexp] Does not support " << out.dtype();
-      throw std::invalid_argument(err.str());
-    }
+  if (out.dtype() == float32) {
+    binary_op<float>(a, b, out, detail::LogAddExp());
+  } else if (out.dtype() == float16) {
+    binary_op<float16_t>(a, b, out, detail::LogAddExp());
+  } else if (out.dtype() == bfloat16) {
+    binary_op<bfloat16_t>(a, b, out, detail::LogAddExp());
+  } else if (issubdtype(out.dtype(), inexact)) {
+    std::ostringstream err;
+    err << "[logaddexp] Does not support " << out.dtype();
+    throw std::invalid_argument(err.str());
   } else {
     throw std::invalid_argument(
         "[logaddexp] Cannot compute logaddexp for arrays with"

--- a/mlx/backend/common/primitives.cpp
+++ b/mlx/backend/common/primitives.cpp
@@ -22,7 +22,7 @@ namespace mlx::core {
 void Abs::eval(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 1);
   auto& in = inputs[0];
-  if (is_unsigned(in.dtype())) {
+  if (issubdtype(in.dtype(), unsignedinteger)) {
     // No-op for unsigned types
     out.copy_shared_buffer(in);
   } else {
@@ -37,7 +37,7 @@ void Arange::eval(const std::vector<array>& inputs, array& out) {
 void ArcCos::eval(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 1);
   const auto& in = inputs[0];
-  if (is_floating_point(out.dtype())) {
+  if (issubdtype(out.dtype(), inexact)) {
     unary_fp(in, out, detail::ArcCos());
   } else {
     throw std::invalid_argument(
@@ -49,7 +49,7 @@ void ArcCos::eval(const std::vector<array>& inputs, array& out) {
 void ArcCosh::eval(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 1);
   const auto& in = inputs[0];
-  if (is_floating_point(out.dtype())) {
+  if (issubdtype(out.dtype(), inexact)) {
     unary_fp(in, out, detail::ArcCosh());
   } else {
     throw std::invalid_argument(
@@ -61,7 +61,7 @@ void ArcCosh::eval(const std::vector<array>& inputs, array& out) {
 void ArcSin::eval(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 1);
   const auto& in = inputs[0];
-  if (is_floating_point(out.dtype())) {
+  if (issubdtype(out.dtype(), inexact)) {
     unary_fp(in, out, detail::ArcSin());
   } else {
     throw std::invalid_argument(
@@ -73,7 +73,7 @@ void ArcSin::eval(const std::vector<array>& inputs, array& out) {
 void ArcSinh::eval(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 1);
   const auto& in = inputs[0];
-  if (is_floating_point(out.dtype())) {
+  if (issubdtype(out.dtype(), inexact)) {
     unary_fp(in, out, detail::ArcSinh());
   } else {
     throw std::invalid_argument(
@@ -85,7 +85,7 @@ void ArcSinh::eval(const std::vector<array>& inputs, array& out) {
 void ArcTan::eval(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 1);
   const auto& in = inputs[0];
-  if (is_floating_point(out.dtype())) {
+  if (issubdtype(out.dtype(), inexact)) {
     unary_fp(in, out, detail::ArcTan());
   } else {
     throw std::invalid_argument(
@@ -97,7 +97,7 @@ void ArcTan::eval(const std::vector<array>& inputs, array& out) {
 void ArcTanh::eval(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 1);
   const auto& in = inputs[0];
-  if (is_floating_point(out.dtype())) {
+  if (issubdtype(out.dtype(), inexact)) {
     unary_fp(in, out, detail::ArcTanh());
   } else {
     throw std::invalid_argument(
@@ -171,7 +171,7 @@ void Broadcast::eval(const std::vector<array>& inputs, array& out) {
 void Ceil::eval(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 1);
   auto& in = inputs[0];
-  if (not is_integral(in.dtype())) {
+  if (issubdtype(in.dtype(), inexact)) {
     unary_fp(in, out, detail::Ceil());
   } else {
     // No-op integer types
@@ -211,7 +211,7 @@ void Copy::eval(const std::vector<array>& inputs, array& out) {
 void Cos::eval(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 1);
   const auto& in = inputs[0];
-  if (is_floating_point(out.dtype())) {
+  if (issubdtype(out.dtype(), inexact)) {
     unary_fp(in, out, detail::Cos());
   } else {
     throw std::invalid_argument(
@@ -223,7 +223,7 @@ void Cos::eval(const std::vector<array>& inputs, array& out) {
 void Cosh::eval(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 1);
   const auto& in = inputs[0];
-  if (is_floating_point(out.dtype())) {
+  if (issubdtype(out.dtype(), inexact)) {
     unary_fp(in, out, detail::Cosh());
   } else {
     throw std::invalid_argument(
@@ -350,7 +350,7 @@ void ErfInv::eval(const std::vector<array>& inputs, array& out) {
 void Exp::eval(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 1);
   const auto& in = inputs[0];
-  if (is_floating_point(out.dtype())) {
+  if (issubdtype(out.dtype(), inexact)) {
     unary_fp(in, out, detail::Exp());
   } else {
     throw std::invalid_argument(
@@ -362,7 +362,7 @@ void Exp::eval(const std::vector<array>& inputs, array& out) {
 void Floor::eval(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 1);
   auto& in = inputs[0];
-  if (not is_integral(in.dtype())) {
+  if (issubdtype(in.dtype(), inexact)) {
     unary_fp(in, out, detail::Floor());
   } else {
     // No-op integer types
@@ -388,7 +388,7 @@ void Full::eval(const std::vector<array>& inputs, array& out) {
 void Log::eval(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 1);
   const auto& in = inputs[0];
-  if (is_floating_point(out.dtype())) {
+  if (issubdtype(out.dtype(), inexact)) {
     switch (base_) {
       case Base::e:
         unary_fp(in, out, detail::Log());
@@ -410,7 +410,7 @@ void Log::eval(const std::vector<array>& inputs, array& out) {
 void Log1p::eval(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 1);
   const auto& in = inputs[0];
-  if (is_floating_point(out.dtype())) {
+  if (issubdtype(out.dtype(), inexact)) {
     unary_fp(in, out, detail::Log1p());
   } else {
     throw std::invalid_argument(
@@ -597,7 +597,7 @@ void Reshape::eval(const std::vector<array>& inputs, array& out) {
 void Round::eval(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 1);
   auto& in = inputs[0];
-  if (not is_integral(in.dtype())) {
+  if (issubdtype(in.dtype(), inexact)) {
     unary_fp(in, out, detail::Round());
   } else {
     // No-op integer types
@@ -608,7 +608,7 @@ void Round::eval(const std::vector<array>& inputs, array& out) {
 void Sigmoid::eval(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 1);
   const auto& in = inputs[0];
-  if (is_floating_point(out.dtype())) {
+  if (issubdtype(out.dtype(), inexact)) {
     unary_fp(in, out, detail::Sigmoid());
   } else {
     throw std::invalid_argument(
@@ -630,7 +630,7 @@ void Sign::eval(const std::vector<array>& inputs, array& out) {
 void Sin::eval(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 1);
   const auto& in = inputs[0];
-  if (is_floating_point(out.dtype())) {
+  if (issubdtype(out.dtype(), inexact)) {
     unary_fp(in, out, detail::Sin());
   } else {
     throw std::invalid_argument(
@@ -642,7 +642,7 @@ void Sin::eval(const std::vector<array>& inputs, array& out) {
 void Sinh::eval(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 1);
   const auto& in = inputs[0];
-  if (is_floating_point(out.dtype())) {
+  if (issubdtype(out.dtype(), inexact)) {
     unary_fp(in, out, detail::Sinh());
   } else {
     throw std::invalid_argument(
@@ -850,7 +850,7 @@ void StopGradient::eval(const std::vector<array>& inputs, array& out) {
 void Tan::eval(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 1);
   const auto& in = inputs[0];
-  if (is_floating_point(out.dtype())) {
+  if (issubdtype(out.dtype(), inexact)) {
     unary_fp(in, out, detail::Tan());
   } else {
     throw std::invalid_argument(
@@ -862,7 +862,7 @@ void Tan::eval(const std::vector<array>& inputs, array& out) {
 void Tanh::eval(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 1);
   const auto& in = inputs[0];
-  if (is_floating_point(out.dtype())) {
+  if (issubdtype(out.dtype(), inexact)) {
     unary_fp(in, out, detail::Tanh());
   } else {
     throw std::invalid_argument(

--- a/mlx/backend/common/scan.cpp
+++ b/mlx/backend/common/scan.cpp
@@ -222,7 +222,7 @@ void scan_dispatch(
     }
     case Scan::Min: {
       auto op = [](U* o, const U* y, const T* x) { *o = (*x < *y) ? *x : *y; };
-      auto init = (is_floating_point(input.dtype()))
+      auto init = (issubdtype(input.dtype(), floating))
           ? static_cast<U>(std::numeric_limits<float>::infinity())
           : std::numeric_limits<U>::max();
       auto opcs = DefaultContiguousScan<T, U, decltype(op)>(op, init);
@@ -232,7 +232,7 @@ void scan_dispatch(
     }
     case Scan::Max: {
       auto op = [](U* o, const U* y, const T* x) { *o = (*x < *y) ? *y : *x; };
-      auto init = (is_floating_point(input.dtype()))
+      auto init = (issubdtype(input.dtype(), floating))
           ? static_cast<U>(-std::numeric_limits<float>::infinity())
           : std::numeric_limits<U>::max();
       auto opcs = DefaultContiguousScan<T, U, decltype(op)>(op, init);

--- a/mlx/backend/metal/matmul.cpp
+++ b/mlx/backend/metal/matmul.cpp
@@ -488,7 +488,7 @@ void steel_matmul(
 
 void Matmul::eval_gpu(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 2);
-  if (!is_floating_point(out.dtype())) {
+  if (!issubdtype(out.dtype(), floating)) {
     throw std::runtime_error(
         "[matmul] Does not yet support non-floating point types.");
   }
@@ -696,7 +696,7 @@ void Matmul::eval_gpu(const std::vector<array>& inputs, array& out) {
 
 void AddMM::eval_gpu(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 3);
-  if (!is_floating_point(out.dtype())) {
+  if (!issubdtype(out.dtype(), floating)) {
     throw std::runtime_error(
         "[matmul] Does not yet support non-floating point types.");
   }

--- a/mlx/backend/metal/primitives.cpp
+++ b/mlx/backend/metal/primitives.cpp
@@ -822,7 +822,7 @@ void Reshape::eval_gpu(const std::vector<array>& inputs, array& out) {
 void Round::eval_gpu(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 1);
   const auto& in = inputs[0];
-  if (not is_integral(in.dtype())) {
+  if (issubdtype(in.dtype(), inexact)) {
     unary_op(inputs, out, "round");
   } else {
     // No-op integer types

--- a/mlx/backend/metal/scaled_dot_product_attention.cpp
+++ b/mlx/backend/metal/scaled_dot_product_attention.cpp
@@ -127,7 +127,7 @@ void ScaledDotProductAttention::eval_gpu(
     const std::vector<array>& inputs,
     array& out) {
   assert(inputs.size() >= 3);
-  if (!is_floating_point(out.dtype())) {
+  if (!issubdtype(out.dtype(), floating)) {
     throw std::runtime_error(
         "[ScaledDotProductAttention] Does not yet support non-floating point types.");
   }

--- a/mlx/backend/metal/softmax.cpp
+++ b/mlx/backend/metal/softmax.cpp
@@ -12,7 +12,7 @@ namespace mlx::core {
 
 void Softmax::eval_gpu(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 1);
-  if (!is_floating_point(out.dtype())) {
+  if (!issubdtype(out.dtype(), floating)) {
     throw std::runtime_error(
         "[softmax] Does not support non-floating point types.");
   }

--- a/mlx/dtype.cpp
+++ b/mlx/dtype.cpp
@@ -141,6 +141,37 @@ TypeToDtype<complex64_t>::operator Dtype() {
   return complex64;
 }
 
+bool issubdtype(const Dtype& a, const Dtype& b) {
+  return a == b;
+}
+
+bool issubdtype(const Dtype::Category& cat, const Dtype& type) {
+  return false;
+}
+
+bool issubdtype(const Dtype& type, const Dtype::Category& cat) {
+  if (std::find(cat.kinds.begin(), cat.kinds.end(), kindof(type)) !=
+      cat.kinds.end()) {
+    return true;
+  }
+  return std::any_of(
+      cat.subcategories.begin(),
+      cat.subcategories.end(),
+      [&type](const auto& subcategory) {
+        return issubdtype(type, subcategory);
+      });
+}
+
+bool issubdtype(const Dtype::Category& a, const Dtype::Category& b) {
+  if (a == b) {
+    return true;
+  }
+  return std::any_of(
+      b.subcategories.begin(),
+      b.subcategories.end(),
+      [&a](const auto& subcategory) { return issubdtype(a, subcategory); });
+}
+
 // Array protocol typestring for Dtype
 std::string dtype_to_array_protocol(const Dtype& t) {
   std::ostringstream r;

--- a/mlx/dtype.h
+++ b/mlx/dtype.h
@@ -38,6 +38,34 @@ struct Dtype {
     V, /* void - used for brain float */
   };
 
+  struct Category {
+    enum class Val {
+      complexfloating,
+      floating,
+      inexact,
+      signedinteger,
+      unsignedinteger,
+      integer,
+      number,
+      generic
+    };
+
+    Val val;
+    const std::vector<const Kind> kinds;
+
+    const std::vector<const Category> subcategories;
+
+    Category(
+        const Val val,
+        const std::vector<const Kind>& kinds,
+        const std::vector<const Category>& subcategories)
+        : val(val), kinds(kinds), subcategories(subcategories) {}
+
+    constexpr operator Val() const {
+      return val;
+    }
+  };
+
   Val val;
   const uint8_t size;
   constexpr explicit Dtype(Val val, uint8_t size) : val(val), size(size){};
@@ -63,6 +91,42 @@ inline constexpr Dtype float32{Dtype::Val::float32, sizeof(float)};
 inline constexpr Dtype bfloat16{Dtype::Val::bfloat16, sizeof(uint16_t)};
 inline constexpr Dtype complex64{Dtype::Val::complex64, sizeof(complex64_t)};
 
+static const Dtype::Category complexfloating = Dtype::Category(
+    Dtype::Category::Val::complexfloating,
+    {Dtype::Kind::c},
+    {});
+static const Dtype::Category floating = Dtype::Category(
+    Dtype::Category::Val::floating,
+    {Dtype::Kind::f, Dtype::Kind::V},
+    {});
+
+static const Dtype::Category inexact = Dtype::Category(
+    Dtype::Category::Val::inexact,
+    {},
+    {floating, complexfloating});
+
+static const Dtype::Category signedinteger =
+    Dtype::Category(Dtype::Category::Val::signedinteger, {Dtype::Kind::i}, {});
+static const Dtype::Category unsignedinteger = Dtype::Category(
+    Dtype::Category::Val::unsignedinteger,
+    {Dtype::Kind::u},
+    {});
+static const Dtype::Category integer = Dtype::Category(
+    Dtype::Category::Val::integer,
+    {},
+    {signedinteger, unsignedinteger});
+
+static const Dtype::Category number =
+    Dtype::Category(Dtype::Category::Val::number, {}, {integer, inexact});
+
+static const Dtype::Category generic =
+    Dtype::Category(Dtype::Category::Val::generic, {Dtype::Kind::b}, {number});
+
+bool issubdtype(const Dtype& a, const Dtype& b);
+bool issubdtype(const Dtype::Category& a, const Dtype& b);
+bool issubdtype(const Dtype& a, const Dtype::Category& b);
+bool issubdtype(const Dtype::Category& a, const Dtype::Category& b);
+
 Dtype promote_types(const Dtype& t1, const Dtype& t2);
 
 inline uint8_t size_of(const Dtype& t) {
@@ -71,19 +135,31 @@ inline uint8_t size_of(const Dtype& t) {
 
 Dtype::Kind kindof(const Dtype& t);
 
+/**
+ * equivalent to `issubdtype(t, unsignedinteger) || issubdtype(t, bool_)`
+ */
 inline bool is_unsigned(const Dtype& t) {
   return kindof(t) == Dtype::Kind::u || kindof(t) == Dtype::Kind::b;
 }
 
+/**
+ * equivalent to `issubdtype(t, floating) && !issubdtype(t, complexfloating)`
+ */
 inline bool is_floating_point(const Dtype& t) {
   return kindof(t) == Dtype::Kind::f || kindof(t) == Dtype::Kind::V ||
       kindof(t) == Dtype::Kind::c;
 }
 
+/**
+ * equivalent to `issubdtype(t, complexfloating)`
+ */
 inline bool is_complex(const Dtype& t) {
   return kindof(t) == Dtype::Kind::c;
 }
 
+/**
+ * equivalent to `issubdtype(t, integer) || issubdtype(t, bool_)`
+ */
 inline bool is_integral(const Dtype& t) {
   return !(is_floating_point(t));
 }

--- a/mlx/dtype.h
+++ b/mlx/dtype.h
@@ -1,4 +1,4 @@
-// Copyright © 2023 Apple Inc.
+// Copyright © 2023-2024 Apple Inc.
 
 #pragma once
 
@@ -38,32 +38,15 @@ struct Dtype {
     V, /* void - used for brain float */
   };
 
-  struct Category {
-    enum class Val {
-      complexfloating,
-      floating,
-      inexact,
-      signedinteger,
-      unsignedinteger,
-      integer,
-      number,
-      generic
-    };
-
-    Val val;
-    const std::vector<const Kind> kinds;
-
-    const std::vector<const Category> subcategories;
-
-    Category(
-        const Val val,
-        const std::vector<const Kind>& kinds,
-        const std::vector<const Category>& subcategories)
-        : val(val), kinds(kinds), subcategories(subcategories) {}
-
-    constexpr operator Val() const {
-      return val;
-    }
+  enum class Category {
+    complexfloating,
+    floating,
+    inexact,
+    signedinteger,
+    unsignedinteger,
+    integer,
+    number,
+    generic
   };
 
   Val val;
@@ -91,36 +74,16 @@ inline constexpr Dtype float32{Dtype::Val::float32, sizeof(float)};
 inline constexpr Dtype bfloat16{Dtype::Val::bfloat16, sizeof(uint16_t)};
 inline constexpr Dtype complex64{Dtype::Val::complex64, sizeof(complex64_t)};
 
-static const Dtype::Category complexfloating = Dtype::Category(
-    Dtype::Category::Val::complexfloating,
-    {Dtype::Kind::c},
-    {});
-static const Dtype::Category floating = Dtype::Category(
-    Dtype::Category::Val::floating,
-    {Dtype::Kind::f, Dtype::Kind::V},
-    {});
-
-static const Dtype::Category inexact = Dtype::Category(
-    Dtype::Category::Val::inexact,
-    {},
-    {floating, complexfloating});
-
-static const Dtype::Category signedinteger =
-    Dtype::Category(Dtype::Category::Val::signedinteger, {Dtype::Kind::i}, {});
-static const Dtype::Category unsignedinteger = Dtype::Category(
-    Dtype::Category::Val::unsignedinteger,
-    {Dtype::Kind::u},
-    {});
-static const Dtype::Category integer = Dtype::Category(
-    Dtype::Category::Val::integer,
-    {},
-    {signedinteger, unsignedinteger});
-
-static const Dtype::Category number =
-    Dtype::Category(Dtype::Category::Val::number, {}, {integer, inexact});
-
-static const Dtype::Category generic =
-    Dtype::Category(Dtype::Category::Val::generic, {Dtype::Kind::b}, {number});
+inline constexpr Dtype::Category complexfloating =
+    Dtype::Category::complexfloating;
+inline constexpr Dtype::Category floating = Dtype::Category::floating;
+inline constexpr Dtype::Category inexact = Dtype::Category::inexact;
+inline constexpr Dtype::Category signedinteger = Dtype::Category::signedinteger;
+inline constexpr Dtype::Category unsignedinteger =
+    Dtype::Category::unsignedinteger;
+inline constexpr Dtype::Category integer = Dtype::Category::integer;
+inline constexpr Dtype::Category number = Dtype::Category::number;
+inline constexpr Dtype::Category generic = Dtype::Category::generic;
 
 bool issubdtype(const Dtype& a, const Dtype& b);
 bool issubdtype(const Dtype::Category& a, const Dtype& b);
@@ -134,35 +97,6 @@ inline uint8_t size_of(const Dtype& t) {
 }
 
 Dtype::Kind kindof(const Dtype& t);
-
-/**
- * equivalent to `issubdtype(t, unsignedinteger) || issubdtype(t, bool_)`
- */
-inline bool is_unsigned(const Dtype& t) {
-  return kindof(t) == Dtype::Kind::u || kindof(t) == Dtype::Kind::b;
-}
-
-/**
- * equivalent to `issubdtype(t, floating) && !issubdtype(t, complexfloating)`
- */
-inline bool is_floating_point(const Dtype& t) {
-  return kindof(t) == Dtype::Kind::f || kindof(t) == Dtype::Kind::V ||
-      kindof(t) == Dtype::Kind::c;
-}
-
-/**
- * equivalent to `issubdtype(t, complexfloating)`
- */
-inline bool is_complex(const Dtype& t) {
-  return kindof(t) == Dtype::Kind::c;
-}
-
-/**
- * equivalent to `issubdtype(t, integer) || issubdtype(t, bool_)`
- */
-inline bool is_integral(const Dtype& t) {
-  return !(is_floating_point(t));
-}
 
 template <typename T>
 struct TypeToDtype {

--- a/mlx/fast.cpp
+++ b/mlx/fast.cpp
@@ -64,7 +64,7 @@ array rms_norm(
     throw std::invalid_argument(msg.str());
   }
   auto out_type = result_type(x, weight);
-  if (!is_floating_point(out_type) || is_complex(out_type)) {
+  if (!issubdtype(out_type, floating)) {
     std::ostringstream msg;
     msg << "[rms_norm] Received unsupported type " << out_type << ".";
     throw std::invalid_argument(msg.str());
@@ -128,7 +128,7 @@ array layer_norm(
       ? ((bias.has_value()) ? result_type(x, *weight, *bias)
                             : result_type(x, *weight))
       : x.dtype();
-  if (!is_floating_point(out_type) || is_complex(out_type)) {
+  if (!issubdtype(out_type, floating)) {
     std::ostringstream msg;
     msg << "[layer_norm] Received unsupported type " << out_type << ".";
     throw std::invalid_argument(msg.str());
@@ -319,7 +319,7 @@ array scaled_dot_product_attention(
   }
 
   auto final_type = result_type(queries, keys, values);
-  if (!is_floating_point(final_type) || is_complex(final_type)) {
+  if (!issubdtype(final_type, floating)) {
     std::ostringstream msg;
     msg << "[scaled_dot_product_attention] Received unsupported type "
         << final_type << ".";

--- a/mlx/linalg.cpp
+++ b/mlx/linalg.cpp
@@ -11,7 +11,7 @@
 namespace mlx::core::linalg {
 
 Dtype at_least_float(const Dtype& d) {
-  return is_floating_point(d) ? d : promote_types(d, float32);
+  return issubdtype(d, inexact) ? d : promote_types(d, float32);
 }
 
 inline array l2_norm(
@@ -19,7 +19,7 @@ inline array l2_norm(
     const std::vector<int>& axis,
     bool keepdims,
     StreamOrDevice s) {
-  if (is_complex(a.dtype())) {
+  if (issubdtype(a.dtype(), complexfloating)) {
     return sqrt(sum(abs(a, s) * abs(a, s), axis, keepdims, s), s);
   } else {
     return sqrt(sum(square(a, s), axis, keepdims, s), s);

--- a/mlx/random.cpp
+++ b/mlx/random.cpp
@@ -97,7 +97,7 @@ array uniform(
     Dtype dtype /* = float32 */,
     const std::optional<array>& key /*= nullopt */,
     StreamOrDevice s /* = {} */) {
-  if (!is_floating_point(dtype) && !is_complex(dtype)) {
+  if (!issubdtype(dtype, floating)) {
     throw std::invalid_argument(
         "Can only generate uniform numbers with real floating point type.");
   }
@@ -179,7 +179,7 @@ array randint(
     Dtype dtype /* = int32 */,
     const std::optional<array>& key /*= nullopt */,
     StreamOrDevice s /* = {} */) {
-  if (!is_integral(dtype)) {
+  if (issubdtype(dtype, inexact)) {
     throw std::invalid_argument(
         "[randint] randint only accepts integer dtypes and bool.");
   }
@@ -192,7 +192,7 @@ array bernoulli(
     const std::vector<int>& shape,
     const std::optional<array>& key /*= nullopt */,
     StreamOrDevice s /* = {} */) {
-  if (!is_floating_point(p.dtype())) {
+  if (!issubdtype(p.dtype(), floating)) {
     throw std::invalid_argument(
         "[bernoulli] bernoulli probability `p` must be a float type.");
   }
@@ -228,7 +228,7 @@ array truncated_normal(
   // Same as
   // https://jax.readthedocs.io/en/latest/_modules/jax/_src/random.html#truncated_normal
 
-  if (!is_floating_point(dtype)) {
+  if (!issubdtype(dtype, floating)) {
     throw std::invalid_argument(
         "[trunc_normal] trunc_normal only accepts floating point dtypes.");
   }

--- a/python/mlx/nn/layers/base.py
+++ b/python/mlx/nn/layers/base.py
@@ -578,3 +578,24 @@ class Module(dict):
         See :func:`train`.
         """
         self.train(False)
+
+    def set_dtype(
+        self,
+        dtype: mx.Dtype,
+        predicate: Optional[Callable[[mx.Dtype], bool]] = lambda x: mx.issubdtype(
+            x, mx.floating
+        ),
+    ):
+        """Set the dtype of the models parameters.
+
+        Args:
+            dtype (Dtype): The new dtype.
+            predicate (~typing.Callable): A predicate to select parameters to cast. By default, only parameters of type
+                :attr:`~mlx.core.floating` will be updated to avoid updating integer parameters to the new dtype.
+        """
+        if predicate is None:
+
+            def predicate(_):
+                return True
+
+        self.apply(lambda x: x.astype(dtype) if predicate(x.dtype) else x)

--- a/python/mlx/nn/layers/base.py
+++ b/python/mlx/nn/layers/base.py
@@ -590,9 +590,10 @@ class Module(dict):
 
         Args:
             dtype (Dtype): The new dtype.
-            predicate (Callable): A predicate to select parameters to cast. By
-              default, only parameters of type :attr:`floating` will be
-              updated to avoid casting integer parameters to the new dtype.
+            predicate (typing.Callable, optional): A predicate to select
+              parameters to cast. By default, only parameters of type
+              :attr:`floating` will be updated to avoid casting integer
+              parameters to the new dtype.
         """
         if predicate is None:
 

--- a/python/mlx/nn/layers/base.py
+++ b/python/mlx/nn/layers/base.py
@@ -586,12 +586,13 @@ class Module(dict):
             x, mx.floating
         ),
     ):
-        """Set the dtype of the models parameters.
+        """Set the dtype of the module's parameters.
 
         Args:
             dtype (Dtype): The new dtype.
-            predicate (~typing.Callable): A predicate to select parameters to cast. By default, only parameters of type
-                :attr:`~mlx.core.floating` will be updated to avoid updating integer parameters to the new dtype.
+            predicate (Callable): A predicate to select parameters to cast. By
+              default, only parameters of type :attr:`floating` will be
+              updated to avoid casting integer parameters to the new dtype.
         """
         if predicate is None:
 

--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -439,6 +439,54 @@ void init_array(nb::module_& m) {
   m.attr("float32") = nb::cast(float32);
   m.attr("bfloat16") = nb::cast(bfloat16);
   m.attr("complex64") = nb::cast(complex64);
+  nb::class_<Dtype::Category>(
+      m,
+      "DtypeCategory",
+      R"pbdoc(
+      Type to hold categories of :class:`dtypes <Dtype>`.
+
+      * :attr:`~mlx.core.generic`
+
+        * :ref:`bool_ <data_types>`
+        * :attr:`~mlx.core.number`
+
+          * :attr:`~mlx.core.integer`
+
+            * :attr:`~mlx.core.unsignedinteger`
+
+              * :ref:`uint8 <data_types>`
+              * :ref:`uint16 <data_types>`
+              * :ref:`uint32 <data_types>`
+              * :ref:`uint64 <data_types>`
+
+            * :attr:`~mlx.core.signedinteger`
+
+              * :ref:`int8 <data_types>`
+              * :ref:`int32 <data_types>`
+              * :ref:`int64 <data_types>`
+
+          * :attr:`~mlx.core.inexact`
+
+            * :attr:`~mlx.core.floating`
+
+              * :ref:`float16 <data_types>`
+              * :ref:`bfloat16 <data_types>`
+              * :ref:`float32 <data_types>`
+
+            * :attr:`~mlx.core.complexfloating`
+
+              * :ref:`complex128 <data_types>`
+
+      See also :func:`~mlx.core.issubdtype`.
+      )pbdoc");
+  m.attr("complexfloating") = nb::cast(complexfloating);
+  m.attr("floating") = nb::cast(floating);
+  m.attr("inexact") = nb::cast(inexact);
+  m.attr("signedinteger") = nb::cast(signedinteger);
+  m.attr("unsignedinteger") = nb::cast(unsignedinteger);
+  m.attr("integer") = nb::cast(integer);
+  m.attr("number") = nb::cast(number);
+  m.attr("generic") = nb::cast(generic);
 
   nb::class_<ArrayAt>(
       m,

--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -254,7 +254,7 @@ array array_from_list(
         std::vector<uint32_t> vals;
         fill_vector(pl, vals);
         return array(vals.begin(), shape, dtype);
-      } else if (is_floating_point(dtype)) {
+      } else if (issubdtype(dtype, inexact)) {
         std::vector<float> vals;
         fill_vector(pl, vals);
         return array(vals.begin(), shape, dtype);
@@ -748,7 +748,7 @@ void init_array(nb::module_& m) {
       .def(
           "__itruediv__",
           [](array& a, const ScalarOrArray v) -> array& {
-            if (!is_floating_point(a.dtype())) {
+            if (!issubdtype(a.dtype(), inexact)) {
               throw std::invalid_argument(
                   "In place division cannot cast to non-floating point type.");
             }
@@ -900,7 +900,7 @@ void init_array(nb::module_& m) {
       .def(
           "__invert__",
           [](const array& a) {
-            if (is_floating_point(a.dtype())) {
+            if (issubdtype(a.dtype(), inexact)) {
               throw std::invalid_argument(
                   "Floating point types not allowed with or bitwise inversion.");
             }
@@ -914,7 +914,8 @@ void init_array(nb::module_& m) {
           "__and__",
           [](const array& a, const ScalarOrArray v) {
             auto b = to_array(v, a.dtype());
-            if (is_floating_point(a.dtype()) || is_floating_point(b.dtype())) {
+            if (issubdtype(a.dtype(), inexact) ||
+                issubdtype(b.dtype(), inexact)) {
               throw std::invalid_argument(
                   "Floating point types not allowed with bitwise and.");
             }
@@ -929,7 +930,8 @@ void init_array(nb::module_& m) {
           "__iand__",
           [](array& a, const ScalarOrArray v) -> array& {
             auto b = to_array(v, a.dtype());
-            if (is_floating_point(a.dtype()) || is_floating_point(b.dtype())) {
+            if (issubdtype(a.dtype(), inexact) ||
+                issubdtype(b.dtype(), inexact)) {
               throw std::invalid_argument(
                   "Floating point types not allowed with bitwise and.");
             }
@@ -946,7 +948,8 @@ void init_array(nb::module_& m) {
           "__or__",
           [](const array& a, const ScalarOrArray v) {
             auto b = to_array(v, a.dtype());
-            if (is_floating_point(a.dtype()) || is_floating_point(b.dtype())) {
+            if (issubdtype(a.dtype(), inexact) ||
+                issubdtype(b.dtype(), inexact)) {
               throw std::invalid_argument(
                   "Floating point types not allowed with or bitwise or.");
             }
@@ -961,7 +964,8 @@ void init_array(nb::module_& m) {
           "__ior__",
           [](array& a, const ScalarOrArray v) -> array& {
             auto b = to_array(v, a.dtype());
-            if (is_floating_point(a.dtype()) || is_floating_point(b.dtype())) {
+            if (issubdtype(a.dtype(), inexact) ||
+                issubdtype(b.dtype(), inexact)) {
               throw std::invalid_argument(
                   "Floating point types not allowed with or bitwise or.");
             }

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -3684,4 +3684,63 @@ void init_ops(nb::module_& m) {
         Returns:
             array or list(array): An array or list of arrays with at least three dimensions.
         )pbdoc");
+  m.def(
+      "issubdtype",
+      nb::overload_cast<const Dtype&, const Dtype&>(&issubdtype),
+      ""_a,
+      ""_a,
+      R"pbdoc(
+        issubdtype(arg1: Union[Dtype, DtypeCategory], arg2: Union[Dtype, DtypeCategory], /) -> bool
+
+        `issubdtype` can be used to check the type of arrays:
+
+        >>> ints = mx.array([1, 2, 3], dtype=mx.int32)
+        >>> mx.issubdtype(ints.dtype, mx.integer)
+        True
+        >>> mx.issubdtype(ints.dtype, mx.floating)
+        False
+
+        >>> floats = mx.array([1, 2, 3], dtype=mx.float32)
+        >>> mx.issubdtype(floats.dtype, mx.integer)
+        False
+        >>> mx.issubdtype(floats.dtype, mx.floating)
+        True
+
+        Similar types of different sizes are not subdtypes of each other:
+
+        >>> mx.issubdtype(mx.float64, mx.float32)
+        False
+        >>> mx.issubdtype(mx.float32, mx.float64)
+        False
+
+        but both are subtypes of `floating`:
+
+        >>> mx.issubdtype(mx.float64, mx.floating)
+        True
+        >>> mx.issubdtype(mx.float32, mx.floating)
+        True
+
+        For convenience, dtype-like objects are allowed too:
+
+        >>> mx.issubdtype(mx.float32, mx.inexact)
+        True
+        >>> mx.issubdtype(mx.signedinteger, mx.floating)
+        False
+      )pbdoc");
+  m.def(
+      "issubdtype",
+      nb::overload_cast<const Dtype&, const Dtype::Category&>(&issubdtype),
+      ""_a,
+      ""_a);
+  m.def(
+      "issubdtype",
+      nb::overload_cast<const Dtype::Category&, const Dtype&>(&issubdtype),
+      ""_a,
+      ""_a);
+  m.def(
+      "issubdtype",
+      nb::overload_cast<const Dtype::Category&, const Dtype::Category&>(
+          &issubdtype),
+      ""_a,
+      ""_a);
 }

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -3690,7 +3690,7 @@ void init_ops(nb::module_& m) {
       ""_a,
       ""_a,
       R"pbdoc(
-        Check if one :obj:`Dytpe` or :obj:`DtypeCategory` is a subtype
+        Check if a :obj:`Dytpe` or :obj:`DtypeCategory` is a subtype
         of another.
 
         >>> ints = mx.array([1, 2, 3], dtype=mx.int32)

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -3690,7 +3690,7 @@ void init_ops(nb::module_& m) {
       ""_a,
       ""_a,
       R"pbdoc(
-        Check if a :obj:`Dytpe` or :obj:`DtypeCategory` is a subtype
+        Check if a :obj:`Dtype` or :obj:`DtypeCategory` is a subtype
         of another.
 
         >>> ints = mx.array([1, 2, 3], dtype=mx.int32)

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -3690,9 +3690,8 @@ void init_ops(nb::module_& m) {
       ""_a,
       ""_a,
       R"pbdoc(
-        issubdtype(arg1: Union[Dtype, DtypeCategory], arg2: Union[Dtype, DtypeCategory], /) -> bool
-
-        `issubdtype` can be used to check the type of arrays:
+        Check if one :obj:`Dytpe` or :obj:`DtypeCategory` is a subtype
+        of another.
 
         >>> ints = mx.array([1, 2, 3], dtype=mx.int32)
         >>> mx.issubdtype(ints.dtype, mx.integer)

--- a/python/src/utils.h
+++ b/python/src/utils.h
@@ -56,7 +56,7 @@ inline array to_array(
   } else if (auto pv = std::get_if<nb::float_>(&v); pv) {
     auto out_t = dtype.value_or(float32);
     return array(
-        nb::cast<float>(*pv), is_floating_point(out_t) ? out_t : float32);
+        nb::cast<float>(*pv), issubdtype(out_t, floating) ? out_t : float32);
   } else if (auto pv = std::get_if<std::complex<float>>(&v); pv) {
     return array(static_cast<complex64_t>(*pv), complex64);
   } else {

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -1492,6 +1492,29 @@ class TestLayers(mlx_tests.MLXTestCase):
             "AvgPool2d(kernel_size=(1, 2), stride=(2, 2), padding=(1, 2))",
         )
 
+    def test_set_dtype(self):
+        def assert_dtype(layer, dtype):
+            for k, v in tree_flatten(layer.parameters()):
+                self.assertEqual(v.dtype, dtype, f"dtype mismatch for {k}")
+
+        layer = nn.Linear(input_dims=4, output_dims=8, bias=True)
+        assert_dtype(layer, mx.float32)
+
+        layer.set_dtype(mx.bfloat16)
+        assert_dtype(layer, mx.bfloat16)
+
+        layer.set_dtype(mx.float32, lambda x: False)
+        assert_dtype(layer, mx.bfloat16)
+
+        layer.set_dtype(mx.int32, lambda x: True)
+        assert_dtype(layer, mx.int32)
+
+        layer.set_dtype(mx.int64, predicate=None)
+        assert_dtype(layer, mx.int64)
+
+        layer.set_dtype(mx.int16, lambda x: mx.issubdtype(x, mx.integer))
+        assert_dtype(layer, mx.int16)
+
     def test_rnn(self):
         layer = nn.RNN(input_size=5, hidden_size=12, bias=True)
         inp = mx.random.normal((2, 25, 5))

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -2026,6 +2026,40 @@ class TestOps(mlx_tests.MLXTestCase):
             self.assertEqual(mx_res.ndim, np_res.ndim)
             self.assertTrue(mx.all(mx.equal(mx_res, atleast_arrays[i])))
 
+    def test_issubdtype(self):
+        self.assertTrue(mx.issubdtype(mx.bfloat16, mx.inexact))
+
+        cats = [
+            "complexfloating",
+            "floating",
+            "inexact",
+            "signedinteger",
+            "unsignedinteger",
+            "integer",
+            "number",
+            "generic",
+            "bool_",
+            "uint8",
+            "uint16",
+            "uint32",
+            "uint64",
+            "int8",
+            "int16",
+            "int32",
+            "int64",
+            "float16",
+            "float32",
+            "complex64",
+        ]
+
+        for a in cats:
+            for b in cats:
+                self.assertEqual(
+                    mx.issubdtype(getattr(mx, a), getattr(mx, b)),
+                    np.issubdtype(getattr(np, a), getattr(np, b)),
+                    f"mx and np don't aggree on {a}, {b}",
+                )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/ops_tests.cpp
+++ b/tests/ops_tests.cpp
@@ -2950,7 +2950,7 @@ TEST_CASE("test issubdtype") {
   for (const auto& cat : cats) {
     CHECK(issubdtype(cat, cat));
     switch (cat) {
-      case Dtype::Category::Val::complexfloating:
+      case Dtype::Category::complexfloating:
         CHECK(issubdtype(cat, complexfloating));
         CHECK_FALSE(issubdtype(cat, floating));
         CHECK(issubdtype(cat, inexact));
@@ -2960,7 +2960,7 @@ TEST_CASE("test issubdtype") {
         CHECK(issubdtype(cat, number));
         CHECK(issubdtype(cat, generic));
         break;
-      case Dtype::Category::Val::floating:
+      case Dtype::Category::floating:
         CHECK_FALSE(issubdtype(cat, complexfloating));
         CHECK(issubdtype(cat, floating));
         CHECK(issubdtype(cat, inexact));
@@ -2970,7 +2970,7 @@ TEST_CASE("test issubdtype") {
         CHECK(issubdtype(cat, number));
         CHECK(issubdtype(cat, generic));
         break;
-      case Dtype::Category::Val::inexact:
+      case Dtype::Category::inexact:
         CHECK_FALSE(issubdtype(cat, complexfloating));
         CHECK_FALSE(issubdtype(cat, floating));
         CHECK(issubdtype(cat, inexact));
@@ -2980,7 +2980,7 @@ TEST_CASE("test issubdtype") {
         CHECK(issubdtype(cat, number));
         CHECK(issubdtype(cat, generic));
         break;
-      case Dtype::Category::Val::signedinteger:
+      case Dtype::Category::signedinteger:
         CHECK_FALSE(issubdtype(cat, complexfloating));
         CHECK_FALSE(issubdtype(cat, floating));
         CHECK_FALSE(issubdtype(cat, inexact));
@@ -2990,7 +2990,7 @@ TEST_CASE("test issubdtype") {
         CHECK(issubdtype(cat, number));
         CHECK(issubdtype(cat, generic));
         break;
-      case Dtype::Category::Val::unsignedinteger:
+      case Dtype::Category::unsignedinteger:
         CHECK_FALSE(issubdtype(cat, complexfloating));
         CHECK_FALSE(issubdtype(cat, floating));
         CHECK_FALSE(issubdtype(cat, inexact));
@@ -3000,7 +3000,7 @@ TEST_CASE("test issubdtype") {
         CHECK(issubdtype(cat, number));
         CHECK(issubdtype(cat, generic));
         break;
-      case Dtype::Category::Val::integer:
+      case Dtype::Category::integer:
         CHECK_FALSE(issubdtype(cat, complexfloating));
         CHECK_FALSE(issubdtype(cat, floating));
         CHECK_FALSE(issubdtype(cat, inexact));
@@ -3010,7 +3010,7 @@ TEST_CASE("test issubdtype") {
         CHECK(issubdtype(cat, number));
         CHECK(issubdtype(cat, generic));
         break;
-      case Dtype::Category::Val::number:
+      case Dtype::Category::number:
         CHECK_FALSE(issubdtype(cat, complexfloating));
         CHECK_FALSE(issubdtype(cat, floating));
         CHECK_FALSE(issubdtype(cat, inexact));
@@ -3020,7 +3020,7 @@ TEST_CASE("test issubdtype") {
         CHECK(issubdtype(cat, number));
         CHECK(issubdtype(cat, generic));
         break;
-      case Dtype::Category::Val::generic:
+      case Dtype::Category::generic:
         CHECK_FALSE(issubdtype(cat, complexfloating));
         CHECK_FALSE(issubdtype(cat, floating));
         CHECK_FALSE(issubdtype(cat, inexact));

--- a/tests/ops_tests.cpp
+++ b/tests/ops_tests.cpp
@@ -2848,6 +2848,192 @@ TEST_CASE("test diag") {
   CHECK(array_equal(out, array({3, 7}, {2})).item<bool>());
 }
 
+TEST_CASE("test issubdtype") {
+  const auto cats = {
+      complexfloating,
+      floating,
+      inexact,
+      signedinteger,
+      unsignedinteger,
+      integer,
+      number,
+      generic};
+  const auto types = {
+      bool_,
+      uint8,
+      uint16,
+      uint32,
+      uint64,
+      int8,
+      int16,
+      int32,
+      int64,
+      float16,
+      float32,
+      bfloat16,
+      complex64};
+  for (const auto& type : types) {
+    CHECK(issubdtype(type, type));
+    CHECK(issubdtype(type, generic));
+    switch (kindof(type)) {
+      case Dtype::Kind::b:
+        CHECK_FALSE(issubdtype(type, complexfloating));
+        CHECK_FALSE(issubdtype(type, floating));
+        CHECK_FALSE(issubdtype(type, inexact));
+        CHECK_FALSE(issubdtype(type, signedinteger));
+        CHECK_FALSE(issubdtype(type, unsignedinteger));
+        CHECK_FALSE(issubdtype(type, integer));
+        CHECK_FALSE(issubdtype(type, number));
+        CHECK(issubdtype(type, generic));
+        break;
+      case Dtype::Kind::u:
+        CHECK_FALSE(issubdtype(type, complexfloating));
+        CHECK_FALSE(issubdtype(type, floating));
+        CHECK_FALSE(issubdtype(type, inexact));
+        CHECK_FALSE(issubdtype(type, signedinteger));
+        CHECK(issubdtype(type, unsignedinteger));
+        CHECK(issubdtype(type, integer));
+        CHECK(issubdtype(type, number));
+        CHECK(issubdtype(type, generic));
+        break;
+      case Dtype::Kind::i:
+        CHECK_FALSE(issubdtype(type, complexfloating));
+        CHECK_FALSE(issubdtype(type, floating));
+        CHECK_FALSE(issubdtype(type, inexact));
+        CHECK(issubdtype(type, signedinteger));
+        CHECK_FALSE(issubdtype(type, unsignedinteger));
+        CHECK(issubdtype(type, integer));
+        CHECK(issubdtype(type, number));
+        CHECK(issubdtype(type, generic));
+        break;
+      case Dtype::Kind::f:
+        CHECK_FALSE(issubdtype(type, complexfloating));
+        CHECK(issubdtype(type, floating));
+        CHECK(issubdtype(type, inexact));
+        CHECK_FALSE(issubdtype(type, signedinteger));
+        CHECK_FALSE(issubdtype(type, unsignedinteger));
+        CHECK_FALSE(issubdtype(type, integer));
+        CHECK(issubdtype(type, number));
+        CHECK(issubdtype(type, generic));
+        break;
+      case Dtype::Kind::c:
+        CHECK(issubdtype(type, complexfloating));
+        CHECK_FALSE(issubdtype(type, floating));
+        CHECK(issubdtype(type, inexact));
+        CHECK_FALSE(issubdtype(type, signedinteger));
+        CHECK_FALSE(issubdtype(type, unsignedinteger));
+        CHECK_FALSE(issubdtype(type, integer));
+        CHECK(issubdtype(type, number));
+        CHECK(issubdtype(type, generic));
+        break;
+      case Dtype::Kind::V:
+        CHECK_FALSE(issubdtype(type, complexfloating));
+        CHECK(issubdtype(type, floating));
+        CHECK(issubdtype(type, inexact));
+        CHECK_FALSE(issubdtype(type, signedinteger));
+        CHECK_FALSE(issubdtype(type, unsignedinteger));
+        CHECK_FALSE(issubdtype(type, integer));
+        CHECK(issubdtype(type, number));
+        CHECK(issubdtype(type, generic));
+        break;
+    }
+  }
+
+  for (const auto& type : types) {
+    CHECK(issubdtype(type, type));
+    CHECK(issubdtype(type, generic));
+    for (auto type1 : types) {
+      CHECK_EQ(issubdtype(type, type1), type == type1);
+    }
+  }
+
+  for (const auto& cat : cats) {
+    CHECK(issubdtype(cat, cat));
+    switch (cat) {
+      case Dtype::Category::Val::complexfloating:
+        CHECK(issubdtype(cat, complexfloating));
+        CHECK_FALSE(issubdtype(cat, floating));
+        CHECK(issubdtype(cat, inexact));
+        CHECK_FALSE(issubdtype(cat, signedinteger));
+        CHECK_FALSE(issubdtype(cat, unsignedinteger));
+        CHECK_FALSE(issubdtype(cat, integer));
+        CHECK(issubdtype(cat, number));
+        CHECK(issubdtype(cat, generic));
+        break;
+      case Dtype::Category::Val::floating:
+        CHECK_FALSE(issubdtype(cat, complexfloating));
+        CHECK(issubdtype(cat, floating));
+        CHECK(issubdtype(cat, inexact));
+        CHECK_FALSE(issubdtype(cat, signedinteger));
+        CHECK_FALSE(issubdtype(cat, unsignedinteger));
+        CHECK_FALSE(issubdtype(cat, integer));
+        CHECK(issubdtype(cat, number));
+        CHECK(issubdtype(cat, generic));
+        break;
+      case Dtype::Category::Val::inexact:
+        CHECK_FALSE(issubdtype(cat, complexfloating));
+        CHECK_FALSE(issubdtype(cat, floating));
+        CHECK(issubdtype(cat, inexact));
+        CHECK_FALSE(issubdtype(cat, signedinteger));
+        CHECK_FALSE(issubdtype(cat, unsignedinteger));
+        CHECK_FALSE(issubdtype(cat, integer));
+        CHECK(issubdtype(cat, number));
+        CHECK(issubdtype(cat, generic));
+        break;
+      case Dtype::Category::Val::signedinteger:
+        CHECK_FALSE(issubdtype(cat, complexfloating));
+        CHECK_FALSE(issubdtype(cat, floating));
+        CHECK_FALSE(issubdtype(cat, inexact));
+        CHECK(issubdtype(cat, signedinteger));
+        CHECK_FALSE(issubdtype(cat, unsignedinteger));
+        CHECK(issubdtype(cat, integer));
+        CHECK(issubdtype(cat, number));
+        CHECK(issubdtype(cat, generic));
+        break;
+      case Dtype::Category::Val::unsignedinteger:
+        CHECK_FALSE(issubdtype(cat, complexfloating));
+        CHECK_FALSE(issubdtype(cat, floating));
+        CHECK_FALSE(issubdtype(cat, inexact));
+        CHECK_FALSE(issubdtype(cat, signedinteger));
+        CHECK(issubdtype(cat, unsignedinteger));
+        CHECK(issubdtype(cat, integer));
+        CHECK(issubdtype(cat, number));
+        CHECK(issubdtype(cat, generic));
+        break;
+      case Dtype::Category::Val::integer:
+        CHECK_FALSE(issubdtype(cat, complexfloating));
+        CHECK_FALSE(issubdtype(cat, floating));
+        CHECK_FALSE(issubdtype(cat, inexact));
+        CHECK_FALSE(issubdtype(cat, signedinteger));
+        CHECK_FALSE(issubdtype(cat, unsignedinteger));
+        CHECK(issubdtype(cat, integer));
+        CHECK(issubdtype(cat, number));
+        CHECK(issubdtype(cat, generic));
+        break;
+      case Dtype::Category::Val::number:
+        CHECK_FALSE(issubdtype(cat, complexfloating));
+        CHECK_FALSE(issubdtype(cat, floating));
+        CHECK_FALSE(issubdtype(cat, inexact));
+        CHECK_FALSE(issubdtype(cat, signedinteger));
+        CHECK_FALSE(issubdtype(cat, unsignedinteger));
+        CHECK_FALSE(issubdtype(cat, integer));
+        CHECK(issubdtype(cat, number));
+        CHECK(issubdtype(cat, generic));
+        break;
+      case Dtype::Category::Val::generic:
+        CHECK_FALSE(issubdtype(cat, complexfloating));
+        CHECK_FALSE(issubdtype(cat, floating));
+        CHECK_FALSE(issubdtype(cat, inexact));
+        CHECK_FALSE(issubdtype(cat, signedinteger));
+        CHECK_FALSE(issubdtype(cat, unsignedinteger));
+        CHECK_FALSE(issubdtype(cat, integer));
+        CHECK_FALSE(issubdtype(cat, number));
+        CHECK(issubdtype(cat, generic));
+        break;
+    }
+  }
+}
+
 TEST_CASE("test atleast_1d") {
   auto x = array(1);
   auto out = atleast_1d(x);


### PR DESCRIPTION
…od to nn.Module with predicate

numeric type hierarchy and issubtype is compatible to the [numpy hierarchy](https://github.com/numpy/numpy/blob/220f0ab2c5958f9d49b9a28c69a760657b06d9b9/numpy/_core/numerictypes.py#L42).

Closes #285.

## Proposed changes

Please include a description of the problem or feature this PR is addressing. If there is a corresponding issue, include the issue #.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
