### PR TITLE
Add Margin Ranking Loss 

### DIFF
--- a/docs/src/python/nn/losses.rst
+++ b/docs/src/python/nn/losses.rst
@@ -18,6 +18,7 @@ Loss Functions
    kl_div_loss
    l1_loss
    log_cosh_loss
+   margin_ranking_loss
    mse_loss
    nll_loss
    smooth_l1_loss

--- a/python/mlx/nn/losses.py
+++ b/python/mlx/nn/losses.py
@@ -577,19 +577,9 @@ def margin_ranking_loss(
         >>> loss
         array(0.773433, dtype=float32)
     """
-    if inputs1.shape != inputs2.shape:
+    if not (inputs1.shape == inputs2.shape == targets.shape):
         raise ValueError(
-            f"Inputs1 shape {inputs1.shape} does not match inputs2 shape {inputs2.shape}."
-        )
-
-    if inputs1.shape != targets.shape:
-        raise ValueError(
-            f"Input1 shape {inputs1.shape} does not match target shape {targets.shape}."
-        )
-
-    if inputs2.shape != targets.shape:
-        raise ValueError(
-            f"Input2 shape {inputs2.shape} does not match target shape {targets.shape}."
+            f"The shapes of the arguments do not match. The provided shapes are inputs1.shape={inputs1.shape}, inputs2.shape={inputs2.shape}, and targets.shape={targets.shape}"
         )
 
     differences = inputs1 - inputs2

--- a/python/mlx/nn/losses.py
+++ b/python/mlx/nn/losses.py
@@ -540,7 +540,7 @@ def margin_ranking_loss(
     inputs2: mx.array,
     targets: mx.array,
     margin: float = 0.0,
-    reduction: Reduction = "mean",
+    reduction: Reduction = "none",
 ) -> mx.array:
     r"""
     Calculate the margin ranking loss that loss given inputs :math:`x_1`, :math:`x_2` and a label
@@ -562,7 +562,7 @@ def margin_ranking_loss(
         margin (float, optional): The margin by which the scores should be separated.
             Default: ``0.0``.
         reduction (str, optional): Specifies the reduction to apply to the output:
-            ``'none'`` | ``'mean'`` | ``'sum'``. Default: ``'mean'``.
+            ``'none'`` | ``'mean'`` | ``'sum'``. Default: ``'none'``.
 
     Returns:
         array: The computed margin ranking loss.

--- a/python/mlx/nn/losses.py
+++ b/python/mlx/nn/losses.py
@@ -579,7 +579,9 @@ def margin_ranking_loss(
     """
     if not (inputs1.shape == inputs2.shape == targets.shape):
         raise ValueError(
-            f"The shapes of the arguments do not match. The provided shapes are inputs1.shape={inputs1.shape}, inputs2.shape={inputs2.shape}, and targets.shape={targets.shape}"
+            f"The shapes of the arguments do not match. The provided shapes are "
+            f"inputs1.shape={inputs1.shape}, inputs2.shape={inputs2.shape}, and "
+            f"targets.shape={targets.shape}."
         )
 
     differences = inputs1 - inputs2

--- a/python/tests/test_losses.py
+++ b/python/tests/test_losses.py
@@ -359,6 +359,26 @@ class TestLosses(mlx_tests.MLXTestCase):
         expected_sum = mx.sum(expected_none)
         self.assertTrue(mx.allclose(losses_sum, expected_sum))
 
+    def test_margin_ranking_loss(self):
+        inputs1 = mx.array([-0.573409, -0.765166, -0.0638])
+        inputs2 = mx.array([0.75596, 0.225763, 0.256995])
+        targets = mx.array([1, 1, -1])
+
+        # Test with no margin
+        losses = nn.losses.margin_ranking_loss(
+            inputs1, inputs2, targets, reduction="none"
+        )
+        print(losses)
+        expected = mx.array([1.329369, 0.990929, 0.0])
+        self.assertTrue(mx.allclose(losses, expected))
+
+        # Test with margin
+        losses = nn.losses.margin_ranking_loss(
+            inputs1, inputs2, targets, margin=0.5, reduction="none"
+        )
+        expected = mx.array([1.829369, 1.490929, 0.179205])
+        self.assertTrue(mx.allclose(losses, expected))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/test_losses.py
+++ b/python/tests/test_losses.py
@@ -368,7 +368,6 @@ class TestLosses(mlx_tests.MLXTestCase):
         losses = nn.losses.margin_ranking_loss(
             inputs1, inputs2, targets, reduction="none"
         )
-        print(losses)
         expected = mx.array([1.329369, 0.990929, 0.0])
         self.assertTrue(mx.allclose(losses, expected))
 


### PR DESCRIPTION
## Proposed changes

This PR adds the [Margin Ranking Loss](https://pytorch.org/docs/stable/generated/torch.nn.MarginRankingLoss.html), which is commonly used for recommendation systems tasks.

The interface conforms to PyTorch, and the test ground-truth values are generated by PyTorch.

Closes #531.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
