### PR TITLE
Faster softmax VJP

### DIFF
--- a/benchmarks/python/comparative/bench_mlx.py
+++ b/benchmarks/python/comparative/bench_mlx.py
@@ -161,6 +161,14 @@ def softmax_fused(axis, x):
     mx.eval(ys)
 
 
+def softmax_fused_grad(axis, x):
+    ys = []
+    for i in range(100):
+        y = mx.grad(lambda x, axis: mx.sum(mx.softmax(x, axis=axis)))(x, axis)
+        ys.append(y)
+    mx.eval(ys)
+
+
 def relu(x):
     y = x
     for i in range(100):
@@ -441,6 +449,9 @@ if __name__ == "__main__":
             print(bench(softmax_fused, axis, x))
         else:
             print(bench(softmax, axis, x))
+
+    elif args.benchmark == "softmax_grad":
+        print(bench(softmax_fused_grad, axis, x))
 
     elif args.benchmark == "relu":
         print(bench(relu, x))

--- a/benchmarks/python/comparative/bench_torch.py
+++ b/benchmarks/python/comparative/bench_torch.py
@@ -117,6 +117,16 @@ def softmax_fused(axis, x):
     sync_if_needed(x)
 
 
+def softmax_fused_grad(axis, x):
+    ys = []
+    for i in range(100):
+        y = torch.func.grad(lambda x, axis: torch.sum(torch.softmax(x, axis=axis)))(
+            x, axis
+        )
+        ys.append(y)
+    sync_if_needed(x)
+
+
 @torch.no_grad()
 def relu(x):
     y = x
@@ -386,6 +396,9 @@ if __name__ == "__main__":
             print(bench(softmax_fused, axis, x))
         else:
             print(bench(softmax, axis, x))
+
+    elif args.benchmark == "softmax_grad":
+        print(bench(softmax_fused_grad, axis, x))
 
     elif args.benchmark == "relu":
         print(bench(relu, x))

--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -2623,9 +2623,13 @@ std::vector<array> Softmax::vjp(
   assert(cotangents.size() == 1);
   auto& s = outputs[0];
   auto sv = multiply(s, cotangents[0], stream());
-  return {subtract(
-      sv,
-      multiply(s, sum(sv, std::vector<int>{-1}, true, stream()), stream()))};
+  return {multiply(
+      s,
+      subtract(
+          cotangents[0],
+          sum(sv, std::vector<int>{-1}, true, stream()),
+          stream()),
+      stream())};
 }
 
 std::vector<array> Softmax::jvp(


### PR DESCRIPTION
## Proposed changes

I have been experimenting with the Softmax VJP implementation, and the new version is 25% faster than the old one. I have included a simple gradient benchmark. This testing was conducted on my M2 Pro PC.

Old Implementation: 1.843306064605713
New Implementation: 1.4345970153808594

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
