### PR TITLE
Fix docstring for correctly rendering

### DIFF
--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -125,7 +125,7 @@ void init_ops(py::module_& m) {
         Args:
             a (array): Input array.
             axis (int or tuple(int), optional): Axes to remove. Defaults
-            to ``None`` in which case all size one axes are removed.
+              to ``None`` in which case all size one axes are removed.
 
         Returns:
             array: The output array with size one axes removed.
@@ -1324,7 +1324,7 @@ void init_ops(py::module_& m) {
           stop (scalar): Stopping value.
           num (int, optional): Number of samples, defaults to ``50``.
           dtype (Dtype, optional): Specifies the data type of the output,
-          default to ``float32``.
+            default to ``float32``.
 
       Returns:
           array: The range of values.
@@ -1622,15 +1622,15 @@ void init_ops(py::module_& m) {
       R"pbdoc(
       tril(x: array, k: int, *, stream: Union[None, Stream, Device] = None) -> array
 
-        Zeros the array above the given diagonal.
+      Zeros the array above the given diagonal.
 
-        Args:
-          x (array): input array.
-          k (int, optional): The diagonal of the 2-D array. Defaults to ``0``.
-          stream (Stream, optional): Stream or device. Defaults to ``None``.
+      Args:
+        x (array): input array.
+        k (int, optional): The diagonal of the 2-D array. Defaults to ``0``.
+        stream (Stream, optional): Stream or device. Defaults to ``None``.
 
-        Returns:
-          array: Array zeroed above the given diagonal
+      Returns:
+        array: Array zeroed above the given diagonal
     )pbdoc");
   m.def(
       "triu",


### PR DESCRIPTION
## Proposed changes

This is a minimal PR that only fixes docstring identation issues that makes documentation rendering incorrectly, eg:

[`mlx.core.linspace`](https://ml-explore.github.io/mlx/build/html/python/_autosummary/mlx.core.linspace.html#mlx.core.linspace)

![image](https://github.com/ml-explore/mlx/assets/4706822/f3105757-f2e2-41c1-9790-3f154911ac90)

and 

[`mlx.core.squeeze`](https://ml-explore.github.io/mlx/build/html/python/_autosummary/mlx.core.squeeze.html#mlx.core.squeeze)

![image](https://github.com/ml-explore/mlx/assets/4706822/81b2243f-58a3-4343-8204-83120014c59f)


## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
