### PR TITLE
Fix detach for multi-output primitives

### DIFF
--- a/mlx/array.cpp
+++ b/mlx/array.cpp
@@ -82,6 +82,12 @@ array::array(
 }
 
 void array::detach() {
+  for (auto& s : array_desc_->siblings) {
+    s.array_desc_->inputs.clear();
+    s.array_desc_->siblings.clear();
+    s.array_desc_->position = 0;
+    s.array_desc_->primitive = nullptr;
+  }
   array_desc_->inputs.clear();
   array_desc_->siblings.clear();
   array_desc_->position = 0;

--- a/mlx/backend/metal/metal.cpp
+++ b/mlx/backend/metal/metal.cpp
@@ -62,9 +62,6 @@ std::function<void()> make_task(
           [s, arr, p = std::move(p)](MTL::CommandBuffer*) mutable {
             if (!arr.is_tracer()) {
               arr.detach();
-              for (auto s : arr.siblings()) {
-                s.detach();
-              }
             }
             p->set_value();
             scheduler::notify_task_completion(s);

--- a/mlx/transforms.cpp
+++ b/mlx/transforms.cpp
@@ -292,9 +292,6 @@ void eval(const std::vector<array>& outputs) {
         arr.primitive().eval_cpu(arr.inputs(), outputs);
         if (!arr.is_tracer()) {
           arr.detach();
-          for (auto s : arr.siblings()) {
-            s.detach();
-          }
         }
         if (p) {
           p->set_value();


### PR DESCRIPTION
Since detach clears the siblings array; manually detaching the siblings after detach is a noop.