### PR TITLE
Properly handle negative axes in python vmap

### DIFF
--- a/python/src/transforms.cpp
+++ b/python/src/transforms.cpp
@@ -308,6 +308,8 @@ auto py_vmap(
                     throw std::invalid_argument(msg.str());
                   }
                   flat_axes.push_back(axis);
+                } else if (l.size() == 1 && l[0].is_none()) {
+                  flat_axes.push_back(-1);
                 } else {
                   throw std::invalid_argument(
                       "[vmap] axis must be int or None.");

--- a/python/src/transforms.cpp
+++ b/python/src/transforms.cpp
@@ -16,6 +16,7 @@
 #include "mlx/graph_utils.h"
 #include "mlx/transforms.h"
 #include "mlx/transforms_impl.h"
+#include "mlx/utils.h"
 #include "python/src/trees.h"
 
 namespace nb = nanobind;
@@ -265,26 +266,43 @@ auto py_vmap(
     const nb::object& out_axes) {
   return [fun, in_axes, out_axes](const nb::args& args) {
     auto axes_to_flat_tree = [](const nb::object& tree,
-                                const nb::object& axes) {
-      auto tree_axes = tree_map(
-          {tree, axes},
-          [](const std::vector<nb::object>& inputs) { return inputs[1]; });
+                                const nb::object& axes,
+                                bool output_axes) {
       std::vector<int> flat_axes;
-      tree_visit(tree_axes, [&flat_axes](nb::handle obj) {
-        if (obj.is_none()) {
-          flat_axes.push_back(-1);
-        } else if (nb::isinstance<nb::int_>(obj)) {
-          flat_axes.push_back(nb::cast<int>(nb::cast<nb::int_>(obj)));
-        } else {
-          throw std::invalid_argument("[vmap] axis must be int or None.");
-        }
-      });
+      tree_visit(
+          {tree, axes},
+          [&flat_axes, output_axes](const std::vector<nb::object>& inputs) {
+            if (nb::isinstance<array>(inputs[0])) {
+              if (inputs[1].is_none()) {
+                flat_axes.push_back(-1);
+              } else if (nb::isinstance<nb::int_>(inputs[1])) {
+                int axis = nb::cast<int>(nb::cast<nb::int_>(inputs[1]));
+                const array& x = nb::cast<array>(inputs[0]);
+                if (axis < 0) {
+                  axis += x.ndim() + output_axes;
+                }
+                if (axis < 0 || axis >= (x.ndim() + output_axes)) {
+                  std::ostringstream msg;
+                  msg << "[vmap] Invalid" << (output_axes ? " output " : " ")
+                      << "vectorization axis " << axis
+                      << " for array with shape " << x.shape();
+                  throw std::invalid_argument(msg.str());
+                }
+                flat_axes.push_back(axis);
+              } else {
+                throw std::invalid_argument("[vmap] axis must be int or None.");
+              }
+            } else {
+              throw std::invalid_argument(
+                  "[vmap] The arguments should contain only arrays");
+            }
+          });
       return flat_axes;
     };
 
     // Inputs must be array or tree of arrays
     auto inputs = tree_flatten(args, true);
-    auto flat_in_axes = axes_to_flat_tree(args, in_axes);
+    auto flat_in_axes = axes_to_flat_tree(args, in_axes, false);
 
     // py_value_out will hold the output of the python function in order to be
     // able to reconstruct the python tree of extra return values
@@ -302,7 +320,7 @@ auto py_vmap(
     auto [trace_inputs, trace_outputs] =
         detail::vmap_trace(vmap_fn, inputs, flat_in_axes);
 
-    auto flat_out_axes = axes_to_flat_tree(py_outputs, out_axes);
+    auto flat_out_axes = axes_to_flat_tree(py_outputs, out_axes, true);
 
     // Perform the vmap
     auto outputs = detail::vmap_replace(

--- a/python/src/trees.h
+++ b/python/src/trees.h
@@ -7,6 +7,9 @@
 namespace nb = nanobind;
 using namespace mlx::core;
 
+void tree_visit(
+    const std::vector<nb::object>& trees,
+    std::function<void(const std::vector<nb::object>&)> visitor);
 void tree_visit(nb::object tree, std::function<void(nb::handle)> visitor);
 
 nb::object tree_map(

--- a/python/tests/test_vmap.py
+++ b/python/tests/test_vmap.py
@@ -122,15 +122,12 @@ class TestVmap(mlx_tests.MLXTestCase):
         self.assertTrue(mx.array_equal(out, my_fun(tree)))
 
         with self.assertRaises(ValueError):
-            mx.vmap(my_fun, in_axes={"a": 0, "b": 0}, out_axes=0)(tree)
-
-        with self.assertRaises(ValueError):
             mx.vmap(my_fun, in_axes={"a": 0, "b": ((0, 0), 0)}, out_axes=0)(tree)
 
-        out = mx.vmap(my_fun, in_axes=({"a": 0, "b": 0},), out_axes=0)(tree)
+        out = mx.vmap(my_fun, in_axes={"a": 0, "b": 0}, out_axes=0)(tree)
         self.assertTrue(mx.array_equal(out, my_fun(tree)))
 
-        out = mx.vmap(my_fun, in_axes=({"a": 0, "b": (0, 0)},), out_axes=0)(tree)
+        out = mx.vmap(my_fun, in_axes={"a": 0, "b": (0, 0)}, out_axes=0)(tree)
         self.assertTrue(mx.array_equal(out, my_fun(tree)))
 
         tree = {
@@ -140,7 +137,7 @@ class TestVmap(mlx_tests.MLXTestCase):
                 mx.random.uniform(shape=(4, 2)),
             ),
         }
-        out = mx.vmap(my_fun, in_axes=({"a": 0, "b": (1, 1)},), out_axes=0)(tree)
+        out = mx.vmap(my_fun, in_axes={"a": 0, "b": (1, 1)}, out_axes=0)(tree)
         expected = (tree["a"] + tree["b"][0].T) * tree["b"][1].T
         self.assertTrue(mx.array_equal(out, expected))
 


### PR DESCRIPTION
Fixes #922 by allowing negative input/output axes in python.

I also made a multi-tree tree_visit to avoid the multiple traversals of the arguments. There is some repetition but I wanted to avoid creating all those python objects just to discard them in the end. Let me know if you think it isn't worth it.