### PR TITLE
Skip compile when transforming

### DIFF
--- a/mlx/compile.cpp
+++ b/mlx/compile.cpp
@@ -86,20 +86,20 @@ std::vector<array> Compiled::vjp(
     const std::vector<array>& cotangents,
     const std::vector<int>& argnums,
     const std::vector<array>& outputs) {
-  throw std::runtime_error("[Compiled] Cannot VJP Compiled primitive.");
+  throw std::runtime_error("[Compiled] Cannot vjp primitive.");
 }
 
 std::vector<array> Compiled::jvp(
     const std::vector<array>& primals,
     const std::vector<array>& tangents,
     const std::vector<int>& argnums) {
-  throw std::runtime_error("[Compiled] Cannot JVP Compiled primitive.");
+  throw std::runtime_error("[Compiled] Cannot jvp primitive.");
 }
 
 std::pair<std::vector<array>, std::vector<int>> Compiled::vmap(
     const std::vector<array>& inputs,
     const std::vector<int>& axes) {
-  throw std::runtime_error("[Compiled] Cannot VMAP Compiled primitive.");
+  throw std::runtime_error("[Compiled] Cannot vmap primitive.");
 }
 
 bool Compiled::is_equivalent(const Primitive& other) const {


### PR DESCRIPTION
## Proposed changes

As per title. This let's us simplify and fuse much more than if we transform over the compiled primitive directly.

Here are a few examples:

### Compile compiled functions
```python
@mx.compile
def fun(x):
    @mx.compile
    def inner(y):
        return mx.abs(mx.exp(y))

    return inner(inner(x))
mx.export_to_dot("graph.dot", fun(mx.array([1.0, 2.0])))
```

Now produces a single fused primitive:

<img width="334" alt="Screenshot 2024-02-05 at 4 27 11 PM" src="https://github.com/ml-explore/mlx/assets/1542805/ab175407-c7ff-4904-8bf4-76b9e91e4a13">


### Grad compiled functions

```python
@mx.compile
def fun(x):
    return mx.exp(mx.exp(x))

x = mx.array(1.0)
out = mx.compile(mx.value_and_grad(fun))(x)
mx.export_to_dot("graph.dot", out)
```

Also now produces a single primitive with no duplicate work since the VJP reuses the exp's.

<img width="551" alt="Screenshot 2024-02-05 at 4 26 39 PM" src="https://github.com/ml-explore/mlx/assets/1542805/61777e58-3658-4b64-a893-935e8412fcda">
