### PR TITLE
scatter_add bindings + tests

### DIFF
--- a/docs/src/python/ops.rst
+++ b/docs/src/python/ops.rst
@@ -91,6 +91,7 @@ Operations
    savez_compressed
    save_gguf
    save_safetensors
+   scatter_add
    sigmoid
    sign
    sin

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -3376,4 +3376,53 @@ void init_ops(py::module_& m) {
       Returns:
         result (array): The outer product.
     )pbdoc");
+  m.def(
+      "scatter_add",
+      [](const array& a,
+         const std::variant<std::monostate, array, std::vector<array>>& indices,
+         const array& updates,
+         const IntOrVec& axes,
+         StreamOrDevice s) {
+        if (auto index = std::get_if<array>(&indices); index) {
+          if (auto axis = std::get_if<int>(&axes); axis) {
+            return scatter_add(a, *index, updates, *axis, s);
+          } else {
+            throw std::invalid_argument(
+                "[scatter_add] One array provided so one axis expected");
+          }
+        } else {
+          if (auto axis = std::get_if<int>(&axes); axis) {
+            throw std::invalid_argument(
+                "[scatter_add] Many indices provided so many axes expected");
+          } else {
+            return scatter_add(
+                a,
+                std::get<std::vector<array>>(indices),
+                updates,
+                std::get<std::vector<int>>(axes),
+                s);
+          }
+        }
+      },
+      "a"_a,
+      py::pos_only(),
+      "indices"_a,
+      "updates"_a,
+      "axes"_a,
+      py::kw_only(),
+      "stream"_a = none,
+      R"pbdoc(
+        scatter_add(a: array, /, indices: List[array], updates: array, axes: Union[int, List[int]], *, stream: Union[None, Stream, Device] = None) -> array
+        Scatter and add atomically the updates to the input array ``a``.
+        Args:
+          a (array): Input array
+          indices (Union[array, List[array]]): The arrays containing the
+            indices to add the updates to
+          updates (array): The array containing the updates to be added
+            to the input
+          axes (Union[int, List[int]]): Defines which axes of the input
+            the indices correspond to
+        Returns:
+          result (array): The input with the ``updates`` added to the locations specidied by ``indices``
+      )pbdoc");
 }

--- a/python/tests/test_autograd.py
+++ b/python/tests/test_autograd.py
@@ -293,6 +293,25 @@ class TestAutograd(mlx_tests.MLXTestCase):
         self.assertTrue(mx.array_equal(dfdx, mx.array([1.0])))
         self.assertEqual(dfdx.dtype, mx.float32)
 
+    def test_scatter_add_vjp(self):
+        def fun(src, updates):
+            x = mx.scatter_add(src, mx.array([1]), updates, 0)
+            return x
+
+        cotan = mx.array([4.0, 5.0, 6.0])
+        _, vjps = mx.vjp(fun, [mx.array([1.0, 2.0, 3.0]), mx.array([[3.0]])], [cotan])
+        mx.eval(vjps)
+
+        self.assertTrue(mx.allclose(vjps[0], mx.array([4.0, 5.0, 6.0])))
+        self.assertTrue(mx.allclose(vjps[1], mx.array([5.0])))
+
+        cotan = mx.array([[4.0], [5.0], [6.0]])
+        _, vjps = mx.vjp(fun, [mx.array([[1.0], [2.0], [3.0]]), mx.array([[[3.0]]])], [cotan])
+        mx.eval(vjps)
+
+        self.assertTrue(mx.allclose(vjps[0], mx.array([[4.0], [5.0], [6.0]])))
+        self.assertTrue(mx.allclose(vjps[1], mx.array([[[5.0]]])))
+
     def test_vjp_types(self):
         def fun(x):
             return x

--- a/python/tests/test_autograd.py
+++ b/python/tests/test_autograd.py
@@ -306,7 +306,9 @@ class TestAutograd(mlx_tests.MLXTestCase):
         self.assertTrue(mx.allclose(vjps[1], mx.array([5.0])))
 
         cotan = mx.array([[4.0], [5.0], [6.0]])
-        _, vjps = mx.vjp(fun, [mx.array([[1.0], [2.0], [3.0]]), mx.array([[[3.0]]])], [cotan])
+        _, vjps = mx.vjp(
+            fun, [mx.array([[1.0], [2.0], [3.0]]), mx.array([[[3.0]]])], [cotan]
+        )
         mx.eval(vjps)
 
         self.assertTrue(mx.allclose(vjps[0], mx.array([[4.0], [5.0], [6.0]])))


### PR DESCRIPTION
## Proposed changes

Python bindings for `scatter_add`, as we need `scatter_*` operations for the development of `mlx-graphs`.
Also added some tests for the `vjp`.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
