### PR TITLE
Return empty array when repeats is 0 in mx.repeat

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -774,7 +774,7 @@ array repeat(const array& arr, int repeats, int axis, StreamOrDevice s) {
   }
 
   if (repeats == 0) {
-    return array({}, arr.dtype());
+    return array(std::initializer_list<int>{}, arr.dtype());
   }
 
   if (repeats == 1) {

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -1699,6 +1699,8 @@ class TestOps(mlx_tests.MLXTestCase):
     def test_repeat(self):
         # Setup data for the tests
         data = mx.array([[[13, 3], [16, 6]], [[14, 4], [15, 5]], [[11, 1], [12, 2]]])
+        # Test repeat 0 times
+        self.assertCmpNumpy([data, 0], mx.repeat, np.repeat)
         # Test repeat along axis 0
         self.assertCmpNumpy([data, 2], mx.repeat, np.repeat, axis=0)
         # Test repeat along axis 1


### PR DESCRIPTION
## Proposed changes

Please include a description of the problem or feature this PR is addressing. If there is a corresponding issue, include the issue #.

Currently mx.repeat is returning array(0, dtype) when repeats is 0, but it should return an empty array. 
#587 

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
