### PR TITLE
Fix array from python list for > 32 bit types

### DIFF
--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -229,9 +229,28 @@ array array_from_list(
       return array(vals.begin(), shape, specified_type.value_or(bool_));
     }
     case pyint: {
-      std::vector<int> vals;
-      fill_vector(pl, vals);
-      return array(vals.begin(), shape, specified_type.value_or(int32));
+      auto dtype = specified_type.value_or(int32);
+      if (dtype == int64) {
+        std::vector<int64_t> vals;
+        fill_vector(pl, vals);
+        return array(vals.begin(), shape, dtype);
+      } else if (dtype == uint64) {
+        std::vector<uint64_t> vals;
+        fill_vector(pl, vals);
+        return array(vals.begin(), shape, dtype);
+      } else if (dtype == uint32) {
+        std::vector<uint32_t> vals;
+        fill_vector(pl, vals);
+        return array(vals.begin(), shape, dtype);
+      } else if (is_floating_point(dtype)) {
+        std::vector<float> vals;
+        fill_vector(pl, vals);
+        return array(vals.begin(), shape, dtype);
+      } else {
+        std::vector<int> vals;
+        fill_vector(pl, vals);
+        return array(vals.begin(), shape, dtype);
+      }
     }
     case pyfloat: {
       std::vector<float> vals;

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -226,6 +226,14 @@ class TestArray(mlx_tests.MLXTestCase):
         x = mx.array([1 + 0j, 2j, True, 0], mx.complex64)
         self.assertEqual(x.tolist(), [1 + 0j, 2j, 1 + 0j, 0j])
 
+        xnp = np.array([0, 4294967295], dtype=np.uint32)
+        x = mx.array([0, 4294967295], dtype=mx.uint32)
+        self.assertTrue(np.array_equal(x, xnp))
+
+        xnp = np.array([0, 4294967295], dtype=np.float32)
+        x = mx.array([0, 4294967295], dtype=mx.float32)
+        self.assertTrue(np.array_equal(x, xnp))
+
     def test_construction_from_lists_of_mlx_arrays(self):
         dtypes = [
             mx.bool_,


### PR DESCRIPTION
Previously we auto downcast to `int` and pybind11 would actually crash at runtime.


Closes #496 