### PR TITLE
[Fix] mx.allclose bug with infinite values

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -1156,7 +1156,7 @@ array allclose(
     double atol /* = 1e-8 */,
     bool equal_nan /* = false */,
     StreamOrDevice s /* = {}*/) {
-    return all(isclose(a, b, rtol, atol, equal_nan, s), s);
+  return all(isclose(a, b, rtol, atol, equal_nan, s), s);
 }
 
 array isclose(
@@ -1167,30 +1167,32 @@ array isclose(
     bool equal_nan /* = false */,
     StreamOrDevice s /* = {}*/) {
   // |a - b| <= atol + rtol * |b|
-    auto rhs = add(array(atol), multiply(array(rtol), abs(b, s), s), s);
-    auto lhs = abs(subtract(a, b, s), s);
-    auto out = less_equal(lhs, rhs, s);
+  auto rhs = add(array(atol), multiply(array(rtol), abs(b, s), s), s);
+  auto lhs = abs(subtract(a, b, s), s);
+  auto out = less_equal(lhs, rhs, s);
 
-    // Correct the result for infinite values.
-    auto any_inf = isinf(a, s) || isinf(b, s) || isneginf(a, s) || isneginf(b, s);
-    auto both_inf = (isinf(a, s) && isinf(b, s)) || (isneginf(a, s) && isneginf(b, s));
-    auto any_nan = isnan(a, s) || isnan(b, s);
+  // Correct the result for infinite values.
+  auto any_inf = isinf(a, s) || isinf(b, s) || isneginf(a, s) || isneginf(b, s);
+  auto both_inf =
+      (isinf(a, s) && isinf(b, s)) || (isneginf(a, s) && isneginf(b, s));
+  auto any_nan = isnan(a, s) || isnan(b, s);
 
-    // Convert all elements where either value is infinite to False.
-    out = out && logical_not(any_inf, s);
+  // Convert all elements where either value is infinite to False.
+  out = out && logical_not(any_inf, s);
 
-    // Convert all the elements where both values are infinite and of the same sign to True.
-    out = out || both_inf;
+  // Convert all the elements where both values are infinite and of the same
+  // sign to True.
+  out = out || both_inf;
 
-    // Convert all the elements where either value is NaN to False.
-    out = out && logical_not(any_nan, s);
+  // Convert all the elements where either value is NaN to False.
+  out = out && logical_not(any_nan, s);
 
-    if (equal_nan) {
-      auto both_nan = isnan(a, s) && isnan(b, s);
-      out = out || both_nan;
-    }
+  if (equal_nan) {
+    auto both_nan = isnan(a, s) && isnan(b, s);
+    out = out || both_nan;
+  }
 
-    return out;
+  return out;
 }
 
 array all(const array& a, bool keepdims, StreamOrDevice s /* = {}*/) {

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -1122,14 +1122,14 @@ array isinf(const array& a, StreamOrDevice s /* = {} */) {
   return logical_or(isposinf(a, s), isneginf(a, s), s);
 }
 
-array isposinf(const array& a, StreamOrDevice s) {
+array isposinf(const array& a, StreamOrDevice s /* = {} */) {
   if (is_integral(a.dtype())) {
     return full(a.shape(), false, bool_, s);
   }
   return equal(a, array(std::numeric_limits<float>::infinity(), a.dtype()), s);
 }
 
-array isneginf(const array& a, StreamOrDevice s) {
+array isneginf(const array& a, StreamOrDevice s /* = {} */) {
   if (is_integral(a.dtype())) {
     return full(a.shape(), false, bool_, s);
   }

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -1154,8 +1154,9 @@ array allclose(
     const array& b,
     double rtol /* = 1e-5 */,
     double atol /* = 1e-8 */,
+    bool equal_nan /* = false */,
     StreamOrDevice s /* = {}*/) {
-    return all(isclose(a, b, rtol, atol, s), s);
+    return all(isclose(a, b, rtol, atol, equal_nan, s), s);
 }
 
 array isclose(
@@ -1163,6 +1164,7 @@ array isclose(
     const array& b,
     double rtol /* = 1e-5 */,
     double atol /* = 1e-8 */,
+    bool equal_nan /* = false */,
     StreamOrDevice s /* = {}*/) {
   // |a - b| <= atol + rtol * |b|
     auto rhs = add(array(atol), multiply(array(rtol), abs(b, s), s), s);
@@ -1182,6 +1184,11 @@ array isclose(
 
     // Convert all the elements where either value is NaN to False.
     out = out && logical_not(any_nan, s);
+
+    if (equal_nan) {
+      auto both_nan = isnan(a, s) && isnan(b, s);
+      out = out || both_nan;
+    }
 
     return out;
 }

--- a/mlx/ops.h
+++ b/mlx/ops.h
@@ -407,7 +407,8 @@ array allclose(
     bool equal_nan = false,
     StreamOrDevice s = {});
 
-/** Returns a boolean array where two arrays are element-wise equal within the specified tolerance. */
+/** Returns a boolean array where two arrays are element-wise equal within the
+ * specified tolerance. */
 array isclose(
     const array& a,
     const array& b,

--- a/mlx/ops.h
+++ b/mlx/ops.h
@@ -406,6 +406,14 @@ array allclose(
     double atol = 1e-8,
     StreamOrDevice s = {});
 
+/** Returns a boolean array where two arrays are element-wise equal within the specified tolerance. */
+array isclose(
+    const array& a,
+    const array& b,
+    double rtol = 1e-5,
+    double atol = 1e-8,
+    StreamOrDevice s = {});
+
 /**
  *  Reduces the input along the given axes. An output value is true
  *  if all the corresponding inputs are true.

--- a/mlx/ops.h
+++ b/mlx/ops.h
@@ -404,6 +404,7 @@ array allclose(
     const array& b,
     double rtol = 1e-5,
     double atol = 1e-8,
+    bool equal_nan = false,
     StreamOrDevice s = {});
 
 /** Returns a boolean array where two arrays are element-wise equal within the specified tolerance. */
@@ -412,6 +413,7 @@ array isclose(
     const array& b,
     double rtol = 1e-5,
     double atol = 1e-8,
+    bool equal_nan = false,
     StreamOrDevice s = {});
 
 /**

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -1673,6 +1673,41 @@ void init_ops(py::module_& m) {
             array: The boolean output scalar indicating if the arrays are close.
       )pbdoc");
   m.def(
+      "isclose",
+      &isclose,
+      "a"_a,
+      "b"_a,
+      py::pos_only(),
+      "rtol"_a = 1e-5,
+      "atol"_a = 1e-8,
+      py::kw_only(),
+      "stream"_a = none,
+      R"pbdoc(
+        isclose(a: array, b: array, /, rtol: float = 1e-05, atol: float = 1e-08, *, stream: Union[None, Stream, Device] = None) -> array
+
+        Returns a boolean array where two arrays are element-wise equal within a tolerance.
+
+        Infinite values are treated as equals if they're of the same sign. NaN are never treated as equals.
+
+        Two values are considered equal if:
+
+        .. code-block::
+
+         all(abs(a - b) <= (atol + rtol * abs(b)))
+
+        Note unlike :func:`array_equal`, this function supports numpy-style
+        broadcasting.
+
+        Args:
+            a (array): Input array.
+            b (array): Input array.
+            rtol (float): Relative tolerance.
+            atol (float): Absolute tolerance.
+
+        Returns:
+            array: The boolean output scalar indicating if the arrays are close.
+      )pbdoc");
+  m.def(
       "all",
       [](const array& a,
          const IntOrVec& axis,

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -1707,7 +1707,7 @@ void init_ops(py::module_& m) {
             b (array): Input array.
             rtol (float): Relative tolerance.
             atol (float): Absolute tolerance.
-            equal_nan (bool): If ``True``, NaNs are treated as equal.
+            equal_nan (bool): If ``True``, NaNs are considered equal.
               Defaults to ``False``.
 
         Returns:

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -566,7 +566,7 @@ void init_ops(py::module_& m) {
         Args:
             a (array): Input array or scalar.
             b (array): Input array or scalar.
-            equal_nan (bool): If ``True``, NaNs are treated as equal.
+            equal_nan (bool): If ``True``, NaNs are considered equal.
               Defaults to ``False``.
 
         Returns:
@@ -1655,6 +1655,8 @@ void init_ops(py::module_& m) {
 
         Approximate comparison of two arrays.
 
+        Infinite values are considered equal if they have the same sign, NaN values are not equal unless ``equal_nan`` is ``True``.
+
         The arrays are considered equal if:
 
         .. code-block::
@@ -1669,7 +1671,7 @@ void init_ops(py::module_& m) {
             b (array): Input array.
             rtol (float): Relative tolerance.
             atol (float): Absolute tolerance.
-            equal_nan (bool): If ``True``, NaNs are treated as equal.
+            equal_nan (bool): If ``True``, NaNs are considered equal.
               Defaults to ``False``.
 
         Returns:

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -1700,7 +1700,7 @@ void init_ops(py::module_& m) {
 
         .. code-block::
 
-         all(abs(a - b) <= (atol + rtol * abs(b)))
+         abs(a - b) <= (atol + rtol * abs(b))
 
         Note unlike :func:`array_equal`, this function supports numpy-style
         broadcasting.

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -1691,7 +1691,8 @@ void init_ops(py::module_& m) {
 
         Returns a boolean array where two arrays are element-wise equal within a tolerance.
 
-        Infinite values are treated as equals if they're of the same sign. NaN are never treated as equals.
+        Infinite values are considered equal if they have the same sign, NaN values are
+        not equal unless ``equal_nan`` is ``True``.
 
         Two values are considered equal if:
 

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -1648,9 +1648,10 @@ void init_ops(py::module_& m) {
       "rtol"_a = 1e-5,
       "atol"_a = 1e-8,
       py::kw_only(),
+      "equal_nan"_a = false,
       "stream"_a = none,
       R"pbdoc(
-        allclose(a: array, b: array, /, rtol: float = 1e-05, atol: float = 1e-08, *, stream: Union[None, Stream, Device] = None) -> array
+        allclose(a: array, b: array, /, rtol: float = 1e-05, atol: float = 1e-08, *, equal_nan: bool = False, stream: Union[None, Stream, Device] = None) -> array
 
         Approximate comparison of two arrays.
 
@@ -1668,6 +1669,8 @@ void init_ops(py::module_& m) {
             b (array): Input array.
             rtol (float): Relative tolerance.
             atol (float): Absolute tolerance.
+            equal_nan (bool): If ``True``, NaNs are treated as equal.
+              Defaults to ``False``.
 
         Returns:
             array: The boolean output scalar indicating if the arrays are close.
@@ -1681,9 +1684,10 @@ void init_ops(py::module_& m) {
       "rtol"_a = 1e-5,
       "atol"_a = 1e-8,
       py::kw_only(),
+      "equal_nan"_a = false,
       "stream"_a = none,
       R"pbdoc(
-        isclose(a: array, b: array, /, rtol: float = 1e-05, atol: float = 1e-08, *, stream: Union[None, Stream, Device] = None) -> array
+        isclose(a: array, b: array, /, rtol: float = 1e-05, atol: float = 1e-08, *, equal_nan: bool = False, stream: Union[None, Stream, Device] = None) -> array
 
         Returns a boolean array where two arrays are element-wise equal within a tolerance.
 
@@ -1703,6 +1707,8 @@ void init_ops(py::module_& m) {
             b (array): Input array.
             rtol (float): Relative tolerance.
             atol (float): Absolute tolerance.
+            equal_nan (bool): If ``True``, NaNs are treated as equal.
+              Defaults to ``False``.
 
         Returns:
             array: The boolean output scalar indicating if the arrays are close.

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -864,6 +864,12 @@ class TestOps(mlx_tests.MLXTestCase):
 
         self.assertListEqual(mx.isclose(a, b).tolist(), [True, False, True])
 
+        a = mx.array([np.nan])
+        self.assertListEqual(mx.isclose(a, a).tolist(), [False])
+
+        a = mx.array([np.nan])
+        self.assertListEqual(mx.isclose(a, a, equal_nan=True).tolist(), [True])
+
     def test_all(self):
         a = mx.array([[True, False], [True, True]])
 

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -855,6 +855,15 @@ class TestOps(mlx_tests.MLXTestCase):
         self.assertFalse(mx.allclose(a, b, 0.01).item())
         self.assertTrue(mx.allclose(a, b, 0.01, 0.1).item())
 
+        c = mx.array(float("inf"))
+        self.assertTrue(mx.allclose(c, c).item())
+
+    def test_isclose(self):
+        a = mx.array([float("inf"), float("inf"), float("-inf")])
+        b = mx.array([float("inf"), float("-inf"), float("-inf")])
+
+        self.assertListEqual(mx.isclose(a, b).tolist(), [True, False, True])
+
     def test_all(self):
         a = mx.array([[True, False], [True, True]])
 

--- a/tests/ops_tests.cpp
+++ b/tests/ops_tests.cpp
@@ -569,7 +569,10 @@ TEST_CASE("test is close") {
   {
     array a({1.0, std::nan("1"), std::nan("1")});
     array b({1.0, std::nan("1"), 2.0});
-    CHECK(array_equal(isclose(a, b, 1e-5, 1e-8, equal_nan = true), array({true, true, false})).item<bool>());
+    CHECK(array_equal(
+              isclose(a, b, 1e-5, 1e-8, equal_nan = true),
+              array({true, true, false}))
+              .item<bool>());
   }
 }
 

--- a/tests/ops_tests.cpp
+++ b/tests/ops_tests.cpp
@@ -569,10 +569,9 @@ TEST_CASE("test is close") {
   {
     array a({1.0, std::nan("1"), std::nan("1")});
     array b({1.0, std::nan("1"), 2.0});
-    CHECK(array_equal(
-              isclose(a, b, 1e-5, 1e-8, equal_nan = true),
-              array({true, true, false}))
-              .item<bool>());
+    CHECK(
+        array_equal(isclose(a, b, 1e-5, 1e-8, true), array({true, true, false}))
+            .item<bool>());
   }
 }
 

--- a/tests/ops_tests.cpp
+++ b/tests/ops_tests.cpp
@@ -545,6 +545,29 @@ TEST_CASE("test all close") {
   CHECK(allclose(x, y, 0.01, 0.1).item<bool>());
 }
 
+TEST_CASE("test is close") {
+  {
+    array a({1.0, std::numeric_limits<float>::infinity()});
+    array b({1.0, std::numeric_limits<float>::infinity()});
+    CHECK(array_equal(isclose(a, b), array({true, true})).item<bool>());
+  }
+  {
+    array a({1.0, -std::numeric_limits<float>::infinity()});
+    array b({1.0, -std::numeric_limits<float>::infinity()});
+    CHECK(array_equal(isclose(a, b), array({true, true})).item<bool>());
+  }
+  {
+    array a({1.0, std::numeric_limits<float>::infinity()});
+    array b({1.0, -std::numeric_limits<float>::infinity()});
+    CHECK(array_equal(isclose(a, b), array({true, false})).item<bool>());
+  }
+  {
+    array a({1.0, std::nan("1"), std::nan("1")});
+    array b({1.0, std::nan("1"), 2.0});
+    CHECK(array_equal(isclose(a, b), array({true, false, false})).item<bool>());
+  }
+}
+
 TEST_CASE("test reduction ops") {
   // Check shapes and throws correctly
   {

--- a/tests/ops_tests.cpp
+++ b/tests/ops_tests.cpp
@@ -514,6 +514,9 @@ TEST_CASE("test is inf") {
   array y(inf);
   CHECK(isinf(y).item<bool>());
 
+  auto neginf = -std::numeric_limits<float>::infinity();
+  CHECK(isinf(array(neginf)).item<bool>());
+
   array z = identity(7);
   CHECK_FALSE(any(isinf(z)).item<bool>());
 

--- a/tests/ops_tests.cpp
+++ b/tests/ops_tests.cpp
@@ -566,6 +566,11 @@ TEST_CASE("test is close") {
     array b({1.0, std::nan("1"), 2.0});
     CHECK(array_equal(isclose(a, b), array({true, false, false})).item<bool>());
   }
+  {
+    array a({1.0, std::nan("1"), std::nan("1")});
+    array b({1.0, std::nan("1"), 2.0});
+    CHECK(array_equal(isclose(a, b, 1e-5, 1e-8, equal_nan = true), array({true, true, false})).item<bool>());
+  }
 }
 
 TEST_CASE("test reduction ops") {


### PR DESCRIPTION
## Proposed changes

This fixes #522 . 

Handle infinite and NaN values gracefully, following the Numpy API. Added a parameter `equal_nan` that treats `NaN` as equal if compared.

Added `mx.isclose`, which returning the results of a element-wise comparisons in a boolean array.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)