### PR TITLE
Implement negative padding in conv with slicing

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -2997,7 +2997,7 @@ array conv_general(
       }
     }
 
-    in = slice(in, starts, stops, s);
+    in = slice(in, std::move(starts), std::move(stops), s);
   }
 
   // Get output shapes


### PR DESCRIPTION
## Proposed changes

Fixes issue in #833
I think we can do the negative strides in the kernels, but for now I'm being careful and handling it through a slice

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
