### PR TITLE
fix cache key in RoPE

### DIFF
--- a/python/mlx/nn/layers/positional_encoding.py
+++ b/python/mlx/nn/layers/positional_encoding.py
@@ -104,9 +104,9 @@ class RoPE(Module):
         dtype=mx.float32,
     ):
         if (N, D, offset, base, scale, dtype) != cls._cos_sin_theta_key:
-            D = D // 2
+            half_D = D // 2
             positions = mx.arange(offset, N, dtype=dtype) * scale
-            freqs = mx.exp(-mx.arange(0.0, D, dtype=dtype) * (math.log(base) / D))
+            freqs = mx.exp(-mx.arange(0.0, half_D, dtype=dtype) * (math.log(base) / half_D))
             theta = mx.reshape(positions, (-1, 1)) * mx.reshape(freqs, (1, -1))
             cls._cos_sin_theta_key = (N, D, offset, base, scale, dtype)
             cls._cos_sin_theta_value = (mx.cos(theta), mx.sin(theta))


### PR DESCRIPTION
the values were being computed for D but the cache key was D // 2

## Proposed changes

the values were being computed for `D` but the cache key was `D // 2`.  This makes a new variable for `half_D` so that it can use the original value of `D` for the cache key.

This should be _slightly_ faster because we will get cache hits and more importantly we won't get false hits if you pass in a D (dimension) which happens to be half of the original D.

Tested with `mistral` from mlx-examples and I see the same results.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
