### PR TITLE
Strided reduce specialization for small reductions

### DIFF
--- a/mlx/backend/metal/kernels/reduction/kernels/reduce_col.metal
+++ b/mlx/backend/metal/kernels/reduction/kernels/reduce_col.metal
@@ -26,6 +26,9 @@ template <typename T, typename U, typename Op>
     const constant int& non_col_ndim [[buffer(11)]],
     uint tid [[thread_position_in_grid]]) {
 
+  // Appease the compiler
+  (void)out_size;
+
   Op op;
   U total_val = Op::init;
 
@@ -33,9 +36,9 @@ template <typename T, typename U, typename Op>
 
   in += elem_to_loc(
         out_idx,
-        shape,
-        strides,
-        ndim);
+        shape + non_col_ndim,
+        strides + non_col_ndim,
+        ndim - non_col_ndim);
 
   for(uint i = 0; i < non_col_reductions; i++) {
     size_t in_idx = elem_to_loc(i, non_col_shapes, non_col_strides, non_col_ndim);

--- a/mlx/backend/metal/reduce.cpp
+++ b/mlx/backend/metal/reduce.cpp
@@ -4,8 +4,6 @@
 #include <cassert>
 #include <sstream>
 
-#include <iostream>
-
 #include "mlx/backend/common/reduce.h"
 #include "mlx/backend/metal/copy.h"
 #include "mlx/backend/metal/device.h"


### PR DESCRIPTION
## Proposed changes

* Improvements for cases where non column and column reductions can all be done by the same thread 

Before:
```
(base) jdigani@mlx-m2-macstudio-2 mlx % python benchmarks/python/comparative/bench_mlx.py sum_axis --size 8x32x2x32x2x128 --axis 2,4
0.7566990852355957
```
After:
```
(base) jdigani@mlx-m2-macstudio-2 mlx % python benchmarks/python/comparative/bench_mlx.py sum_axis --size 8x32x2x32x2x128 --axis 2,4
0.5333571434020996
```
## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)