### PR TITLE
GGUF: Load and save metadata

### DIFF
--- a/mlx/io.h
+++ b/mlx/io.h
@@ -38,18 +38,8 @@ void save_safetensors(
     const std::string& file,
     std::unordered_map<std::string, array>);
 
-using MetaData = std::variant<std::monostate, array, std::string>;
-// TODO pybind had issues casting to this, we might be able
-// to find a workaround but for now no support for nested containers
-/*struct MetaData;
-struct MetaData
-    : public std::
-          variant<std::monostate, array, std::string, std::vector<MetaData>> {
- public:
-  using base =
-      std::variant<std::monostate, array, std::string, std::vector<MetaData>>;
-  using base::base;
-};*/
+using MetaData =
+    std::variant<std::monostate, array, std::string, std::vector<std::string>>;
 
 /** Load metadata and array map from .gguf file format */
 std::pair<

--- a/mlx/io.h
+++ b/mlx/io.h
@@ -1,0 +1,62 @@
+// Copyright © 2023-2024 Apple Inc.
+
+#pragma once
+
+#include <variant>
+
+#include "mlx/array.h"
+#include "mlx/io/load.h"
+#include "mlx/ops.h"
+#include "mlx/stream.h"
+
+namespace mlx::core {
+
+/** Save array to out stream in .npy format */
+void save(std::shared_ptr<io::Writer> out_stream, array a);
+
+/** Save array to file in .npy format */
+void save(const std::string& file, array a);
+
+/** Load array from reader in .npy format */
+array load(std::shared_ptr<io::Reader> in_stream, StreamOrDevice s = {});
+
+/** Load array from file in .npy format */
+array load(const std::string& file, StreamOrDevice s = {});
+
+/** Load array map from .safetensors file format */
+std::unordered_map<std::string, array> load_safetensors(
+    std::shared_ptr<io::Reader> in_stream,
+    StreamOrDevice s = {});
+std::unordered_map<std::string, array> load_safetensors(
+    const std::string& file,
+    StreamOrDevice s = {});
+
+void save_safetensors(
+    std::shared_ptr<io::Writer> in_stream,
+    std::unordered_map<std::string, array>);
+void save_safetensors(
+    const std::string& file,
+    std::unordered_map<std::string, array>);
+
+struct MetaData;
+struct MetaData
+    : public std::
+          variant<std::monostate, array, std::string, std::vector<MetaData>> {
+ public:
+  using base =
+      std::variant<std::monostate, array, std::string, std::vector<MetaData>>;
+  using base::base;
+};
+
+/** Load metadata and array map from .gguf file format */
+std::pair<
+    std::unordered_map<std::string, array>,
+    std::unordered_map<std::string, MetaData>>
+load_gguf(const std::string& file, StreamOrDevice s = {});
+
+void save_gguf(
+    std::string file,
+    std::unordered_map<std::string, array> array_map,
+    std::unordered_map<std::string, MetaData> meta_data = {});
+
+} // namespace mlx::core

--- a/mlx/io.h
+++ b/mlx/io.h
@@ -41,7 +41,7 @@ void save_safetensors(
 using MetaData =
     std::variant<std::monostate, array, std::string, std::vector<std::string>>;
 
-/** Load metadata and array map from .gguf file format */
+/** Load array map and metadata from .gguf file format */
 std::pair<
     std::unordered_map<std::string, array>,
     std::unordered_map<std::string, MetaData>>

--- a/mlx/io.h
+++ b/mlx/io.h
@@ -38,7 +38,10 @@ void save_safetensors(
     const std::string& file,
     std::unordered_map<std::string, array>);
 
-struct MetaData;
+using MetaData = std::variant<std::monostate, array, std::string>;
+// TODO pybind had issues casting to this, we might be able
+// to find a workaround but for now no support for nested containers
+/*struct MetaData;
 struct MetaData
     : public std::
           variant<std::monostate, array, std::string, std::vector<MetaData>> {
@@ -46,7 +49,7 @@ struct MetaData
   using base =
       std::variant<std::monostate, array, std::string, std::vector<MetaData>>;
   using base::base;
-};
+};*/
 
 /** Load metadata and array map from .gguf file format */
 std::pair<

--- a/mlx/io/gguf.cpp
+++ b/mlx/io/gguf.cpp
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <cstring>
 
-#include "mlx/ops.h"
+#include "mlx/io.h"
 #include "mlx/primitives.h"
 #include "mlx/utils.h"
 
@@ -71,55 +71,62 @@ std::pair<allocator::Buffer, Dtype> extract_tensor_data(gguf_tensor* tensor) {
   return {buffer, float16};
 }
 
-void metadata_value_callback(void *privdata, uint32_t type, union gguf_value *val, uint64_t in_array, uint64_t array_len) {
-  auto *value = (struct metadata*) privdata;
+void metadata_value_callback(
+    void* privdata,
+    uint32_t type,
+    union gguf_value* val,
+    uint64_t in_array,
+    uint64_t array_len) {
+  auto value = static_cast<MetaData*>(privdata);
   // TODO: Support all other types.
   switch (type) {
-        case GGUF_VALUE_TYPE_ARRAY_START:
-          break;
-        case GGUF_VALUE_TYPE_ARRAY_END:
-          break;
-        case GGUF_VALUE_TYPE_UINT8:
-          break;
-        case GGUF_VALUE_TYPE_INT8:
-          break;
-        case GGUF_VALUE_TYPE_UINT16:
-          break;
-        case GGUF_VALUE_TYPE_INT16:
-          break;
-        case GGUF_VALUE_TYPE_UINT32:
-          break;
-        case GGUF_VALUE_TYPE_INT32:
-          break;
-        case GGUF_VALUE_TYPE_FLOAT32:
-          break;
-        case GGUF_VALUE_TYPE_BOOL:
-          break;
-        case GGUF_VALUE_TYPE_STRING:
-          value->string = std::string(val->string.string, (int)val->string.len);
-          break;
-        case GGUF_VALUE_TYPE_UINT64:
-          break;
-        case GGUF_VALUE_TYPE_INT64:
-          break;
-        case GGUF_VALUE_TYPE_FLOAT64:
-          break;
-        default:
-          throw std::runtime_error("[load_gguf] unknown value type");
-          break;
-    }
+    case GGUF_VALUE_TYPE_ARRAY_START:
+      break;
+    case GGUF_VALUE_TYPE_ARRAY_END:
+      break;
+    case GGUF_VALUE_TYPE_UINT8:
+      break;
+    case GGUF_VALUE_TYPE_INT8:
+      break;
+    case GGUF_VALUE_TYPE_UINT16:
+      break;
+    case GGUF_VALUE_TYPE_INT16:
+      break;
+    case GGUF_VALUE_TYPE_UINT32:
+      break;
+    case GGUF_VALUE_TYPE_INT32:
+      break;
+    case GGUF_VALUE_TYPE_FLOAT32:
+      break;
+    case GGUF_VALUE_TYPE_BOOL:
+      break;
+    case GGUF_VALUE_TYPE_STRING:
+      *value =
+          std::string(val->string.string, static_cast<int>(val->string.len));
+      break;
+    case GGUF_VALUE_TYPE_UINT64:
+      break;
+    case GGUF_VALUE_TYPE_INT64:
+      break;
+    case GGUF_VALUE_TYPE_FLOAT64:
+      break;
+    default:
+      throw std::runtime_error("[load_gguf] unknown value type");
+      break;
+  }
 }
 
-std::unordered_map<std::string, metadata> load_metadata(gguf_ctx* ctx) {
-  std::unordered_map<std::string, metadata> metadata_map;
+std::unordered_map<std::string, MetaData> load_meta_data(gguf_ctx* ctx) {
+  std::unordered_map<std::string, MetaData> meta_data;
   gguf_key key;
-  while (gguf_get_key(ctx,&key)) {
+  while (gguf_get_key(ctx, &key)) {
     std::string key_name = std::string(key.name, key.namelen);
-    metadata value;
-    gguf_do_with_value(ctx,key.type,key.val,&value,0,0,metadata_value_callback);
-    metadata_map.insert({key_name, value});
+    MetaData value;
+    gguf_do_with_value(
+        ctx, key.type, key.val, &value, 0, 0, metadata_value_callback);
+    meta_data.insert({key_name, value});
   }
-  return metadata_map;
+  return meta_data;
 }
 
 std::unordered_map<std::string, array> load_arrays(gguf_ctx* ctx) {
@@ -140,43 +147,50 @@ std::unordered_map<std::string, array> load_arrays(gguf_ctx* ctx) {
 }
 
 std::pair<
-std::unordered_map<std::string, array>,
-std::unordered_map<std::string, metadata>> load_gguf(
-    const std::string& file,
-    StreamOrDevice s) {
+    std::unordered_map<std::string, array>,
+    std::unordered_map<std::string, MetaData>>
+load_gguf(const std::string& file, StreamOrDevice s) {
   gguf_ctx* ctx = gguf_open(file.c_str());
   if (!ctx) {
     throw std::runtime_error("[load_gguf] gguf_init failed");
   }
-  const auto& metadata_map = load_metadata(ctx);
-  const auto& array_map = load_arrays(ctx);
+  auto meta_data = load_meta_data(ctx);
+  auto arrays = load_arrays(ctx);
   gguf_close(ctx);
-  return {array_map, metadata_map};
+  return {arrays, meta_data};
 }
 
 void save_gguf(
     std::string file,
     std::unordered_map<std::string, array> array_map,
-    std::unordered_map<std::string, metadata> metadata_map) {
+    std::unordered_map<std::string, MetaData> meta_data /* = {} */) {
   // Add .gguf to file name if it is not there
   if (file.length() < 5 || file.substr(file.length() - 5, 5) != ".gguf") {
     file += ".gguf";
   }
+
   gguf_ctx* ctx = gguf_create(file.c_str(), GGUF_OVERWRITE);
   if (!ctx) {
     throw std::runtime_error("[save_gguf] gguf_create failed");
   }
 
-  for (const auto& [key, value] : metadata_map) {
-    if (value.string.has_value()) {
-      const std::string& str = value.string.value();
-      const size_t size = sizeof(gguf_string) + str.length();
-      gguf_string* val = reinterpret_cast<gguf_string*>(new char[size + 1]);
+  // Save any meta data
+  for (const auto& [key, value] : meta_data) {
+    if (auto pv = std::get_if<std::string>(&value); pv) {
+      const std::string& str = *pv;
+      size_t size = sizeof(gguf_string) + str.length();
+      std::vector<char> val_vec(size + 1);
+      gguf_string* val = reinterpret_cast<gguf_string*>(val_vec.data());
       val->len = str.length();
       memcpy(val->string, str.c_str(), str.length());
       val->string[str.length()] = '\0';
-      gguf_append_kv(ctx, key.c_str(), key.length(), GGUF_VALUE_TYPE_STRING, (void *) val, size);
-      delete[] reinterpret_cast<char*>(val);
+      gguf_append_kv(
+          ctx,
+          key.c_str(),
+          key.length(),
+          GGUF_VALUE_TYPE_STRING,
+          static_cast<void*>(val),
+          size);
     }
     // TODO: serialize other types
   }

--- a/mlx/io/safetensor.cpp
+++ b/mlx/io/safetensor.cpp
@@ -3,8 +3,8 @@
 #include <json.hpp>
 #include <stack>
 
+#include "mlx/io.h"
 #include "mlx/io/load.h"
-#include "mlx/ops.h"
 #include "mlx/primitives.h"
 
 using json = nlohmann::json;

--- a/mlx/mlx.h
+++ b/mlx/mlx.h
@@ -6,6 +6,7 @@
 #include "mlx/backend/metal/metal.h"
 #include "mlx/device.h"
 #include "mlx/fft.h"
+#include "mlx/io.h"
 #include "mlx/linalg.h"
 #include "mlx/ops.h"
 #include "mlx/random.h"

--- a/mlx/ops.h
+++ b/mlx/ops.h
@@ -1115,12 +1115,23 @@ void save_safetensors(
     const std::string& file,
     std::unordered_map<std::string, array>);
 
-/** Load array map from .gguf file format */
-std::unordered_map<std::string, array> load_gguf(
-    const std::string& file,
-    StreamOrDevice s = {});
+/** Load metadata and array map from .gguf file format */
 
-void save_gguf(std::string file, std::unordered_map<std::string, array> a);
+struct metadata {
+  std::optional<array> array;
+  std::optional<std::string> string;
+  std::optional<std::vector<metadata>> list;
+};
+
+std::pair<
+    std::unordered_map<std::string, array>,
+    std::unordered_map<std::string, metadata>>
+load_gguf(const std::string& file, StreamOrDevice s = {});
+
+void save_gguf(
+    std::string file,
+    std::unordered_map<std::string, array> array_map,
+    std::unordered_map<std::string, metadata> metadata_map);
 
 /** Compute D = beta * C + alpha * (A @ B) */
 array addmm(

--- a/mlx/ops.h
+++ b/mlx/ops.h
@@ -1,14 +1,13 @@
-// Copyright © 2023 Apple Inc.
+// Copyright © 2023-2024 Apple Inc.
 
 #pragma once
 
 #include <optional>
 #include <variant>
 
-#include "array.h"
-#include "device.h"
-#include "io/load.h"
-#include "stream.h"
+#include "mlx/array.h"
+#include "mlx/device.h"
+#include "mlx/stream.h"
 
 namespace mlx::core {
 
@@ -1040,20 +1039,6 @@ array conv2d(
     int groups = 1,
     StreamOrDevice s = {});
 
-/** Serialization operations */
-
-/** Save array to out stream in .npy format */
-void save(std::shared_ptr<io::Writer> out_stream, array a);
-
-/** Save array to file in .npy format */
-void save(const std::string& file, array a);
-
-/** Load array from reader in .npy format */
-array load(std::shared_ptr<io::Reader> in_stream, StreamOrDevice s = {});
-
-/** Load array from file in .npy format */
-array load(const std::string& file, StreamOrDevice s = {});
-
 /** Quantized matmul multiplies x with a quantized matrix w*/
 array quantized_matmul(
     const array& x,
@@ -1100,39 +1085,6 @@ array outer(const array& a, const array& b, StreamOrDevice s = {});
 /** Compute the inner product of two vectors. */
 array inner(const array& a, const array& b, StreamOrDevice s = {});
 
-/** Load array map from .safetensors file format */
-std::unordered_map<std::string, array> load_safetensors(
-    std::shared_ptr<io::Reader> in_stream,
-    StreamOrDevice s = {});
-std::unordered_map<std::string, array> load_safetensors(
-    const std::string& file,
-    StreamOrDevice s = {});
-
-void save_safetensors(
-    std::shared_ptr<io::Writer> in_stream,
-    std::unordered_map<std::string, array>);
-void save_safetensors(
-    const std::string& file,
-    std::unordered_map<std::string, array>);
-
-/** Load metadata and array map from .gguf file format */
-
-struct metadata {
-  std::optional<array> array;
-  std::optional<std::string> string;
-  std::optional<std::vector<metadata>> list;
-};
-
-std::pair<
-    std::unordered_map<std::string, array>,
-    std::unordered_map<std::string, metadata>>
-load_gguf(const std::string& file, StreamOrDevice s = {});
-
-void save_gguf(
-    std::string file,
-    std::unordered_map<std::string, array> array_map,
-    std::unordered_map<std::string, metadata> metadata_map);
-
 /** Compute D = beta * C + alpha * (A @ B) */
 array addmm(
     array c,
@@ -1141,4 +1093,5 @@ array addmm(
     const float& alpha = 1.f,
     const float& beta = 1.f,
     StreamOrDevice s = {});
+
 } // namespace mlx::core

--- a/python/src/load.cpp
+++ b/python/src/load.cpp
@@ -2,7 +2,6 @@
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-#include <iostream> // TODO
 
 #include <cstring>
 #include <fstream>

--- a/python/src/load.cpp
+++ b/python/src/load.cpp
@@ -181,10 +181,12 @@ std::unordered_map<std::string, array> mlx_load_safetensor_helper(
       "[load_safetensors] Input must be a file-like object, or string");
 }
 
-std::unordered_map<std::string, array> mlx_load_gguf_helper(
-    py::object file,
-    StreamOrDevice s) {
+std::pair<
+    std::unordered_map<std::string, array>,
+    std::unordered_map<std::string, metadata>>
+mlx_load_gguf_helper(py::object file, StreamOrDevice s) {
   if (py::isinstance<py::str>(file)) { // Assume .gguf file path string
+    // TODO: also return metadata.
     return load_gguf(py::cast<std::string>(file), s);
   }
 
@@ -275,7 +277,9 @@ DictOrArray mlx_load_helper(
   } else if (format.value() == "npy") {
     return mlx_load_npy_helper(file, s);
   } else if (format.value() == "gguf") {
-    return mlx_load_gguf_helper(file, s);
+    const auto& [weights, metadata] = mlx_load_gguf_helper(file, s);
+    // TODO: also return metadata
+    return weights;
   } else {
     throw std::invalid_argument("[load] Unknown file format " + format.value());
   }
@@ -448,10 +452,11 @@ void mlx_save_safetensor_helper(py::object file, py::dict d) {
       "[save_safetensors] Input must be a file-like object, or string");
 }
 
-void mlx_save_gguf_helper(py::object file, py::dict d) {
-  auto arrays_map = d.cast<std::unordered_map<std::string, array>>();
+void mlx_save_gguf_helper(py::object file, py::dict a, py::dict m) {
+  auto arrays_map = a.cast<std::unordered_map<std::string, array>>();
+  auto metadata_map = m.cast<std::unordered_map<std::string, metadata>>();
   if (py::isinstance<py::str>(file)) {
-    save_gguf(py::cast<std::string>(file), arrays_map);
+    save_gguf(py::cast<std::string>(file), arrays_map, metadata_map);
     return;
   }
 

--- a/python/src/load.h
+++ b/python/src/load.h
@@ -7,12 +7,17 @@
 #include <string>
 #include <unordered_map>
 #include <variant>
-#include "mlx/ops.h"
+#include "mlx/io.h"
 
 namespace py = pybind11;
 using namespace mlx::core;
 
-using DictOrArray = std::variant<array, std::unordered_map<std::string, array>>;
+using LoadOutputTypes = std::variant<
+    array,
+    std::unordered_map<std::string, array>,
+    std::pair<
+        std::unordered_map<std::string, array>,
+        std::unordered_map<std::string, MetaData>>>;
 
 std::unordered_map<std::string, array> mlx_load_safetensor_helper(
     py::object file,
@@ -21,13 +26,17 @@ void mlx_save_safetensor_helper(py::object file, py::dict d);
 
 std::pair<
     std::unordered_map<std::string, array>,
-    std::unordered_map<std::string, metadata>>
+    std::unordered_map<std::string, MetaData>>
 mlx_load_gguf_helper(py::object file, StreamOrDevice s);
-void mlx_save_gguf_helper(py::object file, py::dict d, py::dict m);
+void mlx_save_gguf_helper(
+    py::object file,
+    py::dict d,
+    std::optional<py::dict> m);
 
-DictOrArray mlx_load_helper(
+LoadOutputTypes mlx_load_helper(
     py::object file,
     std::optional<std::string> format,
+    bool return_metadata,
     StreamOrDevice s);
 void mlx_save_helper(py::object file, array a);
 void mlx_savez_helper(

--- a/python/src/load.h
+++ b/python/src/load.h
@@ -19,10 +19,11 @@ std::unordered_map<std::string, array> mlx_load_safetensor_helper(
     StreamOrDevice s);
 void mlx_save_safetensor_helper(py::object file, py::dict d);
 
-std::unordered_map<std::string, array> mlx_load_gguf_helper(
-    py::object file,
-    StreamOrDevice s);
-void mlx_save_gguf_helper(py::object file, py::dict d);
+std::pair<
+    std::unordered_map<std::string, array>,
+    std::unordered_map<std::string, metadata>>
+mlx_load_gguf_helper(py::object file, StreamOrDevice s);
+void mlx_save_gguf_helper(py::object file, py::dict d, py::dict m);
 
 DictOrArray mlx_load_helper(
     py::object file,

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -3172,7 +3172,7 @@ void init_ops(py::module_& m) {
       "arrays"_a,
       "metadata"_a = none,
       R"pbdoc(
-        save_gguf(file: str, arrays: Dict[str, array], metadata: Dict[str, Union[array, string, list]])
+        save_gguf(file: str, arrays: Dict[str, array], metadata: Dict[str, Union[array, str, List[str]]])
 
         Save array(s) to a binary file in ``.gguf`` format.
 
@@ -3182,9 +3182,9 @@ void init_ops(py::module_& m) {
         Args:
             file (file, str): File in which the array is saved.
             arrays (dict(str, array)): The dictionary of names to arrays to be saved.
-            metadata (dict(str, Union[array, string, list])): The dictionary of
-               metadata to be saved. The values can be an arbitrarily nested list of
-               :obj:`array` or :obj:`string`.
+            metadata (dict(str, Union[array, str, list(str)])): The dictionary of
+               metadata to be saved. The values can be a scalar or 1D obj:`array`,
+               a :obj:`str`, or a :obj:`list` of :obj:`str`.
       )pbdoc");
   m.def(
       "where",

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -3164,8 +3164,9 @@ void init_ops(py::module_& m) {
       &mlx_save_gguf_helper,
       "file"_a,
       "arrays"_a,
+      "metadata"_a,
       R"pbdoc(
-        save_gguf(file: str, arrays: Dict[str, array])
+        save_gguf(file: str, arrays: Dict[str, array], metadata: Dict[str, Union[array, string, list]])
 
         Save array(s) to a binary file in ``.gguf`` format.
 
@@ -3175,6 +3176,7 @@ void init_ops(py::module_& m) {
         Args:
             file (file, str): File in which the array is saved.
             arrays (dict(str, array)): The dictionary of names to arrays to be saved.
+            metadata (dict(str, Union[array,string,list])): The dictionary of metadata to be saved.
       )pbdoc");
   m.def(
       "where",

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -1867,11 +1867,11 @@ void init_ops(py::module_& m) {
         isposinf(a: array, stream: Union[None, Stream, Device] = None) -> array
 
         Return a boolean array indicating which elements are positive infinity.
-        
+
         Args:
             a (array): Input array.
             stream (Union[None, Stream, Device]): Optional stream or device.
-        
+
         Returns:
             array: The boolean array indicating which elements are positive infinity.
       )pbdoc");
@@ -1886,11 +1886,11 @@ void init_ops(py::module_& m) {
         isneginf(a: array, stream: Union[None, Stream, Device] = None) -> array
 
         Return a boolean array indicating which elements are negative infinity.
-        
+
         Args:
             a (array): Input array.
             stream (Union[None, Stream, Device]): Optional stream or device.
-        
+
         Returns:
             array: The boolean array indicating which elements are negative infinity.
       )pbdoc");
@@ -3117,10 +3117,11 @@ void init_ops(py::module_& m) {
       "file"_a,
       py::pos_only(),
       "format"_a = none,
+      "return_metadata"_a = false,
       py::kw_only(),
       "stream"_a = none,
       R"pbdoc(
-        load(file: str, /, format: Optional[str] = None, *, stream: Union[None, Stream, Device] = None) -> Union[array, Dict[str, array]]
+        load(file: str, /, format: Optional[str] = None, return_metadata: bool = False, *, stream: Union[None, Stream, Device] = None) -> Union[array, Dict[str, array]]
 
         Load array(s) from a binary file.
 
@@ -3131,10 +3132,15 @@ void init_ops(py::module_& m) {
             format (str, optional): Format of the file. If ``None``, the format
               is inferred from the file extension. Supported formats: ``npy``,
               ``npz``, and ``safetensors``. Default: ``None``.
+            return_metadata (bool, optional): Load the metadata for formats which
+              support matadata. The metadata will be returned as an additional
+              dictionary.
         Returns:
             result (array, dict):
                 A single array if loading from a ``.npy`` file or a dict mapping
                 names to arrays if loading from a ``.npz`` or ``.safetensors`` file.
+                If ``return_metadata` is ``True`` an additional dictionary of metadata
+                will be returned.
 
         Warning:
 
@@ -3164,7 +3170,7 @@ void init_ops(py::module_& m) {
       &mlx_save_gguf_helper,
       "file"_a,
       "arrays"_a,
-      "metadata"_a,
+      "metadata"_a = none,
       R"pbdoc(
         save_gguf(file: str, arrays: Dict[str, array], metadata: Dict[str, Union[array, string, list]])
 
@@ -3176,7 +3182,9 @@ void init_ops(py::module_& m) {
         Args:
             file (file, str): File in which the array is saved.
             arrays (dict(str, array)): The dictionary of names to arrays to be saved.
-            metadata (dict(str, Union[array,string,list])): The dictionary of metadata to be saved.
+            metadata (dict(str, Union[array, string, list])): The dictionary of
+               metadata to be saved. The values can be an arbitrarily nested list of
+               :obj:`array` or :obj:`string`.
       )pbdoc");
   m.def(
       "where",
@@ -3501,7 +3509,7 @@ void init_ops(py::module_& m) {
             c (array): Input array or scalar.
             a (array): Input array or scalar.
             b (array): Input array or scalar.
-            alpha (float, optional): Scaling factor for the 
+            alpha (float, optional): Scaling factor for the
                 matrix product of ``a`` and ``b`` (default: ``1``)
             beta (float, optional): Scaling factor for ``c`` (default: ``1``)
 

--- a/python/tests/test_blas.py
+++ b/python/tests/test_blas.py
@@ -576,8 +576,8 @@ class TestBlas(mlx_tests.MLXTestCase):
                 ],
             )
 
-            self.assertTrue(mx.allclose(out_ref[0], out_test[0], atol=1e-5).item())
+            self.assertTrue(mx.allclose(out_ref[0], out_test[0], atol=1e-4).item())
 
             for r, t in zip(dout_ref, dout_test):
                 self.assertListEqual(r.shape, t.shape)
-                self.assertTrue(mx.allclose(r, t, atol=1e-5).item())
+                self.assertTrue(mx.allclose(r, t, atol=1e-4).item())

--- a/python/tests/test_load.py
+++ b/python/tests/test_load.py
@@ -117,7 +117,7 @@ class TestLoad(mlx_tests.MLXTestCase):
                             mx.array_equal(load_dict["test"], save_dict["test"])
                         )
 
-    def test_save_and_load_gguf_with_metadata(self):
+    def test_save_and_load_gguf_metadata_basic(self):
         if not os.path.isdir(self.test_dir):
             os.mkdir(self.test_dir)
 
@@ -139,6 +139,7 @@ class TestLoad(mlx_tests.MLXTestCase):
         self.assertTrue(mx.array_equal(load_dict["test"], save_dict["test"]))
         self.assertEqual(len(meta_load_dict), 0)
 
+        # Loads string metadata
         metadata = {"meta": "data"}
         mx.save_gguf(save_file_mlx, save_dict, metadata)
         load_dict, meta_load_dict = mx.load(save_file_mlx, return_metadata=True)
@@ -148,6 +149,14 @@ class TestLoad(mlx_tests.MLXTestCase):
         self.assertTrue("meta" in meta_load_dict)
         self.assertEqual(meta_load_dict["meta"], "data")
 
+    def test_save_and_load_gguf_metadata_arrays(self):
+        if not os.path.isdir(self.test_dir):
+            os.mkdir(self.test_dir)
+
+        save_file_mlx = os.path.join(self.test_dir, f"mlx_gguf_with_metadata.gguf")
+        save_dict = {"test": mx.ones((4, 4), dtype=mx.int32)}
+
+        # Test scalars and one dimensional arrays
         for t in [
             mx.uint8,
             mx.int8,
@@ -174,6 +183,13 @@ class TestLoad(mlx_tests.MLXTestCase):
                 arr = mx.array(1, t)
                 metadata = {"meta": arr}
                 mx.save_gguf(save_file_mlx, save_dict, metadata)
+
+    def test_save_and_load_gguf_metadata_mixed(self):
+        if not os.path.isdir(self.test_dir):
+            os.mkdir(self.test_dir)
+
+        save_file_mlx = os.path.join(self.test_dir, f"mlx_gguf_with_metadata.gguf")
+        save_dict = {"test": mx.ones((4, 4), dtype=mx.int32)}
 
         # Test string and array
         arr = mx.array(1.5)

--- a/python/tests/test_load.py
+++ b/python/tests/test_load.py
@@ -117,6 +117,39 @@ class TestLoad(mlx_tests.MLXTestCase):
                             mx.array_equal(load_dict["test"], save_dict["test"])
                         )
 
+    def test_save_and_load_gguf_with_metadata(self):
+        if not os.path.isdir(self.test_dir):
+            os.mkdir(self.test_dir)
+
+        save_file_mlx = os.path.join(self.test_dir, f"mlx_gguf_with_metadata.gguf")
+        save_dict = {"test": mx.ones((4, 4), dtype=mx.int32)}
+        metadata = {}
+
+        # Empty works
+        mx.save_gguf(save_file_mlx, save_dict, metadata)
+
+        # Loads without the metadata
+        load_dict = mx.load(save_file_mlx)
+        self.assertTrue("test" in load_dict)
+        self.assertTrue(mx.array_equal(load_dict["test"], save_dict["test"]))
+
+        # Loads empty metadata
+        load_dict, meta_load_dict = mx.load(save_file_mlx, return_metadata=True)
+        self.assertTrue("test" in load_dict)
+        self.assertTrue(mx.array_equal(load_dict["test"], save_dict["test"]))
+        self.assertEqual(len(meta_load_dict), 0)
+
+        metadata = {"meta": "data"}
+        mx.save_gguf(save_file_mlx, save_dict, metadata)
+        load_dict, meta_load_dict = mx.load(save_file_mlx, return_metadata=True)
+        self.assertTrue("test" in load_dict)
+        self.assertTrue(mx.array_equal(load_dict["test"], save_dict["test"]))
+        self.assertEqual(len(meta_load_dict), 1)
+        self.assertTrue("meta" in meta_load_dict)
+        self.assertEqual(meta_load_dict["meta"], "data")
+
+        # TODO add tests for more meta data types
+
     def test_save_and_load_fs(self):
         if not os.path.isdir(self.test_dir):
             os.mkdir(self.test_dir)

--- a/tests/load_tests.cpp
+++ b/tests/load_tests.cpp
@@ -54,6 +54,7 @@ TEST_CASE("test gguf") {
     }
   }
 
+  // Test saving and loading string metadata
   std::unordered_map<std::string, MetaData> original_metadata;
   original_metadata.insert({"test_str", "my string"});
 


### PR DESCRIPTION
## Proposed changes

Another incomplete follow up for https://github.com/ml-explore/mlx/pull/350. 

Probably higher priority than https://github.com/ml-explore/mlx/pull/426.

The goal is to be able to load and save metadata. For now, it only supports strings.

Primitive types such as the different flavors of ints and floats should be casted to mx.array scalars. 

I've tested that the file generated by the c++ test can also be read by gguf-tools:

```
~/dev/github/gguf-tools/gguf-tools show /var/folders/sw/_m_mwjxn1mlc4vzkj4b150mm0000gn/T/test_arr.gguf
/var/folders/sw/_m_mwjxn1mlc4vzkj4b150mm0000gn/T/test_arr.gguf (ver 3): 1 key-value pairs, 1 tensors
test_str: [string] my string
f32 tensor test @128, 5 weights, dims [5], 20 bytes
```

cc @awni 

## Checklist

Put an `x` in the boxes that apply.

- [ ] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
