### PR TITLE
Improved quantized matrix vector product

### DIFF
--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -54,7 +54,7 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
 
       int bo = 8;
       int bd = 32;
-      MTL::Size group_dims = MTL::Size(bd, bo, 1);
+      MTL::Size group_dims = MTL::Size(bd, 2, 1);
       MTL::Size grid_dims = MTL::Size(1, (O + bo - 1) / bo, B);
 
       set_array_buffer(compute_encoder, w, 0);

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -41,7 +41,7 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
   int B = x.size() / D;
   int O = out.shape(-1);
   if (transpose_) {
-    // Route to the fast qmv kernel
+    // Route to the fast qmv kernel that has no bounds checking
     if (B < 6 && O % 8 == 0 && D % 512 == 0 && D >= 512) {
       std::ostringstream kname;
       kname << "qmv_" << type_to_name(out) << "_gs_" << group_size_ << "_b_"

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -42,7 +42,7 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
   int O = out.shape(-1);
   if (transpose_) {
     // Route to the specialized qmv kernel
-    if (B < 6 && group_size_ == 32 && bits_ == 4 && O % 32 == 0) {
+    if (B < 6 && group_size_ == 32 && bits_ == 4 && O % 32 == 0 && D >= 512) {
       std::ostringstream kname;
       kname << "qmv_" << type_to_name(out) << "_gs_" << group_size_ << "_b_"
             << bits_ << "_fast";

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -3032,6 +3032,15 @@ array quantized_matmul(
   }
 
   auto dtype = result_type({x, scales, biases});
+  if (!is_floating_point(dtype) || is_complex(dtype)) {
+    std::ostringstream msg;
+    msg << "[quantized_matmul] Only real floating types are supported but "
+        << "the passed types where x.dtype() == " << x.dtype()
+        << ", scales.dtype() == " << scales.dtype()
+        << " and biases.dtype() == " << biases.dtype();
+    throw std::invalid_argument(msg.str());
+  }
+
   auto out = array(
       {x.shape(0), w_outer_dims},
       dtype,


### PR DESCRIPTION
This PR changes the `qmv` kernel. Adds an aligned version and an unaligned version but both are overhauled and improved. 

Further improvements should be possible but for now the following table shows tokens per second when generating with Mistral 7B before and after this PR (keep in mind naive 2 bit is not viable for Mistral 7B):

```
                | Before | After
-------------------------------
float16         |  34.2  |  -
gs=32  bits=2   |  44.6  | 83.1
gs=32  bits=4   |  51.4  | 70.7
gs=64  bits=4   |  54.4  | 74.1
gs=32  bits=8   |  39.8  | 52.6
gs=64  bits=8   |  40.7  | 54.4
gs=128 bits=8   |  40.2  | 55.2

```