### PR TITLE
Fix nan and improve speed for qvm

### DIFF
--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -137,7 +137,7 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
       auto kernel = d.get_kernel(kname.str());
       compute_encoder->setComputePipelineState(kernel);
 
-      int bo = std::min(32, O);
+      int bo = 8;
       int bd = 32;
       MTL::Size group_dims = MTL::Size(bd, bo, 1);
       MTL::Size grid_dims = MTL::Size(1, (O + bo - 1) / bo, B);


### PR DESCRIPTION
This fixes #896 and while I was at it I simplified the `qvm` kernel quite a bit as a first optimization pass. Currently some cases are quite a bit faster while others are a bit slower than before. I think this can be merged and I will do some more optimization to make it purely faster than before.

The bug, btw, had to do with accumulating in `float16`. Just changing that to `float` would fix the bug.

#### Before
```
python benchmarks/python/comparative/bench_mlx.py quant_matmul_64_4 --size 1x1024 --size 1024x128 --size 1024x16 --size 1024x16 --dtype float16 --dtype uint32 --dtype float16 --dtype float16
0.08292818069458008
python benchmarks/python/comparative/bench_mlx.py quant_matmul_64_4 --size 1x4096 --size 4096x512 --size 1024x64 --size 1024x64 --dtype float16 --dtype uint32 --dtype float16 --dtype float16
0.24095416069030762
```

#### After
```
python benchmarks/python/comparative/bench_mlx.py quant_matmul_64_4 --size 1x1024 --size 1024x128 --size 1024x16 --size 1024x16 --dtype float16 --dtype uint32 --dtype float16 --dtype float16
0.04205632209777832
python benchmarks/python/comparative/bench_mlx.py quant_matmul_64_4 --size 1x4096 --size 4096x512 --size 1024x64 --size 1024x64 --dtype float16 --dtype uint32 --dtype float16 --dtype float16
0.09795498847961426
```