### PR TITLE
Fix empty array construction in c++

### DIFF
--- a/mlx/array.cpp
+++ b/mlx/array.cpp
@@ -82,6 +82,13 @@ array::array(std::initializer_list<float> data)
   init(data.begin());
 }
 
+array::array(std::initializer_list<int> data, Dtype dtype)
+    : array_desc_(std::make_shared<ArrayDesc>(
+          std::vector<int>{static_cast<int>(data.size())},
+          dtype)) {
+  init(data.begin());
+}
+
 /* Build an array from a shared buffer */
 array::array(
     allocator::Buffer data,

--- a/mlx/array.h
+++ b/mlx/array.h
@@ -41,6 +41,9 @@ class array {
   /* Special case so empty lists default to float32. */
   array(std::initializer_list<float> data);
 
+  /* Special case so array({}, type) is an empty array. */
+  array(std::initializer_list<int> data, Dtype dtype);
+
   template <typename T>
   array(
       std::initializer_list<T> data,

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -774,7 +774,7 @@ array repeat(const array& arr, int repeats, int axis, StreamOrDevice s) {
   }
 
   if (repeats == 0) {
-    return array(std::initializer_list<int>{}, arr.dtype());
+    return array({}, arr.dtype());
   }
 
   if (repeats == 1) {

--- a/tests/array_tests.cpp
+++ b/tests/array_tests.cpp
@@ -591,3 +591,21 @@ TEST_CASE("test array shared buffer") {
 
   eval(a + b);
 }
+
+TEST_CASE("test make empty array") {
+  auto a = array({});
+  CHECK_EQ(a.size(), 0);
+  CHECK_EQ(a.dtype(), float32);
+
+  a = array({}, int32);
+  CHECK_EQ(a.size(), 0);
+  CHECK_EQ(a.dtype(), int32);
+
+  a = array({}, float32);
+  CHECK_EQ(a.size(), 0);
+  CHECK_EQ(a.dtype(), float32);
+
+  a = array({}, bool_);
+  CHECK_EQ(a.size(), 0);
+  CHECK_EQ(a.dtype(), bool_);
+}


### PR DESCRIPTION
## Proposed changes

Add a specialization so c++ doesn't choose the wrong constructor when making empty arrays.

CC @noahfarr 