### PR TITLE
[Test] Small vector optimization for array inputs

### DIFF
--- a/mlx/array.cpp
+++ b/mlx/array.cpp
@@ -30,7 +30,7 @@ array::array(
     std::vector<int> shape,
     Dtype dtype,
     std::shared_ptr<Primitive> primitive,
-    std::vector<array> inputs)
+    small_vector<array> inputs)
     : array_desc_(std::make_shared<ArrayDesc>(
           std::move(shape),
           dtype,
@@ -161,7 +161,7 @@ void array::move_shared_buffer(array other) {
   move_shared_buffer(other, other.strides(), other.flags(), other.data_size());
 }
 
-void array::ArrayDesc::init() {
+void ArrayDesc::init() {
   strides.resize(shape.size());
   size = 1;
   for (int i = shape.size() - 1; i >= 0; --i) {
@@ -173,16 +173,16 @@ void array::ArrayDesc::init() {
   }
 }
 
-array::ArrayDesc::ArrayDesc(std::vector<int> shape, Dtype dtype)
+ArrayDesc::ArrayDesc(std::vector<int> shape, Dtype dtype)
     : shape(std::move(shape)), dtype(dtype) {
   init();
 }
 
-array::ArrayDesc::ArrayDesc(
+ArrayDesc::ArrayDesc(
     std::vector<int> shape,
     Dtype dtype,
     std::shared_ptr<Primitive> primitive,
-    std::vector<array> inputs)
+    small_vector<array> inputs)
     : shape(std::move(shape)),
       dtype(dtype),
       primitive(std::move(primitive)),

--- a/mlx/backend/metal/metal.cpp
+++ b/mlx/backend/metal/metal.cpp
@@ -77,11 +77,11 @@ std::function<void()> make_task(
       // to its inputs so they don't get donated
       std::vector<array> inputs;
       if (arr.is_tracer()) {
-        inputs = arr.inputs();
+        inputs = arr.inputs().as_vector();
       }
 
       debug_set_primitive_buffer_label(command_buffer, arr.primitive());
-      arr.primitive().eval_gpu(arr.inputs(), outputs);
+      arr.primitive().eval_gpu(arr.inputs().as_vector(), outputs);
     }
     std::vector<std::shared_ptr<array::Data>> buffers;
     for (auto& in : arr.inputs()) {

--- a/mlx/graph_utils.cpp
+++ b/mlx/graph_utils.cpp
@@ -70,7 +70,7 @@ void print_graph(std::ostream& os, const std::vector<array>& outputs) {
       outputs);
 
   NodeNamer namer;
-  auto print_arrs = [&namer, &os](std::vector<array> arrs) {
+  auto print_arrs = [&namer, &os](const auto& arrs) {
     for (auto& arr : arrs) {
       os << namer.get_name(arr);
       os << " [" << arr.shape() << ", " << arr.dtype() << "]";

--- a/mlx/small_vector.h
+++ b/mlx/small_vector.h
@@ -1,0 +1,137 @@
+// Copyright © 2024 Apple Inc.
+
+#pragma once
+
+#include <array>
+#include <sstream>
+#include <variant>
+#include <vector>
+
+namespace mlx::core {
+
+template <typename T, size_t stack_size = 8>
+class small_vector {
+ public:
+  using array_type = std::array<T, stack_size>;
+  using vector_type = std::vector<T>;
+
+  small_vector() : head_(nullptr), size_(0), storage_(nullptr) {}
+
+  small_vector(vector_type vec)
+      : head_(vec.empty() ? nullptr : &vec[0]),
+        size_(vec.size()),
+        storage_(std::move(vec)) {}
+
+  template <
+      typename... Ts,
+      typename = std::enable_if_t<(std::is_same_v<Ts, T> && ...)>>
+  small_vector(Ts... args)
+      : size_(sizeof...(args)), storage_(array_type{std::move(args)...}) {
+    static_assert(
+        sizeof...(args) > 0, "Empty args should go to default constructor.");
+    static_assert(
+        sizeof...(args) < stack_size,
+        "Lots of args not supported in aggregate constructor.");
+    head_ = &std::get<array_type>(storage_)[0];
+  }
+
+  small_vector(small_vector&& moved)
+      : head_(nullptr),
+        size_(moved.size_),
+        storage_(std::move(moved.storage_)) {
+    if (size_ > 0) {
+      if (std::holds_alternative<array_type>(storage_))
+        head_ = &std::get<array_type>(storage_)[0];
+      else if (std::holds_alternative<vector_type>(storage_))
+        head_ = &std::get<vector_type>(storage_)[0];
+    }
+    moved.head_ = nullptr;
+    moved.size_ = 0;
+  }
+
+  small_vector(const small_vector& copy) = delete;
+  small_vector& operator=(const small_vector& assign) = delete;
+
+  void clear() {
+    head_ = nullptr;
+    size_ = 0;
+    storage_ = nullptr;
+  }
+
+  bool empty() const {
+    return size_ == 0;
+  }
+
+  size_t size() const {
+    return size_;
+  }
+
+  T* begin() {
+    return head_;
+  }
+  const T* begin() const {
+    return head_;
+  }
+  T* end() {
+    return head_ + size_;
+  }
+  const T* end() const {
+    return head_ + size_;
+  }
+
+  T& back() {
+    return head_[size_ - 1];
+  }
+  const T& back() const {
+    return head_[size_ - 1];
+  }
+
+  T& operator[](size_t index) {
+    return head_[index];
+  }
+  const T& operator[](size_t index) const {
+    return head_[index];
+  }
+
+  T& at(size_t index) {
+    if (index >= size_) {
+      std::ostringstream msg;
+      msg << "index " << index << " is larger than vector size " << size_;
+      throw std::out_of_range(msg.str());
+    }
+    return head_[index];
+  }
+  const T& at(size_t index) const {
+    return const_cast<small_vector*>(this)->at(index);
+  }
+
+  vector_type& as_vector() {
+    convert_to_vector();
+    return std::get<vector_type>(storage_);
+  }
+
+ private:
+  friend class array;
+
+  void convert_to_vector() {
+    if (std::holds_alternative<vector_type>(storage_)) {
+      return;
+    }
+    if (std::holds_alternative<array_type>(storage_) && size_ > 0) {
+      // Copy the values to vector. While this looks expensive, it is actually
+      // the same cost when you initialize vector with initializer_list.
+      // We will be able to remove most of such calls after migrating all code
+      // to use small_vector.
+      storage_ = vector_type(begin(), end());
+      head_ = &std::get<vector_type>(storage_)[0];
+      return;
+    }
+    storage_ = vector_type();
+  }
+
+  T* head_;
+  size_t size_;
+  std::variant<nullptr_t, array_type, vector_type> storage_;
+};
+
+} // namespace mlx::core

--- a/mlx/transforms.cpp
+++ b/mlx/transforms.cpp
@@ -140,7 +140,7 @@ void eval(std::vector<array> outputs) {
         }
         scheduler::notify_new_task(stream);
         auto outputs = arr.outputs();
-        arr.primitive().eval_cpu(arr.inputs(), outputs);
+        arr.primitive().eval_cpu(arr.inputs().as_vector(), outputs);
         if (!arr.is_tracer()) {
           arr.detach();
         }
@@ -300,7 +300,8 @@ std::pair<std::vector<array>, std::vector<array>> vjp(
       }
     }
 
-    auto vjps = a.primitive().vjp(a.inputs(), cotangents, argnums, outputs);
+    auto vjps =
+        a.primitive().vjp(a.inputs().as_vector(), cotangents, argnums, outputs);
     // Accumulate the vector-jacobian products for each input
     for (int i = 0; i < argnums.size(); ++i) {
       auto in_id = a.inputs()[argnums[i]].id();
@@ -432,7 +433,7 @@ std::pair<std::vector<array>, std::vector<array>> jvp(
       }
     }
 
-    auto jvps = a.primitive().jvp(a.inputs(), tangents, argnums);
+    auto jvps = a.primitive().jvp(a.inputs().as_vector(), tangents, argnums);
     auto outputs = a.outputs();
     for (int i = 0; i < jvps.size(); ++i) {
       tan_map.insert({outputs[i].id(), jvps[i]});


### PR DESCRIPTION
This PR means to be used as an evaluation of the possible performance gain instead of something to be merged. Read this discussion to get the background: https://github.com/ml-explore/mlx/pull/895#issuecomment-2021606855.

In summary, using `std::vector` to store array has 2 problems:
1. `std::vector` does heap allocation for even 1 element.
2. aggregate constructor `std::vector{a1, a2, a3}` copies args.

I wrote a very trivial `small_vector` implementation, which stores elements on stack when aggregate constructor is used, and converts to `std::vector` when needed.

In this way, when using the aggregate constructor there is no heap allocation happened and the args are moved instead of copied.

There is no need to convert the whole codebase to use `small_vector` all at once, it is designed to work with existing code with minimal overhead, so we can replace the `std::vector<array>` with `small_vector<array>` piece by piece.

The overhead should be invisible: the `small_vector` is a thin wrapper of `std::variant<std::array, std::vector>`, and there is no penalty for accessing elements. When calling eval/vjp/jvp the `small_vector` is converted to `std::vector` by copying values from stack storage to `std::vector`, which is expensive but does not make things worse, because the copy would be done anyway when using the aggregate constructor of `std::vector`. And we should be able to remove most of the stack to vector copies eventually.

Currently `small_vector` is designed for computing graphs, but it should also be possible to be used for storing shapes.

There are some large changes in `array.h`, because to use `small_vector` the `ArrayDesc` must know the size of `array` so it can no longer be a sub-class in `array`, and since `ArrayDesc` becomes opaque to `array`, the `array`'s methods can no longer be defined inside the class definition and must be moved out.
