### PR TITLE
checkpoint module's __call__

### DIFF
--- a/docs/src/python/nn.rst
+++ b/docs/src/python/nn.rst
@@ -173,6 +173,7 @@ In detail:
    :toctree: _autosummary
 
    value_and_grad
+   checkpoint
 
 .. toctree::
 

--- a/docs/src/python/transforms.rst
+++ b/docs/src/python/transforms.rst
@@ -17,3 +17,4 @@ Transforms
    jvp
    vjp
    vmap
+   checkpoint

--- a/python/mlx/nn/__init__.py
+++ b/python/mlx/nn/__init__.py
@@ -2,4 +2,4 @@
 
 from mlx.nn import init, losses
 from mlx.nn.layers import *
-from mlx.nn.utils import value_and_grad
+from mlx.nn.utils import checkpoint, value_and_grad

--- a/python/mlx/nn/layers/base.py
+++ b/python/mlx/nn/layers/base.py
@@ -137,7 +137,10 @@ class Module(dict):
             super(Module, self).__getattribute__(key)
 
     def __setattr__(self, key: str, val: Any):
-        if isinstance(val, (mx.array, dict, list, tuple)):
+        # Allow setter properties to pass through to base class
+        prop = vars(self.__class__).get(key, None)
+        is_prop = isinstance(prop, property) and prop.fset is not None
+        if not is_prop and isinstance(val, (mx.array, dict, list, tuple)):
             self[key] = val
         else:
             super(Module, self).__setattr__(key, val)

--- a/python/mlx/nn/utils.py
+++ b/python/mlx/nn/utils.py
@@ -15,7 +15,7 @@ def value_and_grad(model: Module, fn: Callable):
 
     Args:
         model (mlx.nn.Module): The model whose trainable parameters to compute
-                               gradients for
+          gradients for
         fn (Callable): The scalar function to compute gradients for
 
     Returns:
@@ -38,15 +38,14 @@ def value_and_grad(model: Module, fn: Callable):
 
 
 def checkpoint(module: Module):
-    """Transform the passed module to one that performs gradient
-    checkpointing.
+    """Transform the passed module to one that performs gradient checkpointing.
 
     The checkpointing is with respect to the module's trainable parameters and
     inputs of the module's ``__call__`` function.
 
     Args:
-        module (mlx.nn.Module): The module for whose parameters we will be
-            performing gradient checkpointing.
+        module (mlx.nn.Module): The module for which we will perform gradient
+          checkpointing.
 
     Returns:
         The module that saves the inputs and outputs during the forward pass

--- a/python/mlx/nn/utils.py
+++ b/python/mlx/nn/utils.py
@@ -66,8 +66,8 @@ def checkpoint(module: Module):
         return checkpointed_fn(module.trainable_parameters(), *args, **kwargs)
 
     class _(type(module)):
-        def __call__(self, *arg, **kwarg):
-            return wrapped_checkpointed_fn(*arg, **kwarg)
+        def __call__(self, *args, **kwargs):
+            return wrapped_checkpointed_fn(*args, **kwargs)
 
     module.__class__ = _
     return module

--- a/python/src/transforms.cpp
+++ b/python/src/transforms.cpp
@@ -888,7 +888,24 @@ void init_transforms(py::module_& m) {
   m.def(
       "checkpoint",
       [](py::function fun) { return py::cpp_function(PyCheckpointedFun{fun}); },
-      "fun"_a);
+      "fun"_a,
+      R"pbdoc(
+        checkpoint(fun: function) -> function
+
+        Returns a gradient checkpointed function.
+
+        The checkpointed function produces the same output as the input
+        ``fun`` but recomputes all intermediate states during the gradient
+        computation (vjp) rather than storing them.
+
+        Use the checkpoint transformation to reduce memory consumption at the
+        cost of increased computation.
+
+        Args:
+            fun (function): A function which takes a variable number of
+              :class:`array` or trees of :class:`array` and returns
+              a variable number of :class:`array` or trees of :class:`array`.
+      )pbdoc");
 
   // Register static Python object cleanup before the interpreter exits
   auto atexit = py::module_::import("atexit");

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -1487,9 +1487,21 @@ class TestNNUtils(mlx_tests.MLXTestCase):
         lin = nn.Linear(2, 2)
         x = mx.array([0.1, 0.2])
 
+        lin.my_attr = "hello"
+
         expected_y = lin(x)
-        y = nn.utils.checkpoint(lin)(x)
+        clin = nn.utils.checkpoint(lin)
+        y = clin(x)
         self.assertTrue(mx.allclose(expected_y, y))
+
+        # Check get/set attribute
+        self.assertEqual(clin.my_attr, "hello")
+
+        clin.my_attr = "bye"
+        self.assertEqual(clin.my_attr, "bye")
+
+        self.assertTrue(isinstance(clin, nn.Linear))
+        self.assertEqual(repr(clin), repr(lin))
 
 
 if __name__ == "__main__":

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -1481,5 +1481,16 @@ class TestLayers(mlx_tests.MLXTestCase):
         )
 
 
+class TestNNUtils(mlx_tests.MLXTestCase):
+
+    def test_checkpoint(self):
+        lin = nn.Linear(2, 2)
+        x = mx.array([0.1, 0.2])
+
+        expected_y = lin(x)
+        y = nn.utils.checkpoint(lin)(x)
+        self.assertTrue(mx.allclose(expected_y, y))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Proposed changes

Change `nn.utils` to checkpoint the module's `__call__` directly instead of an arbitrary function.

Let's us do stuff like:

```python
self.layers = [nn.utils.checkpoint(l) for l in self.layers]
```

- Added checkpointing to the docs
- Added a few tests to make sure the checkpoint module has the right attributes etc.