### PR TITLE
Add minimum for cosine decay function

### DIFF
--- a/python/mlx/optimizers/schedulers.py
+++ b/python/mlx/optimizers/schedulers.py
@@ -65,7 +65,7 @@ def cosine_decay(init: float, decay_steps: int, minimum: float = 0.0) -> Callabl
         init (float): Initial value.
         decay_steps (int): Number of steps to decay over. The decayed
             value is constant for steps beyond ``decay_steps``.
-        minimum (float): Minimal value to decay to (defaults to 0)
+        minimum (float, optional): Minimal value to decay to. Default: ``0``.
 
     Example:
 

--- a/python/mlx/optimizers/schedulers.py
+++ b/python/mlx/optimizers/schedulers.py
@@ -58,13 +58,14 @@ def step_decay(init: float, decay_rate: float, step_size: int) -> Callable:
     return schedule
 
 
-def cosine_decay(init: float, decay_steps: int) -> Callable:
+def cosine_decay(init: float, decay_steps: int, minimum: float = 0.0) -> Callable:
     r"""Make a cosine decay scheduler.
 
     Args:
         init (float): Initial value.
         decay_steps (int): Number of steps to decay over. The decayed
             value is constant for steps beyond ``decay_steps``.
+        minimum (float): Minimal value to decay to (defaults to 0)
 
     Example:
 
@@ -82,7 +83,7 @@ def cosine_decay(init: float, decay_steps: int) -> Callable:
     def scheduler(step):
         s = mx.minimum(step, decay_steps)
         decay = 0.5 * (1.0 + mx.cos((math.pi / decay_steps) * s))
-        return init * decay
+        return mx.maximum(init * decay, minimum)
 
     return scheduler
 

--- a/python/tests/test_optimizers.py
+++ b/python/tests/test_optimizers.py
@@ -328,6 +328,11 @@ class TestSchedulers(unittest.TestCase):
         expected_lr = 0.1 * 0.5 * (1.0 + math.cos(math.pi * 4 / 10))
         self.assertAlmostEqual(lr, expected_lr, delta=1e-7)
 
+        lr_schedule = opt.cosine_decay(0.1, 10, 0.05)
+        lr = lr_schedule(20)
+        expected_lr = 0.05
+        self.assertEqual(lr, expected_lr)
+
     def test_schedule_joiner(self):
         boundaries = [2, 3, 4]
         schedules = [lambda _: 3, lambda _: 4, lambda _: 5]


### PR DESCRIPTION
## Proposed changes

The Cosine decay schedule is more commonly used to decay the LR to a proportion of a targeted LR rather than to 0.  This simply adds an (optional) argument for the final decayed value.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
