### PR TITLE
Fixing random.normal for half-precision dtype #642

### DIFF
--- a/python/tests/test_random.py
+++ b/python/tests/test_random.py
@@ -96,6 +96,11 @@ class TestRandom(mlx_tests.MLXTestCase):
 
         self.assertEqual(mx.random.normal().dtype, mx.random.normal(dtype=None).dtype)
 
+        # Test not getting -inf or inf with half precison
+        for hp in [mx.float16, mx.bfloat16]:
+            a = abs(mx.random.normal(shape=(10000,), loc=0, scale=1, dtype=hp))
+            self.assertTrue(mx.all(a < mx.inf).item())
+
     def test_randint(self):
         a = mx.random.randint(0, 1, [])
         self.assertEqual(a.shape, ())

--- a/python/tests/test_random.py
+++ b/python/tests/test_random.py
@@ -99,7 +99,7 @@ class TestRandom(mlx_tests.MLXTestCase):
         # Test not getting -inf or inf with half precison
         for hp in [mx.float16, mx.bfloat16]:
             a = abs(mx.random.normal(shape=(10000,), loc=0, scale=1, dtype=hp))
-            self.assertTrue(mx.all(a < mx.inf).item())
+            self.assertTrue(mx.all(a < mx.inf))
 
     def test_randint(self):
         a = mx.random.randint(0, 1, [])


### PR DESCRIPTION
## Proposed changes

Fixing issue #642. The problem was this line:
```c++
auto low = array(std::nextafter(-1.0f, 0.0f), dtype);
```
```nextafter``` works on float, but when creating the array with half-precision the value is casted to `low=-1`, that ultimately leads to `-inf` when applying `erfinv`.

Note that this updates is probably breaking the seed reproducibility for `random.normal`, because now the uniform interval is shorter, so the generated values are slightly different. Here is the output of the code in issue #642 after the change:
```
array([[-0.96582, -0.723145, 0.655273],
       [1.31934, 1.0498, -0.640625],
       [-0.122742, 0.152954, 0.525391],
       [-3.48633, 0.279541, -1.46973]], dtype=float16)
``` 
while before it was
```
array([[-0.967285, -0.724121, 0.654785],
       [1.31836, 1.0498, -0.641113],
       [-0.123352, 0.152344, 0.524902],
       [-inf, 0.279053, -1.46973]], dtype=float16)
```
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
