### PR TITLE
Improve readbility of jvb/vjp/value_and_grad

### DIFF
--- a/mlx/array.h
+++ b/mlx/array.h
@@ -253,6 +253,9 @@ class array {
   }
 
   /** The array's siblings. */
+  std::vector<array>& siblings() {
+    return array_desc_->siblings;
+  };
   const std::vector<array>& siblings() const {
     return array_desc_->siblings;
   };


### PR DESCRIPTION
I had some difficulties understanding the code and I made some changes which I think can improve the readbility of the functions.

There is no changes on the code's actual behavior in this PR, but I will try to simplify the functions once this is merged.

## Proposed changes

1. Add comments and rename some variables to meaningful names.
2. Use size_t instead of int as vector index when possible, it is easier to tell if the arg supports negative index this way, and this will be required when you enable more compiler warnings in future.
3. Use explicit type name instead of auto in places where it is hard to tell the type by reading code.
4. Reorder some code for easier understanding.
5. For code that does the same thing, make them look the same. (I'll try to remove duplicate code in later PRs.)
6. Some places were creating copies of arrays implicitly, as a bonus of this PR I changed them to use reference or move semantics.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
