### PR TITLE
Add loc and scale to random.normal

### DIFF
--- a/mlx/random.cpp
+++ b/mlx/random.cpp
@@ -161,8 +161,12 @@ array normal(
   auto low = array(std::nextafter(-1.0f, 0.0f), dtype);
   auto high = array(1.0f, dtype);
   auto samples = uniform(low, high, shape, dtype, key, stream);
-  auto normal_samples = multiply(array(std::sqrt(2.0), dtype), erfinv(samples, stream), stream);
-  return add(multiply(normal_samples, array(scale, dtype), stream), array(loc, dtype), stream);
+  auto normal_samples =
+      multiply(array(std::sqrt(2.0), dtype), erfinv(samples, stream), stream);
+  return add(
+      multiply(normal_samples, array(scale, dtype), stream),
+      array(loc, dtype),
+      stream);
 }
 
 array randint(

--- a/mlx/random.cpp
+++ b/mlx/random.cpp
@@ -153,14 +153,16 @@ array uniform(
 array normal(
     const std::vector<int>& shape,
     Dtype dtype,
+    const float loc,
+    const float scale,
     const std::optional<array>& key /*= nullopt */,
     StreamOrDevice s /* = {} */) {
   auto stream = to_stream(s);
   auto low = array(std::nextafter(-1.0f, 0.0f), dtype);
   auto high = array(1.0f, dtype);
   auto samples = uniform(low, high, shape, dtype, key, stream);
-  return multiply(
-      array(std::sqrt(2.0), dtype), erfinv(samples, stream), stream);
+  auto normal_samples = multiply(array(std::sqrt(2.0), dtype), erfinv(samples, stream), stream);
+  return add(multiply(normal_samples, array(scale, dtype), stream), array(loc, dtype), stream);
 }
 
 array randint(

--- a/mlx/random.h
+++ b/mlx/random.h
@@ -95,13 +95,17 @@ inline array uniform(
 array normal(
     const std::vector<int>& shape,
     Dtype dtype,
+    const float loc = 0.0,
+    const float scale = 1.0,
     const std::optional<array>& key = std::nullopt,
     StreamOrDevice s = {});
 inline array normal(
     const std::vector<int>& shape,
+    const float loc = 0.0,
+    const float scale = 1.0,
     const std::optional<array>& key = std::nullopt,
     StreamOrDevice s = {}) {
-  return normal(shape, float32, key, s);
+  return normal(shape, float32, loc, scale, key, s);
 }
 
 /** Generate integer samples uniformly at random */

--- a/python/src/random.cpp
+++ b/python/src/random.cpp
@@ -99,13 +99,17 @@ void init_random(py::module_& parent_module) {
       "normal",
       [](const std::vector<int>& shape,
          std::optional<Dtype> type,
+         float loc,
+         float scale,
          const std::optional<array>& key,
          StreamOrDevice s) {
-        return normal(shape, type.value_or(float32), key, s);
+        return normal(shape, type.value_or(float32), loc, scale, key, s);
       },
 
       "shape"_a = std::vector<int>{},
       "dtype"_a = std::optional{float32},
+      "loc"_a = 0.0,
+      "scale"_a = 1.0,
       "key"_a = none,
       "stream"_a = none,
       R"pbdoc(
@@ -114,6 +118,8 @@ void init_random(py::module_& parent_module) {
         Args:
             shape (list(int), optional): Shape of the output. Default is ``()``.
             dtype (Dtype, optional): Type of the output. Default is ``float32``.
+            loc (float, optional): Mean of the distribution. Default is ``0.0``.
+            scale (float, optional): Standard deviation of the distribution. Default is ``1.0``.
             key (array, optional): A PRNG key. Default: None.
 
         Returns:

--- a/python/tests/test_random.py
+++ b/python/tests/test_random.py
@@ -80,6 +80,20 @@ class TestRandom(mlx_tests.MLXTestCase):
             a = mx.random.normal(dtype=t)
             self.assertEqual(a.dtype, t)
 
+        # Generate with a given mean and standard deviation
+        a = mx.random.normal(shape=(3, 2), loc=1, scale=2.0)
+        b = mx.array([[0.0371162, 2.54261], [3.65259, 0.821914], [-2.07296, 2.24906]])
+        self.assertTrue(mx.all(mx.abs(a - b) < 1e-5).item())
+
+        # Generate with a given mean and standard deviation and dtype
+        a = mx.random.normal(shape=(3, 2), loc=1, scale=2.0, dtype=mx.float16)
+        self.assertEqual(a.dtype, mx.float16)
+        b = mx.array(
+            [[1.26758, 0.763184], [-1.0293, 2.33984], [0.598633, 2.9082]],
+            dtype=mx.float16,
+        )
+        self.assertTrue(mx.all(mx.abs(a - b) < 1e-5).item())
+
         self.assertEqual(mx.random.normal().dtype, mx.random.normal(dtype=None).dtype)
 
     def test_randint(self):


### PR DESCRIPTION
## Proposed changes

Currently, random.normal always returns results with mean 0 and std 1. To get values with some other mean or std you currently need to rescale them. I added an optional loc and an optional scale parameter to random.normal that does the rescaling directly like in numpy, torch and tf. 

Issue: #618 

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
