### PR TITLE
Some fixes in cache / thread safety

### DIFF
--- a/mlx/backend/metal/allocator.h
+++ b/mlx/backend/metal/allocator.h
@@ -19,12 +19,11 @@ class BufferCache {
  public:
   BufferCache(MTL::Device* device);
   ~BufferCache();
-  void clear();
 
   MTL::Buffer* reuse_from_cache(size_t size);
   void recycle_to_cache(MTL::Buffer* buf);
   void release_cached_buffers(size_t min_bytes_to_free);
-  size_t pool_size() {
+  size_t cache_size() {
     return pool_size_;
   }
 
@@ -38,11 +37,11 @@ class BufferCache {
     MTL::Buffer* buf;
   };
 
+  void clear();
   void add_at_head(BufferHolder* to_add);
   void remove_from_list(BufferHolder* to_remove);
 
   MTL::Device* device_;
-  std::mutex cache_mutex_;
 
   std::multimap<size_t, BufferHolder*> buffer_pool_;
   BufferHolder* head_;
@@ -64,7 +63,7 @@ class MetalAllocator : public allocator::Allocator {
     return peak_memory_;
   };
   size_t get_cache_memory() {
-    return buffer_cache_.pool_size();
+    return buffer_cache_.cache_size();
   };
   size_t set_cache_limit(size_t limit);
   size_t set_memory_limit(size_t limit, bool relaxed);
@@ -84,6 +83,8 @@ class MetalAllocator : public allocator::Allocator {
   size_t peak_memory_{0};
   size_t max_pool_size_;
   bool relaxed_{true};
+
+  std::mutex mutex_;
 };
 
 MetalAllocator& allocator();

--- a/python/mlx/optimizers/optimizers.py
+++ b/python/mlx/optimizers/optimizers.py
@@ -217,9 +217,12 @@ class RMSprop(Optimizer):
           to improve numerical stability. Default: ``1e-8``
     """
 
-    def __init__(self,
+    def __init__(
+        self,
         learning_rate: Union[float, Callable[[mx.array], mx.array]],
-         alpha: float = 0.99, eps: float = 1e-8):
+        alpha: float = 0.99,
+        eps: float = 1e-8,
+    ):
         super().__init__()
 
         self._maybe_schedule("learning_rate", learning_rate)
@@ -271,9 +274,11 @@ class Adagrad(Optimizer):
           denominator to improve numerical stability. Default: ``1e-8``
     """
 
-    def __init__(self,
+    def __init__(
+        self,
         learning_rate: Union[float, Callable[[mx.array], mx.array]],
-        eps: float = 1e-8):
+        eps: float = 1e-8,
+    ):
         super().__init__()
 
         self._maybe_schedule("learning_rate", learning_rate)
@@ -322,9 +327,12 @@ class AdaDelta(Optimizer):
           numerical stability. Default: `1e-8`
     """
 
-    def __init__(self,
+    def __init__(
+        self,
         learning_rate: Union[float, Callable[[mx.array], mx.array]],
-         rho: float = 0.9, eps: float = 1e-6):
+        rho: float = 0.9,
+        eps: float = 1e-6,
+    ):
         super().__init__()
 
         self._maybe_schedule("learning_rate", learning_rate)
@@ -391,7 +399,8 @@ class Adam(Optimizer):
     def __init__(
         self,
         learning_rate: Union[float, Callable[[mx.array], mx.array]],
-        betas: List[float] = [0.9, 0.999], eps: float = 1e-8
+        betas: List[float] = [0.9, 0.999],
+        eps: float = 1e-8,
     ):
         super().__init__()
 
@@ -496,7 +505,8 @@ class Adamax(Adam):
     def __init__(
         self,
         learning_rate: Union[float, Callable[[mx.array], mx.array]],
-        betas: List[float] = [0.9, 0.999], eps: float = 1e-8
+        betas: List[float] = [0.9, 0.999],
+        eps: float = 1e-8,
     ):
         super().__init__(learning_rate, betas, eps)
         if not 0.0 <= eps:

--- a/python/mlx/optimizers/optimizers.py
+++ b/python/mlx/optimizers/optimizers.py
@@ -210,14 +210,16 @@ class RMSprop(Optimizer):
         w_{t+1} &= w_t - \lambda \frac{g_t}{\sqrt{v_{t+1}} + \epsilon}
 
     Args:
-        learning_rate (float): The learning rate :math:`\lambda`.
+        learning_rate (float or callable): The learning rate :math:`\lambda`.
         alpha (float, optional): The smoothing constant :math:`\alpha`.
           Default: ``0.99``
         eps (float, optional): The term :math:`\epsilon` added to the denominator
           to improve numerical stability. Default: ``1e-8``
     """
 
-    def __init__(self, learning_rate: float, alpha: float = 0.99, eps: float = 1e-8):
+    def __init__(self,
+        learning_rate: Union[float, Callable[[mx.array], mx.array]],
+         alpha: float = 0.99, eps: float = 1e-8):
         super().__init__()
 
         self._maybe_schedule("learning_rate", learning_rate)
@@ -264,12 +266,14 @@ class Adagrad(Optimizer):
         w_{t+1} &= w_t - \lambda \frac{g_t}{\sqrt{v_{t+1}} + \epsilon}
 
     Args:
-        learning_rate (float): The learning rate :math:`\lambda`.
+        learning_rate (float or callable): The learning rate :math:`\lambda`.
         eps (float, optional): The term :math:`\epsilon` added to the
           denominator to improve numerical stability. Default: ``1e-8``
     """
 
-    def __init__(self, learning_rate: float, eps: float = 1e-8):
+    def __init__(self,
+        learning_rate: Union[float, Callable[[mx.array], mx.array]],
+        eps: float = 1e-8):
         super().__init__()
 
         self._maybe_schedule("learning_rate", learning_rate)
@@ -311,14 +315,16 @@ class AdaDelta(Optimizer):
         w_{t+1} &= w_t - \lambda \Delta w_{t+1}
 
     Args:
-        learning_rate (float): The learning rate :math:`\lambda`.
+        learning_rate (float or callable): The learning rate :math:`\lambda`.
         rho (float, optional): The coefficient :math:`\rho` used for computing a
             running average of squared gradients. Default: ``0.9``
         eps (float, optional): The term :math:`\epsilon` added to the denominator to improve
           numerical stability. Default: `1e-8`
     """
 
-    def __init__(self, learning_rate: float, rho: float = 0.9, eps: float = 1e-6):
+    def __init__(self,
+        learning_rate: Union[float, Callable[[mx.array], mx.array]],
+         rho: float = 0.9, eps: float = 1e-6):
         super().__init__()
 
         self._maybe_schedule("learning_rate", learning_rate)
@@ -374,7 +380,7 @@ class Adam(Optimizer):
         w_{t+1} &= w_t - \lambda \frac{m_{t+1}}{\sqrt{v_{t+1} + \epsilon}}
 
     Args:
-        learning_rate (float): The learning rate :math:`\lambda`.
+        learning_rate (float or callable): The learning rate :math:`\lambda`.
         betas (Tuple[float, float], optional): The coefficients
           :math:`(\beta_1, \beta_2)` used for computing running averages of the
           gradient and its square. Default: ``(0.9, 0.999)``
@@ -383,7 +389,9 @@ class Adam(Optimizer):
     """
 
     def __init__(
-        self, learning_rate: float, betas: List[float] = [0.9, 0.999], eps: float = 1e-8
+        self,
+        learning_rate: Union[float, Callable[[mx.array], mx.array]],
+        betas: List[float] = [0.9, 0.999], eps: float = 1e-8
     ):
         super().__init__()
 
@@ -430,7 +438,7 @@ class AdamW(Adam):
         w_{t+1} &= w_t - \alpha (\frac{m_{t+1}}{\sqrt{v_{t+1} + \epsilon}} + \lambda w_t)
 
     Args:
-        learning_rate (float): The learning rate :math:`\alpha`.
+        learning_rate (float or callable): The learning rate :math:`\alpha`.
         betas (Tuple[float, float], optional): The coefficients
           :math:`(\beta_1, \beta_2)` used for computing running averages of the
           gradient and its square. Default: ``(0.9, 0.999)``
@@ -442,7 +450,7 @@ class AdamW(Adam):
 
     def __init__(
         self,
-        learning_rate: float,
+        learning_rate: Union[float, Callable[[mx.array], mx.array]],
         betas: List[float] = [0.9, 0.999],
         eps: float = 1e-8,
         weight_decay: float = 0.01,
@@ -477,7 +485,7 @@ class Adamax(Adam):
         w_{t+1} &= w_t - \lambda \frac{m_{t+1}}{v_{t+1} + \epsilon}
 
     Args:
-        learning_rate (float): The learning rate :math:`\lambda`.
+        learning_rate (float or callable): The learning rate :math:`\lambda`.
         betas (Tuple[float, float], optional): The coefficients
           :math:`(\beta_1, \beta_2)` used for computing running averages of the
           gradient and its square. Default: ``(0.9, 0.999)``
@@ -486,7 +494,9 @@ class Adamax(Adam):
     """
 
     def __init__(
-        self, learning_rate: float, betas: List[float] = [0.9, 0.999], eps: float = 1e-8
+        self,
+        learning_rate: Union[float, Callable[[mx.array], mx.array]],
+        betas: List[float] = [0.9, 0.999], eps: float = 1e-8
     ):
         super().__init__(learning_rate, betas, eps)
         if not 0.0 <= eps:
@@ -537,7 +547,7 @@ class Lion(Optimizer):
         w_{t + 1} &= w_t - \eta (\text{sign}(c_t) + \lambda w_t)
 
     Args:
-        learning_rate (float): The learning rate :math:`\eta`.
+        learning_rate (float or callable): The learning rate :math:`\eta`.
         betas (Tuple[float, float], optional): The coefficients
           :math:`(\beta_1, \beta_2)` used for computing the gradient
           momentum and update direction. Default: ``(0.9, 0.99)``
@@ -546,7 +556,7 @@ class Lion(Optimizer):
 
     def __init__(
         self,
-        learning_rate: float,
+        learning_rate: Union[float, Callable[[mx.array], mx.array]],
         betas: List[float] = [0.9, 0.99],
         weight_decay: float = 0.0,
     ):
@@ -583,7 +593,8 @@ class Adafactor(Optimizer):
     <https://arxiv.org/abs/1804.04235>`_
 
     Args:
-        learning_rate (float, optional): The learning rate. Default: ``None``.
+        learning_rate (float or callable, optional): The learning rate.
+            Default: ``None``.
         eps (tuple(float, float), optional): The first term :math:`\epsilon_1`
             added to the square of the gradients to improve numerical
             stability and the second term :math:`\epsilon_2` is used for
@@ -610,7 +621,7 @@ class Adafactor(Optimizer):
 
     def __init__(
         self,
-        learning_rate: Optional[float] = None,
+        learning_rate: Union[float, Callable[[mx.array], mx.array], None],
         eps: Tuple[float, float] = (1e-30, 1e-3),
         clip_threshold: float = 1.0,
         decay_rate: float = -0.8,

--- a/python/mlx/optimizers/optimizers.py
+++ b/python/mlx/optimizers/optimizers.py
@@ -276,7 +276,7 @@ class Adagrad(Optimizer):
 
     def __init__(
         self,
-        learning_rate: Union[float, Callable[[mx.array], mx.array]] = None,
+        learning_rate: Union[float, Callable[[mx.array], mx.array]],
         eps: float = 1e-8,
     ):
         super().__init__()
@@ -631,7 +631,7 @@ class Adafactor(Optimizer):
 
     def __init__(
         self,
-        learning_rate: Union[float, Callable[[mx.array], mx.array], None],
+        learning_rate: Union[float, Callable[[mx.array], mx.array], None] = None,
         eps: Tuple[float, float] = (1e-30, 1e-3),
         clip_threshold: float = 1.0,
         decay_rate: float = -0.8,

--- a/python/mlx/optimizers/optimizers.py
+++ b/python/mlx/optimizers/optimizers.py
@@ -276,7 +276,7 @@ class Adagrad(Optimizer):
 
     def __init__(
         self,
-        learning_rate: Union[float, Callable[[mx.array], mx.array]],
+        learning_rate: Union[float, Callable[[mx.array], mx.array]] = None,
         eps: float = 1e-8,
     ):
         super().__init__()

--- a/python/tests/test_optimizers.py
+++ b/python/tests/test_optimizers.py
@@ -299,16 +299,16 @@ class TestOptimizers(mlx_tests.MLXTestCase):
 class TestSchedulers(unittest.TestCase):
     def test_decay_lr(self):
         for optim_class in optimizers_dict.values():
-            lr_schedule = opt.step_decay(1e-1, 0.9, 1000)
+            lr_schedule = opt.step_decay(1e-1, 0.9, 1)
             optimizer = optim_class(learning_rate=lr_schedule)
 
             params = {"w": mx.ones((5, 5))}
             grads = tree_map(lambda x: mx.ones_like(x), params)
 
             for it in range(10):
+                optimizer.apply_gradients(grads, params)
                 expected_lr = 0.1 * (0.9**it)
                 self.assertAlmostEqual(optimizer.learning_rate, expected_lr, delta=1e-7)
-                return optimizer.apply_gradients(grads, params)
 
     def test_step_decay(self):
         lr_schedule = opt.step_decay(1e-1, 0.9, 1000)


### PR DESCRIPTION
## Proposed changes

- Change the cache limit so it's more closely respected. On `free` we don't add to the cache if we are already above the limit
- Moved locks from buffer to malloc / free are more thread safe. No noticeable regression as we were already acquiring the locks on anyway when querying the buffer cache.

Adding something like below to MLX LM generate script effectively halts the cache growth without any degradation to TPS. It's not the prettiest, but seems to be pretty effective.

```python
    def set_cache_limit():
        _, cache = model(mx.array([[0]]))
        cache_size = max_tokens * sum(c.nbytes for _, c in tree_flatten(cache))
        cache_size += 10 * 2**20  # buffer
        mx.metal.set_cache_limit(cache_size)

    set_cache_limit()
```

### Benchmarks:

No cache limit:

```
Generation: 59.588 tokens-per-sec
Memory Peak: 1822.406 Cache: 9105.971
```

Cache disabled:
```
Generation: 53.861 tokens-per-sec
Memory Peak: 1822.146 Cache: 0.000
```

Cache limited to max kv-cache size:

```
Generation: 58.017 tokens-per-sec
Memory Peak: 1821.762 Cache: 948.803
```