### PR TITLE
Async eval

### DIFF
--- a/mlx/array.cpp
+++ b/mlx/array.cpp
@@ -93,7 +93,9 @@ void array::detach() {
 }
 
 void array::eval() {
-  mlx::core::eval({*this});
+  if (!is_evaled()) {
+    mlx::core::eval({*this});
+  }
 }
 
 bool array::is_tracer() const {

--- a/mlx/transforms.cpp
+++ b/mlx/transforms.cpp
@@ -38,7 +38,7 @@ class Synchronizer : public Primitive {
 // are currently under a function transformation.
 int detail::InTracing::tracing_counter{0};
 
-void eval(std::vector<array> outputs) {
+std::shared_future<void> async_eval(std::vector<array> outputs) {
   std::function<void(const array&)> recurse;
   std::queue<array> tape;
   std::unordered_set<std::uintptr_t> cache;
@@ -152,8 +152,11 @@ void eval(std::vector<array> outputs) {
       scheduler::enqueue(stream, std::move(task));
     }
   }
+  return deps[synchronizer.id()];
+}
 
-  deps[synchronizer.id()].wait();
+void eval(std::vector<array> outputs) {
+  async_eval(std::move(outputs)).wait();
 }
 
 std::pair<std::vector<array>, std::vector<array>> vjp(

--- a/mlx/transforms.h
+++ b/mlx/transforms.h
@@ -2,9 +2,12 @@
 
 #pragma once
 
+#include <future>
 #include "mlx/array.h"
 
 namespace mlx::core {
+
+std::shared_future<void> async_eval(std::vector<array> outputs);
 
 void eval(std::vector<array> outputs);
 

--- a/python/src/transforms.cpp
+++ b/python/src/transforms.cpp
@@ -599,6 +599,7 @@ void init_transforms(nb::module_& m) {
       m,
       "Synchronizer",
       R"pbdoc(
+      A synchronization object returned by :func:`async_eval`.
       )pbdoc")
       .def("wait", [](const std::shared_future<void>& f) { f.wait(); });
 
@@ -636,10 +637,13 @@ void init_transforms(nb::module_& m) {
       R"pbdoc(
         Asynchronously evaluate an :class:`array` or tree of :class:`array`.
 
-        You must call ``wait`` on the returned synchronization object before
-        using any arrays that are asynchronously evaluated.
+        .. warning::
 
-        Note:
+          You must call ``wait`` on the returned synchronization object before
+          using any arrays that are asynchronously evaluated.
+
+        .. note::
+
           This is an experimental API and may change in future versions.
 
         Args:

--- a/python/src/transforms.cpp
+++ b/python/src/transforms.cpp
@@ -595,6 +595,13 @@ class PyCheckpointedFun {
 };
 
 void init_transforms(nb::module_& m) {
+  nb::class_<std::shared_future<void>>(
+      m,
+      "Synchronizer",
+      R"pbdoc(
+      )pbdoc")
+      .def("wait", [](const std::shared_future<void>& f) { f.wait(); });
+
   m.def(
       "eval",
       [](const nb::args& args) {
@@ -614,6 +621,35 @@ void init_transforms(nb::module_& m) {
               or a tree of arrays. If a tree is given the nodes can be a Python
               :class:`list`, :class:`tuple` or :class:`dict`. Leaves which are not
               arrays are ignored.
+      )pbdoc");
+  m.def(
+      "async_eval",
+      [](const nb::args& args) {
+        std::vector<array> arrays = tree_flatten(args, false);
+        {
+          nb::gil_scoped_release nogil;
+          return async_eval(arrays);
+        }
+      },
+      nb::arg(),
+      nb::sig("def async_eval(*args) -> Synchronizer"),
+      R"pbdoc(
+        Asynchronously evaluate an :class:`array` or tree of :class:`array`.
+
+        You must call ``wait`` on the returned synchronization object before
+        using any arrays that are asynchronously evaluated.
+
+        Note:
+          This is an experimental API and may change in future versions.
+
+        Args:
+            *args (arrays or trees of arrays): Each argument can be a single array
+              or a tree of arrays. If a tree is given the nodes can be a Python
+              :class:`list`, :class:`tuple` or :class:`dict`. Leaves which are not
+              arrays are ignored.
+
+        Returns:
+            Synchronizer: A synchronization object.
       )pbdoc");
   m.def(
       "jvp",

--- a/python/tests/test_eval.py
+++ b/python/tests/test_eval.py
@@ -32,6 +32,12 @@ class TestEval(mlx_tests.MLXTestCase):
         mx.eval(state)
         self.assertEqual(x.item(), 3)
 
+    def test_async_eval(self):
+        x = mx.array(1) + mx.array(1) + mx.array(1)
+        sync = mx.async_eval(x)
+        sync.wait()
+        self.assertEqual(x.item(), 3)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/test_eval.py
+++ b/python/tests/test_eval.py
@@ -38,6 +38,12 @@ class TestEval(mlx_tests.MLXTestCase):
         sync.wait()
         self.assertEqual(x.item(), 3)
 
+        # It should be safe to call eval on the array which has been async
+        # eval'ed
+        x = mx.array(1) + mx.array(1) + mx.array(1)
+        sync = mx.async_eval(x)
+        self.assertEqual(x.item(), 3)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Exposes an async evaluation for pipelining graph construction with compute.

Used like so in MLX LM:

```python
    y, prob = _step(y)

    while True:
        sync = mx.async_eval(y)
        next_out = _step(y)
        sync.wait()
        yield y.item(), prob
        y, prob = next_out
```

Pre: `95.905 tokens-per-sec`
Post: `99.682 tokens-per-sec`
