### PR TITLE
array.swapaxes should point to swapaxes free function

### DIFF
--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -1147,7 +1147,7 @@ void init_array(py::module_& m) {
           "axis2"_a,
           py::kw_only(),
           "stream"_a = none,
-          "See :func:`moveaxis`.")
+          "See :func:`swapaxes`.")
       .def(
           "transpose",
           [](const array& a, py::args axes, StreamOrDevice s) {


### PR DESCRIPTION
## Proposed changes

I noticed that the docs for `mx.array.swapaxes()` pointed to `mx.moveaxis()` rather than `mx.swapaxes()`

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
