### PR TITLE
Enable cross_entropy loss to handle dense targets

### DIFF
--- a/python/mlx/nn/losses.py
+++ b/python/mlx/nn/losses.py
@@ -31,12 +31,13 @@ def cross_entropy(
     Computes the cross entropy loss.
 
     Args:
-        logits (array): The unnormalized predicted logits.
-        targets (array): The ground truth values. These can be class indices or probabilities for
-            each class, depending on its shape. If ``targets`` are class indices, then the shape of
-            ``targets`` should match the shape of ``logits``, excluding the ``axis`` dimension.
-            If ``targets`` are probabilities (or one-hot encoded), then the shape of ``targets``
-            should be identical to the shape of ``logits``.
+        logits (array): The unnormalized logits.
+        targets (array): The ground truth values. These can be class indices or
+            probabilities for each class. If the ``targets`` are class indices,
+            then ``targets`` shape should match the ``logits`` shape with
+            the ``axis`` dimension removed. If the ``targets`` are probabilities
+            (or one-hot encoded), then the ``targets`` shape should be the same as
+            the ``logits`` shape.
         weights (array, optional): Optional weights for each target. Default: ``None``.
         axis (int, optional): The axis over which to compute softmax. Default: ``-1``.
         label_smoothing (float, optional): Label smoothing factor. Default: ``0``.
@@ -48,18 +49,18 @@ def cross_entropy(
 
     Examples:
         >>> import mlx.core as mx
-        >>> from mlx.nn.losses import cross_entropy
-
+        >>> import mlx.nn as nn
+        >>>
         >>> # Class indices as targets
         >>> logits = mx.array([[2.0, -1.0], [-1.0, 2.0]])
         >>> targets = mx.array([0, 1])
-        >>> cross_entropy(logits, targets)
+        >>> nn.losses.cross_entropy(logits, targets)
         array([0.0485873, 0.0485873], dtype=float32)
-
+        >>>
         >>> # Probabilities (or one-hot vectors) as targets
         >>> logits = mx.array([[2.0, -1.0], [-1.0, 2.0]])
         >>> targets = mx.array([[0.9, 0.1], [0.1, 0.9]])
-        >>> cross_entropy(logits, targets)
+        >>> nn.losses.cross_entropy(logits, targets)
         array([0.348587, 0.348587], dtype=float32)
     """
     if label_smoothing < 0 or label_smoothing >= 1:

--- a/python/mlx/nn/losses.py
+++ b/python/mlx/nn/losses.py
@@ -81,7 +81,7 @@ def cross_entropy(
         )
 
     if targets_as_probs:
-        score = mx.sum(logits * targets, axis=axis)  # mx.inner doesn't support axis
+        score = mx.sum(logits * targets, axis=axis)
     else:
         score = mx.take_along_axis(logits, targets[..., None], axis).squeeze(-1)
 
@@ -101,12 +101,10 @@ def cross_entropy(
 
     # Apply weights if provided
     if weights is not None:
-        if (targets_as_probs and weights.shape != _drop_dim(targets.shape, axis)) or (
-            not targets_as_probs and weights.shape != targets.shape
-        ):
+        if weights.shape != loss.shape:
             raise ValueError(
                 f"Weights with shape {weights.shape} is not the same as "
-                f"targets with shape {targets.shape}."
+                f"output loss with shape {loss.shape}."
             )
         loss *= weights
 

--- a/python/tests/test_losses.py
+++ b/python/tests/test_losses.py
@@ -10,100 +10,61 @@ import numpy as np
 
 class TestLosses(mlx_tests.MLXTestCase):
     def test_cross_entropy(self):
+        # No weights, no label smoothing
         logits = mx.array([[0.0, -float("inf")], [-float("inf"), 0.0]])
-        targets = mx.array([0, 1])
+        indices = mx.array([0, 1])
+        expected = mx.array([0.0, 0.0])
+        loss = nn.losses.cross_entropy(logits, indices, reduction="none")
+        self.assertTrue(mx.allclose(loss, expected))
 
-        # Test with reduction 'none'
-        losses_none = nn.losses.cross_entropy(logits, targets, reduction="none")
-        expected_none = mx.array([0.0, 0.0])
-        self.assertTrue(mx.array_equal(losses_none, expected_none))
+        probs = mx.array([[1.0, 0.0], [0.0, 1.0]])
+        loss = nn.losses.cross_entropy(logits, probs, reduction="none")
+        self.assertTrue(mx.isnan(loss).all())  # produce NaNs, like PyTorch
 
-        # Test with reduction 'mean'
-        losses_mean = nn.losses.cross_entropy(logits, targets, reduction="mean")
-        expected_mean = mx.mean(expected_none)
-        self.assertEqual(losses_mean, expected_mean)
-
-        # Test with reduction 'sum'
-        losses_sum = nn.losses.cross_entropy(logits, targets, reduction="sum")
-        expected_sum = mx.sum(expected_none)
-        self.assertEqual(losses_sum, expected_sum)
-
-        # Test cases with weights and no label smoothing
+        # With weights, no label smoothing
         logits = mx.array([[2.0, -1.0], [-1.0, 2.0]])
-        targets = mx.array([0, 1])
+        indices = mx.array([0, 1])
         weights = mx.array([1.0, 2.0])
+        expected = mx.array([0.04858735, 0.0971747])
+        loss = nn.losses.cross_entropy(
+            logits, indices, weights=weights, reduction="none"
+        )
+        self.assertTrue(mx.allclose(loss, expected))
 
-        # Reduction 'none'
-        losses_none = nn.losses.cross_entropy(
-            logits,
-            targets,
-            weights=weights,
-            reduction="none",
-        )
-        expected_none = mx.array([0.04858735, 0.0971747])  # Calculated losses
-        self.assertTrue(
-            np.allclose(losses_none, expected_none, atol=1e-5),
-            "Test case failed for cross_entropy loss --reduction='none' --weights=[1.0, 2.0]",
-        )
+        probs = mx.array([[1.0, 0.0], [0.0, 1.0]])
+        loss = nn.losses.cross_entropy(logits, probs, weights=weights, reduction="none")
+        self.assertTrue(mx.allclose(loss, expected))
 
-        # Reduction 'mean'
-        losses_mean = nn.losses.cross_entropy(
-            logits,
-            targets,
-            weights=weights,
-            reduction="mean",
+        # No weights, with label smoothing
+        logits = mx.array([[2.0, -1.0], [-1.0, 2.0]])
+        indices = mx.array([0, 1])
+        expected = mx.array([0.498587, 0.498587])
+        loss = nn.losses.cross_entropy(
+            logits, indices, label_smoothing=0.3, reduction="none"
         )
-        expected_mean = mx.mean(expected_none)
-        self.assertTrue(
-            np.allclose(losses_mean, expected_mean, atol=1e-5),
-            "Test case failed for cross_entropy loss --reduction='mean' --weights=[1.0, 2.0]",
-        )
+        self.assertTrue(mx.allclose(loss, expected))
 
-        # Reduction 'sum'
-        losses_sum = nn.losses.cross_entropy(
-            logits,
-            targets,
-            weights=weights,
-            reduction="sum",
+        probs = mx.array([[1.0, 0.0], [0.0, 1.0]])
+        loss = nn.losses.cross_entropy(
+            logits, probs, label_smoothing=0.3, reduction="none"
         )
-        expected_sum = mx.sum(expected_none)
-        self.assertTrue(
-            np.allclose(losses_sum, expected_sum, atol=1e-5),
-            "Test case failed for cross_entropy loss --reduction='sum' --weights=[1.0, 2.0]",
-        )
+        self.assertTrue(mx.allclose(loss, expected))
 
-        # Test case with equal weights and label smoothing > 0
-        logits = mx.array(
-            [[0, 0.2, 0.7, 0.1, 0], [0, 0.9, 0.2, 0.2, 1], [1, 0.2, 0.7, 0.9, 1]]
+        # With weights and label smoothing
+        logits = mx.array([[2.0, -1.0], [-1.0, 2.0]])
+        indices = mx.array([0, 1])
+        weights = mx.array([1.0, 2.0])
+        expected = mx.array([0.49858734, 0.9971747])
+        loss = nn.losses.cross_entropy(
+            logits, indices, weights=weights, label_smoothing=0.3, reduction="none"
         )
-        target = mx.array([2, 1, 0])
+        self.assertTrue(mx.allclose(loss, expected))
 
-        losses_none = nn.losses.cross_entropy(
-            logits, target, label_smoothing=0.3, reduction="none"
+        probs = mx.array([[1.0, 0.0], [0.0, 1.0]])
+        loss = nn.losses.cross_entropy(
+            logits, probs, weights=weights, label_smoothing=0.3, reduction="none"
         )
-        expected_none = mx.array([1.29693, 1.38617, 1.48176])
-        self.assertTrue(
-            mx.allclose(expected_none, losses_none),
-            "Test case failed for cross_entropy --label_smoothing=0.3 --reduction='none'",
-        )
-
-        expected_mean = mx.mean(expected_none)
-        losses_mean = nn.losses.cross_entropy(
-            logits, target, label_smoothing=0.3, reduction="mean"
-        )
-        self.assertTrue(
-            mx.allclose(losses_mean, expected_mean),
-            "Test case failed for cross_entropy --label_smoothing=0.3 --reduction='mean'",
-        )
-
-        expected_sum = mx.sum(expected_none)
-        losses_sum = nn.losses.cross_entropy(
-            logits, target, label_smoothing=0.3, reduction="sum"
-        )
-        self.assertTrue(
-            mx.allclose(losses_sum, expected_sum),
-            "Test case failed for cross_entropy --label_smoothing=0.3 --reduction='sum'",
-        )
+        self.assertTrue(mx.allclose(loss, expected))
 
     def test_binary_cross_entropy(self):
         def _test_logits_as_inputs():


### PR DESCRIPTION
## Proposed changes

Dense targets means probabilities or one-hot encodings.

Currently, the `cross_entropy` loss only supports targets to be class indices. However, in PyTorch, the [`CrossEntropyLoss`](https://pytorch.org/docs/stable/generated/torch.nn.CrossEntropyLoss.html) supports targets to be both class indices and probabilities (or one-hot encodings). In TensorFlow, two seperate cross-entropy loss layers are provided: [`CategoricalCrossentropy`](https://www.tensorflow.org/api_docs/python/tf/keras/losses/CategoricalCrossentropy) and [`SparseCategoricalCrossentropy`](https://www.tensorflow.org/api_docs/python/tf/keras/losses/SparseCategoricalCrossentropy), to support two different types of targets.

This PR enhances the `cross_entropy` loss to support both sparse targets (class indices) and dense targets (probabilities or one-hot encodings). It can infer what type of targets from the shape, like PyTorch does.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
