### PR TITLE
update layer weight dims for  command-r-+

### DIFF
--- a/python/mlx/nn/layers/normalization.py
+++ b/python/mlx/nn/layers/normalization.py
@@ -1,6 +1,6 @@
 # Copyright © 2023 Apple Inc.
 
-from typing import Tuple
+from typing import Tuple, Union, Sequence
 
 import mlx.core as mx
 from mlx.nn.layers.base import Module
@@ -91,11 +91,11 @@ class LayerNorm(Module):
     """
 
     def __init__(
-        self, dims: int, eps: float = 1e-5, affine: bool = True, bias: bool = True
+        self, dims: Union[int, Sequence[int]], eps: float = 1e-5, affine: bool = True, bias: bool = True
     ):
         super().__init__()
         if affine:
-            self.weight = mx.ones((dims,))
+            self.weight = mx.ones((dims,)) if isinstance(dims, int) else mx.ones(dims)
             if bias:
                 self.bias = mx.zeros((dims,))
         self.eps = eps

--- a/python/mlx/nn/layers/normalization.py
+++ b/python/mlx/nn/layers/normalization.py
@@ -1,6 +1,6 @@
 # Copyright © 2023 Apple Inc.
 
-from typing import Tuple, Union, Sequence
+from typing import Sequence, Tuple, Union
 
 import mlx.core as mx
 from mlx.nn.layers.base import Module
@@ -91,7 +91,11 @@ class LayerNorm(Module):
     """
 
     def __init__(
-        self, dims: Union[int, Sequence[int]], eps: float = 1e-5, affine: bool = True, bias: bool = True
+        self,
+        dims: Union[int, Sequence[int]],
+        eps: float = 1e-5,
+        affine: bool = True,
+        bias: bool = True,
     ):
         super().__init__()
         if affine:

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -1606,6 +1606,19 @@ class TestLayers(mlx_tests.MLXTestCase):
         self.assertEqual(h_out.shape, (44, 12))
         self.assertEqual(c_out.shape, (44, 12))
 
+    def test_layer_norm(self):
+        # Test with a scalar dimension
+        layer_norm = nn.LayerNorm(dims=5, eps=1e-6, affine=True, bias=False)
+        input_data = mx.random.normal((2, 3, 5))
+        output = layer_norm(input_data)
+        self.assertEqual(output.shape, (2, 3, 5))
+
+        # Test with a sequence of dimensions
+        layer_norm = nn.LayerNorm(dims=(2, 3, 5), eps=1e-6, affine=True, bias=False)
+        input_data = mx.random.normal((2, 3, 5))
+        output = layer_norm(input_data)
+        self.assertEqual(output.shape, (2, 3, 5))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Proposed changes

Add N-D weight to nn.LayerNorm to support the mlx-lm implementation of [command-r+ from CohereForAI](https://huggingface.co/CohereForAI/c4ai-command-r-plus). 

Fast LayerNorm only supports 1-D weights.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
