### PR TITLE
Make the Binary Cross Entropy Loss able to handle probabilities as input.

### DIFF
--- a/python/tests/test_losses.py
+++ b/python/tests/test_losses.py
@@ -105,6 +105,61 @@ class TestLosses(mlx_tests.MLXTestCase):
             "Test case failed for cross_entropy --label_smoothing=0.3 --reduction='sum'",
         )
 
+    def test_binary_cross_entropy(self):
+        def _test_logits_as_inputs():
+            logits = mx.array([0.105361, 0.223144, 1.20397, 0.916291])
+            targets = mx.array([0, 0, 1, 1])
+
+            # Test with reduction 'none'
+            losses_none = nn.losses.binary_cross_entropy(
+                logits, targets, reduction="none"
+            )
+            expected_none = mx.array([0.747215, 0.810930, 0.262365, 0.336472])
+            self.assertTrue(mx.allclose(losses_none, expected_none))
+
+            # Test with reduction 'mean'
+            losses_mean = nn.losses.binary_cross_entropy(
+                logits, targets, reduction="mean"
+            )
+            expected_mean = mx.mean(expected_none)
+            self.assertEqual(losses_mean, expected_mean)
+
+            # Test with reduction 'sum'
+            losses_sum = nn.losses.binary_cross_entropy(
+                logits, targets, reduction="sum"
+            )
+            expected_sum = mx.sum(expected_none)
+            self.assertEqual(losses_sum, expected_sum)
+
+        def _test_probs_as_inputs():
+            probs = mx.array([0.5, 0.6, 0.7, 0.8])
+            targets = mx.array([0, 0, 1, 1])
+
+            # Test with reduction 'none'
+            losses_none = nn.losses.binary_cross_entropy(
+                probs, targets, with_logits=False, reduction="none"
+            )
+            expected_none = mx.array([0.693147, 0.916291, 0.356675, 0.223144])
+            print(losses_none, expected_none)
+            self.assertTrue(mx.allclose(losses_none, expected_none))
+
+            # Test with reduction 'mean'
+            losses_mean = nn.losses.binary_cross_entropy(
+                probs, targets, with_logits=False, reduction="mean"
+            )
+            expected_mean = mx.mean(expected_none)
+            self.assertTrue(mx.allclose(losses_mean, expected_mean))
+
+            # Test with reduction 'sum'
+            losses_sum = nn.losses.binary_cross_entropy(
+                probs, targets, with_logits=False, reduction="sum"
+            )
+            expected_sum = mx.sum(expected_none)
+            self.assertTrue(mx.allclose(losses_sum, expected_sum))
+
+        _test_logits_as_inputs()
+        _test_probs_as_inputs()
+
     def test_l1_loss(self):
         predictions = mx.array([0.5, 0.2, 0.9, 0.0])
         targets = mx.array([0.5, 0.2, 0.9, 0.0])


### PR DESCRIPTION
## Proposed changes

Currently, the `binary_cross_entropy()` in MLX can only handle logits as input. In PyTorch, there are two seperate binary cross entropy loss:

1. [torch.nn.functional.binary_cross_entropy — PyTorch 2.1 documentation](https://pytorch.org/docs/stable/generated/torch.nn.functional.binary_cross_entropy.html)
2. [torch.nn.functional.binary_cross_entropy_with_logits — PyTorch 2.1 documentation](https://pytorch.org/docs/stable/generated/torch.nn.functional.binary_cross_entropy_with_logits.html)

The `binary_cross_entropy()` in MLX is actually the `binary_cross_entropy_with_logits()` in PyTorch. To enable the non-logit version, this PR adds an extra (optional) parameter `with_logits` to `binary_cross_entropy()`. If this parameter is given `False`, the input is regarded as probabilities.

To make this change backward-compatible, the `with_logits` is given a default value `True`, thus existing user code don't need to change.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
