### PR TITLE
Option for precise softmax

### DIFF
--- a/mlx/backend/accelerate/softmax.cpp
+++ b/mlx/backend/accelerate/softmax.cpp
@@ -355,7 +355,6 @@ void Softmax::eval_cpu(const std::vector<array>& inputs, array& out) {
       break;
     case float16:
       if (precise_) {
-        std::cout << "PRECISE SMAX? " << std::endl;
         softmax<
             float16_t,
             float,

--- a/mlx/backend/accelerate/softmax.cpp
+++ b/mlx/backend/accelerate/softmax.cpp
@@ -201,7 +201,7 @@ struct NeonFp16SimdOps {
   }
 };
 
-template <typename T, typename VT, typename Ops, int N>
+template <typename T, typename AccT, typename VT, typename Ops, int N>
 void softmax(const array& in, array& out) {
   Ops ops;
 
@@ -218,13 +218,21 @@ void softmax(const array& in, array& out) {
     VT vmaximum = ops.init(-std::numeric_limits<float>::infinity());
     size_t s = M;
     while (s >= N) {
-      vmaximum = ops.max(ops.load(current_in_ptr), vmaximum);
+      VT vals;
+      if constexpr (std::is_same<T, AccT>::value) {
+        vals = ops.load(current_in_ptr);
+      } else {
+        for (int i = 0; i < N; ++i) {
+          vals[i] = static_cast<AccT>(current_in_ptr[i]);
+        }
+      }
+      vmaximum = ops.max(vals, vmaximum);
       current_in_ptr += N;
       s -= N;
     }
-    T maximum = ops.reduce_max(vmaximum);
+    AccT maximum = ops.reduce_max(vmaximum);
     while (s-- > 0) {
-      maximum = std::max(maximum, *current_in_ptr);
+      maximum = std::max(maximum, static_cast<AccT>(*current_in_ptr));
       current_in_ptr++;
     }
 
@@ -235,17 +243,20 @@ void softmax(const array& in, array& out) {
     s = M;
     while (s >= N) {
       VT vexp = ops.exp(ops.sub(*(VT*)current_in_ptr, maximum));
-      ops.store(current_out_ptr, vexp);
-      *(VT*)current_out_ptr = vexp;
+      if constexpr (std::is_same<T, AccT>::value) {
+        ops.store(current_out_ptr, vexp);
+      }
       vnormalizer = ops.add(vnormalizer, vexp);
       current_in_ptr += N;
       current_out_ptr += N;
       s -= N;
     }
-    T normalizer = ops.reduce_add(vnormalizer);
+    AccT normalizer = ops.reduce_add(vnormalizer);
     while (s-- > 0) {
-      T _exp = std::exp(*current_in_ptr - maximum);
-      *current_out_ptr = _exp;
+      AccT _exp = std::exp(*current_in_ptr - maximum);
+      if (std::is_same<T, AccT>::value) {
+        *current_out_ptr = _exp;
+      }
       normalizer += _exp;
       current_in_ptr++;
       current_out_ptr++;
@@ -256,12 +267,28 @@ void softmax(const array& in, array& out) {
     current_out_ptr = out_ptr;
     s = M;
     while (s >= N) {
-      ops.store(current_out_ptr, ops.mul(*(VT*)current_out_ptr, normalizer));
+      if constexpr (std::is_same<T, AccT>::value) {
+        ops.store(current_out_ptr, ops.mul(*(VT*)current_out_ptr, normalizer));
+      } else {
+        VT vexp;
+        for (int i = 0; i < N; ++i) {
+          vexp[i] = static_cast<AccT>(current_in_ptr[i]);
+        }
+        vexp = ops.exp(ops.sub(vexp, maximum));
+        for (int i = 0; i < N; ++i) {
+          current_out_ptr[i] = vexp[i];
+        }
+      }
       current_out_ptr += N;
       s -= N;
     }
     while (s-- > 0) {
-      *current_out_ptr *= normalizer;
+      if (std::is_same<T, AccT>::value) {
+        *current_out_ptr *= normalizer;
+      } else {
+        AccT _exp = std::exp(*current_in_ptr - maximum);
+        *current_out_ptr = static_cast<T>(_exp * normalizer);
+      }
       current_out_ptr++;
     }
   }
@@ -308,15 +335,29 @@ void Softmax::eval_cpu(const std::vector<array>& inputs, array& out) {
           "Softmax is defined only for floating point types");
       break;
     case float32:
-      softmax<float, simd_float16, AccelerateSimdOps<float, simd_float16>, 16>(
-          in, out);
+      softmax<
+          float,
+          float,
+          simd_float16,
+          AccelerateSimdOps<float, simd_float16>,
+          16>(in, out);
       break;
     case float16:
-      softmax<
-          float16_t,
-          float16x8_t,
-          NeonFp16SimdOps<float16_t, float16x8_t>,
-          8>(in, out);
+      if (precise_) {
+        softmax<
+            float16_t,
+            float,
+            simd_float16,
+            AccelerateSimdOps<float, simd_float16>,
+            16>(in, out);
+      } else {
+        softmax<
+            float16_t,
+            float16_t,
+            float16x8_t,
+            NeonFp16SimdOps<float16_t, float16x8_t>,
+            8>(in, out);
+      }
       break;
     case bfloat16:
       eval(inputs, out);

--- a/mlx/backend/metal/kernels/softmax.metal
+++ b/mlx/backend/metal/kernels/softmax.metal
@@ -36,14 +36,14 @@ template <typename T, typename AccT = T, int N_READS = SOFTMAX_N_READS>
 
   in += gid * axis_size + lid * N_READS;
   if (lid * N_READS + N_READS <= axis_size) {
-    for (int i=0; i<N_READS; i++) {
-        ld[i] = AccT(in[i]);
+    for (int i = 0; i < N_READS; i++) {
+      ld[i] = AccT(in[i]);
     }
   } else {
-      for (int i = 0; i < N_READS; i++) {
-        ld[i] =
-            ((lid * N_READS + i) < axis_size) ? AccT(in[i]) : Limits<AccT>::finite_min;
-      }
+    for (int i = 0; i < N_READS; i++) {
+      ld[i] = ((lid * N_READS + i) < axis_size) ? AccT(in[i])
+                                                : Limits<AccT>::finite_min;
+    }
   }
   if (simd_group_id == 0) {
     local_max[simd_lane_id] = Limits<AccT>::finite_min;
@@ -94,15 +94,15 @@ template <typename T, typename AccT = T, int N_READS = SOFTMAX_N_READS>
   // Normalize and write to the output
   out += gid * axis_size + lid * N_READS;
   if (lid * N_READS + N_READS <= axis_size) {
-    for (int i=0; i<N_READS; i++) {
-        out[i] = T(ld[i] * normalizer);
+    for (int i = 0; i < N_READS; i++) {
+      out[i] = T(ld[i] * normalizer);
     }
   } else {
-      for (int i = 0; i < N_READS; i++) {
-        if ((lid * N_READS + i) < axis_size) {
-          out[i] = T(ld[i] * normalizer);
-        }
+    for (int i = 0; i < N_READS; i++) {
+      if ((lid * N_READS + i) < axis_size) {
+        out[i] = T(ld[i] * normalizer);
       }
+    }
   }
 }
 
@@ -137,8 +137,8 @@ template <typename T, typename AccT = T, int N_READS = SOFTMAX_N_READS>
       }
     } else {
       for (int i = 0; i < N_READS; i++) {
-        vals[i] =
-            (offset + i < axis_size) ? AccT(in[offset + i]) : Limits<AccT>::finite_min;
+        vals[i] = (offset + i < axis_size) ? AccT(in[offset + i])
+                                           : Limits<AccT>::finite_min;
       }
     }
     prevmax = maxval;
@@ -184,13 +184,14 @@ template <typename T, typename AccT = T, int N_READS = SOFTMAX_N_READS>
        r++) {
     int offset = r * lsize * N_READS + lid * N_READS;
     if (offset + N_READS <= axis_size) {
-      for (int i=0; i<N_READS; i++) {
+      for (int i = 0; i < N_READS; i++) {
         out[offset + i] = T(softmax_exp(in[offset + i] - maxval) * normalizer);
       }
     } else {
       for (int i = 0; i < N_READS; i++) {
         if (offset + i < axis_size) {
-          out[offset + i] = T(softmax_exp(in[offset + i] - maxval) * normalizer);
+          out[offset + i] =
+              T(softmax_exp(in[offset + i] - maxval) * normalizer);
         }
       }
     }

--- a/mlx/backend/metal/softmax.cpp
+++ b/mlx/backend/metal/softmax.cpp
@@ -53,8 +53,15 @@ void Softmax::eval_gpu(const std::vector<array>& inputs, array& out) {
   const int n_reads = SOFTMAX_N_READS;
   const int looped_limit = SOFTMAX_LOOPED_LIMIT;
   std::string op_name = "softmax_";
+  int smem_itemsize;
   if (axis_size > looped_limit) {
     op_name += "looped_";
+  }
+  if (in.dtype() != float32 && precise_) {
+    smem_itemsize = sizeof(float);
+    op_name += "precise_";
+  } else {
+    smem_itemsize = in.itemsize();
   }
   op_name += type_to_name(out);
   auto compute_encoder = d.get_command_encoder(s.index);
@@ -82,8 +89,8 @@ void Softmax::eval_gpu(const std::vector<array>& inputs, array& out) {
         compute_encoder, in.data_shared_ptr() == nullptr ? out : in, 0);
     set_array_buffer(compute_encoder, out, 1);
     compute_encoder->setBytes(&axis_size, sizeof(int), 2);
-    compute_encoder->setThreadgroupMemoryLength(simd_size * in.itemsize(), 0);
-    compute_encoder->setThreadgroupMemoryLength(simd_size * in.itemsize(), 1);
+    compute_encoder->setThreadgroupMemoryLength(simd_size * smem_itemsize, 0);
+    compute_encoder->setThreadgroupMemoryLength(simd_size * smem_itemsize, 1);
     compute_encoder->dispatchThreads(grid_dims, group_dims);
   }
   d.get_command_buffer(s.index)->addCompletedHandler(

--- a/mlx/fast.cpp
+++ b/mlx/fast.cpp
@@ -550,10 +550,7 @@ array scaled_dot_product_attention(
     if (needs_mask) {
       scores = add(scores, inputs[3], s);
     }
-    scores = astype(
-        softmax(astype(scores, float32, s), std::vector<int>{-1}, s),
-        final_type,
-        s);
+    scores = softmax(scores, std::vector<int>{-1}, true, s);
     auto out = matmul(scores, v, s);
     if (n_repeats > 1) {
       out = reshape(out, {B, n_q_heads, L, -1}, s);

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -2622,22 +2622,11 @@ array softmax(
     bool precise /* = false */,
     StreamOrDevice s /* = {}*/) {
   if (axes.size() == 1 && (a.ndim() == axes[0] + 1 || axes[0] == -1)) {
-    auto stream = to_stream(s);
     auto dtype = at_least_float(a.dtype());
-    if (stream.device == Device::cpu && precise) {
-      return astype(
-          array(
-              a.shape(),
-              float32,
-              std::make_shared<Softmax>(stream, false),
-              {astype(a, float32, s)}),
-          dtype,
-          s);
-    }
     return array(
         a.shape(),
         dtype,
-        std::make_shared<Softmax>(stream, precise),
+        std::make_shared<Softmax>(to_stream(s), precise),
         {astype(a, dtype, s)});
   } else {
     auto in = a;

--- a/mlx/ops.h
+++ b/mlx/ops.h
@@ -976,14 +976,16 @@ array rsqrt(const array& a, StreamOrDevice s = {});
 array softmax(
     const array& a,
     const std::vector<int>& axes,
+    bool precise = false,
     StreamOrDevice s = {});
 
 /** Softmax of an array. */
-array softmax(const array& a, StreamOrDevice s = {});
+array softmax(const array& a, bool precise = false, StreamOrDevice s = {});
 
 /** Softmax of an array. */
-inline array softmax(const array& a, int axis, StreamOrDevice s = {}) {
-  return softmax(a, std::vector<int>{axis}, s);
+inline array
+softmax(const array& a, int axis, bool precise = false, StreamOrDevice s = {}) {
+  return softmax(a, std::vector<int>{axis}, precise, s);
 }
 
 /** Raise elements of a to the power of b element-wise */

--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -3005,6 +3005,11 @@ std::vector<array> Softmax::jvp(
       multiply(s, sum(sv, std::vector<int>{-1}, true, stream()), stream()))};
 }
 
+bool Softmax::is_equivalent(const Primitive& other) const {
+  const Softmax& s_other = static_cast<const Softmax&>(other);
+  return precise_ == s_other.precise_;
+}
+
 std::pair<std::vector<array>, std::vector<int>> Sort::vmap(
     const std::vector<array>& inputs,
     const std::vector<int>& axes) {

--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -2975,7 +2975,7 @@ std::pair<std::vector<array>, std::vector<int>> Softmax::vmap(
   } else {
     softmax_axes.push_back(-2);
   }
-  return {{softmax(inputs[0], softmax_axes, stream())}, axes};
+  return {{softmax(inputs[0], softmax_axes, precise_, stream())}, axes};
 }
 
 std::vector<array> Softmax::vjp(
@@ -2998,7 +2998,7 @@ std::vector<array> Softmax::jvp(
     const std::vector<int>& argnums) {
   assert(primals.size() == 1);
   assert(tangents.size() == 1);
-  auto s = softmax(primals[0], std::vector<int>{-1}, stream());
+  auto s = softmax(primals[0], std::vector<int>{-1}, precise_, stream());
   auto sv = multiply(s, tangents[0], stream());
   return {subtract(
       sv,

--- a/mlx/primitives.h
+++ b/mlx/primitives.h
@@ -1702,7 +1702,8 @@ class SliceUpdate : public UnaryPrimitive {
 
 class Softmax : public UnaryPrimitive {
  public:
-  explicit Softmax(Stream stream) : UnaryPrimitive(stream){};
+  explicit Softmax(Stream stream, bool precise)
+      : UnaryPrimitive(stream), precise_(precise){};
 
   void eval_cpu(const std::vector<array>& inputs, array& out) override;
   void eval_gpu(const std::vector<array>& inputs, array& out) override;
@@ -1715,6 +1716,7 @@ class Softmax : public UnaryPrimitive {
 
  private:
   void eval(const std::vector<array>& inputs, array& out);
+  bool precise_;
 };
 
 class Sort : public UnaryPrimitive {

--- a/mlx/primitives.h
+++ b/mlx/primitives.h
@@ -1711,8 +1711,9 @@ class Softmax : public UnaryPrimitive {
   DEFINE_VMAP()
   DEFINE_GRADS()
   DEFINE_PRINT(Softmax)
-  DEFINE_DEFAULT_IS_EQUIVALENT()
   DEFINE_INPUT_OUTPUT_SHAPE()
+
+  bool is_equivalent(const Primitive& other) const override;
 
  private:
   void eval(const std::vector<array>& inputs, array& out);

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -2430,12 +2430,13 @@ void init_ops(nb::module_& m) {
       )pbdoc");
   m.def(
       "softmax",
-      [](const array& a, const IntOrVec& axis, StreamOrDevice s) {
-        return softmax(a, get_reduce_axes(axis, a.ndim()), s);
+      [](const array& a, const IntOrVec& axis, bool precise, StreamOrDevice s) {
+        return softmax(a, get_reduce_axes(axis, a.ndim()), precise, s);
       },
       nb::arg(),
       "axis"_a = nb::none(),
       nb::kw_only(),
+      "precise"_a = false,
       "stream"_a = nb::none(),
       nb::sig(
           "def softmax(a: array, /, axis: Union[None, int, Sequence[int]] = None, *, stream: Union[None, Stream, Device] = None) -> array"),

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -1431,10 +1431,11 @@ class TestOps(mlx_tests.MLXTestCase):
         self.assertAlmostEqual(out.sum().item(), 8.0, 5)
 
         # Precise
-        a = (10 * mx.random.uniform(shape=(1024,))).astype(mx.float16)
-        out_expect = mx.softmax(a.astype(mx.float32)).astype(mx.float16)
-        out = mx.softmax(a, axis=-1, precise=True)
-        self.assertTrue(mx.allclose(out_expect, out))
+        for t in [mx.float16, mx.bfloat16]:
+            a = (10 * mx.random.normal(shape=(1024,))).astype(t)
+            out_expect = mx.softmax(a.astype(mx.float32)).astype(t)
+            out = mx.softmax(a, axis=-1, precise=True)
+            self.assertTrue(mx.allclose(out_expect, out))
 
     def test_concatenate(self):
         a_npy = np.random.randn(32, 32, 32)

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -1430,6 +1430,12 @@ class TestOps(mlx_tests.MLXTestCase):
         out = mx.softmax(y[:, 0:2], axis=-1)
         self.assertAlmostEqual(out.sum().item(), 8.0, 5)
 
+        # Precise
+        a = (10 * mx.random.uniform(shape=(1024,))).astype(mx.float16)
+        out_expect = mx.softmax(a.astype(mx.float32)).astype(mx.float16)
+        out = mx.softmax(a, axis=-1, precise=True)
+        self.assertTrue(mx.allclose(out_expect, out))
+
     def test_concatenate(self):
         a_npy = np.random.randn(32, 32, 32)
         b_npy = np.random.randn(32, 32, 32)


### PR DESCRIPTION
- Option to allow softmax to accumulate in float for half-type inputs

## Generation

Command `python -m mlx_lm.generate --model mlx-community/NeuralBeagle14-7B-4bit-mlx --prompt "Write a story about Einstein" --temp 0.0 --max-tokens 512`

|| Pre | Post
----- | ---- | ----
Prompt | 211.785  | 213.709 
Generation | 90.733 | 92.392
Iter 70: Train loss 1.117, Learning Rate 1.000e-05, It/sec 1.375, Tokens/sec 591.958, Trained Tokens 27487, Peak mem 16.213 GB

## LoRA

Slight memory saving with LoRA, no real diff in speed (as expected).

Command `python -m mlx_lm.lora --model mistralai/Mistral-7B-Instruct-v0.1 --data ../lora/data --train --iters 100 --steps-per-report 10`

| | Pre | Post
| ---- | --- | ---
Tokens/sec | 591.013 | 591.958,
Peak mem (GB) | 16.460 | 16.213
