### PR TITLE
[feat] upsample with bicubic interpolation

### DIFF
--- a/python/mlx/nn/layers/upsample.py
+++ b/python/mlx/nn/layers/upsample.py
@@ -181,7 +181,7 @@ class Upsample(Module):
             Otherwise, the number of scale factors provided must match the
             number of spatial dimensions.
         mode (str, optional): The upsampling algorithm, either ``"nearest"``,
-            ``"linear"`` or ``cubic``. Default: ``"nearest"``.
+            ``"linear"`` or ``"cubic"``. Default: ``"nearest"``.
         align_corners (bool, optional): Changes the way the corners are treated
             during ``"linear"`` upsampling.  See the note above and the
             examples below for more details.  Default: ``False``.

--- a/python/mlx/nn/layers/upsample.py
+++ b/python/mlx/nn/layers/upsample.py
@@ -164,13 +164,14 @@ class Upsample(Module):
     For example, an audio signal would be 3D with 1 spatial dimension, an image
     4D with 2 and so on and so forth.
 
-    There are two upsampling algorithms implemented nearest neighbor upsampling
-    and linear interpolation. Both can be applied to any number of spatial
-    dimensions and the linear interpolation will be bilinear, trilinear etc
-    when applied to more than one spatial dimension.
+    There are three upsampling algorithms implemented nearest neighbor upsampling,
+    linear interpolation, and cubic interpolation. All can be applied to any number
+    of spatial dimensions. The linear interpolation will be bilinear, trilinear etc
+    when applied to more than one spatial dimension. And cubic interpolation will be
+    bicubic when there are 2 spatial dimensions.
 
     .. note::
-       When using one of the linear interpolation modes the ``align_corners``
+       When using one of the linear or cubic interpolation modes the ``align_corners``
        argument changes how the corners are treated in the input image. If
        ``align_corners=True`` then the top and left edge of the input and
        output will be matching as will the bottom right edge.
@@ -183,7 +184,7 @@ class Upsample(Module):
         mode (str, optional): The upsampling algorithm, either ``"nearest"``,
             ``"linear"`` or ``"cubic"``. Default: ``"nearest"``.
         align_corners (bool, optional): Changes the way the corners are treated
-            during ``"linear"`` upsampling.  See the note above and the
+            during ``"linear"`` and ``"cubic"`` upsampling.  See the note above and the
             examples below for more details.  Default: ``False``.
 
     Examples:

--- a/python/tests/test_upsample.py
+++ b/python/tests/test_upsample.py
@@ -40,10 +40,7 @@ class TestConv(mlx_tests.MLXTestCase):
                 np_dtype = getattr(np, dtype)
                 np.random.seed(0)
                 iH, iW = idim
-                # in_np = np.random.normal(-1.0, 1.0, (N, iH, iW, C)).astype(np_dtype)
-                in_np = (
-                    np.arange(N * iH * iW * C).reshape(N, iH, iW, C).astype(np_dtype)
-                )
+                in_np = np.random.normal(-1.0, 1.0, (N, iH, iW, C)).astype(np_dtype)
 
                 in_mx = mx.array(in_np)
                 in_pt = torch.from_numpy(in_np.transpose(0, 3, 1, 2)).to("cpu")
@@ -79,6 +76,8 @@ class TestConv(mlx_tests.MLXTestCase):
                     ((4, 4), (0.5, 0.5)),
                     ((7, 7), (2.0, 2.0)),
                     ((10, 10), (0.2, 0.2)),
+                    ((11, 21), (3.0, 3.0)),
+                    ((11, 21), (3.0, 2.0)),
                 ):
                     # only test linear and cubic interpolation
                     # there will be numerical difference in nearest

--- a/python/tests/test_upsample.py
+++ b/python/tests/test_upsample.py
@@ -1,0 +1,100 @@
+# Copyright © 2023-2024 Apple Inc.
+
+import unittest
+
+import mlx.core as mx
+import mlx.nn as nn
+import mlx_tests
+import numpy as np
+
+try:
+    import torch
+    import torch.nn.functional as F
+
+    has_torch = True
+except ImportError as e:
+    has_torch = False
+
+
+class TestConv(mlx_tests.MLXTestCase):
+    @unittest.skipIf(not has_torch, "requires Torch")
+    def test_torch_upsample(self):
+        def run_upsample(
+            N,
+            C,
+            idim,
+            scale_factor,
+            mode,
+            align_corner,
+            dtype="float32",
+            atol=1e-5,
+        ):
+            with self.subTest(
+                N=N,
+                C=C,
+                idim=idim,
+                scale_factor=scale_factor,
+                mode=mode,
+                align_corner=align_corner,
+            ):
+                np_dtype = getattr(np, dtype)
+                np.random.seed(0)
+                iH, iW = idim
+                # in_np = np.random.normal(-1.0, 1.0, (N, iH, iW, C)).astype(np_dtype)
+                in_np = (
+                    np.arange(N * iH * iW * C).reshape(N, iH, iW, C).astype(np_dtype)
+                )
+
+                in_mx = mx.array(in_np)
+                in_pt = torch.from_numpy(in_np.transpose(0, 3, 1, 2)).to("cpu")
+
+                out_mx = nn.Upsample(
+                    scale_factor=scale_factor,
+                    mode=mode,
+                    align_corners=align_corner,
+                )(in_mx)
+                mode_pt = {
+                    "linear": "bilinear",
+                    "cubic": "bicubic",
+                }[mode]
+                out_pt = F.interpolate(
+                    in_pt,
+                    scale_factor=scale_factor,
+                    mode=mode_pt,
+                    align_corners=align_corner,
+                )
+                out_pt = torch.permute(out_pt, (0, 2, 3, 1)).numpy(force=True)
+                self.assertEqual(out_pt.shape, out_mx.shape)
+                self.assertTrue(np.allclose(out_pt, out_mx, atol=atol))
+
+        for dtype in ("float32",):
+            for N, C in ((1, 1), (2, 3)):
+                # only test cases in which target sizes are intergers
+                # if not, there will be numerical difference between mlx
+                # and torch due to different indices selection.
+                for idim, scale_factor in (
+                    ((2, 2), (1.0, 1.0)),
+                    ((2, 2), (1.5, 1.5)),
+                    ((2, 2), (2.0, 2.0)),
+                    ((4, 4), (0.5, 0.5)),
+                    ((7, 7), (2.0, 2.0)),
+                    ((10, 10), (0.2, 0.2)),
+                ):
+                    # only test linear and cubic interpolation
+                    # there will be numerical difference in nearest
+                    # due to different indices selection.
+                    for mode in ("cubic", "linear"):
+                        for align_corner in (False, True):
+                            run_upsample(
+                                N,
+                                C,
+                                idim,
+                                scale_factor,
+                                mode,
+                                align_corner,
+                                dtype=dtype,
+                            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_upsample.py
+++ b/python/tests/test_upsample.py
@@ -16,7 +16,7 @@ except ImportError as e:
     has_torch = False
 
 
-class TestConv(mlx_tests.MLXTestCase):
+class TestUpsample(mlx_tests.MLXTestCase):
     @unittest.skipIf(not has_torch, "requires Torch")
     def test_torch_upsample(self):
         def run_upsample(


### PR DESCRIPTION
## Proposed changes

- Enable `mode="cubic"` for `nn.Upsample` with bicubic interpolation
- Refactor the function `upsample_linear()` a little to reuse part of the code
- Remove `indices = mx.clip(indices, 0, N - 1)` in `_scaled_indices ()` to align the result with PyTorch. Add another two lines in `_linear_indices()` to make sure the linear interpolation result won't change.

## Not covered in this PR

- The numerical results are aligned to PyTorch only when the `input_size * scale_factor` is an integer (tested in `test_upsample.py`. Otherwise the indices selections of the two frameworks are different. The same thing also happens to the existing `linear` and `nearest` interpolations.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
