### PR TITLE
Increase test tolerance for fast.layer_norm

### DIFF
--- a/python/tests/test_fast.py
+++ b/python/tests/test_fast.py
@@ -181,7 +181,7 @@ class TestFast(mlx_tests.MLXTestCase):
             return x
 
         # Per dtype absolute tolerance
-        tolerances = {mx.float32: 2e-6, mx.float16: 2e-3, mx.bfloat16: 2e-2}
+        tolerances = {mx.float32: 3e-6, mx.float16: 3e-3, mx.bfloat16: 3e-2}
 
         dtypes = [mx.float32, mx.float16, mx.bfloat16]
         epss = [1e-3, 1e-5]


### PR DESCRIPTION
I wrote a comparison with numpy using double to do the computation. The error of the reference implementation and the kernel is pretty much the same with the kernel winning ~50% of the time. For float32 it is well below 1e-6 for small vectors so I think it is fine to just increase the tolerance a bit.