### PR TITLE
Add the Mean Squared Logarithmic Error (MSLE) loss function

### DIFF
--- a/docs/src/python/nn/losses.rst
+++ b/docs/src/python/nn/losses.rst
@@ -19,6 +19,7 @@ Loss Functions
    l1_loss
    log_cosh_loss
    mse_loss
+   msle_loss
    nll_loss
    smooth_l1_loss
    triplet_loss

--- a/python/mlx/nn/losses.py
+++ b/python/mlx/nn/losses.py
@@ -171,6 +171,49 @@ def mse_loss(
     return _reduce(loss, reduction)
 
 
+def msle_loss(
+    inputs: mx.array, targets: mx.array, reduction: Reduction = "mean"
+) -> float:
+    r"""
+    Calculate the mean squared logarithmic error (MSLE) between predictions and
+    targets.
+
+    The loss is given by:
+
+    .. math::
+        \text{MSLE} = \frac{1}{N}\sum_i^N (\log(1 + y_i) - \log(1 + \hat{y_i}))^2
+
+    Where is :math:`y` is the targets, and :math:`\hat{y}` is the predictions.
+
+    Args:
+        inputs (array): The predicted values.
+        targets (array): The target values.
+        reduction (str, optional): Specifies the reduction to apply to the output:
+          ``'none'`` | ``'mean'`` | ``'sum'``. Default: ``'mean'``.
+
+    Returns:
+        array: The computed mean squared logarithmic error.
+
+    Examples:
+        >>> import mlx.core as mx
+        >>> import mlx.nn as nn
+
+        >>> targets = mx.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        >>> predictions = mx.array([0.8, 2.1, 2.9, 4.2, 5.2])
+        >>> loss = nn.losses.msle_loss(predictions, targets, "mean")
+        >>> loss
+        array(0.00308609, dtype=float32)
+    """
+    if inputs.shape != targets.shape:
+        raise ValueError(
+            f"Predictions shape {inputs.shape} does not match targets shape {targets.shape}."
+        )
+
+    loss = (mx.log1p(targets) - mx.log1p(inputs)) ** 2
+
+    return _reduce(loss, reduction)
+
+
 def nll_loss(
     inputs: mx.array, targets: mx.array, axis: int = -1, reduction: Reduction = "none"
 ) -> mx.array:

--- a/python/tests/test_losses.py
+++ b/python/tests/test_losses.py
@@ -209,6 +209,28 @@ class TestLosses(mlx_tests.MLXTestCase):
             losses_sum, expected_sum, "Test case failed for mse_loss --reduction='sum'"
         )
 
+    def test_msle_loss(self):
+        predictions = mx.array([0.8, 2.1, 2.9, 4.2, 5.2])
+        targets = mx.array([1.0, 2.0, 3.0, 4.0, 5.0])
+
+        expected_none = mx.array(
+            [0.01110085, 0.00107517, 0.00064099, 0.00153826, 0.00107517]
+        )
+        expected_mean = mx.mean(expected_none)
+        expected_sum = mx.sum(expected_none)
+
+        # Test with reduction 'none'
+        losses_none = nn.losses.msle_loss(predictions, targets, reduction="none")
+        self.assertTrue(mx.allclose(losses_none, expected_none))
+
+        # Test with reduction 'mean'
+        losses_mean = nn.losses.msle_loss(predictions, targets, reduction="mean")
+        self.assertTrue(mx.allclose(losses_mean, expected_mean))
+
+        # Test with reduction 'sum'
+        losses_sum = nn.losses.msle_loss(predictions, targets, reduction="sum")
+        self.assertTrue(mx.allclose(losses_sum, expected_sum))
+
     def test_smooth_l1_loss(self):
         predictions = mx.array([1.5, 2.5, 0.5, 3.5])
         targets = mx.array([1.0, 2.0, 0.5, 2.5])


### PR DESCRIPTION
## Proposed changes

Mean Squared Logarithmic Error (MSLE) is a loss function used in regression problems. Some ML frameworks/libraries contain this loss function, including:

- [TensorFlow (tf.keras.losses.MeanSquaredLogarithmicError)](https://www.tensorflow.org/api_docs/python/tf/keras/losses/MeanSquaredLogarithmicError)
- [torchmetrics (MeanSquaredLogError)](https://lightning.ai/docs/torchmetrics/stable/regression/mean_squared_log_error.html)
- [scikit-learn (mean_squared_log_error)](https://scikit-learn.org/stable/modules/model_evaluation.html#mean-squared-log-error)

This PR adds a `msle_loss` function to `nn.losses` module.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
