### PR TITLE
Fix race in multi-stream eval

### DIFF
--- a/mlx/array.h
+++ b/mlx/array.h
@@ -256,8 +256,7 @@ class array {
     array_desc_->position = position;
   }
 
-  /** The i-th output of the array's primitive (i.e. this array and
-   * its siblings). */
+  /** The i-th output of the array's primitive. */
   const array& output(int i) const {
     if (i == array_desc_->position) {
       return *this;

--- a/mlx/array.h
+++ b/mlx/array.h
@@ -256,6 +256,18 @@ class array {
     array_desc_->position = position;
   }
 
+  /** The i-th output of the array's primitive (i.e. this array and
+   * its siblings). */
+  const array& output(int i) const {
+    if (i == array_desc_->position) {
+      return *this;
+    } else if (i < array_desc_->position) {
+      return siblings()[i];
+    } else {
+      return siblings()[i + 1];
+    }
+  };
+
   /** The outputs of the array's primitive (i.e. this array and
    * its siblings) in the order the primitive expects. */
   std::vector<array> outputs() const {


### PR DESCRIPTION
Use the 0th output to get the id for dependencies rather than the primitive's id. The input's primitive may be deleted before the output array is scheduled