### PR TITLE
Support Chaining for some of functionalities of `nn.Module` (#885)

### DIFF
--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -15,6 +15,7 @@ MLX was developed with contributions from the following individuals:
 - Hinrik Snær Guðmundsson: Added `atleast_1d`, `atleast_2d`, `atleast_3d` ops.
 - Luca Arnaboldi: Added `Ceil` and `Floor` ops; implemented pickling, copy and deepcopy for mlx arrays.
 - Brian Keene & Atila Orhon, with Argmax Inc.: Added `fast.scaled_dot_product_attention`
+- AmirHossein Razlighi: Added chaining support for some of the ops in `nn.Module`.
 <a href="https://github.com/ml-explore/mlx/graphs/contributors">
   <img class="dark-light" src="https://contrib.rocks/image?repo=ml-explore/mlx&anon=0&columns=20&max=100&r=true" />
 </a>

--- a/python/mlx/nn/layers/base.py
+++ b/python/mlx/nn/layers/base.py
@@ -566,7 +566,7 @@ class Module(dict):
                 Default: ``False``.
 
         Returns:
-            The module instance with unfreezed parameters.
+            The module instance with unfrozen parameters.
         """
 
         def _unfreeze_impl(_, m):

--- a/python/mlx/nn/layers/base.py
+++ b/python/mlx/nn/layers/base.py
@@ -146,7 +146,7 @@ class Module(dict):
         self,
         file_or_weights: Union[str, List[Tuple[str, mx.array]]],
         strict: bool = True,
-    ) -> self:
+    ):
         """
         Update the model's weights from a ``.npz``, a ``.safetensors`` file, or a list.
 
@@ -318,7 +318,7 @@ class Module(dict):
 
         return self.filter_and_map(self.valid_child_filter, is_leaf_fn=_is_leaf_module)
 
-    def update(self, parameters: dict) -> self:
+    def update(self, parameters: dict):
         """Replace the parameters of this Module with the provided ones in the
         dict of dicts and lists.
 
@@ -367,7 +367,7 @@ class Module(dict):
         self,
         map_fn: Callable[[mx.array], mx.array],
         filter_fn: Optional[Callable[["mlx.nn.Module", str, Any], bool]] = None,
-    ) -> self:
+    ):
         """Map all the parameters using the provided ``map_fn`` and immediately
         update the module with the mapped parameters.
 
@@ -386,7 +386,7 @@ class Module(dict):
         self.update(self.filter_and_map(filter_fn, map_fn))
         return self
 
-    def update_modules(self, modules: dict) -> self:
+    def update_modules(self, modules: dict):
         """Replace the child modules of this :class:`Module` instance with the
         provided ones in the dict of dicts and lists.
 
@@ -427,7 +427,7 @@ class Module(dict):
         apply(self, modules)
         return self
 
-    def apply_to_modules(self, apply_fn: Callable[[str, "mlx.nn.Module"], Any]) -> self:
+    def apply_to_modules(self, apply_fn: Callable[[str, "mlx.nn.Module"], Any]):
         """Apply a function to all the modules in this instance (including this
         instance).
 
@@ -482,7 +482,7 @@ class Module(dict):
         recurse: bool = True,
         keys: Optional[Union[str, List[str]]] = None,
         strict: bool = False,
-    ) -> self:
+    ):
         """Freeze the Module's parameters or some of them. Freezing a parameter means not
         computing gradients for it.
 
@@ -537,7 +537,7 @@ class Module(dict):
         recurse: bool = True,
         keys: Optional[Union[str, List[str]]] = None,
         strict: bool = False,
-    ) -> self:
+    ):
         """Unfreeze the Module's parameters or some of them.
 
         This function is idempotent ie unfreezing a model that is not frozen is
@@ -581,7 +581,7 @@ class Module(dict):
             _unfreeze_impl("", self)
         return self
 
-    def train(self, mode: bool = True) -> self:
+    def train(self, mode: bool = True):
         """Set the model in or out of training mode.
 
         Training mode only applies to certain layers. For example
@@ -601,7 +601,7 @@ class Module(dict):
         self.apply_to_modules(_set_train)
         return self
 
-    def eval(self) -> self:
+    def eval(self):
         """Set the model to evaluation mode.
 
         See :func:`train`.

--- a/python/mlx/nn/layers/base.py
+++ b/python/mlx/nn/layers/base.py
@@ -146,7 +146,7 @@ class Module(dict):
         self,
         file_or_weights: Union[str, List[Tuple[str, mx.array]]],
         strict: bool = True,
-    ):
+    ) -> "Module":
         """
         Update the model's weights from a ``.npz``, a ``.safetensors`` file, or a list.
 
@@ -318,7 +318,7 @@ class Module(dict):
 
         return self.filter_and_map(self.valid_child_filter, is_leaf_fn=_is_leaf_module)
 
-    def update(self, parameters: dict):
+    def update(self, parameters: dict) -> "Module":
         """Replace the parameters of this Module with the provided ones in the
         dict of dicts and lists.
 
@@ -367,7 +367,7 @@ class Module(dict):
         self,
         map_fn: Callable[[mx.array], mx.array],
         filter_fn: Optional[Callable[["mlx.nn.Module", str, Any], bool]] = None,
-    ):
+    ) -> "Module":
         """Map all the parameters using the provided ``map_fn`` and immediately
         update the module with the mapped parameters.
 
@@ -386,7 +386,7 @@ class Module(dict):
         self.update(self.filter_and_map(filter_fn, map_fn))
         return self
 
-    def update_modules(self, modules: dict):
+    def update_modules(self, modules: dict) -> "Module":
         """Replace the child modules of this :class:`Module` instance with the
         provided ones in the dict of dicts and lists.
 
@@ -427,7 +427,9 @@ class Module(dict):
         apply(self, modules)
         return self
 
-    def apply_to_modules(self, apply_fn: Callable[[str, "mlx.nn.Module"], Any]):
+    def apply_to_modules(
+        self, apply_fn: Callable[[str, "mlx.nn.Module"], Any]
+    ) -> "Module":
         """Apply a function to all the modules in this instance (including this
         instance).
 
@@ -482,7 +484,7 @@ class Module(dict):
         recurse: bool = True,
         keys: Optional[Union[str, List[str]]] = None,
         strict: bool = False,
-    ):
+    ) -> "Module":
         """Freeze the Module's parameters or some of them. Freezing a parameter means not
         computing gradients for it.
 
@@ -537,7 +539,7 @@ class Module(dict):
         recurse: bool = True,
         keys: Optional[Union[str, List[str]]] = None,
         strict: bool = False,
-    ):
+    ) -> "Module":
         """Unfreeze the Module's parameters or some of them.
 
         This function is idempotent ie unfreezing a model that is not frozen is
@@ -581,7 +583,7 @@ class Module(dict):
             _unfreeze_impl("", self)
         return self
 
-    def train(self, mode: bool = True):
+    def train(self, mode: bool = True) -> "Module":
         """Set the model in or out of training mode.
 
         Training mode only applies to certain layers. For example
@@ -601,7 +603,7 @@ class Module(dict):
         self.apply_to_modules(_set_train)
         return self
 
-    def eval(self):
+    def eval(self) -> "Module":
         """Set the model to evaluation mode.
 
         See :func:`train`.

--- a/python/mlx/nn/layers/base.py
+++ b/python/mlx/nn/layers/base.py
@@ -160,7 +160,7 @@ class Module(dict):
               shapes are not checked. Default: ``True``.
 
         Returns:
-            The model with the updated weights.
+            The module instance after updating the weights.
 
         Example:
 
@@ -334,7 +334,7 @@ class Module(dict):
             parameters (dict): A complete or partial dictionary of the modules
                                parameters.
         Returns:
-            The model with the updated parameters.
+            The module instance after updating the parameters.
         """
 
         def apply(dst, parameters):
@@ -380,7 +380,7 @@ class Module(dict):
                 map (default: :meth:`Module.valid_parameter_filter`).
 
         Returns:
-            The model with the updated parameters.
+            The module instance after updating the parameters.
         """
         filter_fn = filter_fn or Module.valid_parameter_filter
         self.update(self.filter_and_map(filter_fn, map_fn))

--- a/python/mlx/nn/layers/base.py
+++ b/python/mlx/nn/layers/base.py
@@ -402,7 +402,7 @@ class Module(dict):
             modules (dict): A complete or partial dictionary of the modules
                 submodules.
         Returns:
-            The module instance with the updated submodules.
+            The module instance after updating the submodules.
         """
 
         def apply(dst, modules):
@@ -437,7 +437,7 @@ class Module(dict):
             apply_fn (Callable): The function to apply to the modules.
 
         Returns:
-            The module instance with the updated submodules.
+            The module instance after updating submodules.
         """
         module_stack = [("", self)]
         while module_stack:
@@ -510,7 +510,7 @@ class Module(dict):
                 Default: ``False``.
 
         Returns:
-            The module instance with frozen parameters.
+            The module instance after freezing the parameters.
         """
 
         def _freeze_impl(_, m):
@@ -566,7 +566,7 @@ class Module(dict):
                 Default: ``False``.
 
         Returns:
-            The module instance with unfrozen parameters.
+            The module instance after unfreezing the parameters.
         """
 
         def _unfreeze_impl(_, m):
@@ -594,7 +594,7 @@ class Module(dict):
             mode (bool): Indicate if the model should be in training or
                 evaluation mode. Default: ``True``.
         Returns:
-            The module instance with the updated training mode.
+            The module instance after updating the training mode.
         """
 
         def _set_train(_, m):

--- a/python/mlx/nn/layers/base.py
+++ b/python/mlx/nn/layers/base.py
@@ -146,7 +146,7 @@ class Module(dict):
         self,
         file_or_weights: Union[str, List[Tuple[str, mx.array]]],
         strict: bool = True,
-    ):
+    ) -> Module:
         """
         Update the model's weights from a ``.npz``, a ``.safetensors`` file, or a list.
 
@@ -158,6 +158,9 @@ class Module(dict):
               weights exactly match the parameters of the model. Otherwise,
               only the weights actually contained in the model are loaded and
               shapes are not checked. Default: ``True``.
+
+        Returns:
+            The model with the updated weights.
 
         Example:
 
@@ -218,6 +221,7 @@ class Module(dict):
                     )
 
         self.update(tree_unflatten(weights))
+        return self
 
     def save_weights(self, file: str):
         """
@@ -314,7 +318,7 @@ class Module(dict):
 
         return self.filter_and_map(self.valid_child_filter, is_leaf_fn=_is_leaf_module)
 
-    def update(self, parameters: dict):
+    def update(self, parameters: dict) -> Module:
         """Replace the parameters of this Module with the provided ones in the
         dict of dicts and lists.
 
@@ -329,6 +333,8 @@ class Module(dict):
         Args:
             parameters (dict): A complete or partial dictionary of the modules
                                parameters.
+        Returns:
+            The model with the updated parameters.
         """
 
         def apply(dst, parameters):
@@ -355,12 +361,13 @@ class Module(dict):
                         apply(current_value, new_value)
 
         apply(self, parameters)
+        return self
 
     def apply(
         self,
         map_fn: Callable[[mx.array], mx.array],
         filter_fn: Optional[Callable[["mlx.nn.Module", str, Any], bool]] = None,
-    ):
+    ) -> Module:
         """Map all the parameters using the provided ``map_fn`` and immediately
         update the module with the mapped parameters.
 
@@ -371,11 +378,15 @@ class Module(dict):
             map_fn (Callable): Maps an array to another array
             filter_fn (Callable, optional): Filter to select which arrays to
                 map (default: :meth:`Module.valid_parameter_filter`).
+
+        Returns:
+            The model with the updated parameters.
         """
         filter_fn = filter_fn or Module.valid_parameter_filter
         self.update(self.filter_and_map(filter_fn, map_fn))
+        return self
 
-    def update_modules(self, modules: dict):
+    def update_modules(self, modules: dict) -> Module:
         """Replace the child modules of this :class:`Module` instance with the
         provided ones in the dict of dicts and lists.
 
@@ -390,6 +401,8 @@ class Module(dict):
         Args:
             modules (dict): A complete or partial dictionary of the modules
                 submodules.
+        Returns:
+            The module instance with the updated submodules.
         """
 
         def apply(dst, modules):
@@ -412,13 +425,19 @@ class Module(dict):
                         apply(current_value, new_value)
 
         apply(self, modules)
+        return self
 
-    def apply_to_modules(self, apply_fn: Callable[[str, "mlx.nn.Module"], Any]):
+    def apply_to_modules(
+        self, apply_fn: Callable[[str, "mlx.nn.Module"], Any]
+    ) -> Module:
         """Apply a function to all the modules in this instance (including this
         instance).
 
         Args:
             apply_fn (Callable): The function to apply to the modules.
+
+        Returns:
+            The module instance with the updated submodules.
         """
         module_stack = [("", self)]
         while module_stack:
@@ -428,6 +447,7 @@ class Module(dict):
             module_stack.extend(
                 tree_flatten(mod.children(), prefix=prefix, is_leaf=self.is_module)
             )
+        return self
 
     def modules(self):
         """Return a list with all the modules in this instance.
@@ -464,7 +484,7 @@ class Module(dict):
         recurse: bool = True,
         keys: Optional[Union[str, List[str]]] = None,
         strict: bool = False,
-    ):
+    ) -> Module:
         """Freeze the Module's parameters or some of them. Freezing a parameter means not
         computing gradients for it.
 
@@ -488,6 +508,9 @@ class Module(dict):
                 ``module.freeze(keys="bias")``.
             strict (bool, optional): If set to ``True`` validate that the passed keys exist.
                 Default: ``False``.
+
+        Returns:
+            The module instance with freezed parameters.
         """
 
         def _freeze_impl(_, m):
@@ -508,6 +531,7 @@ class Module(dict):
             self.apply_to_modules(_freeze_impl)
         else:
             _freeze_impl("", self)
+        return self
 
     def unfreeze(
         self,
@@ -515,7 +539,7 @@ class Module(dict):
         recurse: bool = True,
         keys: Optional[Union[str, List[str]]] = None,
         strict: bool = False,
-    ):
+    ) -> Module:
         """Unfreeze the Module's parameters or some of them.
 
         This function is idempotent ie unfreezing a model that is not frozen is
@@ -540,6 +564,9 @@ class Module(dict):
                 ``module.unfreeze(keys="bias")``.
             strict (bool, optional): If set to ``True`` validate that the passed keys exist.
                 Default: ``False``.
+
+        Returns:
+            The module instance with unfreezed parameters.
         """
 
         def _unfreeze_impl(_, m):
@@ -554,8 +581,9 @@ class Module(dict):
             self.apply_to_modules(_unfreeze_impl)
         else:
             _unfreeze_impl("", self)
+        return self
 
-    def train(self, mode: bool = True):
+    def train(self, mode: bool = True) -> Module:
         """Set the model in or out of training mode.
 
         Training mode only applies to certain layers. For example
@@ -565,16 +593,19 @@ class Module(dict):
         Args:
             mode (bool): Indicate if the model should be in training or
                 evaluation mode. Default: ``True``.
+        Returns:
+            The module instance with the updated training mode.
         """
 
         def _set_train(_, m):
             m._training = mode
 
         self.apply_to_modules(_set_train)
+        return self
 
-    def eval(self):
+    def eval(self) -> Module:
         """Set the model to evaluation mode.
 
         See :func:`train`.
         """
-        self.train(False)
+        return self.train(False)

--- a/python/mlx/nn/layers/base.py
+++ b/python/mlx/nn/layers/base.py
@@ -146,7 +146,7 @@ class Module(dict):
         self,
         file_or_weights: Union[str, List[Tuple[str, mx.array]]],
         strict: bool = True,
-    ) -> Module:
+    ) -> self:
         """
         Update the model's weights from a ``.npz``, a ``.safetensors`` file, or a list.
 
@@ -318,7 +318,7 @@ class Module(dict):
 
         return self.filter_and_map(self.valid_child_filter, is_leaf_fn=_is_leaf_module)
 
-    def update(self, parameters: dict) -> Module:
+    def update(self, parameters: dict) -> self:
         """Replace the parameters of this Module with the provided ones in the
         dict of dicts and lists.
 
@@ -367,7 +367,7 @@ class Module(dict):
         self,
         map_fn: Callable[[mx.array], mx.array],
         filter_fn: Optional[Callable[["mlx.nn.Module", str, Any], bool]] = None,
-    ) -> Module:
+    ) -> self:
         """Map all the parameters using the provided ``map_fn`` and immediately
         update the module with the mapped parameters.
 
@@ -386,7 +386,7 @@ class Module(dict):
         self.update(self.filter_and_map(filter_fn, map_fn))
         return self
 
-    def update_modules(self, modules: dict) -> Module:
+    def update_modules(self, modules: dict) -> self:
         """Replace the child modules of this :class:`Module` instance with the
         provided ones in the dict of dicts and lists.
 
@@ -427,9 +427,7 @@ class Module(dict):
         apply(self, modules)
         return self
 
-    def apply_to_modules(
-        self, apply_fn: Callable[[str, "mlx.nn.Module"], Any]
-    ) -> Module:
+    def apply_to_modules(self, apply_fn: Callable[[str, "mlx.nn.Module"], Any]) -> self:
         """Apply a function to all the modules in this instance (including this
         instance).
 
@@ -484,7 +482,7 @@ class Module(dict):
         recurse: bool = True,
         keys: Optional[Union[str, List[str]]] = None,
         strict: bool = False,
-    ) -> Module:
+    ) -> self:
         """Freeze the Module's parameters or some of them. Freezing a parameter means not
         computing gradients for it.
 
@@ -539,7 +537,7 @@ class Module(dict):
         recurse: bool = True,
         keys: Optional[Union[str, List[str]]] = None,
         strict: bool = False,
-    ) -> Module:
+    ) -> self:
         """Unfreeze the Module's parameters or some of them.
 
         This function is idempotent ie unfreezing a model that is not frozen is
@@ -583,7 +581,7 @@ class Module(dict):
             _unfreeze_impl("", self)
         return self
 
-    def train(self, mode: bool = True) -> Module:
+    def train(self, mode: bool = True) -> self:
         """Set the model in or out of training mode.
 
         Training mode only applies to certain layers. For example
@@ -603,7 +601,7 @@ class Module(dict):
         self.apply_to_modules(_set_train)
         return self
 
-    def eval(self) -> Module:
+    def eval(self) -> self:
         """Set the model to evaluation mode.
 
         See :func:`train`.

--- a/python/mlx/nn/layers/base.py
+++ b/python/mlx/nn/layers/base.py
@@ -510,7 +510,7 @@ class Module(dict):
                 Default: ``False``.
 
         Returns:
-            The module instance with freezed parameters.
+            The module instance with frozen parameters.
         """
 
         def _freeze_impl(_, m):

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -152,11 +152,9 @@ class TestBase(mlx_tests.MLXTestCase):
         pre_freeze_num_params = len(m.parameters())
         m.freeze().unfreeze()
         self.assertEqual(len(m.parameters()), pre_freeze_num_params)
-        new_params_dict = m.parameters()
-        for key in new_params_dict:
-            new_params_dict[key] = new_params_dict[key] + 1
+        params_dict = m.parameters()
 
-        self.assertFalse(m.update(new_params_dict).eval()._training)
+        self.assertFalse(m.update(params_dict).eval()._training)
         self.assertTrue(m.train()._training)
 
 

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -147,6 +147,18 @@ class TestBase(mlx_tests.MLXTestCase):
         m.state["hello"] = "world"
         self.assertEqual(m.state["hello"], "world")
 
+    def test_chaining(self):
+        m = nn.Sequential(nn.Linear(2, 2), nn.ReLU(), nn.Linear(2, 1))
+        pre_freeze_num_params = len(m.parameters())
+        m.freeze().unfreeze()
+        self.assertEqual(len(m.parameters()), pre_freeze_num_params)
+        new_params_dict = m.parameters()
+        for key in new_params_dict:
+            new_params_dict[key] = new_params_dict[key] + 1
+
+        self.assertFalse(m.update(new_params_dict).eval()._training)
+        self.assertTrue(m.train()._training)
+
 
 class TestLayers(mlx_tests.MLXTestCase):
     def test_identity(self):


### PR DESCRIPTION
## Proposed changes

Closes issue #885 . This PR adds chaining support for some of functionalities in `nn.Module`. In this PR, functions like `.freeze()`, `.update()`, `train()`, etc. return the instance of that Module, instead of returning None. So, operations like these are possible:
```
import mlx.core as mx
import mlx.nn as nn

m = nn.Sequential(nn.Linear(2, 2), nn.ReLU(), nn.Linear(2, 1))
m.freeze().unfreeze().train()
```

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
