### PR TITLE
Fix arange with inf step

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -83,6 +83,11 @@ array arange(
   if (std::isnan(start) || std::isnan(step) || std::isnan(stop)) {
     throw std::invalid_argument("[arange] Cannot compute length.");
   }
+  if (std::isinf(start) || std::isinf(stop)) {
+    throw std::invalid_argument("[arange] Cannot compute length.");
+  }
+  step = std::clamp(
+      step, static_cast<double>(INT_MIN), static_cast<double>(INT_MAX));
   double real_size = std::ceil((stop - start) / step);
   if (std::isnan(real_size)) {
     throw std::invalid_argument("[arange] Cannot compute length.");

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -1044,6 +1044,10 @@ class TestOps(mlx_tests.MLXTestCase):
             a = mx.arange(0, float("inf"), float("inf"))
         with self.assertRaises(ValueError):
             a = mx.arange(float("inf"), 1, float("inf"))
+        with self.assertRaises(ValueError):
+            a = mx.arange(float("inf"), 1, 5)
+        with self.assertRaises(ValueError):
+            a = mx.arange(float("-inf"), 1, 5)
 
         a = mx.arange(5)
         expected = [0, 1, 2, 3, 4]
@@ -1128,6 +1132,19 @@ class TestOps(mlx_tests.MLXTestCase):
         ]
         self.assertListEqual(a.tolist(), expected)
         self.assertEqual(a.dtype, mx.int32)
+
+        a = mx.arange(0, 10, 100)
+        expected = [0]
+        self.assertListEqual(a.tolist(), expected)
+        self.assertEqual(a.dtype, mx.int32)
+
+        a = mx.arange(0, 10, float("inf"))
+        expected = [0]
+        self.assertListEqual(a.tolist(), expected)
+
+        a = mx.arange(0, -10, float("-inf"))
+        expected = [0]
+        self.assertListEqual(a.tolist(), expected)
 
     def test_unary_ops(self):
         def test_ops(npop, mlxop, x, y, atol):


### PR DESCRIPTION
## Proposed changes

Please include a description of the problem or feature this PR is addressing. If there is a corresponding issue, include the issue #.
Arange currently returns an empty list when step is inf, but it should be a list that only contains the start value.
#530 

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
