### PR TITLE
Dynamic buffers

### DIFF
--- a/mlx/backend/accelerate/softmax.cpp
+++ b/mlx/backend/accelerate/softmax.cpp
@@ -355,6 +355,7 @@ void Softmax::eval_cpu(const std::vector<array>& inputs, array& out) {
       break;
     case float16:
       if (precise_) {
+        std::cout << "PRECISE SMAX? " << std::endl;
         softmax<
             float16_t,
             float,

--- a/mlx/backend/accelerate/softmax.cpp
+++ b/mlx/backend/accelerate/softmax.cpp
@@ -355,7 +355,6 @@ void Softmax::eval_cpu(const std::vector<array>& inputs, array& out) {
       break;
     case float16:
       if (precise_) {
-        std::cout << "PRECISE SMAX? " << std::endl;
         softmax<
             float16_t,
             float,

--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -118,6 +118,18 @@ Device::Device() {
   auto pool = new_scoped_memory_pool();
   device_ = load_device();
   library_map_ = {{"mlx", load_library(device_)}};
+
+  auto arch = std::string(device_->architecture()->name()->utf8String());
+  // Try to determine the category and fallback to small:
+  if (arch.empty()) {
+    category_ = Category::small;
+  } else if (arch.back() == 'd') {
+    category_ = Category::large;
+  } else if (arch.back() == 's') {
+    category_ = Category::medium;
+  } else {
+    category_ = Category::small;
+  }
 }
 
 Device::~Device() {

--- a/mlx/backend/metal/device.h
+++ b/mlx/backend/metal/device.h
@@ -83,7 +83,7 @@ struct CommandEncoder {
     enc->setBuffer(a_buf, base_offset, idx);
 
     // Rough estimate of the amount of memory used
-    enc.cb_info.bytes += a.nbytes();
+    cb_info.bytes += a.nbytes();
   }
 
   void set_output_array(array& a, int idx, int offset = 0) {

--- a/mlx/backend/metal/device.h
+++ b/mlx/backend/metal/device.h
@@ -111,6 +111,12 @@ struct CommandEncoder {
 
 class Device {
  public:
+  enum Category {
+    small = 0,
+    medium = 1,
+    large = 2,
+  };
+
   Device();
   Device(const Device&) = delete;
   Device& operator=(const Device&) = delete;
@@ -120,6 +126,9 @@ class Device {
     return device_;
   };
 
+  Category category() {
+    return category_;
+  };
   void new_queue(int index);
   MTL::CommandBuffer* new_command_buffer(int index);
   MTL::CommandBuffer* get_command_buffer(int index);
@@ -212,6 +221,7 @@ class Device {
   std::unordered_map<std::string, MTL::ComputePipelineState*> kernel_map_;
   std::unordered_map<std::string, MTL::Library*> library_map_;
   std::mutex mtx_;
+  Category category_;
 };
 
 Device& device(mlx::core::Device);

--- a/mlx/backend/metal/device.h
+++ b/mlx/backend/metal/device.h
@@ -83,7 +83,7 @@ struct CommandEncoder {
     enc->setBuffer(a_buf, base_offset, idx);
 
     // Rough estimate of the amount of memory used
-    cb_info.bytes += a.nbytes();
+    cb_info.bytes += a.data_size();
   }
 
   void set_output_array(array& a, int idx, int offset = 0) {

--- a/mlx/backend/metal/kernels/utils.h
+++ b/mlx/backend/metal/kernels/utils.h
@@ -134,51 +134,6 @@ elem_to_loc_3(uint3 elem, constant const stride_t strides[3]) {
 }
 
 template <int NDIM>
-METAL_FUNC size_t elem_to_loc_nd(
-    uint elem,
-    device const int* shape,
-    device const size_t* strides) {
-  size_t loc = (elem % shape[NDIM - 1]) * strides[NDIM - 1];
-
-  MLX_MTL_PRAGMA_UNROLL
-  for (int d = NDIM - 2; d >= 0; --d) {
-    elem /= shape[d + 1];
-    loc += (elem % shape[d]) * strides[d];
-  }
-
-  return loc;
-}
-
-template <int NDIM>
-METAL_FUNC size_t elem_to_loc_nd(
-    uint3 elem,
-    constant const int shape[NDIM],
-    constant const size_t strides[NDIM]) {
-  size_t loc = elem.x * strides[NDIM - 1] + elem.y * strides[NDIM - 2];
-  for (int d = NDIM - 3; d >= 0; --d) {
-    loc += (elem.z % shape[d]) * strides[d];
-    elem.z /= shape[d];
-  }
-  return loc;
-}
-
-template <int NDIM>
-METAL_FUNC int64_t elem_to_loc_nd(
-    uint elem,
-    constant const int shape[NDIM],
-    constant const int64_t strides[NDIM]) {
-  int64_t loc = (elem % shape[NDIM - 1]) * strides[NDIM - 1];
-
-  MLX_MTL_PRAGMA_UNROLL
-  for (int d = NDIM - 2; d >= 0; --d) {
-    elem /= shape[d + 1];
-    loc += (elem % shape[d]) * strides[d];
-  }
-
-  return loc;
-}
-
-template <int NDIM>
 METAL_FUNC int64_t elem_to_loc_nd(
     uint3 elem,
     constant const int shape[NDIM],

--- a/mlx/backend/metal/metal.cpp
+++ b/mlx/backend/metal/metal.cpp
@@ -23,13 +23,13 @@ int get_env_val(const char* name, int fallback) {
 }
 
 constexpr int default_max_ops[3] = {
-    10, // Category::small
-    30, // Category::medium
+    20, // Category::small
+    25, // Category::medium
     50, // Category::large
 };
 
 constexpr int default_max_mb[3] = {
-    20, // Category::small
+    50, // Category::small
     50, // Category::medium
     50, // Category::large
 };

--- a/mlx/backend/metal/metal.cpp
+++ b/mlx/backend/metal/metal.cpp
@@ -1,7 +1,6 @@
 // Copyright © 2023-2024 Apple Inc.
 #include <cstdlib>
 #include <future>
-#include <iostream> // TODO
 #include <memory>
 
 #include "mlx/backend/metal/device.h"

--- a/mlx/backend/metal/metal.cpp
+++ b/mlx/backend/metal/metal.cpp
@@ -24,7 +24,7 @@ int get_env_val(const char* name, int fallback) {
 }
 
 int max_ops_per_buffer() {
-  static int max_ops_per_buffer_ = get_env_val("MLX_MAX_OPS_PER_BUFFER", 30);
+  static int max_ops_per_buffer_ = get_env_val("MLX_MAX_OPS_PER_BUFFER", 40);
   return max_ops_per_buffer_;
 }
 

--- a/mlx/backend/metal/metal.cpp
+++ b/mlx/backend/metal/metal.cpp
@@ -24,7 +24,7 @@ int get_env_val(const char* name, int fallback) {
 
 constexpr int default_max_ops[3] = {
     20, // Category::small
-    25, // Category::medium
+    40, // Category::medium
     50, // Category::large
 };
 


### PR DESCRIPTION
Add a memory limit for command buffer packing and increase the default limit for the number of ops.

Also added a device category property:
- small is everything < Max
- medium = Max
- large = Ultra

Set the default `MLX_MAX_OPS_PER_BUFFER` and `MLX_MAX_MB_PER_BUFFER` based on the category.

Some stats:

Generation:

```
python -m mlx_lm.generate --model mlx-community/NeuralBeagle14-7B-4bit-mlx --prompt "Write a story about Einstein" --temp 0.0 --max-tokens 256
```
|| Pre | Post |
--- |--- | --- |
M2 Ultra | 103.631 | 106.234 |
M1 Max |  54.814 | 61.198 |
M1 Mini | 12.601  | 12.915 |
M2 Mini | 20.114 | 20.603 |

Transformer training

```
 python main.py --gpu --num_blocks 20 --batch_size 8
```

| | Its/s | Memory (GB)
--- | --- | ---
Pre | 0.997 | 26.937
Post | 0.996  | 23.873 