### PR TITLE
Use uintptr_t instead of size_t to store funtion id

### DIFF
--- a/mlx/transforms_impl.h
+++ b/mlx/transforms_impl.h
@@ -20,12 +20,12 @@ std::vector<array> vmap_replace(
 // idea.
 std::function<std::vector<array>(const std::vector<array>&)> compile(
     const std::function<std::vector<array>(const std::vector<array>&)>& fun,
-    size_t fun_id,
+    std::uintptr_t fun_id,
     bool shapeless = false,
     std::vector<uint64_t> constants = {});
 
 // Erase cached compile functions
-void compile_erase(size_t fun_id);
+void compile_erase(std::uintptr_t fun_id);
 
 // Create an InTracing object during tracing operations to signify to the rest
 // of the codebase that we are during tracing so evals should not throw away

--- a/python/src/transforms.cpp
+++ b/python/src/transforms.cpp
@@ -313,15 +313,15 @@ auto py_vmap(
   };
 }
 
-std::unordered_map<size_t, nb::object>& tree_cache() {
+std::unordered_map<std::uintptr_t, nb::object>& tree_cache() {
   // This map is used to Cache the tree structure of the outputs
-  static std::unordered_map<size_t, nb::object> tree_cache_;
+  static std::unordered_map<std::uintptr_t, nb::object> tree_cache_;
   return tree_cache_;
 }
 
 struct PyCompiledFun {
   nb::callable fun;
-  size_t fun_id;
+  std::uintptr_t fun_id;
   nb::object captured_inputs;
   nb::object captured_outputs;
   bool shapeless;
@@ -333,7 +333,7 @@ struct PyCompiledFun {
       nb::object outputs,
       bool shapeless)
       : fun(fun),
-        fun_id(reinterpret_cast<size_t>(fun.ptr())),
+        fun_id(reinterpret_cast<std::uintptr_t>(fun.ptr())),
         captured_inputs(inputs),
         captured_outputs(outputs),
         shapeless(shapeless) {}
@@ -342,7 +342,8 @@ struct PyCompiledFun {
   PyCompiledFun& operator=(const PyCompiledFun&) = delete;
   PyCompiledFun& operator=(PyCompiledFun&& other) = delete;
   PyCompiledFun(PyCompiledFun&& other)
-      : fun(std::move(other.fun)), fun_id(reinterpret_cast<size_t>(fun.ptr())) {
+      : fun(std::move(other.fun)),
+        fun_id(reinterpret_cast<std::uintptr_t>(fun.ptr())) {
     other.fun_id = 0;
     captured_inputs = std::move(other.captured_inputs);
     captured_outputs = std::move(other.captured_outputs);


### PR DESCRIPTION
## Proposed changes

The `uintptr_t` is guaranteed to be able to hold a pointer but `size_t` is not. Also when I see a variable with `uintptr_t` type I know it means to be an ID, so code becomes easier to read.

Also does some small cleanup of the compile cache code.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
