### PR TITLE
faster bfloat quantized mat-vec and vec-mat

### DIFF
--- a/mlx/backend/metal/kernels/quantized.metal
+++ b/mlx/backend/metal/kernels/quantized.metal
@@ -55,8 +55,6 @@ template <typename T, const int BM, const int BN, const int group_size, const in
   thread U scale = 1;
   thread U bias = 0;
   thread U x_thread[el_per_thread];
-  // 32 x 32 x 1 thread group
-  // 1 x (out / 32) x 1
 
   // Adjust positions
   const int in_vec_size_w = in_vec_size / el_per_thread;


### PR DESCRIPTION
## Proposed changes

Faster bfloat with quantized matmul.

### qmv 4096 x (14336, 4096).T

Pre: 

```
Time mlx.core.float16: 0.273
Time mlx.core.bfloat16: 0.548
Time mlx.core.float32: 0.333
```

Post:

```
Time mlx.core.float16: 0.270
Time mlx.core.bfloat16: 0.329
Time mlx.core.float32: 0.326
```

### qvm 4096 by 4096 x 4096

Pre:

```
Time mlx.core.float16: 0.395
Time mlx.core.bfloat16: 0.672
Time mlx.core.float32: 0.397
```

Post:

```
Time mlx.core.float16: 0.386
Time mlx.core.bfloat16: 0.425
Time mlx.core.float32: 0.391
```