### PR TITLE
expose numpy compatible strides attribute in python extension.

### DIFF
--- a/docs/src/python/array.rst
+++ b/docs/src/python/array.rst
@@ -16,6 +16,7 @@ Array
     array.ndim
     array.shape
     array.size
+    array.strides
     Dtype
     array.abs
     array.all

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -1179,6 +1179,23 @@ class TestArray(mlx_tests.MLXTestCase):
         self.assertTrue(a_np.flags.owndata)
         self.assertTrue(a_np.flags.writeable)
 
+    def test_strides(self):
+        test_cases = [
+            (mx.bool_, np.bool_, (1, 1)),
+            (mx.bool_, np.bool_, (2, 3)),
+            (mx.uint8, np.uint8, (3, 2)),
+            (mx.float32, np.float32, (1, 2, 3, 4)),
+        ]
+        for mlx_dtype, np_dtype, shape in test_cases:
+            a_np = np.ones(shape, dtype=np_dtype)
+            a_mx = mx.ones(shape, dtype=mlx_dtype)
+            self.assertEqual(
+                a_np.strides, a_mx.strides, f"{shape}{mlx_dtype}{np_dtype}"
+            )
+            self.assertEqual(
+                a_np.T.strides, a_mx.T.strides, f"{shape}{mlx_dtype}{np_dtype}"
+            )
+
     def test_buffer_protocol(self):
         dtypes_list = [
             (mx.bool_, np.bool_, None),


### PR DESCRIPTION
## Proposed changes

expose numpy compatible strides attribute in python extension.

See https://numpy.org/doc/stable/reference/generated/numpy.ndarray.strides.html

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
