### PR TITLE
Do not store iostream in shared_ptr

### DIFF
--- a/python/src/load.cpp
+++ b/python/src/load.cpp
@@ -121,7 +121,7 @@ class PyFileReader : public io::Reader {
     return out;
   }
 
-  size_t tell() const override {
+  size_t tell() override {
     size_t out;
     {
       nb::gil_scoped_acquire gil;
@@ -334,7 +334,7 @@ class PyFileWriter : public io::Writer {
     return out;
   }
 
-  size_t tell() const override {
+  size_t tell() override {
     size_t out;
     {
       nb::gil_scoped_acquire gil;


### PR DESCRIPTION

## Proposed changes

There is no need to store iostream in shared_ptr, doing so adds the cost of a heap allocation.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
