### PR TITLE
make python array SupportsAbs conform (like numpy)

### DIFF
--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -1110,6 +1110,7 @@ void init_array(py::module_& m) {
           py::kw_only(),
           "stream"_a = none,
           "See :func:`abs`.")
+      .def("__abs__", &mlx::core::abs, "See :func:`abs`.")
       .def(
           "square",
           &square,

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -696,6 +696,8 @@ class TestOps(mlx_tests.MLXTestCase):
         expected = np.abs(a, dtype=np.float32)
         self.assertTrue(np.allclose(result, expected))
 
+        self.assertTrue(np.allclose(a.abs(), abs(a)))
+
     def test_negative(self):
         a = mx.array([-1.0, 1.0, -2.0, 3.0])
         result = mx.negative(a)


### PR DESCRIPTION
## Proposed changes

make python array [SupportsAbs](https://docs.python.org/3/library/typing.html#typing.SupportsAbs) conform (like numpy)

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
