### PR TITLE
feat: enhancement of the error message for mlx.core.mean

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -1316,6 +1316,15 @@ array mean(
     const std::vector<int>& axes,
     bool keepdims /* = false */,
     StreamOrDevice s /* = {}*/) {
+  int ndim = a.ndim();
+  for (int axis : axes) {
+    if (axis < -ndim || axis >= ndim) {
+      throw std::invalid_argument(
+          "[mean] axis " + std::to_string(axis) +
+          " is out of bounds for array with " + std::to_string(ndim) +
+          " dimensions.");
+    }
+  }
   auto nelements = compute_number_of_elements(a, axes);
   auto dtype = at_least_float(a.dtype());
   return multiply(sum(a, axes, keepdims, s), array(1.0 / nelements, dtype), s);

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -1319,10 +1319,11 @@ array mean(
   int ndim = a.ndim();
   for (int axis : axes) {
     if (axis < -ndim || axis >= ndim) {
-      throw std::invalid_argument(
-          "[mean] axis " + std::to_string(axis) +
-          " is out of bounds for array with " + std::to_string(ndim) +
-          " dimensions.");
+      std::ostringstream msg;
+      msg << "[mean] axis " + std::to_string(axis) +
+              " is out of bounds for array with " + std::to_string(ndim) +
+              " dimensions.";
+      throw std::invalid_argument(msg.str());
     }
   }
   auto nelements = compute_number_of_elements(a, axes);

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -1320,9 +1320,8 @@ array mean(
   for (int axis : axes) {
     if (axis < -ndim || axis >= ndim) {
       std::ostringstream msg;
-      msg << "[mean] axis " + std::to_string(axis) +
-              " is out of bounds for array with " + std::to_string(ndim) +
-              " dimensions.";
+      msg << "[mean] axis " << axis + " is out of bounds for array with "
+          << ndim + " dimensions.";
       throw std::invalid_argument(msg.str());
     }
   }


### PR DESCRIPTION
## Proposed changes

Added an error message when there is a mismatch of dims and axes in mlx.core.mean
Issue: https://github.com/ml-explore/mlx/issues/578

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
