### PR TITLE
Change unary/binary vmap to accept vector as axis

### DIFF
--- a/mlx/transforms.h
+++ b/mlx/transforms.h
@@ -146,23 +146,6 @@ std::function<array(const array&)> inline grad(
 }
 
 /**
- * Automatically vectorize a unary function over the requested axes.
- */
-std::function<array(const array&)> vmap(
-    const std::function<array(const array&)>& fun,
-    int in_axis = 0,
-    int out_axis = 0);
-
-/**
- * Automatically vectorize a binary function over the requested axes.
- */
-std::function<array(const array&, const array&)> vmap(
-    const std::function<array(const array&, const array&)>& fun,
-    int in_axis_a = 0,
-    int in_axis_b = 0,
-    int out_axis = 0);
-
-/**
  * Automatically vectorize a function over the requested axes.
  *
  * The input function to `vmap` takes as an argument a vector of arrays and
@@ -172,9 +155,25 @@ std::function<array(const array&, const array&)> vmap(
  * function.
  */
 std::function<std::vector<array>(const std::vector<array>&)> vmap(
-    const std::function<std::vector<array>(const std::vector<array>&)>& fun,
-    const std::vector<int>& in_axes = {},
-    const std::vector<int>& out_axes = {});
+    std::function<std::vector<array>(const std::vector<array>&)> fun,
+    std::vector<int> in_axes = {},
+    std::vector<int> out_axes = {});
+
+/**
+ * Automatically vectorize a unary function over the requested axes.
+ */
+std::function<array(array)> vmap(
+    std::function<array(const array&)> fun,
+    std::vector<int> in_axis = {0},
+    std::vector<int> out_axis = {0});
+
+/**
+ * Automatically vectorize a binary function over the requested axes.
+ */
+std::function<array(array, array)> vmap(
+    std::function<array(const array&, const array&)> fun,
+    std::vector<int> in_axis = {0, 0},
+    std::vector<int> out_axis = {0});
 
 /**
  * Return the results of calling fun with args but if their vjp is computed it

--- a/tests/fft_tests.cpp
+++ b/tests/fft_tests.cpp
@@ -242,7 +242,7 @@ TEST_CASE("test fft vmap") {
   auto y = vmap(fft_fn)(x);
   CHECK(array_equal(y, fft::fft(x)).item<bool>());
 
-  y = vmap(fft_fn, 1, 1)(x);
+  y = vmap(fft_fn, {1}, {1})(x);
   CHECK(array_equal(y, fft::fft(x, 0)).item<bool>());
 
   auto rfft_fn = [](array x) { return fft::rfft(x); };
@@ -250,7 +250,7 @@ TEST_CASE("test fft vmap") {
   y = vmap(rfft_fn)(x);
   CHECK(array_equal(y, fft::rfft(x)).item<bool>());
 
-  y = vmap(rfft_fn, 1, 1)(x);
+  y = vmap(rfft_fn, {1}, {1})(x);
   CHECK(array_equal(y, fft::rfft(x, 0)).item<bool>());
 
   set_default_device(device);

--- a/tests/ops_tests.cpp
+++ b/tests/ops_tests.cpp
@@ -2225,12 +2225,14 @@ TEST_CASE("test scan op") {
   CHECK(array_equal(y, expected).item<bool>());
 
   // Check the vmap implementation
-  auto fun = [](array x) { return cumsum(x, 0, false, true); };
-  y = vmap(fun, 0, 0)(x);
+  std::function<array(array)> fun = [](array x) {
+    return cumsum(x, 0, false, true);
+  };
+  y = vmap(fun)(x);
   expected = array({1.0f, 3.0f, 3.0f, 7.0f, 5.0f, 11.0f, 7.0f, 15.0f}, {4, 2});
   CHECK(array_equal(y, expected).item<bool>());
 
-  y = vmap(fun, 1, 1)(x);
+  y = vmap(fun, {1}, {1})(x);
   expected = array({1.0f, 2.0f, 4.0f, 6.0f, 9.0f, 12.0f, 16.0f, 20.0f}, {4, 2});
   CHECK(array_equal(y, expected).item<bool>());
 }

--- a/tests/random_tests.cpp
+++ b/tests/random_tests.cpp
@@ -161,7 +161,7 @@ TEST_CASE("test random bits") {
          1110694964u,
          3819641963u},
         {2, 3});
-    CHECK(array_equal(vmap(fn, 1)(key), expected).item<bool>());
+    CHECK(array_equal(vmap(fn, {1})(key), expected).item<bool>());
 
     // Vmap twice
     key = array(
@@ -199,7 +199,7 @@ TEST_CASE("test random bits") {
         {3, 2, 2});
     CHECK(array_equal(out, expected).item<bool>());
 
-    out = vmap(vmap(fn, 1), 0)(key);
+    out = vmap(vmap(fn, {1}), {0})(key);
     expected = array(
         {1948878966u,
          4237131848u,
@@ -331,7 +331,7 @@ TEST_CASE("test random uniform") {
     auto fun = [](array k, array low) {
       return random::uniform(low, 1, {3}, float32, k);
     };
-    auto out = vmap(fun, -1)(key, zeros({2, 3}));
+    auto out = vmap(fun, {-1})(key, zeros({2, 3}));
     CHECK_EQ(out.shape(), std::vector<int>{2, 3});
 
     key = zeros({2, 2}, uint32);

--- a/tests/vmap_tests.cpp
+++ b/tests/vmap_tests.cpp
@@ -18,11 +18,11 @@ TEST_CASE("test simple vmap") {
     auto expected = array({0, 1, 2, 3, 4, 5, 6, 7}, {2, 4});
     CHECK(array_equal(vfun(x), expected).item<bool>());
 
-    vfun = vmap([](array input) { return reshape(input, {4}); }, 1);
+    vfun = vmap([](array input) { return reshape(input, {4}); }, {1});
     expected = array({0, 1, 4, 5, 2, 3, 6, 7}, {2, 4});
     CHECK(array_equal(vfun(x), expected).item<bool>());
 
-    vfun = vmap([](array input) { return reshape(input, {4}); }, 1, 1);
+    vfun = vmap([](array input) { return reshape(input, {4}); }, {1}, {1});
     expected = array({0, 2, 1, 3, 4, 6, 5, 7}, {4, 2});
     CHECK(array_equal(vfun(x), expected).item<bool>());
   }
@@ -31,10 +31,10 @@ TEST_CASE("test simple vmap") {
   {
     auto fun = [](array input) { return broadcast_to(input, {4, 2}); };
 
-    CHECK_THROWS_AS(vmap(fun, 0, -1), std::invalid_argument);
-    CHECK_THROWS_AS(vmap(fun, -1, 0), std::invalid_argument);
+    CHECK_THROWS_AS(vmap(fun, {0}, {-1}), std::invalid_argument);
+    CHECK_THROWS_AS(vmap(fun, {-1}, {0}), std::invalid_argument);
 
-    auto vfun = vmap(fun, -1, -1);
+    auto vfun = vmap(fun, {-1}, {-1});
     auto x = zeros({2});
     CHECK(array_equal(vfun(x), zeros({4, 2})).item<bool>());
 
@@ -42,24 +42,24 @@ TEST_CASE("test simple vmap") {
     x = zeros({3, 2});
     CHECK(array_equal(vfun(x), zeros({3, 4, 2})).item<bool>());
 
-    vfun = vmap(fun, 0, 1);
+    vfun = vmap(fun, {0}, {1});
     CHECK(array_equal(vfun(x), zeros({4, 3, 2})).item<bool>());
 
-    vfun = vmap(fun, 0, 2);
+    vfun = vmap(fun, {0}, {2});
     CHECK(array_equal(vfun(x), zeros({4, 2, 3})).item<bool>());
 
-    vfun = vmap(fun, 0, 2);
+    vfun = vmap(fun, {0}, {2});
     x = zeros({2, 3});
     CHECK_THROWS_AS(vfun(x), std::invalid_argument);
 
     x = zeros({2, 3});
-    vfun = vmap(fun, 1);
+    vfun = vmap(fun, {1});
     CHECK(array_equal(vfun(x), zeros({3, 4, 2})).item<bool>());
 
-    vfun = vmap(fun, 1, 1);
+    vfun = vmap(fun, {1}, {1});
     CHECK(array_equal(vfun(x), zeros({4, 3, 2})).item<bool>());
 
-    vfun = vmap(fun, 1, 2);
+    vfun = vmap(fun, {1}, {2});
     CHECK(array_equal(vfun(x), zeros({4, 2, 3})).item<bool>());
   }
 
@@ -70,17 +70,17 @@ TEST_CASE("test simple vmap") {
     auto x = array({0, 1, 2, 3, 4, 5}, {3, 2});
     CHECK(array_equal(vfun(x), x).item<bool>());
 
-    vfun = vmap(fun, 0, 1);
+    vfun = vmap(fun, {0}, {1});
     CHECK(array_equal(vfun(x), transpose(x)).item<bool>());
 
     x = array({0, 1, 2, 3, 4, 5, 6, 7}, {2, 2, 2});
     vfun = vmap(fun);
     CHECK(array_equal(vfun(x), transpose(x, {0, 2, 1})).item<bool>());
 
-    vfun = vmap(fun, 1, 1);
+    vfun = vmap(fun, {1}, {1});
     CHECK(array_equal(vfun(x), transpose(x, {2, 1, 0})).item<bool>());
 
-    vfun = vmap(fun, 2, 2);
+    vfun = vmap(fun, {2}, {2});
     CHECK(array_equal(vfun(x), transpose(x, {1, 0, 2})).item<bool>());
 
     // vmap twice
@@ -307,7 +307,7 @@ TEST_CASE("test vmap creation ops") {
 
     x = array({1, 2, 3}, {1, 3});
     CHECK_THROWS_AS(vmap(fun)(x), std::invalid_argument);
-    out = vmap(fun, 1, 1)(x);
+    out = vmap(fun, {1}, {1})(x);
     expected = array({1, 2, 3, 1, 2, 3}, {2, 3});
     CHECK(array_equal(out, expected).item<bool>());
   }
@@ -325,7 +325,7 @@ TEST_CASE("test vmap slice") {
   {
     auto fun = [](array in) { return slice(in, {0, 1}, {2, 3}); };
     auto x = reshape(arange(12), {2, 2, 3});
-    auto out = vmap(fun, 1, 0)(x);
+    auto out = vmap(fun, {1}, {0})(x);
     auto expected = reshape(array({1, 2, 7, 8, 4, 5, 10, 11}), {2, 2, 2});
     CHECK(array_equal(out, expected).item<bool>());
   }


### PR DESCRIPTION
## Proposed changes

It is hard to tell what the code does without looking at the source code when you call something like `vmap(fun, 1, 2)`.

Refactored the code of vmap to make use of move semantics.

Reordered the code so the order of declaration matches the definition.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
