### PR TITLE
Make ops aware of rvalues: astype/as_strided/copy/full

### DIFF
--- a/mlx/ops.h
+++ b/mlx/ops.h
@@ -41,40 +41,33 @@ array linspace(
     StreamOrDevice s = {});
 
 /** Convert an array to the given data type. */
-array astype(const array& a, Dtype dtype, StreamOrDevice s = {});
+array astype(array a, Dtype dtype, StreamOrDevice s = {});
 
 /** Create a view of an array with the given shape and strides. */
 array as_strided(
-    const array& a,
+    array a,
     std::vector<int> shape,
     std::vector<size_t> strides,
     size_t offset,
     StreamOrDevice s = {});
 
 /** Copy another array. */
-array copy(const array& a, StreamOrDevice s = {});
+array copy(array a, StreamOrDevice s = {});
 
 /** Fill an array of the given shape with the given value(s). */
 array full(
-    const std::vector<int>& shape,
-    const array& vals,
+    std::vector<int> shape,
+    array vals,
     Dtype dtype,
     StreamOrDevice s = {});
-array full(
-    const std::vector<int>& shape,
-    const array& vals,
-    StreamOrDevice s = {});
+array full(std::vector<int> shape, array vals, StreamOrDevice s = {});
 template <typename T>
-array full(
-    const std::vector<int>& shape,
-    T val,
-    Dtype dtype,
-    StreamOrDevice s = {}) {
-  return full(shape, array(val, dtype), to_stream(s));
+array full(std::vector<int> shape, T val, Dtype dtype, StreamOrDevice s = {}) {
+  return full(std::move(shape), array(val, dtype), to_stream(s));
 }
 template <typename T>
-array full(const std::vector<int>& shape, T val, StreamOrDevice s = {}) {
-  return full(shape, array(val), to_stream(s));
+array full(std::vector<int> shape, T val, StreamOrDevice s = {}) {
+  return full(std::move(shape), array(val), to_stream(s));
 }
 
 /** Fill an array of the given shape with zeros. */

--- a/mlx/primitives.h
+++ b/mlx/primitives.h
@@ -420,12 +420,12 @@ class AsStrided : public UnaryPrimitive {
  public:
   explicit AsStrided(
       Stream stream,
-      const std::vector<int>& shape,
-      const std::vector<size_t>& strides,
+      std::vector<int> shape,
+      std::vector<size_t> strides,
       size_t offset)
       : UnaryPrimitive(stream),
-        shape_(shape),
-        strides_(strides),
+        shape_(std::move(shape)),
+        strides_(std::move(strides)),
         offset_(offset){};
 
   void eval_cpu(const std::vector<array>& inputs, array& out) override;


### PR DESCRIPTION
## Proposed changes

When compositing transforms lots of temporary of arrays will be created and passed to next primitive, and by making ops accepting args by value we can avoid lots of copies of temporary arrays.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
