### PR TITLE
CI change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,7 @@ workflows:
   nightly_build:
     when: << pipeline.parameters.nightly_build >>
     jobs:
-      - build_package:
+      - build_release:
           matrix:
             parameters:
               python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
@@ -187,7 +187,7 @@ workflows:
 #  weekly_build:
 #    when: << pipeline.parameters.weekly_build >>
 #    jobs:
-#      - build_dev_release:
+#      - build_release:
 #          matrix:
 #            parameters:
 #              python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,44 +57,36 @@ jobs:
           command: ./build/tests/tests
 
   mac_build_and_test:
-    machine: true
-    resource_class: ml-explore/m-builder
+    macos:
+      xcode: "15.2.0"
+    resource_class: macos.m1.large.gen1
     steps:
       - checkout
       - run:
           name: Install dependencies
           command: |
-            eval "$(conda shell.bash hook)"
-            rm -r $CONDA_PREFIX/envs/runner-env
-            conda create -y -n runner-env python=3.9
-            conda activate runner-env
-            pip install --upgrade cmake
-            pip install --upgrade pybind11[global]
-            pip install pybind11-stubgen
-            pip install numpy
-            pip install torch
-            pip install tensorflow
-            pip install unittest-xml-reporting
+            brew install python
+            pip3 install --upgrade cmake
+            pip3 install --upgrade pybind11[global]
+            pip3 install pybind11-stubgen
+            pip3 install numpy
+            pip3 install torch
+            pip3 install tensorflow
+            pip3 install unittest-xml-reporting
       - run:
           name: Install Python package
           command: |
-            eval "$(conda shell.bash hook)"
-            conda activate runner-env
-            CMAKE_BUILD_PARALLEL_LEVEL="" python setup.py build_ext --inplace
-            CMAKE_BUILD_PARALLEL_LEVEL="" python setup.py develop
+            CMAKE_BUILD_PARALLEL_LEVEL="" python3 setup.py build_ext --inplace
+            CMAKE_BUILD_PARALLEL_LEVEL="" python3 setup.py develop
       - run:
           name: Generate package stubs
           command: |
-            eval "$(conda shell.bash hook)"
-            conda activate runner-env
-            python setup.py generate_stubs
+            python3 setup.py generate_stubs
       - run:
           name: Run Python tests
           command: |
-            eval "$(conda shell.bash hook)"
-            conda activate runner-env
-            DEVICE=cpu python -m xmlrunner discover -v python/tests -o test-results/cpu
-            DEVICE=gpu python -m xmlrunner discover -v python/tests -o test-results/gpu
+            DEVICE=cpu python3 -m xmlrunner discover -v python/tests -o test-results/cpu
+            DEVICE=gpu python3 -m xmlrunner discover -v python/tests -o test-results/gpu
       # TODO: Reenable when extension api becomes stable
       # - run:
       #     name: Build example extension
@@ -273,31 +265,31 @@ workflows:
         - not: << pipeline.parameters.nightly_build >>
         - not: << pipeline.parameters.weekly_build >>
     jobs:
-      - linux_build_and_test
       - mac_build_and_test
-      - build_release:
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
-          matrix:
-            parameters:
-              python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-              macos_version: ["13", "14"]
-  nightly_build:
-    when: << pipeline.parameters.nightly_build >>
-    jobs:
-      - build_package:
-          matrix:
-            parameters:
-              python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-              macos_version: ["13", "14"]
-  weekly_build:
-    when: << pipeline.parameters.weekly_build >>
-    jobs:
-      - build_dev_release:
-          matrix:
-            parameters:
-              python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-              macos_version: ["13", "14"]
+#      - linux_build_and_test
+#      - build_release:
+#          filters:
+#            tags:
+#              only: /^v.*/
+#            branches:
+#              ignore: /.*/
+#          matrix:
+#            parameters:
+#              python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+#              macos_version: ["13", "14"]
+#  nightly_build:
+#    when: << pipeline.parameters.nightly_build >>
+#    jobs:
+#      - build_package:
+#          matrix:
+#            parameters:
+#              python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+#              macos_version: ["13", "14"]
+#  weekly_build:
+#    when: << pipeline.parameters.weekly_build >>
+#    jobs:
+#      - build_dev_release:
+#          matrix:
+#            parameters:
+#              python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+#              macos_version: ["13", "14"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,17 +179,17 @@ workflows:
     jobs:
       - mac_build_and_test
       - linux_build_and_test
-#      - build_release:
-#          filters:
-#            tags:
-#              only: /^v.*/
-#            branches:
-#              ignore: /.*/
-#          matrix:
-#            parameters:
-#              python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-#              xcode_version: ["14.3.1", "15.2.0"]
-#              build_env: ["PYPI_RELEASE=1"]
+      - build_release:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+          matrix:
+            parameters:
+              python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+              xcode_version: ["14.3.1", "15.2.0"]
+              build_env: ["PYPI_RELEASE=1"]
   nightly_build:
     when: << pipeline.parameters.nightly_build >>
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,7 @@ jobs:
           name: Install dependencies
           command: |
             brew install python@<< parameters.python_version >>
+            python<< parameters.python_version >> -m pip install --upgrade pip
             python<< parameters.python_version >> -m pip install --upgrade cmake
             python<< parameters.python_version >> -m pip install --upgrade pybind11[global]
             python<< parameters.python_version >> -m pip install pybind11-stubgen
@@ -183,7 +184,8 @@ workflows:
       - build_release:
           matrix:
             parameters:
-              python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+              #python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+              python_version: ["3.12"]
               xcode_version: ["14.3.1", "15.2.0"]
 #  weekly_build:
 #    when: << pipeline.parameters.weekly_build >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,7 @@ jobs:
       - run:
           name: Build CPP only
           command: |
+            source env/bin/activate
             mkdir -p build && cd build && cmake .. && make -j
       - run:
           name: Run CPP tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,12 +130,13 @@ jobs:
             python<< parameters.python_version >> -m pip install pybind11-stubgen
             python<< parameters.python_version >> -m pip install numpy
             python<< parameters.python_version >> -m pip install twine
+            python<< parameters.python_version >> -m pip install build
       - run:
           name: Install Python package
           command: |
             DEV_RELEASE=1 \
               CMAKE_BUILD_PARALLEL_LEVEL="" \
-              python<< parameters.python_version >> setup.py develop
+              python<< parameters.python_version >> -m pip install .
       - run:
           name: Generate package stubs
           command: |
@@ -145,7 +146,7 @@ jobs:
           command: |
             << parameters.build_env >> \
               CMAKE_BUILD_PARALLEL_LEVEL="" \
-              python<< parameters.python_version >> setup.py bdist_wheel
+              python<< parameters.python_version >> -m build -w
       - when:
           condition: << parameters.build_env >>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ jobs:
           name: Install dependencies
           command: |
             brew install python
+            pip3 install --upgrade pip
             pip3 install --upgrade cmake
             pip3 install --upgrade pybind11[global]
             pip3 install pybind11-stubgen

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
       - run:
           name: Run Python tests
           command: |
-            DEVICE=cpu python3.9 -m xmlrunner discover -v python/tests -o test-results/cpu
+            LOW_MEMORY=1 DEVICE=cpu python3.9 -m xmlrunner discover -v python/tests -o test-results/cpu
             # TODO: Reenable when Circle CI can run gpu jobs
             # DEVICE=gpu python3.9 -m xmlrunner discover -v python/tests -o test-results/gpu
       # TODO: Reenable when extension api becomes stable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,8 +80,7 @@ jobs:
           name: Install Python package
           command: |
             source env/bin/activate
-            CMAKE_BUILD_PARALLEL_LEVEL="" python setup.py build_ext --inplace
-            CMAKE_BUILD_PARALLEL_LEVEL="" python setup.py develop
+            CMAKE_BUILD_PARALLEL_LEVEL="" pip install -e . -v
       - run:
           name: Generate package stubs
           command: |
@@ -136,6 +135,7 @@ jobs:
             pip install --upgrade pip
             pip install --upgrade cmake
             pip install --upgrade pybind11[global]
+            pip install --upgrade setuptools
             pip install pybind11-stubgen
             pip install numpy
             pip install twine
@@ -146,7 +146,7 @@ jobs:
             source env/bin/activate
             DEV_RELEASE=1 \
               CMAKE_BUILD_PARALLEL_LEVEL="" \
-              pip install .
+              pip install . -v
       - run:
           name: Generate package stubs
           command: |
@@ -199,12 +199,12 @@ workflows:
               #python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
               python_version: ["3.12"]
               xcode_version: ["14.3.1", "15.2.0"]
-#  weekly_build:
-#    when: << pipeline.parameters.weekly_build >>
-#    jobs:
-#      - build_release:
-#          matrix:
-#            parameters:
-#              python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-#              xcode_version: ["14.3.1", "15.2.0"]
-#              build_env: ["DEV_RELEASE=1"]
+  weekly_build:
+    when: << pipeline.parameters.weekly_build >>
+    jobs:
+      - build_release:
+          matrix:
+            parameters:
+              python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+              xcode_version: ["14.3.1", "15.2.0"]
+              build_env: ["DEV_RELEASE=1"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,36 +65,35 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            brew install python
-            pip3 install --upgrade pip
-            pip3 install --upgrade cmake
-            pip3 install --upgrade pybind11[global]
-            pip3 install pybind11-stubgen
-            pip3 install numpy
-            pip3 install torch
-            pip3 install tensorflow
-            pip3 install unittest-xml-reporting
+            brew install python@3.9
+            python3.9 -m pip install --upgrade pip
+            python3.9 -m pip install --upgrade cmake
+            python3.9 -m pip install --upgrade pybind11[global]
+            python3.9 -m pip install pybind11-stubgen
+            python3.9 -m pip install numpy
+            python3.9 -m pip install torch
+            python3.9 -m pip install tensorflow
+            python3.9 -m pip install unittest-xml-reporting
       - run:
           name: Install Python package
           command: |
-            CMAKE_BUILD_PARALLEL_LEVEL="" python3 setup.py build_ext --inplace
-            CMAKE_BUILD_PARALLEL_LEVEL="" python3 setup.py develop
+            CMAKE_BUILD_PARALLEL_LEVEL="" python3.9 setup.py build_ext --inplace
+            CMAKE_BUILD_PARALLEL_LEVEL="" python3.9 setup.py develop
       - run:
           name: Generate package stubs
           command: |
-            python3 setup.py generate_stubs
+            python3.9 setup.py generate_stubs
       - run:
           name: Run Python tests
           command: |
-            DEVICE=cpu python3 -m xmlrunner discover -v python/tests -o test-results/cpu
-            DEVICE=gpu python3 -m xmlrunner discover -v python/tests -o test-results/gpu
+            DEVICE=cpu python3.9 -m xmlrunner discover -v python/tests -o test-results/cpu
+            # TODO: Reenable when Circle CI can run gpu jobs
+            # DEVICE=gpu python3.9 -m xmlrunner discover -v python/tests -o test-results/gpu
       # TODO: Reenable when extension api becomes stable
       # - run:
       #     name: Build example extension
       #     command: |
-      #       eval "$(conda shell.bash hook)"
-      #       conda activate runner-env
-      #       cd examples/extensions && python -m pip install . 
+      #       cd examples/extensions && python3.11 -m pip install . 
       - store_test_results:
           path: test-results
       - run:
@@ -103,159 +102,57 @@ jobs:
             mkdir -p build && cd build && cmake .. && make -j
       - run:
           name: Run CPP tests
-          command: METAL_DEVICE_WRAPPER_TYPE=1 METAL_DEBUG_ERROR_MODE=0 ./build/tests/tests
+          #command: METAL_DEVICE_WRAPPER_TYPE=1 METAL_DEBUG_ERROR_MODE=0 ./build/tests/tests
+          command: DEVICE=cpu ./build/tests/tests
 
   build_release:
-    machine: true
-    resource_class: ml-explore/m-builder
     parameters:
       python_version:
         type: string
         default: "3.9"
-      macos_version:
+      xcode_version:
         type: string
-        default: "14"
+        default: "15.2.0"
+      build_env:
+        type: string
+        default: ""
+    macos:
+      xcode: << parameters.xcode_version >>
+    resource_class: macos.m1.large.gen1
     steps:
       - checkout
       - run:
           name: Install dependencies
           command: |
-            eval "$(conda shell.bash hook)"
-            rm -r $CONDA_PREFIX/envs/runner-env
-            conda create -y -n runner-env python=<< parameters.python_version >>
-            conda activate runner-env
-            pip install --upgrade cmake
-            pip install --upgrade pybind11[global]
-            pip install pybind11-stubgen
-            pip install numpy
-            pip install twine
-      # TODO: Update build system to switch away from setup.py develop
+            brew install python@<< parameters.python_version >>
+            python<< parameters.python_version >> -m pip install --upgrade cmake
+            python<< parameters.python_version >> -m pip install --upgrade pybind11[global]
+            python<< parameters.python_version >> -m pip install pybind11-stubgen
+            python<< parameters.python_version >> -m pip install numpy
+            python<< parameters.python_version >> -m pip install twine
       - run:
           name: Install Python package
           command: |
-            eval "$(conda shell.bash hook)"
-            conda activate runner-env
-            DEVELOPER_DIR=$(developer_dir_macos_<< parameters.macos_version >>) \
-              PYPI_RELEASE=1 \
+            DEV_RELEASE=1 \
               CMAKE_BUILD_PARALLEL_LEVEL="" \
-              python setup.py develop
+              python<< parameters.python_version >> setup.py develop
       - run:
           name: Generate package stubs
           command: |
-            eval "$(conda shell.bash hook)"
-            conda activate runner-env
-            python setup.py generate_stubs
+            python<< parameters.python_version >> setup.py generate_stubs
       - run:
-          name: Publish Python package
+          name: Build Python package
           command: |
-            eval "$(conda shell.bash hook)"
-            conda activate runner-env
-            DEVELOPER_DIR=$(developer_dir_macos_<< parameters.macos_version >>) \
-              PYPI_RELEASE=1 \
+            << parameters.build_env >> \
               CMAKE_BUILD_PARALLEL_LEVEL="" \
-              python setup.py bdist_wheel
-            twine upload dist/* --repository mlx
-      - store_artifacts:
-          path: dist/
-
-  build_dev_release:
-    machine: true
-    resource_class: ml-explore/m-builder
-    parameters:
-      python_version:
-        type: string
-        default: "3.9"
-      macos_version:
-        type: string
-        default: "14"
-    steps:
-      - checkout
-      - run:
-          name: Install dependencies
-          command: |
-            eval "$(conda shell.bash hook)"
-            rm -r $CONDA_PREFIX/envs/runner-env
-            conda create -y -n runner-env python=<< parameters.python_version >>
-            conda activate runner-env
-            pip install --upgrade cmake
-            pip install --upgrade pybind11[global]
-            pip install pybind11-stubgen
-            pip install numpy
-            pip install twine
-      - run:
-          name: Install Python package
-          command: |
-            eval "$(conda shell.bash hook)"
-            conda activate runner-env
-            DEVELOPER_DIR=$(developer_dir_macos_<< parameters.macos_version >>) \
-              DEV_RELEASE=1 \
-              CMAKE_BUILD_PARALLEL_LEVEL="" \
-              python setup.py develop
-      - run:
-          name: Generate package stubs
-          command: |
-            eval "$(conda shell.bash hook)"
-            conda activate runner-env
-            python setup.py generate_stubs
-      - run:
-          name: Publish Python package
-          command: |
-            eval "$(conda shell.bash hook)"
-            conda activate runner-env
-            DEVELOPER_DIR=$(developer_dir_macos_<< parameters.macos_version >>) \
-              DEV_RELEASE=1 \
-              CMAKE_BUILD_PARALLEL_LEVEL="" \
-              python setup.py bdist_wheel
-            twine upload dist/* --repository mlx
-      - store_artifacts:
-          path: dist/
-
-  build_package:
-    machine: true
-    resource_class: ml-explore/m-builder
-    parameters:
-      python_version:
-        type: string
-        default: "3.9"
-      macos_version:
-        type: string
-        default: "14"
-    steps:
-      - checkout
-      - run:
-          name: Install dependencies
-          command: |
-            eval "$(conda shell.bash hook)"
-            rm -r $CONDA_PREFIX/envs/runner-env
-            conda create -y -n runner-env python=<< parameters.python_version >>
-            conda activate runner-env
-            pip install --upgrade cmake
-            pip install --upgrade pybind11[global]
-            pip install pybind11-stubgen
-            pip install numpy
-            pip install twine
-      - run:
-          name: Install Python package
-          command: |
-            eval "$(conda shell.bash hook)"
-            conda activate runner-env
-            DEVELOPER_DIR=$(developer_dir_macos_<< parameters.macos_version >>) \
-              CMAKE_BUILD_PARALLEL_LEVEL="" \
-              python setup.py develop
-      - run:
-          name: Generate package stubs
-          command: |
-            eval "$(conda shell.bash hook)"
-            conda activate runner-env
-            python setup.py generate_stubs
-      - run:
-          name: Build package distribution
-          command: |
-            eval "$(conda shell.bash hook)"
-            conda activate runner-env
-            DEVELOPER_DIR=$(developer_dir_macos_<< parameters.macos_version >>) \
-              CMAKE_BUILD_PARALLEL_LEVEL="" \
-              python setup.py bdist_wheel
+              python<< parameters.python_version >> setup.py bdist_wheel
+      - when:
+          condition: << parameters.build_env >>
+          steps:
+            - run:
+                name: Upload package
+                command: |
+                  echo twine upload dist/*
       - store_artifacts:
           path: dist/
 
@@ -267,7 +164,7 @@ workflows:
         - not: << pipeline.parameters.weekly_build >>
     jobs:
       - mac_build_and_test
-#      - linux_build_and_test
+      - linux_build_and_test
 #      - build_release:
 #          filters:
 #            tags:
@@ -277,15 +174,16 @@ workflows:
 #          matrix:
 #            parameters:
 #              python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-#              macos_version: ["13", "14"]
-#  nightly_build:
-#    when: << pipeline.parameters.nightly_build >>
-#    jobs:
-#      - build_package:
-#          matrix:
-#            parameters:
-#              python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-#              macos_version: ["13", "14"]
+#              xcode_version: ["14.3.1", "15.2.0"]
+#              build_env: ["PYPI_RELEASE=1"]
+  nightly_build:
+    when: << pipeline.parameters.nightly_build >>
+    jobs:
+      - build_package:
+          matrix:
+            parameters:
+              python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+              xcode_version: ["14.3.1", "15.2.0"]
 #  weekly_build:
 #    when: << pipeline.parameters.weekly_build >>
 #    jobs:
@@ -293,4 +191,5 @@ workflows:
 #          matrix:
 #            parameters:
 #              python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-#              macos_version: ["13", "14"]
+#              xcode_version: ["14.3.1", "15.2.0"]
+#              build_env: ["DEV_RELEASE=1"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,27 +66,32 @@ jobs:
           name: Install dependencies
           command: |
             brew install python@3.9
-            python3.9 -m pip install --upgrade pip
-            python3.9 -m pip install --upgrade cmake
-            python3.9 -m pip install --upgrade pybind11[global]
-            python3.9 -m pip install pybind11-stubgen
-            python3.9 -m pip install numpy
-            python3.9 -m pip install torch
-            python3.9 -m pip install tensorflow
-            python3.9 -m pip install unittest-xml-reporting
+            python3.9 -m venv env
+            source env/bin/activate
+            pip install --upgrade pip
+            pip install --upgrade cmake
+            pip install --upgrade pybind11[global]
+            pip install pybind11-stubgen
+            pip install numpy
+            pip install torch
+            pip install tensorflow
+            pip install unittest-xml-reporting
       - run:
           name: Install Python package
           command: |
-            CMAKE_BUILD_PARALLEL_LEVEL="" python3.9 setup.py build_ext --inplace
-            CMAKE_BUILD_PARALLEL_LEVEL="" python3.9 setup.py develop
+            source env/bin/activate
+            CMAKE_BUILD_PARALLEL_LEVEL="" python setup.py build_ext --inplace
+            CMAKE_BUILD_PARALLEL_LEVEL="" python setup.py develop
       - run:
           name: Generate package stubs
           command: |
-            python3.9 setup.py generate_stubs
+            source env/bin/activate
+            python setup.py generate_stubs
       - run:
           name: Run Python tests
           command: |
-            LOW_MEMORY=1 DEVICE=cpu python3.9 -m xmlrunner discover -v python/tests -o test-results/cpu
+            source env/bin/activate
+            LOW_MEMORY=1 DEVICE=cpu python -m xmlrunner discover -v python/tests -o test-results/cpu
             # TODO: Reenable when Circle CI can run gpu jobs
             # DEVICE=gpu python3.9 -m xmlrunner discover -v python/tests -o test-results/gpu
       # TODO: Reenable when extension api becomes stable
@@ -125,35 +130,41 @@ jobs:
           name: Install dependencies
           command: |
             brew install python@<< parameters.python_version >>
-            python<< parameters.python_version >> -m pip install --upgrade pip
-            python<< parameters.python_version >> -m pip install --upgrade cmake
-            python<< parameters.python_version >> -m pip install --upgrade pybind11[global]
-            python<< parameters.python_version >> -m pip install pybind11-stubgen
-            python<< parameters.python_version >> -m pip install numpy
-            python<< parameters.python_version >> -m pip install twine
-            python<< parameters.python_version >> -m pip install build
+            python<< parameters.python_version >> -m venv env
+            source env/bin/activate
+            pip install --upgrade pip
+            pip install --upgrade cmake
+            pip install --upgrade pybind11[global]
+            pip install pybind11-stubgen
+            pip install numpy
+            pip install twine
+            pip install build
       - run:
           name: Install Python package
           command: |
+            source env/bin/activate
             DEV_RELEASE=1 \
               CMAKE_BUILD_PARALLEL_LEVEL="" \
-              python<< parameters.python_version >> -m pip install .
+              pip install .
       - run:
           name: Generate package stubs
           command: |
-            python<< parameters.python_version >> setup.py generate_stubs
+            source env/bin/activate
+            python setup.py generate_stubs
       - run:
           name: Build Python package
           command: |
+            source env/bin/activate
             << parameters.build_env >> \
               CMAKE_BUILD_PARALLEL_LEVEL="" \
-              python<< parameters.python_version >> -m build -w
+              python -m build -w
       - when:
           condition: << parameters.build_env >>
           steps:
             - run:
                 name: Upload package
                 command: |
+                  source env/bin/activate
                   echo twine upload dist/*
       - store_artifacts:
           path: dist/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
                 name: Upload package
                 command: |
                   source env/bin/activate
-                  echo twine upload dist/*
+                  twine upload dist/*
       - store_artifacts:
           path: dist/
 
@@ -196,8 +196,7 @@ workflows:
       - build_release:
           matrix:
             parameters:
-              #python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-              python_version: ["3.12"]
+              python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
               xcode_version: ["14.3.1", "15.2.0"]
   weekly_build:
     when: << pipeline.parameters.weekly_build >>

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include CMakeLists.txt
 recursive-include mlx/ *
 include python/src/*
-python/mlx/py.typed # support type hinting as in PEP-561
+include python/mlx/py.typed # support type hinting as in PEP-561

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -1,6 +1,7 @@
 # Copyright © 2023-2024 Apple Inc.
 
 import math
+import os
 import unittest
 from itertools import permutations
 
@@ -1566,8 +1567,11 @@ class TestOps(mlx_tests.MLXTestCase):
                             d_np = np.take(b_mx, np.arange(kth), axis=axis)
                             self.assertTrue(np.all(d_np <= c_mx))
 
+    @unittest.skipIf(
+        os.getenv("LOW_MEMORY", None) is not None,
+        "This test requires a lot of memory",
+    )
     def test_large_binary(self):
-        return
         a = mx.ones([1000, 2147484], mx.int8)
         b = mx.ones([2147484], mx.int8)
         self.assertEqual((a + b)[0, 0].item(), 2)

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -1567,6 +1567,7 @@ class TestOps(mlx_tests.MLXTestCase):
                             self.assertTrue(np.all(d_np <= c_mx))
 
     def test_large_binary(self):
+        return
         a = mx.ones([1000, 2147484], mx.int8)
         b = mx.ones([2147484], mx.int8)
         self.assertEqual((a + b)[0, 0].item(), 2)


### PR DESCRIPTION
Update CI to run on Circle-CI runners. We should make it a habit to run the tests locally since the GPU tests won't be running on CI any more.

Other than that everything should be the same, with the difference that release builds now take ~3m instead of 20m since they all run in parallel. I made a dev release `pip install mlx==0.1.0.dev20240207` and tested it as best I could, everything seems to work as before.