### PR TITLE
Added TeX line breaks to mlx.optimizers.Lion docstring

### DIFF
--- a/python/mlx/optimizers.py
+++ b/python/mlx/optimizers.py
@@ -465,8 +465,8 @@ class Lion(Optimizer):
 
     .. math::
 
-        c_{t + 1} &= \beta_1 m_t + (1 - \beta_1) g_t
-        m_{t + 1} &= \beta_2 m_t + (1 - \beta_2) g_t
+        c_{t + 1} &= \beta_1 m_t + (1 - \beta_1) g_t \\
+        m_{t + 1} &= \beta_2 m_t + (1 - \beta_2) g_t \\
         w_{t + 1} &= w_t - \eta (\text{sign}(c_t) + \lambda w_t)
 
     Args:


### PR DESCRIPTION
## Proposed changes

Fixes the "misplaced &" MathJax error for optimizers.Lion in documentation by adding two `\\` in the docstring

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
