### PR TITLE
fixes for building and running on iOS

### DIFF
--- a/mlx/backend/common/conv.cpp
+++ b/mlx/backend/common/conv.cpp
@@ -3,7 +3,11 @@
 #include <cassert>
 
 #ifdef ACCELERATE_NEW_LAPACK
+#if __has_include(<vecLib/vecLib.h>)
 #include <vecLib/cblas_new.h>
+#else
+#include <Accelerate/Accelerate.h>
+#endif
 #else
 #include <cblas.h>
 #endif

--- a/mlx/backend/common/conv.cpp
+++ b/mlx/backend/common/conv.cpp
@@ -3,11 +3,7 @@
 #include <cassert>
 
 #ifdef ACCELERATE_NEW_LAPACK
-#if __has_include(<vecLib/vecLib.h>)
-#include <vecLib/cblas_new.h>
-#else
 #include <Accelerate/Accelerate.h>
-#endif
 #else
 #include <cblas.h>
 #endif

--- a/mlx/backend/common/default_primitives.cpp
+++ b/mlx/backend/common/default_primitives.cpp
@@ -1,7 +1,11 @@
 // Copyright © 2023-2024 Apple Inc.
 
 #ifdef ACCELERATE_NEW_LAPACK
+#if __has_include(<vecLib/vecLib.h>)
 #include <vecLib/cblas_new.h>
+#else
+#include <Accelerate/Accelerate.h>
+#endif
 #else
 #include <cblas.h>
 #endif

--- a/mlx/backend/common/default_primitives.cpp
+++ b/mlx/backend/common/default_primitives.cpp
@@ -1,11 +1,7 @@
 // Copyright © 2023-2024 Apple Inc.
 
 #ifdef ACCELERATE_NEW_LAPACK
-#if __has_include(<vecLib/vecLib.h>)
-#include <vecLib/cblas_new.h>
-#else
 #include <Accelerate/Accelerate.h>
-#endif
 #else
 #include <cblas.h>
 #endif

--- a/mlx/backend/common/qrf.cpp
+++ b/mlx/backend/common/qrf.cpp
@@ -5,7 +5,11 @@
 #include "mlx/primitives.h"
 
 #ifdef ACCELERATE_NEW_LAPACK
+#if __has_include(<vecLib/lapack.h>)
 #include <vecLib/lapack.h>
+#else
+#include <Accelerate/Accelerate.h>
+#endif
 #else
 #include <lapack.h>
 #endif

--- a/mlx/backend/common/qrf.cpp
+++ b/mlx/backend/common/qrf.cpp
@@ -5,11 +5,7 @@
 #include "mlx/primitives.h"
 
 #ifdef ACCELERATE_NEW_LAPACK
-#if __has_include(<vecLib/lapack.h>)
-#include <vecLib/lapack.h>
-#else
 #include <Accelerate/Accelerate.h>
-#endif
 #else
 #include <lapack.h>
 #endif

--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -26,7 +26,8 @@ static constexpr const char* default_mtllib_path = METAL_PATH;
 
 auto load_device() {
   auto devices = MTL::CopyAllDevices();
-  auto device = static_cast<MTL::Device*>(devices->object(0));
+  auto device = static_cast<MTL::Device*>(devices->object(0))
+      ?: MTL::CreateSystemDefaultDevice();
   if (!device) {
     throw std::runtime_error("Failed to load device");
   }


### PR DESCRIPTION
## Proposed changes

Fixes for building and running on iOS:

- veclib imports are not available -- use Accelerate in those cases
- getting the default device requires a different API

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)

Verified manually.