### PR TITLE
Reduce vmap + some fixes

### DIFF
--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -360,6 +360,20 @@ bool ArgReduce::is_equivalent(const Primitive& other) const {
   return reduce_type_ == r_other.reduce_type_ && axis_ == r_other.axis_;
 }
 
+std::pair<std::vector<array>, std::vector<int>> ArgReduce::vmap(
+    const std::vector<array>& inputs,
+    const std::vector<int>& axes) {
+  int reduce_ax = axis_ + (axis_ >= axes[0]);
+  auto& in = inputs[0];
+  std::vector<array> out;
+  if (reduce_type_ == ArgReduce::ArgMin) {
+    out.push_back(argmin(in, reduce_ax, true, stream()));
+  } else {
+    out.push_back(argmax(in, reduce_ax, true, stream()));
+  }
+  return {out, axes};
+}
+
 std::pair<std::vector<array>, std::vector<int>> ArgSort::vmap(
     const std::vector<array>& inputs,
     const std::vector<int>& axes) {

--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -1,5 +1,4 @@
 // Copyright © 2023-2024 Apple Inc.
-
 #include <algorithm>
 #include <cassert>
 #include <cmath>
@@ -2153,7 +2152,36 @@ std::vector<array> Reduce::vjp(
 std::pair<std::vector<array>, std::vector<int>> Reduce::vmap(
     const std::vector<array>& inputs,
     const std::vector<int>& axes) {
-  throw std::runtime_error("Reduce::vmap not yet implemented.");
+  auto ax = axes[0];
+  auto reduce_axes = axes_;
+  for (auto& rax : reduce_axes) {
+    if (rax >= ax) {
+      rax++;
+    }
+  }
+  auto& in = inputs[0];
+  std::vector<array> out;
+  switch (reduce_type_) {
+    case Reduce::And:
+      out.push_back(all(in, reduce_axes, true, stream()));
+      break;
+    case Reduce::Or:
+      out.push_back(any(in, reduce_axes, true, stream()));
+      break;
+    case Reduce::Sum:
+      out.push_back(sum(in, reduce_axes, true, stream()));
+      break;
+    case Reduce::Prod:
+      out.push_back(prod(in, reduce_axes, true, stream()));
+      break;
+    case Reduce::Min:
+      out.push_back(min(in, reduce_axes, true, stream()));
+      break;
+    case Reduce::Max:
+      out.push_back(max(in, reduce_axes, true, stream()));
+      break;
+  }
+  return {out, axes};
 }
 
 bool Reduce::is_equivalent(const Primitive& other) const {

--- a/mlx/primitives.h
+++ b/mlx/primitives.h
@@ -341,6 +341,7 @@ class ArgReduce : public UnaryPrimitive {
   void eval_cpu(const std::vector<array>& inputs, array& out) override;
   void eval_gpu(const std::vector<array>& inputs, array& out) override;
 
+  DEFINE_VMAP()
   DEFINE_PRINT(ArgReduce)
   bool is_equivalent(const Primitive& other) const override;
 

--- a/mlx/transforms.cpp
+++ b/mlx/transforms.cpp
@@ -1,7 +1,6 @@
 // Copyright © 2023-2024 Apple Inc.
 #include <algorithm>
 #include <future>
-#include <iostream> // TODO
 #include <numeric>
 #include <set>
 #include <sstream>

--- a/python/tests/test_vmap.py
+++ b/python/tests/test_vmap.py
@@ -220,6 +220,40 @@ class TestVmap(mlx_tests.MLXTestCase):
         )
         self.assertTrue(mx.array_equal(out, expected))
 
+    def test_vmap_reduce(self):
+        a = mx.ones((5, 5), mx.int32)
+        out = mx.vmap(lambda x: x.sum())(a)
+        self.assertTrue(mx.array_equal(out, mx.full((5,), 5)))
+
+        out = mx.vmap(lambda x: x.sum(keepdims=True))(a)
+        self.assertTrue(mx.array_equal(out, mx.full((5, 1), 5)))
+
+        out = mx.vmap(lambda x: x.sum(axis=0))(a)
+        self.assertTrue(mx.array_equal(out, mx.full((5,), 5)))
+
+        a = mx.ones((5, 3, 2), mx.int32)
+        out = mx.vmap(lambda x: x.sum(axis=(0, 1)))(a)
+        self.assertTrue(mx.array_equal(out, mx.full((5,), 6)))
+
+        a = mx.ones((5, 3, 2), mx.int32)
+        out = mx.vmap(lambda x: x.sum(axis=(0, 1)), in_axes=(1,))(a)
+        self.assertTrue(mx.array_equal(out, mx.full((3,), 10)))
+
+        a = mx.ones((5, 3, 2), mx.int32)
+        out = mx.vmap(lambda x: x.sum(axis=(0, 1)), in_axes=(2,))(a)
+        self.assertTrue(mx.array_equal(out, mx.full((2,), 15)))
+
+    def test_mismatch_input_sizes(self):
+        a = mx.ones((10, 1))
+        b = mx.ones((1, 1, 1, 5))
+
+        with self.assertRaises(ValueError):
+            out = mx.vmap(lambda x, y: x + y)(a, b)
+
+        b = mx.ones((10, 5))
+        with self.assertRaises(ValueError):
+            out = mx.vmap(lambda x, y: x + y, in_axes=(0, 1))(a, b)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/test_vmap.py
+++ b/python/tests/test_vmap.py
@@ -1,4 +1,4 @@
-# Copyright © 2023 Apple Inc.
+# Copyright © 2023-2024 Apple Inc.
 
 import unittest
 

--- a/python/tests/test_vmap.py
+++ b/python/tests/test_vmap.py
@@ -243,6 +243,16 @@ class TestVmap(mlx_tests.MLXTestCase):
         out = mx.vmap(lambda x: x.sum(axis=(0, 1)), in_axes=(2,))(a)
         self.assertTrue(mx.array_equal(out, mx.full((2,), 15)))
 
+    def test_vmap_argreduce(self):
+        a = mx.array([[1, 2, 3], [2, 3, 1]])
+        out = mx.vmap(lambda x: mx.argmin(x))(a)
+        expected = mx.array([0, 2])
+        self.assertTrue(mx.array_equal(out, expected))
+
+        out = mx.vmap(lambda x: mx.argmax(x))(a)
+        expected = mx.array([2, 1])
+        self.assertTrue(mx.array_equal(out, expected))
+
     def test_mismatch_input_sizes(self):
         a = mx.ones((10, 1))
         b = mx.ones((1, 1, 1, 5))


### PR DESCRIPTION
## Proposed changes

- Add vmap for reductions - closes #442
- Change reductions to explicitly squeeze unkept dims. This has two benefits: 1. Catch more merges for simplify, 2. Simplifies vmap code a lot
- Throw if inputs do not have same shape along vmap axes - closes #600