### PR TITLE
Async eval

### DIFF
--- a/mlx/backend/accelerate/softmax.cpp
+++ b/mlx/backend/accelerate/softmax.cpp
@@ -355,6 +355,7 @@ void Softmax::eval_cpu(const std::vector<array>& inputs, array& out) {
       break;
     case float16:
       if (precise_) {
+        std::cout << "PRECISE SMAX? " << std::endl;
         softmax<
             float16_t,
             float,

--- a/mlx/backend/accelerate/softmax.cpp
+++ b/mlx/backend/accelerate/softmax.cpp
@@ -355,7 +355,6 @@ void Softmax::eval_cpu(const std::vector<array>& inputs, array& out) {
       break;
     case float16:
       if (precise_) {
-        std::cout << "PRECISE SMAX? " << std::endl;
         softmax<
             float16_t,
             float,

--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -205,16 +205,21 @@ void Device::end_encoding(int index) {
   }
 }
 
-MTL::ComputeCommandEncoder* Device::get_command_encoder(int index) {
+MTL::ComputeCommandEncoder* Device::get_command_encoder(
+    int index,
+    bool serial /* = false */) {
   auto eit = encoder_map_.find(index);
-  if (eit == encoder_map_.end()) {
-    auto cb = get_command_buffer(index);
-    auto compute_encoder = cb->computeCommandEncoder();
-    // Increment ref count so the buffer is not garbage collected
-    compute_encoder->retain();
-    eit = encoder_map_.insert({index, compute_encoder}).first;
+  if (eit != encoder_map_.end()) {
+    eit->second->endEncoding();
+    eit->second->release();
   }
-  return eit->second;
+  auto cb = get_command_buffer(index);
+  auto compute_encoder = cb->computeCommandEncoder(
+      serial ? MTL::DispatchTypeSerial : MTL::DispatchTypeConcurrent);
+  // Increment ref count so the buffer is not garbage collected
+  compute_encoder->retain();
+  encoder_map_[index] = compute_encoder;
+  return compute_encoder;
 }
 
 void Device::register_library(

--- a/mlx/backend/metal/device.h
+++ b/mlx/backend/metal/device.h
@@ -51,7 +51,9 @@ class Device {
   int get_command_buffer_ops(int index);
   void increment_command_buffer_ops(int index);
   void commit_command_buffer(int index);
-  MTL::ComputeCommandEncoder* get_command_encoder(int index);
+  MTL::ComputeCommandEncoder* get_command_encoder(
+      int index,
+      bool serial = false);
   void end_encoding(int index);
 
   void register_library(

--- a/mlx/backend/metal/matmul.cpp
+++ b/mlx/backend/metal/matmul.cpp
@@ -907,7 +907,7 @@ void AddMM::eval_gpu(const std::vector<array>& inputs, array& out) {
           << "_K_" << ((K % bk == 0) ? "t" : "n") << "aligned";
 
     // Encode and dispatch gemm kernel
-    auto compute_encoder = d.get_command_encoder(s.index);
+    auto compute_encoder = d.get_command_encoder(s.index, true);
     auto kernel = d.get_kernel(kname.str());
     compute_encoder->setComputePipelineState(kernel);
 

--- a/mlx/backend/metal/metal.cpp
+++ b/mlx/backend/metal/metal.cpp
@@ -93,7 +93,6 @@ std::function<void()> make_task(
     if (!arr.is_tracer()) {
       arr.detach();
     }
-
     if (p) {
       metal::device(s.device).end_encoding(s.index);
       scheduler::notify_new_task(s);

--- a/mlx/backend/metal/normalization.cpp
+++ b/mlx/backend/metal/normalization.cpp
@@ -160,7 +160,7 @@ void RMSNormVJP::eval_gpu(
     op_name += "_looped";
   }
   op_name += type_to_name(gx);
-  auto compute_encoder = d.get_command_encoder(s.index);
+  auto compute_encoder = d.get_command_encoder(s.index, true);
   {
     auto kernel = d.get_kernel(op_name);
 
@@ -350,7 +350,7 @@ void LayerNormVJP::eval_gpu(
   }
 
   // Finish with the gradient for b in case we had a b
-  auto compute_encoder = d.get_command_encoder(s.index);
+  auto compute_encoder = d.get_command_encoder(s.index, true);
   if (gb.ndim() == 1 && gb.size() == axis_size) {
     ReductionPlan plan(
         ReductionOpType::ContiguousStridedReduce, {n_rows}, {axis_size});

--- a/mlx/backend/metal/reduce.cpp
+++ b/mlx/backend/metal/reduce.cpp
@@ -573,8 +573,8 @@ void Reduce::eval_gpu(const std::vector<array>& inputs, array& out) {
   // Initialize output
   auto& s = stream();
   auto& d = metal::device(s.device);
-  auto compute_encoder = d.get_command_encoder(s.index);
   {
+    auto compute_encoder = d.get_command_encoder(s.index, true);
     auto kernel = d.get_kernel("i" + op_name + type_to_name(out));
     size_t nthreads = out.size();
     MTL::Size grid_dims = MTL::Size(nthreads, 1, 1);
@@ -602,6 +602,7 @@ void Reduce::eval_gpu(const std::vector<array>& inputs, array& out) {
       in = in_copy;
       plan = get_reduction_plan(in, axes_);
     }
+    auto compute_encoder = d.get_command_encoder(s.index, true);
 
     // Reducing over everything and the data is all there no broadcasting or
     // slicing etc.

--- a/mlx/backend/metal/sort.cpp
+++ b/mlx/backend/metal/sort.cpp
@@ -131,7 +131,7 @@ void multi_block_sort(
       dev_vals_0, dev_vals_1, dev_idxs_0, dev_idxs_1, block_partitions};
 
   // Prepare command encoder
-  auto compute_encoder = d.get_command_encoder(s.index);
+  auto compute_encoder = d.get_command_encoder(s.index, true);
 
   // Do blockwise sort
   {

--- a/mlx/transforms.cpp
+++ b/mlx/transforms.cpp
@@ -38,7 +38,7 @@ class Synchronizer : public Primitive {
 // are currently under a function transformation.
 int detail::InTracing::tracing_counter{0};
 
-void eval(std::vector<array> outputs) {
+std::shared_future<void> async_eval(std::vector<array> outputs) {
   std::function<void(const array&)> recurse;
   std::queue<array> tape;
   std::unordered_set<std::uintptr_t> cache;
@@ -152,8 +152,11 @@ void eval(std::vector<array> outputs) {
       scheduler::enqueue(stream, std::move(task));
     }
   }
+  return deps[synchronizer.id()];
+}
 
-  deps[synchronizer.id()].wait();
+void eval(std::vector<array> outputs) {
+  async_eval(std::move(outputs)).wait();
 }
 
 std::pair<std::vector<array>, std::vector<array>> vjp(

--- a/mlx/transforms.h
+++ b/mlx/transforms.h
@@ -2,9 +2,12 @@
 
 #pragma once
 
+#include <future>
 #include "mlx/array.h"
 
 namespace mlx::core {
+
+std::shared_future<void> async_eval(std::vector<array> outputs);
 
 void eval(std::vector<array> outputs);
 

--- a/python/src/transforms.cpp
+++ b/python/src/transforms.cpp
@@ -595,6 +595,13 @@ class PyCheckpointedFun {
 };
 
 void init_transforms(nb::module_& m) {
+  nb::class_<std::shared_future<void>>(
+      m,
+      "Synchronizer",
+      R"pbdoc(
+      )pbdoc")
+      .def("wait", [](const std::shared_future<void>& f) { f.wait(); });
+
   m.def(
       "eval",
       [](const nb::args& args) {
@@ -614,6 +621,35 @@ void init_transforms(nb::module_& m) {
               or a tree of arrays. If a tree is given the nodes can be a Python
               :class:`list`, :class:`tuple` or :class:`dict`. Leaves which are not
               arrays are ignored.
+      )pbdoc");
+  m.def(
+      "async_eval",
+      [](const nb::args& args) {
+        std::vector<array> arrays = tree_flatten(args, false);
+        {
+          nb::gil_scoped_release nogil;
+          return async_eval(arrays);
+        }
+      },
+      nb::arg(),
+      nb::sig("def async_eval(*args) -> Synchronizer"),
+      R"pbdoc(
+        Asynchronously evaluate an :class:`array` or tree of :class:`array`.
+
+        You must call ``wait`` on the returned synchronization object before
+        using any arrays that are asynchronously evaluated.
+
+        Note:
+          This is an experimental API and may change in future versions.
+
+        Args:
+            *args (arrays or trees of arrays): Each argument can be a single array
+              or a tree of arrays. If a tree is given the nodes can be a Python
+              :class:`list`, :class:`tuple` or :class:`dict`. Leaves which are not
+              arrays are ignored.
+
+        Returns:
+            Synchronizer: A synchronization object.
       )pbdoc");
   m.def(
       "jvp",

--- a/python/src/utils.h
+++ b/python/src/utils.h
@@ -33,10 +33,10 @@ inline std::vector<int> get_reduce_axes(const IntOrVec& v, int dims) {
 }
 
 inline array to_array_with_accessor(nb::object obj) {
-  if (nb::hasattr(obj, "__mlx_array__")) {
-    return nb::cast<array>(obj.attr("__mlx_array__")());
-  } else if (nb::isinstance<array>(obj)) {
+  if (nb::isinstance<array>(obj)) {
     return nb::cast<array>(obj);
+  } else if (nb::hasattr(obj, "__mlx_array__")) {
+    return nb::cast<array>(obj.attr("__mlx_array__")());
   } else {
     std::ostringstream msg;
     msg << "Invalid type  " << nb::type_name(obj.type()).c_str()

--- a/python/tests/test_eval.py
+++ b/python/tests/test_eval.py
@@ -32,6 +32,12 @@ class TestEval(mlx_tests.MLXTestCase):
         mx.eval(state)
         self.assertEqual(x.item(), 3)
 
+    def test_async_eval(self):
+        x = mx.array(1) + mx.array(1) + mx.array(1)
+        sync = mx.async_eval(x)
+        sync.wait()
+        self.assertEqual(x.item(), 3)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Exposes an async evaluation for pipelining graph construction with compute.

Used like so in MLX LM:

```python
    y, prob = _step(y)

    while True:
        sync = mx.async_eval(y)
        next_out = _step(y)
        sync.wait()
        yield y.item(), prob
        y, prob = next_out
```
