### PR TITLE
Fix reshaping of empty arrays

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -300,19 +300,27 @@ array reshape(
       size *= shape[i];
     }
   }
+
+  // Infer the shape
   if (size > 0) {
     auto q_and_r = std::ldiv(a.size(), size);
     if (infer_idx >= 0) {
       shape[infer_idx] = q_and_r.quot;
       size *= q_and_r.quot;
     }
+  } else if (infer_idx >= 0) {
+    std::ostringstream msg;
+    throw std::invalid_argument("Cannot infer the shape of an empty array");
   }
+
+  // Check the the reshaping is valid
   if (a.size() != size) {
     std::ostringstream msg;
     msg << "Cannot reshape array of size " << a.size() << " into shape "
         << shape << ".";
     throw std::invalid_argument(msg.str());
   }
+
   return array(
       shape, a.dtype(), std::make_unique<Reshape>(to_stream(s), shape), {a});
 }

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -293,7 +293,8 @@ array reshape(
   for (int i = 0; i < shape.size(); ++i) {
     if (shape[i] == -1) {
       if (infer_idx >= 0) {
-        throw std::invalid_argument("Reshape can only infer one dimension.");
+        throw std::invalid_argument(
+            "[reshape] Reshape can only infer one dimension.");
       }
       infer_idx = i;
     } else {
@@ -309,15 +310,15 @@ array reshape(
       size *= q_and_r.quot;
     }
   } else if (infer_idx >= 0) {
-    std::ostringstream msg;
-    throw std::invalid_argument("Cannot infer the shape of an empty array");
+    throw std::invalid_argument(
+        "[reshape] Cannot infer the shape of an empty array");
   }
 
   // Check the the reshaping is valid
   if (a.size() != size) {
     std::ostringstream msg;
-    msg << "Cannot reshape array of size " << a.size() << " into shape "
-        << shape << ".";
+    msg << "[reshape] Cannot reshape array of size " << a.size()
+        << " into shape " << shape << ".";
     throw std::invalid_argument(msg.str());
   }
 


### PR DESCRIPTION
Simply fixes #789 .

```python
import mlx.core as mx
import numpy as np

x = mx.random.normal((100, 0, 1024))
y = np.random.randn(100, 0, 1024)

x.reshape(2, 50, 0).shape  # (2, 50, 0)
y.reshape(2, 50, 0).shape  # (2, 50, 0)

x.reshape(2, 50, -1).shape  # (2, 50, 0)
y.reshape(2, 50, -1).shape  # (2, 50, 0)

x.reshape(2, 50, 0, -1).shape  # throws ValueError: Cannot infer the shape of an empty array
y.reshape(2, 50, 0, -1).shape  # throws ValueError: cannot reshape array of size 0 into shape (2,50,0,newaxis)
```