### PR TITLE
No copy command encoder

### DIFF
--- a/mlx/backend/metal/device.h
+++ b/mlx/backend/metal/device.h
@@ -39,6 +39,7 @@ using MTLFCList =
 struct CommandEncoder {
   CommandEncoder(MTL::ComputeCommandEncoder* enc)
       : enc(enc), concurrent(false){};
+  CommandEncoder(const CommandEncoder&) = delete;
   CommandEncoder& operator=(const CommandEncoder&) = delete;
 
   struct ConcurrentContext {
@@ -197,7 +198,7 @@ class Device {
   MTL::Device* device_;
   std::unordered_map<int32_t, MTL::CommandQueue*> queue_map_;
   std::unordered_map<int32_t, std::pair<int, MTL::CommandBuffer*>> buffer_map_;
-  std::unordered_map<int32_t, CommandEncoder> encoder_map_;
+  std::unordered_map<int32_t, std::unique_ptr<CommandEncoder>> encoder_map_;
   std::unordered_map<std::string, MTL::ComputePipelineState*> kernel_map_;
   std::unordered_map<std::string, MTL::Library*> library_map_;
   std::mutex mtx_;

--- a/python/tests/test_fast.py
+++ b/python/tests/test_fast.py
@@ -248,7 +248,7 @@ class TestFast(mlx_tests.MLXTestCase):
 
     def test_layer_norm(self):
         # Per dtype absolute tolerance
-        tolerances = {mx.float32: 3e-6, mx.float16: 3e-3, mx.bfloat16: 3e-2}
+        tolerances = {mx.float32: 1e-5, mx.float16: 5e-3, mx.bfloat16: 5e-2}
 
         dtypes = [mx.float32, mx.float16, mx.bfloat16]
         epss = [1e-3, 1e-5]


### PR DESCRIPTION
Won't compile if you do:

```
auto compute_encoder = d.get_command_encoder(s.index);
```

which previously would silently work and cause nasty synchronization issues.

That will now give:
```
error: call to deleted constructor of 'CommandEncoder'
  auto compute_encoder = d.get_command_encoder(s.index);
```