### PR TITLE
mlx.core.flatten lacks dimension check

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -320,7 +320,8 @@ array flatten(
   }
   if (end_ax < start_ax) {
     throw std::invalid_argument(
-        "[flatten] start_axis must be less than or equal to end_axis");
+        "[flatten] Invalid combination of start_axis and end_axis. "
+        "start_axis must be less than or equal to end_axis");
   }
   if (start_ax >= ndim) {
     std::ostringstream msg;


### PR DESCRIPTION
issue #557

 previous code :
```
if (end_ax < start_ax) {
    throw std::invalid_argument(
        
        "start_axis must be less than or equal to end_axis");
  } ``
```

after adding the error msg : 

```
if (end_ax < start_ax) {
    throw std::invalid_argument(
        "[flatten] Invalid combination of start_axis and end_axis. "
        "start_axis must be less than or equal to end_axis");
  }
```

-----
ig it will solve the issue 
-----


## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
