### PR TITLE
Update set item

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -558,8 +558,7 @@ array slice_update(
       normalize_slice(src.shape(), start, stop, strides);
 
   // Broadcast update shape to slice shape
-  auto upd_shape_broadcast = broadcast_shapes(upd_shape, update.shape());
-  auto update_broadcasted = broadcast_to(update, upd_shape_broadcast, s);
+  auto update_broadcasted = broadcast_to(update, upd_shape, s);
 
   // If the entire src is the slice, just return the update
   if (!has_neg_strides && upd_shape == src.shape()) {
@@ -571,7 +570,7 @@ array slice_update(
       src.dtype(),
       std::make_unique<SliceUpdate>(
           to_stream(s), std::move(start), std::move(stop), std::move(strides)),
-      {src, update});
+      {src, update_broadcasted});
 }
 
 /** Update a slice from the source array with stride 1 in each dimension */

--- a/python/src/indexing.cpp
+++ b/python/src/indexing.cpp
@@ -491,6 +491,35 @@ std::tuple<std::vector<array>, array, std::vector<int>> mlx_scatter_args_slice(
   // Check and update slice params
   get_slice_params(start, end, stride, in_slice, end);
 
+  // If simple stride
+  if (stride == 1) {
+    // Squeeze out singleton dims from the start of update
+    int s = 0;
+    for (; s < update.ndim() && update.shape(s) == 1; s++)
+      ;
+    auto up_shape =
+        std::vector<int>(update.shape().begin() + s, update.shape().end());
+    auto up = reshape(update, up_shape);
+
+    // Build array to mark start of slice
+    auto idx = array({start}, {1}, uint32);
+
+    // Get slice size
+    int slice_size = (end - start);
+
+    // Broadcast update to slide size
+    std::vector<int> up_shape_broadcast = {1, slice_size};
+    up_shape_broadcast.insert(
+        up_shape_broadcast.end(), src.shape().begin() + 1, src.shape().end());
+
+    up = broadcast_to(update, up_shape_broadcast);
+
+    auto indices = std::vector<array>{idx};
+    auto axes = std::vector<int>{0};
+
+    return {indices, up, axes};
+  }
+
   return mlx_scatter_args_array(
       src, arange(start, end, stride, uint32), update);
 }


### PR DESCRIPTION
## Proposed changes

* Update `mlx_set_item` to rely on scatter slices instead of expanding indices with `arange` if slice stride is 1
* Update `mlx_set_item` to route to `slice_update` where possible

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
