### PR TITLE
Speed up CPU sorting

### DIFF
--- a/mlx/backend/common/sort.cpp
+++ b/mlx/backend/common/sort.cpp
@@ -130,7 +130,7 @@ void sort(const array& in, array& out, int axis) {
     StridedIterator st(data_ptr, axis_stride, 0);
     StridedIterator ed(data_ptr, axis_stride, axis_size);
 
-    std::stable_sort(st, ed);
+    std::sort(st, ed);
   }
 }
 


### PR DESCRIPTION
## Proposed changes

Sorting on the CPU was using a stable sort, which is not the default in numpy/torch and was therefore quite a bit slower. Switching to `std::sort` speeds up sorting of a 64x128x1024 matrix 1.1x to 4.2x depending on the sort axis (best of 10 runs on M1 pro):

```
           device    lib  axis     t_ms   speedup
-------------------------------------------------
   before     cpu    mlx     0  1263.40
   after      cpu    mlx     0   373.36      3.3x

   before     cpu    mlx     1   957.94
   after      cpu    mlx     1   228.17      4.2x

   before     cpu    mlx     2   255.36
   after      cpu    mlx     2   277.79      1.1x
```

This is how mlx compares to NumPy and Pytorch (note that the latter is multithreaded, so not really a fair comparison):

```
  device    lib  axis    t_ms
-----------------------------
     cpu    mlx     0  373.36
     cpu     np     0  226.97
     cpu  torch     0   52.12

     cpu    mlx     1  228.17
     cpu     np     1  237.17
     cpu  torch     1   43.99

     cpu    mlx     2  277.79
     cpu     np     2  299.10
     cpu  torch     2   53.27
```

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
