### PR TITLE
Add scatter_min VJP

### DIFF
--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -2134,7 +2134,7 @@ std::vector<array> Scatter::vjp(
       break;
     default:
       throw std::runtime_error(
-          "[scatter] VJP not implemented for this scattering reduction type");
+          "[scatter] VJP not implemented for scatter_prod");
   }
 
   const array& values = primals[0];

--- a/python/tests/test_autograd.py
+++ b/python/tests/test_autograd.py
@@ -316,6 +316,29 @@ class TestAutograd(mlx_tests.MLXTestCase):
         self.assertTrue(mx.allclose(vjps[0], mx.array([[4.0], [5.0], [6.0]])))
         self.assertTrue(mx.allclose(vjps[1], mx.array([[[5.0]]])))
 
+    def test_scatter_min_vjp(self):
+        def fun(src, updates):
+            x = src.at[1].minimum(updates)
+            return x
+
+        cotan = mx.array([4.0, 5.0, 6.0])
+        _, vjps = mx.vjp(fun, [mx.array([1.0, 2.0, 3.0]), mx.array([[3.0]])], [cotan])
+        mx.eval(vjps)
+
+        # Update larger than value
+        self.assertTrue(mx.allclose(vjps[0], mx.array([4.0, 5.0, 6.0])))
+        self.assertTrue(mx.allclose(vjps[1], mx.array([0.0])))
+
+        cotan = mx.array([[4.0], [5.0], [6.0]])
+        _, vjps = mx.vjp(
+            fun, [mx.array([[1.0], [2.0], [3.0]]), mx.array([[[2.0]]])], [cotan]
+        )
+        mx.eval(vjps)
+
+        # Update and value are equal
+        self.assertTrue(mx.allclose(vjps[0], mx.array([[4.0], [5.0], [6.0]])))
+        self.assertTrue(mx.allclose(vjps[1], mx.array([[[5.0]]])))
+
     def test_vjp_types(self):
         def fun(x):
             return x


### PR DESCRIPTION
## Proposed changes

Implemented `scatter_min` operation's vjp, similarly as with `scatter_max`.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
