### PR TITLE
Get nanobind with FetchContent.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,11 +164,11 @@ target_include_directories(
 if (MLX_BUILD_PYTHON_BINDINGS)
   message(STATUS "Building Python bindings.")
   find_package(Python 3.8 COMPONENTS Interpreter Development.Module REQUIRED)
-  execute_process(
-    COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
-    OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE NB_DIR)
-  list(APPEND CMAKE_PREFIX_PATH "${NB_DIR}")
-  find_package(nanobind CONFIG REQUIRED)
+  FetchContent_Declare(nanobind
+    GIT_REPOSITORY https://github.com/wjakob/nanobind.git
+    GIT_TAG        4148debcf91f5ccab0c3b8d67b5c3cabd61f407f
+    )
+  FetchContent_MakeAvailable(nanobind)
   add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/python/src)
 endif()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
   "setuptools>=42",
-  "nanobind@git+https://github.com/wjakob/nanobind.git#egg=4148debcf91f5ccab0c3b8d67b5c3cabd61f407f",
   "cmake>=3.24",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Proposed changes

I noticed that `doctest/json/gguflib/metal_cpp` dependencies are managed using `FetchContent`. It would be consistent to manage `nanobind` in the same way. This approach ensures that the `nanobind` include directory remains constant (`build/_deps/nanobind-src/include`) within the `compile_commands.json` file. This consistency is crucial for tools like `clangd` and `ccls` to function correctly.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
