### PR TITLE
Add ArrayDesc destructor to avoid possible stack overflow

### DIFF
--- a/mlx/array.cpp
+++ b/mlx/array.cpp
@@ -203,7 +203,7 @@ array::ArrayDesc::~ArrayDesc() {
   std::vector<std::shared_ptr<ArrayDesc>> for_deletion;
 
   for (array& a : inputs) {
-    if (a.array_desc_ != nullptr && a.array_desc_.use_count() == 1) {
+    if (a.array_desc_.use_count() == 1) {
       for_deletion.push_back(std::move(a.array_desc_));
     }
   }
@@ -215,7 +215,7 @@ array::ArrayDesc::~ArrayDesc() {
     for_deletion.pop_back();
 
     for (array& a : top->inputs) {
-      if (a.array_desc_ != nullptr && a.array_desc_.use_count() == 1) {
+      if (a.array_desc_.use_count() == 1) {
         for_deletion.push_back(std::move(a.array_desc_));
       }
     }

--- a/mlx/array.h
+++ b/mlx/array.h
@@ -404,6 +404,8 @@ class array {
         std::shared_ptr<Primitive> primitive,
         std::vector<array> inputs);
 
+    ~ArrayDesc();
+
    private:
     // Initialize size, strides, and other metadata
     void init();


### PR DESCRIPTION
The following script failed before this PR

```python
import gc

import mlx.core as mx

x = mx.ones(1)
for i in range(300_000):
    x = 2 * x
del x
gc.collect()
```

Weirdly, it failed with segmentation fault rather than stack overflow error but it may be an artifact of it being in the destructor. The stack trace was >260k levels deep so I think in general this is not too bad to do.

I measured no slowdown for Mistral inference or transformer training in comparison to main.