### PR TITLE
Support for list indexing (#908)

### DIFF
--- a/docs/src/usage/indexing.rst
+++ b/docs/src/usage/indexing.rst
@@ -46,7 +46,8 @@ You can index with ``None`` to create a new axis:
   [1, 8]
 
 
-You can also use an :obj:`array` to index another :obj:`array`:
+You can also use an :obj:`array` to index another :obj:`array`. Alongside, you can use :obj:`list` to index an array.
+This works exactly as it does in numpy. (Note that the list, implicitly gets converted to :obj:`array` before indexing.)
 
 .. code-block:: shell
 
@@ -54,14 +55,9 @@ You can also use an :obj:`array` to index another :obj:`array`:
   >>> idx = mx.array([5, 7]) 
   >>> arr[idx]
   array([5, 7], dtype=int32)
-
-Also, you can use :obj:`list` or :obj:`tuple` to index an array. It works exactly as it does in numpy. About usage of :obj:`list`, it
-is worth mentioning that the list, implicitly gets converted to :obj:`array` before indexing. So, it follows the same behaviour as
-indexing via :obj:`array`.
-
-.. code-block:: shell
-
-  >>> arr = mx.arange(10)
+  >>> idx = [5, 7]
+  >>> arr[idx]
+  array([5, 7], dtype=int32)
   >>> arr[[1, 3, 5]]
   array([1, 3, 5], dtype=int32)
   >>> arr.reshape(2, 5)[(1, 3)]

--- a/docs/src/usage/indexing.rst
+++ b/docs/src/usage/indexing.rst
@@ -55,6 +55,18 @@ You can also use an :obj:`array` to index another :obj:`array`:
   >>> arr[idx]
   array([5, 7], dtype=int32)
 
+Also, you can use :obj:`list` or :obj:`tuple` to index an array. It works exactly as it does in numpy. About usage of :obj:`list`, it
+is worth mentioning that the list, implicitly gets converted to :obj:`array` before indexing. So, it follows the same behaviour as
+indexing via :obj:`array`.
+
+.. code-block:: shell
+
+  >>> arr = mx.arange(10)
+  >>> arr[[1, 3, 5]]
+  array([1, 3, 5], dtype=int32)
+  >>> arr.reshape(2, 5)[(1, 3)]
+  array(8, dtype=int32)
+
 Mixing and matching integers, :obj:`slice`, ``...``, and :obj:`array` indices
 works just as in NumPy.
 

--- a/python/src/array.h
+++ b/python/src/array.h
@@ -1,0 +1,10 @@
+#include <optional>
+
+#include <nanobind/nanobind.h>
+#include "mlx/dtype.h"
+
+namespace nb = nanobind;
+using namespace mlx::core;
+
+template <typename T>
+array array_from_list(T pl, std::optional<Dtype> dtype);

--- a/python/src/indexing.cpp
+++ b/python/src/indexing.cpp
@@ -482,8 +482,12 @@ array mlx_get_item_list(array src, const nb::list& entries) {
               "Cannot index mlx array using the given type yet");
         }
       }
-      auto arr = array({gather_indices.begin(), gather_indices.end()}, uint32);
-      std::vector<int> slice_sizes = {src.shape(axis), 1};
+      auto arr = array(
+          gather_indices.begin(),
+          {static_cast<int>(gather_indices.size())},
+          uint32);
+      std::vector<int> slice_sizes = src.shape();
+      std::fill(slice_sizes.begin(), slice_sizes.end(), 1);
       gathered.push_back(gather(src, arr, {axis}, slice_sizes));
       axis++;
     } else {
@@ -498,7 +502,7 @@ array mlx_get_item_list(array src, const nb::list& entries) {
     os << gathered[i];
     printf("%s\n", os.str().c_str());
   }
-  src = concatenate(gathered, axis);
+  src = stack(gathered, 0);
   return src;
 }
 

--- a/python/src/utils.h
+++ b/python/src/utils.h
@@ -90,6 +90,17 @@ inline array to_array(
   }
 }
 
+inline void throw_if_invalid_index(const array& src, int sub_, int axis) {
+  // check if the index is greater than the dimension of array in this
+  // specific dimension
+  if (sub_ >= src.shape(axis)) {
+    std::ostringstream msg;
+    msg << "Index " << sub_ << " is out of bounds for dimension " << axis
+        << " with size " << src.shape(axis);
+    throw std::invalid_argument(msg.str());
+  }
+}
+
 inline std::pair<array, array> to_arrays(
     const ScalarOrArray& a,
     const ScalarOrArray& b) {

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -1042,6 +1042,10 @@ class TestArray(mlx_tests.MLXTestCase):
         idx = [0, 2, 4]
         self.assertTrue(np.array_equal(a[[idx]], np.array([[0, 1], [4, 5], [8, 9]])))
 
+        a = mx.array([[1, 2], [3, 4]])
+        idx = [[0, 1], 1]
+        self.assertTrue(np.array_equal(a[idx], np.array([2, 4])))
+
     def test_setitem(self):
         a = mx.array(0)
         a[None] = 1

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -1029,7 +1029,7 @@ class TestArray(mlx_tests.MLXTestCase):
         a_mlx = mx.array(a_np)
         self.assertTrue(np.array_equal(a_np[2:-1, 0], np.array(a_mlx[2:-1, 0])))
 
-    def test_indexing_with_list(self):
+    def test_basic_indexing_with_list(self):
         a = mx.array([1, 2, 3, 4, 5])
         idx = [0, 2, 4]
         self.assertTrue(np.array_equal(np.array(a[[idx]]), np.array([1, 3, 5])))
@@ -1038,8 +1038,9 @@ class TestArray(mlx_tests.MLXTestCase):
         idx = [0, 2]
         self.assertTrue(np.array_equal(a[[idx]], np.array([[1, 2], [5, 6]])))
 
-        idx = [0, 1]
-        self.assertTrue(np.array_equal(a[:, idx], np.array([[1, 2], [3, 4], [5, 6]])))
+        a = mx.arange(10).reshape(5, 2)
+        idx = [0, 2, 4]
+        self.assertTrue(np.array_equal(a[[idx]], np.array([[0, 1], [4, 5], [8, 9]])))
 
     def test_setitem(self):
         a = mx.array(0)

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -1032,19 +1032,21 @@ class TestArray(mlx_tests.MLXTestCase):
     def test_basic_indexing_with_list(self):
         a = mx.array([1, 2, 3, 4, 5])
         idx = [0, 2, 4]
-        self.assertTrue(np.array_equal(np.array(a[[idx]]), np.array([1, 3, 5])))
+        self.assertTrue(np.array_equal(np.array(a[idx]), np.array(a)[idx]))
 
         a = mx.array([[1, 2], [3, 4], [5, 6]])
         idx = [0, 2]
-        self.assertTrue(np.array_equal(a[[idx]], np.array([[1, 2], [5, 6]])))
+        self.assertTrue(np.array_equal(np.array(a[idx]), np.array(a)[idx]))
 
         a = mx.arange(10).reshape(5, 2)
         idx = [0, 2, 4]
-        self.assertTrue(np.array_equal(a[[idx]], np.array([[0, 1], [4, 5], [8, 9]])))
+        self.assertTrue(np.array_equal(np.array(a[idx]), np.array(a)[idx]))
 
         a = mx.array([[1, 2], [3, 4]])
         idx = [[0, 1], 1]
-        self.assertTrue(np.array_equal(a[idx], np.array([2, 4])))
+        print(np.array(a)[idx])
+        with self.assertRaises(ValueError):
+            a[idx]
 
     def test_setitem(self):
         a = mx.array(0)

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -1044,7 +1044,6 @@ class TestArray(mlx_tests.MLXTestCase):
 
         a = mx.array([[1, 2], [3, 4]])
         idx = [[0, 1], 1]
-        print(np.array(a)[idx])
         with self.assertRaises(ValueError):
             a[idx]
 

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -1029,6 +1029,18 @@ class TestArray(mlx_tests.MLXTestCase):
         a_mlx = mx.array(a_np)
         self.assertTrue(np.array_equal(a_np[2:-1, 0], np.array(a_mlx[2:-1, 0])))
 
+    def test_indexing_with_list(self):
+        a = mx.array([1, 2, 3, 4, 5])
+        idx = [0, 2, 4]
+        self.assertTrue(np.array_equal(np.array(a[[idx]]), np.array([1, 3, 5])))
+
+        a = mx.array([[1, 2], [3, 4], [5, 6]])
+        idx = [0, 2]
+        self.assertTrue(np.array_equal(a[[idx]], np.array([[1, 2], [5, 6]])))
+
+        idx = [0, 1]
+        self.assertTrue(np.array_equal(a[:, idx], np.array([[1, 2], [3, 4], [5, 6]])))
+
     def test_setitem(self):
         a = mx.array(0)
         a[None] = 1


### PR DESCRIPTION
## Proposed changes

This closes issue #908. Indexing using lists is now supported for `mlx.core.array` type. Examples are as follows:
```
a = mx.array([1, 2, 3, 4, 5])
a[[ [0,2,4] ]] # array([1, 3, 5], dtype=int32)

a = mx.arange(10).reshape(5, 2)
a[[ [0,2,4] ]] # array([[0, 1],
                       #           [4, 5],
                       #           [8, 9]], dtype=int32)


 a[[ [0,1], [1] ]] # array([1, 3], dtype=int32)

```

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
