### PR TITLE
Async eval2

### DIFF
--- a/mlx/array.cpp
+++ b/mlx/array.cpp
@@ -176,7 +176,7 @@ void array::ArrayDesc::init() {
 }
 
 array::ArrayDesc::ArrayDesc(std::vector<int> shape, Dtype dtype)
-    : shape(std::move(shape)), dtype(dtype), evaled(true) {
+    : shape(std::move(shape)), dtype(dtype) {
   init();
 }
 

--- a/mlx/array.cpp
+++ b/mlx/array.cpp
@@ -176,7 +176,7 @@ void array::ArrayDesc::init() {
 }
 
 array::ArrayDesc::ArrayDesc(std::vector<int> shape, Dtype dtype)
-    : shape(std::move(shape)), dtype(dtype) {
+    : shape(std::move(shape)), dtype(dtype), evaled(true) {
   init();
 }
 

--- a/mlx/array.h
+++ b/mlx/array.h
@@ -317,7 +317,11 @@ class array {
 
   // Check if the array has been evaluated
   bool is_evaled() const {
-    return array_desc_->data != nullptr;
+    return array_desc_->evaled;
+  }
+  // Mark the array as evaluated
+  bool set_evaled() const {
+    return array_desc_->evaled = true;
   }
 
   // Mark the array as a tracer array (true) or not.
@@ -369,6 +373,9 @@ class array {
     size_t size;
     Dtype dtype;
     std::shared_ptr<Primitive> primitive;
+
+    // Whether or not the array is evaluated
+    bool evaled{false};
 
     // Indicates an array is being used in a graph transform
     // and should not be detached from the graph

--- a/mlx/array.h
+++ b/mlx/array.h
@@ -317,11 +317,17 @@ class array {
 
   // Check if the array has been evaluated
   bool is_evaled() const {
-    return array_desc_->evaled;
+    return array_desc_->data_ptr != nullptr;
   }
+
+  // Check if the array has been async evaluated
+  bool is_async_evaled() const {
+    return array_desc_->async_evaled;
+  }
+
   // Mark the array as evaluated
-  bool set_evaled() const {
-    return array_desc_->evaled = true;
+  bool set_async_evaled() const {
+    return array_desc_->async_evaled = true;
   }
 
   // Mark the array as a tracer array (true) or not.
@@ -374,8 +380,8 @@ class array {
     Dtype dtype;
     std::shared_ptr<Primitive> primitive;
 
-    // Whether or not the array is evaluated
-    bool evaled{false};
+    // Whether or not the array has been asynchronously evaluated
+    bool async_evaled{false};
 
     // Indicates an array is being used in a graph transform
     // and should not be detached from the graph

--- a/mlx/array.h
+++ b/mlx/array.h
@@ -317,7 +317,7 @@ class array {
 
   // Check if the array has been evaluated
   bool is_evaled() const {
-    return array_desc_->data_ptr != nullptr;
+    return array_desc_->data != nullptr;
   }
 
   // Check if the array has been async evaluated

--- a/mlx/transforms.cpp
+++ b/mlx/transforms.cpp
@@ -80,15 +80,14 @@ std::shared_future<void> async_eval(std::vector<array> outputs) {
           }
         }
 
-    cache.insert(id);
-    for (auto& s : a.siblings()) {
-      cache.insert(s.id());
-    }
-
-    if (!a.is_evaled() || (!a.is_tracer() && a.has_primitive())) {
-      if (!a.has_primitive()) {
-        throw std::invalid_argument(
-            "[eval] Attempting to eval an array without a primitive.");
+        if (cache.find(in.id()) == cache.end()) {
+          dfs.emplace(in, 0);
+          cache.insert(in.id());
+          for (auto& s : in.siblings()) {
+            cache.insert(s.id());
+          }
+        }
+        continue;
       }
 
       // All inputs are done being processed, process this array

--- a/mlx/transforms.cpp
+++ b/mlx/transforms.cpp
@@ -62,10 +62,18 @@ std::shared_future<void> eval_impl(std::vector<array> outputs, bool async) {
       if (idx < a.inputs().size()) {
         // Add an input, and continue
         auto& in = a.inputs()[idx++];
+
+        // Async evaled arrays could not have been tracers and are safe to
+        // ignore
         if (in.is_async_evaled()) {
           continue;
         }
+
         if (!in.is_evaled()) {
+          if (async && in.is_tracer()) {
+            throw std::invalid_argument(
+                "[async_eval] Not allowed inside a graph transfomration.");
+          }
           if (!in.has_primitive()) {
             throw std::invalid_argument(
                 "[eval] Attempting to eval an array without a primitive.");

--- a/python/src/transforms.cpp
+++ b/python/src/transforms.cpp
@@ -654,6 +654,20 @@ void init_transforms(nb::module_& m) {
 
         Returns:
             Synchronizer: A synchronization object.
+
+        Example:
+            >>> x = mx.array(1.0)
+            >>> y = mx.exp(x)
+            >>> sync = mx.async_eval(y)
+            >>> sync.wait() # wait for y to be computed
+            >>> print(y)
+            >>>
+            >>> y = mx.exp(x)
+            >>> mx.async_eval(y)
+            >>> z = y + 3
+            >>> sync = mx.async_eval(z)
+            >>> sync.wait() # wait for z (and y) to be computed
+            >>> print(z)
       )pbdoc");
   m.def(
       "jvp",

--- a/python/tests/test_eval.py
+++ b/python/tests/test_eval.py
@@ -44,6 +44,15 @@ class TestEval(mlx_tests.MLXTestCase):
         sync = mx.async_eval(x)
         self.assertEqual(x.item(), 3)
 
+        x = mx.array([1, 2, 3])
+        y = 2 * x
+        s1 = mx.async_eval(y)
+        z = 2 * y
+        s2 = mx.async_eval(z)
+        s2.wait()
+        self.assertTrue(mx.array_equal(y, mx.array([2, 4, 6])))
+        self.assertTrue(mx.array_equal(z, mx.array([4, 8, 12])))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Allows multiple calls to async eval.

Example of client code here https://github.com/ml-explore/mlx-examples/pull/679/files, still pretty simple IMO

```
python -m mlx_lm.generate --model mlx-community/NeuralBeagle14-7B-4bit-mlx --prompt "Write a story about Einstein" --temp 0.0 --max-tokens 256
```


Pre: `103.5 tps`
Post: `107.5 tps`

With 50 ops per buffer: `112.0 tps`