### PR TITLE
Add `conda` install option to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,16 @@ in the documentation.
 
 MLX is available on [PyPI](https://pypi.org/project/mlx/). To install the Python API, run:
 
+**With `pip`**:
+
 ```
 pip install mlx
+```
+
+**With `conda`**:
+
+```
+conda install -c conda-forge mlx
 ```
 
 Checkout the


### PR DESCRIPTION
Add conda install option in docs.

## Proposed changes

This PR updates the README file with the installation option for installing `mlx` with `conda` from conda-forge channel.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have updated the necessary documentation (if needed)
