### PR TITLE
Comparing python objects (such as list/tuple) with `mlx.core.array`

### DIFF
--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -15,7 +15,7 @@ MLX was developed with contributions from the following individuals:
 - Hinrik Snær Guðmundsson: Added `atleast_1d`, `atleast_2d`, `atleast_3d` ops.
 - Luca Arnaboldi: Added `Ceil` and `Floor` ops; implemented pickling, copy and deepcopy for mlx arrays.
 - Brian Keene & Atila Orhon, with Argmax Inc.: Added `fast.scaled_dot_product_attention`
-- AmirHossein Razlighi: Added chaining support for some of the ops in `nn.Module`, Some Debug and Enhancements in `mlx.core.array`
+- AmirHossein Razlighi: Added chaining support for some of the ops in `nn.Module`. Comparison works for non array objects in `mlx.core.array`.
 <a href="https://github.com/ml-explore/mlx/graphs/contributors">
   <img class="dark-light" src="https://contrib.rocks/image?repo=ml-explore/mlx&anon=0&columns=20&max=100&r=true" />
 </a>

--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -15,6 +15,7 @@ MLX was developed with contributions from the following individuals:
 - Hinrik Snær Guðmundsson: Added `atleast_1d`, `atleast_2d`, `atleast_3d` ops.
 - Luca Arnaboldi: Added `Ceil` and `Floor` ops; implemented pickling, copy and deepcopy for mlx arrays.
 - Brian Keene & Atila Orhon, with Argmax Inc.: Added `fast.scaled_dot_product_attention`
+- AmirHossein Razlighi: Some Debug and Enhancements in `mlx.core.array`
 <a href="https://github.com/ml-explore/mlx/graphs/contributors">
   <img class="dark-light" src="https://contrib.rocks/image?repo=ml-explore/mlx&anon=0&columns=20&max=100&r=true" />
 </a>

--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -821,7 +821,7 @@ void init_array(nb::module_& m) {
           "__ne__",
           [](const array& a, const ScalarOrArray v) -> std::variant<array, bool> {
             if(!isMlxArray(v)) {
-              return false; // return false in case of object comparison which is not mlx array
+              return true; // return true in case of object comparison which is not mlx array
             }
             return not_equal(a, to_array(v, a.dtype()));
           },

--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -760,11 +760,13 @@ void init_array(nb::module_& m) {
           "other"_a)
       .def(
           "__eq__",
-          [](const array& a, const ScalarOrArray& v) -> std::variant<array, bool> {
+          [](const array& a,
+             const ScalarOrArray& v) -> std::variant<array, bool> {
             auto check_for_obj = std::get_if<nb::object>(&v);
             if (check_for_obj) {
-              // return false in case of object comparison which is not mlx array
-              if(!isMlxCoreArray(*check_for_obj)) {
+              // return false in case of object comparison which is not mlx
+              // array
+              if (!isMlxCoreArray(*check_for_obj)) {
                 return false;
               }
             }
@@ -773,11 +775,13 @@ void init_array(nb::module_& m) {
           "other"_a)
       .def(
           "__lt__",
-          [](const array& a, const ScalarOrArray v) -> std::variant<array, bool> {
+          [](const array& a,
+             const ScalarOrArray v) -> std::variant<array, bool> {
             auto check_for_obj = std::get_if<nb::object>(&v);
             if (check_for_obj) {
-              // return false in case of object comparison which is not mlx array
-              if(!isMlxCoreArray(*check_for_obj)) {
+              // return false in case of object comparison which is not mlx
+              // array
+              if (!isMlxCoreArray(*check_for_obj)) {
                 return false;
               }
             }
@@ -786,11 +790,13 @@ void init_array(nb::module_& m) {
           "other"_a)
       .def(
           "__le__",
-          [](const array& a, const ScalarOrArray v) -> std::variant<array, bool> {
+          [](const array& a,
+             const ScalarOrArray v) -> std::variant<array, bool> {
             auto check_for_obj = std::get_if<nb::object>(&v);
             if (check_for_obj) {
-              // return false in case of object comparison which is not mlx array
-              if(!isMlxCoreArray(*check_for_obj)) {
+              // return false in case of object comparison which is not mlx
+              // array
+              if (!isMlxCoreArray(*check_for_obj)) {
                 return false;
               }
             }
@@ -799,11 +805,13 @@ void init_array(nb::module_& m) {
           "other"_a)
       .def(
           "__gt__",
-          [](const array& a, const ScalarOrArray v) -> std::variant<array, bool> {
+          [](const array& a,
+             const ScalarOrArray v) -> std::variant<array, bool> {
             auto check_for_obj = std::get_if<nb::object>(&v);
             if (check_for_obj) {
-              // return false in case of object comparison which is not mlx array
-              if(!isMlxCoreArray(*check_for_obj)) {
+              // return false in case of object comparison which is not mlx
+              // array
+              if (!isMlxCoreArray(*check_for_obj)) {
                 return false;
               }
             }
@@ -812,11 +820,13 @@ void init_array(nb::module_& m) {
           "other"_a)
       .def(
           "__ge__",
-          [](const array& a, const ScalarOrArray v) -> std::variant<array, bool> {
+          [](const array& a,
+             const ScalarOrArray v) -> std::variant<array, bool> {
             auto check_for_obj = std::get_if<nb::object>(&v);
             if (check_for_obj) {
-              // return false in case of object comparison which is not mlx array
-              if(!isMlxCoreArray(*check_for_obj)) {
+              // return false in case of object comparison which is not mlx
+              // array
+              if (!isMlxCoreArray(*check_for_obj)) {
                 return false;
               }
             }
@@ -825,11 +835,12 @@ void init_array(nb::module_& m) {
           "other"_a)
       .def(
           "__ne__",
-          [](const array& a, const ScalarOrArray v) -> std::variant<array, bool> {
+          [](const array& a,
+             const ScalarOrArray v) -> std::variant<array, bool> {
             auto check_for_obj = std::get_if<nb::object>(&v);
             if (check_for_obj) {
               // return true in case of object inequlity which is not mlx array
-              if(!isMlxCoreArray(*check_for_obj)) {
+              if (!isMlxCoreArray(*check_for_obj)) {
                 return true;
               }
             }

--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -80,16 +80,6 @@ auto to_scalar(array& a) {
   }
 }
 
-bool isMlxArray(const ScalarOrArray& v) {
-    auto check_for_obj = std::get_if<nb::object>(&v);
-    if (check_for_obj) {
-        if(isMlxCoreArray(*check_for_obj)) {
-            return true;
-        }
-    }
-    return false;
-}
-
 nb::object tolist(array& a) {
   if (a.ndim() == 0) {
     return to_scalar(a);
@@ -784,8 +774,12 @@ void init_array(nb::module_& m) {
       .def(
           "__lt__",
           [](const array& a, const ScalarOrArray v) -> std::variant<array, bool> {
-            if(!isMlxArray(v)) {
-              return false; // return false in case of object comparison which is not mlx array
+            auto check_for_obj = std::get_if<nb::object>(&v);
+            if (check_for_obj) {
+              // return false in case of object comparison which is not mlx array
+              if(!isMlxCoreArray(*check_for_obj)) {
+                return false;
+              }
             }
             return less(a, to_array(v, a.dtype()));
           },
@@ -793,8 +787,12 @@ void init_array(nb::module_& m) {
       .def(
           "__le__",
           [](const array& a, const ScalarOrArray v) -> std::variant<array, bool> {
-            if(!isMlxArray(v)) {
-              return false; // return false in case of object comparison which is not mlx array
+            auto check_for_obj = std::get_if<nb::object>(&v);
+            if (check_for_obj) {
+              // return false in case of object comparison which is not mlx array
+              if(!isMlxCoreArray(*check_for_obj)) {
+                return false;
+              }
             }
             return less_equal(a, to_array(v, a.dtype()));
           },
@@ -802,8 +800,12 @@ void init_array(nb::module_& m) {
       .def(
           "__gt__",
           [](const array& a, const ScalarOrArray v) -> std::variant<array, bool> {
-            if(!isMlxArray(v)) {
-              return false; // return false in case of object comparison which is not mlx array
+            auto check_for_obj = std::get_if<nb::object>(&v);
+            if (check_for_obj) {
+              // return false in case of object comparison which is not mlx array
+              if(!isMlxCoreArray(*check_for_obj)) {
+                return false;
+              }
             }
             return greater(a, to_array(v, a.dtype()));
           },
@@ -811,8 +813,12 @@ void init_array(nb::module_& m) {
       .def(
           "__ge__",
           [](const array& a, const ScalarOrArray v) -> std::variant<array, bool> {
-            if(!isMlxArray(v)) {
-              return false; // return false in case of object comparison which is not mlx array
+            auto check_for_obj = std::get_if<nb::object>(&v);
+            if (check_for_obj) {
+              // return false in case of object comparison which is not mlx array
+              if(!isMlxCoreArray(*check_for_obj)) {
+                return false;
+              }
             }
             return greater_equal(a, to_array(v, a.dtype()));
           },
@@ -820,8 +826,12 @@ void init_array(nb::module_& m) {
       .def(
           "__ne__",
           [](const array& a, const ScalarOrArray v) -> std::variant<array, bool> {
-            if(!isMlxArray(v)) {
-              return true; // return true in case of object comparison which is not mlx array
+            auto check_for_obj = std::get_if<nb::object>(&v);
+            if (check_for_obj) {
+              // return true in case of object inequlity which is not mlx array
+              if(!isMlxCoreArray(*check_for_obj)) {
+                return true;
+              }
             }
             return not_equal(a, to_array(v, a.dtype()));
           },

--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -774,8 +774,8 @@ void init_array(nb::module_& m) {
              const ScalarOrArray& v) -> std::variant<array, bool> {
             auto check_for_obj = std::get_if<nb::object>(&v);
             if (check_for_obj) {
-              // return false in case of object comparison which is not mlx
-              // array
+              // return false in case of object comparison which is not
+              // mlx array
               if (!isMlxCoreArray(*check_for_obj)) {
                 return false;
               }
@@ -789,10 +789,11 @@ void init_array(nb::module_& m) {
              const ScalarOrArray v) -> std::variant<array, bool> {
             auto check_for_obj = std::get_if<nb::object>(&v);
             if (check_for_obj) {
-              // return false in case of object comparison which is not mlx
-              // array
+              // throw an exception in case of object comparison which is not
+              // mlx array
               if (!isMlxCoreArray(*check_for_obj)) {
-                return false;
+                throw std::invalid_argument(
+                    "Object comparison is not a valid operation on an mlx array.");
               }
             }
             return less(a, to_array(v, a.dtype()));
@@ -804,10 +805,11 @@ void init_array(nb::module_& m) {
              const ScalarOrArray v) -> std::variant<array, bool> {
             auto check_for_obj = std::get_if<nb::object>(&v);
             if (check_for_obj) {
-              // return false in case of object comparison which is not mlx
-              // array
+              // throw an exception in case of object comparison which is not
+              // mlx array
               if (!isMlxCoreArray(*check_for_obj)) {
-                return false;
+                throw std::invalid_argument(
+                    "Object comparison is not a valid operation on an mlx array.");
               }
             }
             return less_equal(a, to_array(v, a.dtype()));
@@ -819,10 +821,11 @@ void init_array(nb::module_& m) {
              const ScalarOrArray v) -> std::variant<array, bool> {
             auto check_for_obj = std::get_if<nb::object>(&v);
             if (check_for_obj) {
-              // return false in case of object comparison which is not mlx
-              // array
+              // throw an exception in case of object comparison which is not
+              // mlx array
               if (!isMlxCoreArray(*check_for_obj)) {
-                return false;
+                throw std::invalid_argument(
+                    "Object comparison is not a valid operation on an mlx array.");
               }
             }
             return greater(a, to_array(v, a.dtype()));
@@ -834,10 +837,11 @@ void init_array(nb::module_& m) {
              const ScalarOrArray v) -> std::variant<array, bool> {
             auto check_for_obj = std::get_if<nb::object>(&v);
             if (check_for_obj) {
-              // return false in case of object comparison which is not mlx
-              // array
+              // throw an exception in case of object comparison which is not
+              // mlx array
               if (!isMlxCoreArray(*check_for_obj)) {
-                return false;
+                throw std::invalid_argument(
+                    "Object comparison is not a valid operation on an mlx array.");
               }
             }
             return greater_equal(a, to_array(v, a.dtype()));

--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -80,6 +80,16 @@ auto to_scalar(array& a) {
   }
 }
 
+bool isMlxArray(const ScalarOrArray& v) {
+    auto check_for_obj = std::get_if<nb::object>(&v);
+    if (check_for_obj) {
+        if(isMlxCoreArray(*check_for_obj)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 nb::object tolist(array& a) {
   if (a.ndim() == 0) {
     return to_scalar(a);
@@ -764,8 +774,7 @@ void init_array(nb::module_& m) {
             auto check_for_obj = std::get_if<nb::object>(&v);
             if (check_for_obj) {
               // return false in case of object comparison which is not mlx array
-              std::string type_name = nb::type_name(check_for_obj->type()).c_str();
-              if (type_name.find("mlx.core.array") == std::string::npos) {
+              if(!isMlxCoreArray(*check_for_obj)) {
                 return false;
               }
             }
@@ -774,31 +783,46 @@ void init_array(nb::module_& m) {
           "other"_a)
       .def(
           "__lt__",
-          [](const array& a, const ScalarOrArray v) {
+          [](const array& a, const ScalarOrArray v) -> std::variant<array, bool> {
+            if(!isMlxArray(v)) {
+              return false; // return false in case of object comparison which is not mlx array
+            }
             return less(a, to_array(v, a.dtype()));
           },
           "other"_a)
       .def(
           "__le__",
-          [](const array& a, const ScalarOrArray v) {
+          [](const array& a, const ScalarOrArray v) -> std::variant<array, bool> {
+            if(!isMlxArray(v)) {
+              return false; // return false in case of object comparison which is not mlx array
+            }
             return less_equal(a, to_array(v, a.dtype()));
           },
           "other"_a)
       .def(
           "__gt__",
-          [](const array& a, const ScalarOrArray v) {
+          [](const array& a, const ScalarOrArray v) -> std::variant<array, bool> {
+            if(!isMlxArray(v)) {
+              return false; // return false in case of object comparison which is not mlx array
+            }
             return greater(a, to_array(v, a.dtype()));
           },
           "other"_a)
       .def(
           "__ge__",
-          [](const array& a, const ScalarOrArray v) {
+          [](const array& a, const ScalarOrArray v) -> std::variant<array, bool> {
+            if(!isMlxArray(v)) {
+              return false; // return false in case of object comparison which is not mlx array
+            }
             return greater_equal(a, to_array(v, a.dtype()));
           },
           "other"_a)
       .def(
           "__ne__",
-          [](const array& a, const ScalarOrArray v) {
+          [](const array& a, const ScalarOrArray v) -> std::variant<array, bool> {
+            if(!isMlxArray(v)) {
+              return false; // return false in case of object comparison which is not mlx array
+            }
             return not_equal(a, to_array(v, a.dtype()));
           },
           "other"_a)

--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -822,7 +822,7 @@ void init_array(nb::module_& m) {
           "__eq__",
           [](const array& a,
              const ScalarOrArray& v) -> std::variant<array, bool> {
-            if (!is_convertable_to_array(v)) {
+            if (!is_comparable_with_array(v)) {
               return false;
             }
             return equal(a, to_array(v, a.dtype()));
@@ -856,7 +856,7 @@ void init_array(nb::module_& m) {
           "__ne__",
           [](const array& a,
              const ScalarOrArray v) -> std::variant<array, bool> {
-            if (!is_convertable_to_array(v)) {
+            if (!is_comparable_with_array(v)) {
               return true;
             }
             return not_equal(a, to_array(v, a.dtype()));

--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -822,10 +822,9 @@ void init_array(nb::module_& m) {
           "__eq__",
           [](const array& a,
              const ScalarOrArray& v) -> std::variant<array, bool> {
-            bool is_convertable = is_convertable_to_array(v);
-            if (!is_convertable) {
+            if (!is_convertable_to_array(v)) {
               return false;
-            } // Hi
+            }
             return equal(a, to_array(v, a.dtype()));
           },
           "other"_a)
@@ -857,8 +856,7 @@ void init_array(nb::module_& m) {
           "__ne__",
           [](const array& a,
              const ScalarOrArray v) -> std::variant<array, bool> {
-            bool is_convertable = is_convertable_to_array(v);
-            if (!is_convertable) {
+            if (!is_convertable_to_array(v)) {
               return true;
             }
             return not_equal(a, to_array(v, a.dtype()));

--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -775,7 +775,7 @@ void init_array(nb::module_& m) {
             bool is_convertable = is_convertable_to_array(v);
             if (!is_convertable) {
               return false;
-            }
+            } // Hi
             return equal(a, to_array(v, a.dtype()));
           },
           "other"_a)

--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -772,78 +772,34 @@ void init_array(nb::module_& m) {
           "__eq__",
           [](const array& a,
              const ScalarOrArray& v) -> std::variant<array, bool> {
-            auto check_for_obj = std::get_if<nb::object>(&v);
-            if (check_for_obj) {
-              // return false in case of object comparison which is not
-              // mlx array
-              if (!isMlxCoreArray(*check_for_obj)) {
-                return false;
-              }
+            bool is_convertable = is_convertable_to_array(v);
+            if (!is_convertable) {
+              return false;
             }
             return equal(a, to_array(v, a.dtype()));
           },
           "other"_a)
       .def(
           "__lt__",
-          [](const array& a,
-             const ScalarOrArray v) -> std::variant<array, bool> {
-            auto check_for_obj = std::get_if<nb::object>(&v);
-            if (check_for_obj) {
-              // throw an exception in case of object comparison which is not
-              // mlx array
-              if (!isMlxCoreArray(*check_for_obj)) {
-                throw std::invalid_argument(
-                    "Object comparison is not a valid operation on an mlx array.");
-              }
-            }
+          [](const array& a, const ScalarOrArray v) -> array {
             return less(a, to_array(v, a.dtype()));
           },
           "other"_a)
       .def(
           "__le__",
-          [](const array& a,
-             const ScalarOrArray v) -> std::variant<array, bool> {
-            auto check_for_obj = std::get_if<nb::object>(&v);
-            if (check_for_obj) {
-              // throw an exception in case of object comparison which is not
-              // mlx array
-              if (!isMlxCoreArray(*check_for_obj)) {
-                throw std::invalid_argument(
-                    "Object comparison is not a valid operation on an mlx array.");
-              }
-            }
+          [](const array& a, const ScalarOrArray v) -> array {
             return less_equal(a, to_array(v, a.dtype()));
           },
           "other"_a)
       .def(
           "__gt__",
-          [](const array& a,
-             const ScalarOrArray v) -> std::variant<array, bool> {
-            auto check_for_obj = std::get_if<nb::object>(&v);
-            if (check_for_obj) {
-              // throw an exception in case of object comparison which is not
-              // mlx array
-              if (!isMlxCoreArray(*check_for_obj)) {
-                throw std::invalid_argument(
-                    "Object comparison is not a valid operation on an mlx array.");
-              }
-            }
+          [](const array& a, const ScalarOrArray v) -> array {
             return greater(a, to_array(v, a.dtype()));
           },
           "other"_a)
       .def(
           "__ge__",
-          [](const array& a,
-             const ScalarOrArray v) -> std::variant<array, bool> {
-            auto check_for_obj = std::get_if<nb::object>(&v);
-            if (check_for_obj) {
-              // throw an exception in case of object comparison which is not
-              // mlx array
-              if (!isMlxCoreArray(*check_for_obj)) {
-                throw std::invalid_argument(
-                    "Object comparison is not a valid operation on an mlx array.");
-              }
-            }
+          [](const array& a, const ScalarOrArray v) -> array {
             return greater_equal(a, to_array(v, a.dtype()));
           },
           "other"_a)
@@ -851,12 +807,9 @@ void init_array(nb::module_& m) {
           "__ne__",
           [](const array& a,
              const ScalarOrArray v) -> std::variant<array, bool> {
-            auto check_for_obj = std::get_if<nb::object>(&v);
-            if (check_for_obj) {
-              // return true in case of object inequlity which is not mlx array
-              if (!isMlxCoreArray(*check_for_obj)) {
-                return true;
-              }
+            bool is_convertable = is_convertable_to_array(v);
+            if (!is_convertable) {
+              return true;
             }
             return not_equal(a, to_array(v, a.dtype()));
           },

--- a/python/src/utils.h
+++ b/python/src/utils.h
@@ -45,8 +45,8 @@ inline array to_array_with_accessor(nb::object obj) {
 }
 
 inline bool isMlxCoreArray(const nb::object& obj) {
-    std::string type_name = nb::type_name(obj.type()).c_str();
-    return type_name.find("mlx.core.array") != std::string::npos;
+  std::string type_name = nb::type_name(obj.type()).c_str();
+  return type_name.find("mlx.core.array") != std::string::npos;
 }
 
 inline array to_array(

--- a/python/src/utils.h
+++ b/python/src/utils.h
@@ -45,8 +45,7 @@ inline array to_array_with_accessor(nb::object obj) {
 }
 
 inline bool isMlxCoreArray(const nb::object& obj) {
-  std::string type_name = nb::type_name(obj.type()).c_str();
-  return type_name.find("mlx.core.array") != std::string::npos;
+  return nb::hasattr(obj, "__mlx_array__") || nb::isinstance<array>(obj);
 }
 
 inline array to_array(
@@ -66,6 +65,17 @@ inline array to_array(
     return array(static_cast<complex64_t>(*pv), complex64);
   } else {
     return to_array_with_accessor(std::get<nb::object>(v));
+  }
+}
+
+inline std::variant<array, bool> to_array_or_bool(
+    const ScalarOrArray& v,
+    std::optional<Dtype> dtype = std::nullopt) {
+  // try to convert to array, if it fails, return false
+  try {
+    return to_array(v, dtype);
+  } catch (const std::exception& e) {
+    return false;
   }
 }
 

--- a/python/src/utils.h
+++ b/python/src/utils.h
@@ -44,8 +44,21 @@ inline array to_array_with_accessor(nb::object obj) {
   }
 }
 
-inline bool isMlxCoreArray(const nb::object& obj) {
-  return nb::hasattr(obj, "__mlx_array__") || nb::isinstance<array>(obj);
+inline bool is_convertable_to_array(const ScalarOrArray& v) {
+  // Checks if the value can be converted to an array (or is already an
+  // mlx array)
+  if (auto pv = std::get_if<nb::bool_>(&v); pv) {
+    return true;
+  } else if (auto pv = std::get_if<nb::int_>(&v); pv) {
+    return true;
+  } else if (auto pv = std::get_if<nb::float_>(&v); pv) {
+    return true;
+  } else if (auto pv = std::get_if<std::complex<float>>(&v); pv) {
+    return true;
+  } else if (auto pv = std::get_if<nb::object>(&v); pv) {
+    return nb::hasattr(*pv, "__mlx_array__") || nb::isinstance<array>(*pv);
+  }
+  return false;
 }
 
 inline array to_array(
@@ -65,17 +78,6 @@ inline array to_array(
     return array(static_cast<complex64_t>(*pv), complex64);
   } else {
     return to_array_with_accessor(std::get<nb::object>(v));
-  }
-}
-
-inline std::variant<array, bool> to_array_or_bool(
-    const ScalarOrArray& v,
-    std::optional<Dtype> dtype = std::nullopt) {
-  // try to convert to array, if it fails, return false
-  try {
-    return to_array(v, dtype);
-  } catch (const std::exception& e) {
-    return false;
   }
 }
 

--- a/python/src/utils.h
+++ b/python/src/utils.h
@@ -44,21 +44,16 @@ inline array to_array_with_accessor(nb::object obj) {
   }
 }
 
-inline bool is_convertable_to_array(const ScalarOrArray& v) {
-  // Checks if the value can be converted to an array (or is already an
+inline bool is_comparable_with_array(const ScalarOrArray& v) {
+  // Checks if the value can be compared to an array (or is already an
   // mlx array)
-  if (auto pv = std::get_if<nb::bool_>(&v); pv) {
-    return true;
-  } else if (auto pv = std::get_if<nb::int_>(&v); pv) {
-    return true;
-  } else if (auto pv = std::get_if<nb::float_>(&v); pv) {
-    return true;
-  } else if (auto pv = std::get_if<std::complex<float>>(&v); pv) {
-    return true;
-  } else if (auto pv = std::get_if<nb::object>(&v); pv) {
+  if (auto pv = std::get_if<nb::object>(&v); pv) {
     return nb::isinstance<array>(*pv) || nb::hasattr(*pv, "__mlx_array__");
+  } else {
+    // If it's not an object, it's a scalar (nb::int_, nb::float_, etc.)
+    // and can be compared to an array
+    return true;
   }
-  return false;
 }
 
 inline array to_array(

--- a/python/src/utils.h
+++ b/python/src/utils.h
@@ -44,6 +44,11 @@ inline array to_array_with_accessor(nb::object obj) {
   }
 }
 
+inline bool isMlxCoreArray(const nb::object& obj) {
+    std::string type_name = nb::type_name(obj.type()).c_str();
+    return type_name.find("mlx.core.array") != std::string::npos;
+}
+
 inline array to_array(
     const ScalarOrArray& v,
     std::optional<Dtype> dtype = std::nullopt) {

--- a/python/src/utils.h
+++ b/python/src/utils.h
@@ -56,7 +56,7 @@ inline bool is_convertable_to_array(const ScalarOrArray& v) {
   } else if (auto pv = std::get_if<std::complex<float>>(&v); pv) {
     return true;
   } else if (auto pv = std::get_if<nb::object>(&v); pv) {
-    return nb::hasattr(*pv, "__mlx_array__") || nb::isinstance<array>(*pv);
+    return nb::isinstance<array>(*pv) || nb::hasattr(*pv, "__mlx_array__");
   }
   return false;
 }

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -109,17 +109,21 @@ class TestEquality(mlx_tests.MLXTestCase):
         a = mx.array([1, 2, 3])
         b = [1, 2, 3]
         c = [1, 2, 4]
-
-        self.assertTrue(mx.all(a == b))
-        # self.assertFalse(a == c)
+        
+        # mlx array equality returns false if is compared with any kind of 
+        # object which is not an mlx array
+        self.assertFalse(a == b)
+        self.assertFalse(a == c)
     
     def test_tuple_equals_array(self):
         a = mx.array([1, 2, 3])
         b = (1, 2, 3)
         c = (1, 2, 4)
 
-        self.assertTrue(mx.all(a == b))
-        # self.assertFalse(a == c)
+        # mlx array equality returns false if is compared with any kind of 
+        # object which is not an mlx array
+        self.assertFalse(a == b)
+        self.assertFalse(a == c)
 
 class TestArray(mlx_tests.MLXTestCase):
     def test_array_basics(self):

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -96,7 +96,7 @@ class TestEquality(mlx_tests.MLXTestCase):
         c = mx.array([1, 2, 4])
         self.assertTrue(mx.all(a == b))
         self.assertFalse(mx.all(a == c))
-    
+
     def test_array_eq_scalar(self):
         a = mx.array([1, 2, 3])
         b = 1
@@ -104,23 +104,23 @@ class TestEquality(mlx_tests.MLXTestCase):
 
         self.assertTrue(mx.any(a == b))
         self.assertFalse(mx.all(a == c))
-    
+
     def test_list_equals_array(self):
         a = mx.array([1, 2, 3])
         b = [1, 2, 3]
         c = [1, 2, 4]
-        
-        # mlx array equality returns false if is compared with any kind of 
+
+        # mlx array equality returns false if is compared with any kind of
         # object which is not an mlx array
         self.assertFalse(a == b)
         self.assertFalse(a == c)
-    
+
     def test_tuple_equals_array(self):
         a = mx.array([1, 2, 3])
         b = (1, 2, 3)
         c = (1, 2, 4)
 
-        # mlx array equality returns false if is compared with any kind of 
+        # mlx array equality returns false if is compared with any kind of
         # object which is not an mlx array
         self.assertFalse(a == b)
         self.assertFalse(a == c)
@@ -133,7 +133,7 @@ class TestInequality(mlx_tests.MLXTestCase):
         c = mx.array([1, 2, 4])
         self.assertFalse(mx.any(a != b))
         self.assertTrue(mx.any(a != c))
-    
+
     def test_array_ne_scalar(self):
         a = mx.array([1, 2, 3])
         b = 1
@@ -141,26 +141,27 @@ class TestInequality(mlx_tests.MLXTestCase):
 
         self.assertFalse(mx.all(a != b))
         self.assertTrue(mx.any(a != c))
-    
+
     def test_list_not_equals_array(self):
         a = mx.array([1, 2, 3])
         b = [1, 2, 3]
         c = [1, 2, 4]
-        
-        # mlx array inequality returns true if is compared with any kind of 
+
+        # mlx array inequality returns true if is compared with any kind of
         # object which is not an mlx array
         self.assertTrue(a != b)
         self.assertTrue(a != c)
-    
+
     def test_tuple_not_equals_array(self):
         a = mx.array([1, 2, 3])
         b = (1, 2, 3)
         c = (1, 2, 4)
 
-        # mlx array inequality returns true if is compared with any kind of 
+        # mlx array inequality returns true if is compared with any kind of
         # object which is not an mlx array
         self.assertTrue(a != b)
         self.assertTrue(a != c)
+
 
 class TestArray(mlx_tests.MLXTestCase):
     def test_array_basics(self):

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -112,6 +112,14 @@ class TestEquality(mlx_tests.MLXTestCase):
 
         self.assertTrue(mx.all(a == b))
         # self.assertFalse(a == c)
+    
+    def test_tuple_equals_array(self):
+        a = mx.array([1, 2, 3])
+        b = (1, 2, 3)
+        c = (1, 2, 4)
+
+        self.assertTrue(mx.all(a == b))
+        # self.assertFalse(a == c)
 
 class TestArray(mlx_tests.MLXTestCase):
     def test_array_basics(self):

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -89,6 +89,30 @@ class TestDtypes(mlx_tests.MLXTestCase):
                 self.assertListEqual(list(z.shape), list(y.shape))
 
 
+class TestEquality(mlx_tests.MLXTestCase):
+    def test_array_eq_array(self):
+        a = mx.array([1, 2, 3])
+        b = mx.array([1, 2, 3])
+        c = mx.array([1, 2, 4])
+        self.assertTrue(mx.all(a == b))
+        self.assertFalse(mx.all(a == c))
+    
+    def test_array_eq_scalar(self):
+        a = mx.array([1, 2, 3])
+        b = 1
+        c = 4
+
+        self.assertTrue(mx.any(a == b))
+        self.assertFalse(mx.all(a == c))
+    
+    def test_list_equals_array(self):
+        a = mx.array([1, 2, 3])
+        b = [1, 2, 3]
+        c = [1, 2, 4]
+
+        self.assertTrue(mx.all(a == b))
+        # self.assertFalse(a == c)
+
 class TestArray(mlx_tests.MLXTestCase):
     def test_array_basics(self):
         x = mx.array(1)

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -125,6 +125,43 @@ class TestEquality(mlx_tests.MLXTestCase):
         self.assertFalse(a == b)
         self.assertFalse(a == c)
 
+
+class TestInequality(mlx_tests.MLXTestCase):
+    def test_array_ne_array(self):
+        a = mx.array([1, 2, 3])
+        b = mx.array([1, 2, 3])
+        c = mx.array([1, 2, 4])
+        self.assertFalse(mx.any(a != b))
+        self.assertTrue(mx.any(a != c))
+    
+    def test_array_ne_scalar(self):
+        a = mx.array([1, 2, 3])
+        b = 1
+        c = 4
+
+        self.assertFalse(mx.all(a != b))
+        self.assertTrue(mx.any(a != c))
+    
+    def test_list_not_equals_array(self):
+        a = mx.array([1, 2, 3])
+        b = [1, 2, 3]
+        c = [1, 2, 4]
+        
+        # mlx array inequality returns true if is compared with any kind of 
+        # object which is not an mlx array
+        self.assertTrue(a != b)
+        self.assertTrue(a != c)
+    
+    def test_tuple_not_equals_array(self):
+        a = mx.array([1, 2, 3])
+        b = (1, 2, 3)
+        c = (1, 2, 4)
+
+        # mlx array inequality returns true if is compared with any kind of 
+        # object which is not an mlx array
+        self.assertTrue(a != b)
+        self.assertTrue(a != c)
+
 class TestArray(mlx_tests.MLXTestCase):
     def test_array_basics(self):
         x = mx.array(1)

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -141,9 +141,14 @@ class TestInequality(mlx_tests.MLXTestCase):
         a = mx.array([1, 2, 3])
         b = 1
         c = 4
-
+        d = 1.5
+        e = 2.5
+        f = mx.array([1, 2.5, 3.25])
         self.assertFalse(mx.all(a != b))
         self.assertTrue(mx.any(a != c))
+        self.assertTrue(mx.any(a != d))
+        self.assertTrue(mx.any(a != e))
+        self.assertFalse(mx.all(a != f))
 
     def test_list_not_equals_array(self):
         a = mx.array([1, 2, 3])
@@ -164,6 +169,39 @@ class TestInequality(mlx_tests.MLXTestCase):
         # object which is not an mlx array
         self.assertTrue(a != b)
         self.assertTrue(a != c)
+
+    def test_obj_inequality_array(self):
+        str_ = "hello"
+        a = mx.array([1, 2, 3])
+        lst_ = [1, 2, 3]
+        tpl_ = (1, 2, 3)
+
+        # check if object comparison(</>/<=/>=) with mlx array should throw an exception
+        # if not, the tests will fail
+        with self.assertRaises(ValueError):
+            a < str_
+        with self.assertRaises(ValueError):
+            a > str_
+        with self.assertRaises(ValueError):
+            a <= str_
+        with self.assertRaises(ValueError):
+            a >= str_
+        with self.assertRaises(ValueError):
+            a < lst_
+        with self.assertRaises(ValueError):
+            a > lst_
+        with self.assertRaises(ValueError):
+            a <= lst_
+        with self.assertRaises(ValueError):
+            a >= lst_
+        with self.assertRaises(ValueError):
+            a < tpl_
+        with self.assertRaises(ValueError):
+            a > tpl_
+        with self.assertRaises(ValueError):
+            a <= tpl_
+        with self.assertRaises(ValueError):
+            a >= tpl_
 
 
 class TestArray(mlx_tests.MLXTestCase):

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -101,9 +101,12 @@ class TestEquality(mlx_tests.MLXTestCase):
         a = mx.array([1, 2, 3])
         b = 1
         c = 4
-
+        d = 2.5
+        e = mx.array([1, 2.5, 3.25])
         self.assertTrue(mx.any(a == b))
         self.assertFalse(mx.all(a == c))
+        self.assertFalse(mx.all(a == d))
+        self.assertTrue(mx.any(a == e))
 
     def test_list_equals_array(self):
         a = mx.array([1, 2, 3])


### PR DESCRIPTION
## Proposed changes

This closes issue #866. When trying to compare python list or tuple with an mlx.core.array, mlx throws exception. Right now, regarding the comments in the related issue, mlx returns False (following the way it is done in PyTorch). An example is as follows:
```
import mlx.core as mx

a = mx.array([1, 2, 3])
a == [1, 2, 3] # False
a == mx.array([1,2,3]) # True
a != [1, 2, 3] # True
a == (1, 2) # False
```

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
