### PR TITLE
Integrate doctest into cmake

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,8 @@ if (MLX_BUILD_METAL)
   )
 endif()
 
+include(${doctest_SOURCE_DIR}/scripts/cmake/doctest.cmake)
+
 target_sources(tests PRIVATE
   allocator_tests.cpp
   array_tests.cpp
@@ -37,4 +39,5 @@ target_sources(tests PRIVATE
 )
 
 target_link_libraries(tests PRIVATE mlx doctest)
+doctest_discover_tests(tests)
 add_test(NAME tests COMMAND tests)


### PR DESCRIPTION
Calls doctest helper function to register tests with cmake. This enables the ability to filter / extract more information while using ctest.

Now running ctest you can now see a test count and progressions system vs previous blank terminal.
```bash
        Start   1: test simple allocations
  1/173 Test   #1: test simple allocations ......................   Passed    0.05 sec
        Start   2: test large allocations
  2/173 Test   #2: test large allocations .......................   Passed    0.04 sec
        Start   3: test arg reduce small
  3/173 Test   #3: test arg reduce small ........................   Passed    0.09 sec
        Start   4: test arg reduce against cpu
  4/173 Test   #4: test arg reduce against cpu ..................   Passed    0.07 sec
        Start   5: test arg reduce bool
```

Also can now run the following to filter tests
```shell
ctest -R array
```