### PR TITLE
Try a stack-based DFS for eval

### DIFF
--- a/mlx/transforms.cpp
+++ b/mlx/transforms.cpp
@@ -1,7 +1,6 @@
 // Copyright © 2023-2024 Apple Inc.
 #include <algorithm>
 #include <future>
-#include <iostream> // TODO
 #include <numeric>
 #include <set>
 #include <sstream>

--- a/mlx/transforms.cpp
+++ b/mlx/transforms.cpp
@@ -67,8 +67,12 @@ std::shared_future<void> async_eval(std::vector<array> outputs) {
       if (idx < a.inputs().size()) {
         // Add an input, and continue
         auto& in = a.inputs()[idx++];
-
         if (!in.is_evaled()) {
+          if (!in.has_primitive()) {
+            throw std::invalid_argument(
+                "[eval] Attempting to eval an array without a primitive.");
+          }
+
           // If the input is being computed on a different stream, we need to
           // manage the dependency.
           if (a.primitive().stream() != in.primitive().stream()) {
@@ -88,10 +92,6 @@ std::shared_future<void> async_eval(std::vector<array> outputs) {
 
       // All inputs are done being processed, process this array
       if (!a.is_evaled() || (!a.is_tracer() && a.has_primitive())) {
-        if (!a.has_primitive()) {
-          throw std::invalid_argument(
-              "[eval] Attempting to eval an array without a primitive.");
-        }
         tape.push(a);
       }
       dfs.pop();


### PR DESCRIPTION
Benchmarks:

100 layer MNIST on the CPU (for maximum graph overhead):

Pre: 4.206 (s)
Post: 4.143 (s)

TPS for 4-bit Mistral is unaffected:

```
MLX_MAX_OPS_PER_BUFFER=50 python -m mlx_lm.generate --model mlx-community/NeuralBeagle14-7B-4bit-mlx --prompt "Write a story about Einstein" --temp 0.0 --max-tokens 256
```