### PR TITLE
Fix cpu compile

### DIFF
--- a/mlx/backend/common/compiled.cpp
+++ b/mlx/backend/common/compiled.cpp
@@ -169,11 +169,12 @@ void compiled_allocate_outputs(
     for (int i = 0; i < inputs.size() && o < outputs.size(); ++i) {
       auto& in = inputs[i];
       // Conditions for donation
-      // - Contiguous
-      // - Donatable
       // - Correct size
+      // - Not a scalar
+      // - Donatable
       // - Not a constant
-      if (in.flags().contiguous && !is_scalar(in) && in.is_donatable() &&
+      if (in.itemsize() == outputs[o].itemsize() && !is_scalar(in) &&
+          in.is_donatable() &&
           constant_ids_.find(inputs_[i].id()) == constant_ids_.end()) {
         if (move_buffers) {
           outputs[o++].move_shared_buffer(in);

--- a/mlx/backend/common/compiled.cpp
+++ b/mlx/backend/common/compiled.cpp
@@ -126,4 +126,101 @@ std::string build_lib_name(
   return os.str();
 }
 
+bool compiled_check_contiguity(
+    const std::vector<array>& inputs,
+    const std::vector<int>& shape) {
+  bool contiguous = true;
+  bool all_contig = true;
+  bool all_row_contig = true;
+  bool all_col_contig = true;
+  int non_scalar_inputs = 0;
+  for (const auto& x : inputs) {
+    if (is_scalar(x)) {
+      continue;
+    }
+    non_scalar_inputs++;
+    bool shape_eq = x.shape() == shape;
+    all_contig &= (x.flags().contiguous && shape_eq);
+    all_row_contig &= (x.flags().row_contiguous && shape_eq);
+    all_col_contig &= (x.flags().col_contiguous && shape_eq);
+  }
+  if (non_scalar_inputs > 1 && !all_row_contig && !all_col_contig) {
+    contiguous = false;
+  } else if (non_scalar_inputs == 1 && !all_contig) {
+    contiguous = false;
+  } else if (non_scalar_inputs == 0 && !shape.empty()) {
+    contiguous = false;
+  }
+  return contiguous;
+}
+
+void compiled_allocate_outputs(
+    const std::vector<array>& inputs,
+    std::vector<array>& outputs,
+    const std::vector<array>& inputs_,
+    const std::unordered_set<uintptr_t>& constant_ids_,
+    bool contiguous,
+    bool move_buffers /* = false */) {
+  if (contiguous) {
+    int o = 0;
+    std::vector<size_t> strides;
+    size_t data_size;
+    array::Flags flags;
+    for (int i = 0; i < inputs.size() && o < outputs.size(); ++i) {
+      auto& in = inputs[i];
+      // Conditions for donation
+      // - Contiguous
+      // - Donatable
+      // - Correct size
+      // - Not a constant
+      if (in.flags().contiguous && !is_scalar(in) && in.is_donatable() &&
+          constant_ids_.find(inputs_[i].id()) == constant_ids_.end()) {
+        if (move_buffers) {
+          outputs[o++].move_shared_buffer(in);
+        } else {
+          outputs[o++].copy_shared_buffer(in);
+        }
+      }
+      // Get representative input flags to properly set non-donated outputs
+      if (strides.empty() && in.size() == outputs[0].size()) {
+        strides = in.strides();
+        flags = in.flags();
+        data_size = in.data_size();
+      }
+    }
+    for (; o < outputs.size(); ++o) {
+      outputs[o].set_data(
+          allocator::malloc_or_wait(data_size * outputs[o].itemsize()),
+          data_size,
+          strides,
+          flags);
+    }
+  } else {
+    int o = 0;
+    for (int i = 0; i < inputs.size() && o < outputs.size(); ++i) {
+      auto& in = inputs[i];
+      // Conditions for donation
+      // - Row contiguous
+      // - Donatable
+      // - Correct size
+      // - Not a constant
+      if (in.flags().row_contiguous && in.nbytes() == outputs[o].nbytes() &&
+          in.is_donatable() &&
+          constant_ids_.find(inputs_[i].id()) == constant_ids_.end()) {
+        if (move_buffers) {
+          outputs[o].move_shared_buffer(
+              in, outputs[o].strides(), in.flags(), in.data_size());
+        } else {
+          outputs[o].copy_shared_buffer(
+              in, outputs[o].strides(), in.flags(), in.data_size());
+        }
+        o++;
+      }
+    }
+    for (; o < outputs.size(); ++o) {
+      outputs[o].set_data(allocator::malloc_or_wait(outputs[o].nbytes()));
+    }
+  }
+}
+
 } // namespace mlx::core

--- a/mlx/backend/common/compiled.h
+++ b/mlx/backend/common/compiled.h
@@ -53,4 +53,18 @@ inline bool is_scalar(const array& x) {
   return x.ndim() == 0;
 }
 
+// Check if we can use a contiguous operation given inputs and the output shape
+bool compiled_check_contiguity(
+    const std::vector<array>& inputs,
+    const std::vector<int>& shape);
+
+// Allocate space for the outputs possibly with input donation
+void compiled_allocate_outputs(
+    const std::vector<array>& inputs,
+    std::vector<array>& outputs,
+    const std::vector<array>& inputs_,
+    const std::unordered_set<uintptr_t>& constant_ids_,
+    bool contiguous,
+    bool move_buffers = false);
+
 } // namespace mlx::core

--- a/mlx/backend/common/compiled_cpu.cpp
+++ b/mlx/backend/common/compiled_cpu.cpp
@@ -60,7 +60,8 @@ void* compile(
   constexpr int max_file_name_length = 245;
   if (kernel_name.size() > max_file_name_length) {
     std::ostringstream file_name;
-    file_name << std::string_view(kernel_name).substr(0, max_file_name_length - 16);
+    file_name
+        << std::string_view(kernel_name).substr(0, max_file_name_length - 16);
     auto file_id = std::hash<std::string>{}(kernel_name);
     file_name << "_" << std::hex << std::setw(16) << file_id << std::dec;
     kernel_file_name = file_name.str();

--- a/mlx/backend/common/compiled_cpu.cpp
+++ b/mlx/backend/common/compiled_cpu.cpp
@@ -266,25 +266,10 @@ void Compiled::eval_cpu(
   // Figure out which kernel we are using
   auto& shape = outputs[0].shape();
   bool contiguous = true;
-  {
-    bool all_contig = true;
-    bool all_row_contig = true;
-    bool all_col_contig = true;
-    int non_scalar_inputs = 0;
-    for (auto& x : inputs) {
-      if (is_scalar(x)) {
-        continue;
-      }
-      non_scalar_inputs++;
-      bool shape_eq = x.shape() == shape;
-      all_contig &= (x.flags().contiguous && shape_eq);
-      all_row_contig &= (x.flags().row_contiguous && shape_eq);
-      all_col_contig &= (x.flags().col_contiguous && shape_eq);
-    }
-    if (non_scalar_inputs > 1 && !all_row_contig && !all_col_contig) {
+  for (auto& x : inputs) {
+    if ((!x.flags().row_contiguous || x.shape() != shape) && !is_scalar(x)) {
       contiguous = false;
-    } else if (non_scalar_inputs == 1 && !all_contig) {
-      contiguous = false;
+      break;
     }
   }
 
@@ -360,37 +345,7 @@ void Compiled::eval_cpu(
   }
 
   // Allocate space for the outputs possibly with input donation
-  if (contiguous) {
-    int o = 0;
-    std::vector<size_t> strides;
-    size_t data_size;
-    array::Flags flags;
-    for (int i = 0; i < inputs.size() && o < outputs.size(); ++i) {
-      auto& in = inputs[i];
-      // Conditions for donation
-      // - Contiguous
-      // - Donatable
-      // - Correct size
-      // - Not a constant
-      if (in.flags().contiguous && !is_scalar(in) && in.is_donatable() &&
-          constant_ids_.find(inputs_[i].id()) == constant_ids_.end()) {
-        outputs[o++].copy_shared_buffer(in);
-      }
-      // Get representative input flags to properly set non-donated outputs
-      if (strides.empty() && in.size() == outputs[0].size()) {
-        strides = in.strides();
-        flags = in.flags();
-        data_size = in.data_size();
-      }
-    }
-    for (; o < outputs.size(); ++o) {
-      outputs[o].set_data(
-          allocator::malloc_or_wait(data_size * outputs[o].itemsize()),
-          data_size,
-          strides,
-          flags);
-    }
-  } else {
+  {
     int o = 0;
     for (int i = 0; i < inputs.size() && o < outputs.size(); ++i) {
       auto& in = inputs[i];

--- a/mlx/backend/common/compiled_cpu.cpp
+++ b/mlx/backend/common/compiled_cpu.cpp
@@ -265,13 +265,7 @@ void Compiled::eval_cpu(
 
   // Figure out which kernel we are using
   auto& shape = outputs[0].shape();
-  bool contiguous = true;
-  for (auto& x : inputs) {
-    if ((!x.flags().row_contiguous || x.shape() != shape) && !is_scalar(x)) {
-      contiguous = false;
-      break;
-    }
-  }
+  bool contiguous = compiled_check_contiguity(inputs, shape);
 
   // Handle all broadcasting and collect function input arguments
   std::vector<void*> args;
@@ -344,28 +338,8 @@ void Compiled::eval_cpu(
     fn_ptr = compile(kernel_name, kernel.str());
   }
 
-  // Allocate space for the outputs possibly with input donation
-  {
-    int o = 0;
-    for (int i = 0; i < inputs.size() && o < outputs.size(); ++i) {
-      auto& in = inputs[i];
-      // Conditions for donation
-      // - Row contiguous
-      // - Donatable
-      // - Correct size
-      // - Not a constant
-      if (in.flags().row_contiguous && in.nbytes() == outputs[o].nbytes() &&
-          in.is_donatable() &&
-          constant_ids_.find(inputs_[i].id()) == constant_ids_.end()) {
-        outputs[o].copy_shared_buffer(
-            in, outputs[o].strides(), in.flags(), in.data_size());
-        o++;
-      }
-    }
-    for (; o < outputs.size(); ++o) {
-      outputs[o].set_data(allocator::malloc_or_wait(outputs[o].nbytes()));
-    }
-  }
+  compiled_allocate_outputs(
+      inputs, outputs, inputs_, constant_ids_, contiguous, false);
 
   for (auto& x : outputs) {
     args.push_back(x.data<void>());

--- a/python/tests/test_compile.py
+++ b/python/tests/test_compile.py
@@ -671,6 +671,24 @@ class TestCompile(mlx_tests.MLXTestCase):
         out = cmean(x)
         self.assertTrue(mx.allclose(out, mean(x)))
 
+    def test_compile_broadcast_only(self):
+        def fn(a):
+            a = mx.broadcast_to(a, (1,))
+            return a + a
+        out = mx.compile(fn)(mx.array(2.0))
+        # TODO debug crash here
+        repr(out)
+        self.assertTrue(mx.array_equal(out, mx.array([4.0])))
+
+    def test_compile_with_long_name(self):
+        def fn(a, b):
+            for _ in range(10):
+                a = a - 1.0
+                b = b - 1.0
+            return a + b
+        out = mx.compile(fn)(mx.array(10.0), mx.array(20.0))
+        self.assertEqual(out.item(), 10.0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/test_compile.py
+++ b/python/tests/test_compile.py
@@ -675,6 +675,7 @@ class TestCompile(mlx_tests.MLXTestCase):
         def fn(a):
             a = mx.broadcast_to(a, (1,))
             return a + a
+
         out = mx.compile(fn)(mx.array(2.0))
         # TODO debug crash here
         repr(out)
@@ -686,6 +687,7 @@ class TestCompile(mlx_tests.MLXTestCase):
                 a = a - 1.0
                 b = b - 1.0
             return a + b
+
         out = mx.compile(fn)(mx.array(10.0), mx.array(20.0))
         self.assertEqual(out.item(), 10.0)
 

--- a/python/tests/test_compile.py
+++ b/python/tests/test_compile.py
@@ -677,8 +677,8 @@ class TestCompile(mlx_tests.MLXTestCase):
             return a + a
 
         out = mx.compile(fn)(mx.array(2.0))
-        # TODO debug crash here
-        repr(out)
+        # Make sure repr can be called
+        self.assertTrue(repr(out) is not None)
         self.assertTrue(mx.array_equal(out, mx.array([4.0])))
 
     def test_compile_with_long_name(self):


### PR DESCRIPTION
- Fix file name length bug for CPU compile
- Add test for another bug causing a segfault when all inputs are scalars

Simplified the contiguity stuff for the CPU it was too complicated and I think buggy, it just uses the exact same logic as the GPU eval now. We may want to improve both the CPU and GPU contiguity conditions at some point, but I think it needs more care.

Transformer training runs now with CPU compile.