### PR TITLE
Fix loading `Module` lists with with empty modules at end

### DIFF
--- a/python/mlx/nn/layers/base.py
+++ b/python/mlx/nn/layers/base.py
@@ -312,7 +312,7 @@ class Module(dict):
                         elif isinstance(current_value, (dict, list)):
                             apply(current_value, new_value)
             elif isinstance(parameters, list):
-                for i in range(len(dst)):
+                for i in range(len(parameters)):
                     current_value = dst[i]
                     new_value = parameters[i]
                     if isinstance(current_value, mx.array):

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -71,7 +71,7 @@ class TestBase(mlx_tests.MLXTestCase):
 
     def test_save_safetensors_weights(self):
         def make_model():
-            return nn.Sequential(nn.Linear(2, 2), nn.ReLU(), nn.Linear(2, 2))
+            return nn.Sequential(nn.Linear(2, 2), nn.ReLU(), nn.Linear(2, 2), nn.ReLU())
 
         m = make_model()
         tdir = tempfile.TemporaryDirectory()


### PR DESCRIPTION
## Proposed changes

We don't know the size of the list when we unflatten parameters so we just clip it to the last number. This causes issues when updating the container with empty modules at the end of a list.

Closes #646 