### PR TITLE
Add missing && in eval

### DIFF
--- a/mlx/transforms.cpp
+++ b/mlx/transforms.cpp
@@ -37,7 +37,7 @@ class Synchronizer : public Primitive {
 // are currently under a function transformation.
 int detail::InTracing::tracing_counter{0};
 
-void eval(const std::vector<array>& outputs) {
+void eval(std::vector<array> outputs) {
   std::function<void(const array&)> recurse;
   std::queue<array> tape;
   std::unordered_set<std::uintptr_t> cache;
@@ -52,8 +52,8 @@ void eval(const std::vector<array>& outputs) {
     }
   }
 
-  auto synchronizer =
-      array({}, bool_, std::make_unique<Synchronizer>(stream), outputs);
+  auto synchronizer = array(
+      {}, bool_, std::make_unique<Synchronizer>(stream), std::move(outputs));
 
   size_t depth_counter = 0;
   recurse = [&](const array& a) {

--- a/mlx/transforms.h
+++ b/mlx/transforms.h
@@ -6,10 +6,10 @@
 
 namespace mlx::core {
 
-void eval(const std::vector<array>& outputs);
+void eval(std::vector<array> outputs);
 
 template <typename... Arrays>
-void eval(Arrays... outputs) {
+void eval(Arrays&&... outputs) {
   eval(std::vector<array>{std::forward<Arrays>(outputs)...});
 }
 


### PR DESCRIPTION
## Proposed changes

Without the && args would be copied and perfect forwarding won't work.

To avoid eval calling itself recursively, the const ref version of eval is changed to take by value instead, which will also save a copy of array when a rvalue is passed.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
