### PR TITLE
Shared events for synchronization + async eval

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ elseif (MLX_BUILD_METAL)
   FetchContent_Declare(
     metal_cpp
     URL ${METAL_CPP_URL}
-    PATCH_COMMAND patch -i ${METAL_CPP_PATCH}
+    PATCH_COMMAND patch -N -i ${METAL_CPP_PATCH} || true
   )
 
   FetchContent_MakeAvailable(metal_cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,8 +82,10 @@ elseif (MLX_BUILD_METAL)
   message(STATUS "Building with SDK for macOS version ${MACOS_VERSION}")
 
   if (${MACOS_VERSION} GREATER_EQUAL 14.2)
+    set(METAL_CPP_PATCH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/metal.14.2.diff)
     set(METAL_CPP_URL https://developer.apple.com/metal/cpp/files/metal-cpp_macOS14.2_iOS17.2.zip)
   elseif (${MACOS_VERSION} GREATER_EQUAL 14.0)
+    set(METAL_CPP_PATCH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/metal.14.0.diff)
     set(METAL_CPP_URL https://developer.apple.com/metal/cpp/files/metal-cpp_macOS14_iOS17-beta.zip)
   else()
     message(FATAL_ERROR "MLX requires macOS SDK >= 14.0 to be built with MLX_BUILD_METAL=ON" )
@@ -92,6 +94,7 @@ elseif (MLX_BUILD_METAL)
   FetchContent_Declare(
     metal_cpp
     URL ${METAL_CPP_URL}
+    PATCH_COMMAND patch -i ${METAL_CPP_PATCH}
   )
 
   FetchContent_MakeAvailable(metal_cpp)

--- a/cmake/metal.14.0.diff
+++ b/cmake/metal.14.0.diff
@@ -1,0 +1,36 @@
+diff -ur Metal/MTLEvent.hpp MetalNew/MTLEvent.hpp
+--- Metal/MTLEvent.hpp	2023-06-01 12:18:26
++++ MetalNew/MTLEvent.hpp	2024-04-15 07:36:59
+@@ -62,6 +62,7 @@
+ 
+     uint64_t                 signaledValue() const;
+     void                     setSignaledValue(uint64_t signaledValue);
++    bool                     waitUntilSignaledValue(uint64_t signaledValue, uint64_t timeoutMS);
+ };
+ 
+ class SharedEventHandle : public NS::SecureCoding<SharedEventHandle>
+@@ -138,6 +139,11 @@
+ _MTL_INLINE void MTL::SharedEvent::setSignaledValue(uint64_t signaledValue)
+ {
+     Object::sendMessage<void>(this, _MTL_PRIVATE_SEL(setSignaledValue_), signaledValue);
++}
++
++// method: waitUntilSignaledValue
++_MTL_INLINE bool MTL::SharedEvent::waitUntilSignaledValue(uint64_t signaledValue, uint64_t timeoutMS) {
++    return Object::sendMessage<bool>(this, _MTL_PRIVATE_SEL(waitUntilSignaledValue_timeoutMS_), signaledValue, timeoutMS);
+ }
+ 
+ // static method: alloc
+diff -ur Metal/MTLHeaderBridge.hpp MetalNew/MTLHeaderBridge.hpp
+--- Metal/MTLHeaderBridge.hpp	2023-06-01 12:18:26
++++ MetalNew/MTLHeaderBridge.hpp	2024-04-15 07:37:29
+@@ -1906,6 +1906,9 @@
+     "setShouldMaximizeConcurrentCompilation:");
+ _MTL_PRIVATE_DEF_SEL(setSignaledValue_,
+     "setSignaledValue:");
++_MTL_PRIVATE_DEF_SEL(
++    waitUntilSignaledValue_timeoutMS_,
++    "waitUntilSignaledValue:timeoutMS:");
+ _MTL_PRIVATE_DEF_SEL(setSize_,
+     "setSize:");
+ _MTL_PRIVATE_DEF_SEL(setSlice_,

--- a/cmake/metal.14.2.diff
+++ b/cmake/metal.14.2.diff
@@ -1,0 +1,36 @@
+diff -ur Metal/MTLEvent.hpp MetalNew/MTLEvent.hpp
+--- Metal/MTLEvent.hpp	2024-04-15 07:12:10
++++ MetalNew/MTLEvent.hpp	2024-04-15 07:15:50
+@@ -62,6 +62,7 @@
+ 
+     uint64_t                 signaledValue() const;
+     void                     setSignaledValue(uint64_t signaledValue);
++    bool                     waitUntilSignaledValue(uint64_t signaledValue, uint64_t timeoutMS);
+ };
+ 
+ class SharedEventHandle : public NS::SecureCoding<SharedEventHandle>
+@@ -138,6 +139,11 @@
+ _MTL_INLINE void MTL::SharedEvent::setSignaledValue(uint64_t signaledValue)
+ {
+     Object::sendMessage<void>(this, _MTL_PRIVATE_SEL(setSignaledValue_), signaledValue);
++}
++
++// method: waitUntilSignaledValue
++_MTL_INLINE bool MTL::SharedEvent::waitUntilSignaledValue(uint64_t signaledValue, uint64_t timeoutMS) {
++    return Object::sendMessage<bool>(this, _MTL_PRIVATE_SEL(waitUntilSignaledValue_timeoutMS_), signaledValue, timeoutMS);
+ }
+ 
+ // static method: alloc
+diff -ur Metal/MTLHeaderBridge.hpp MetalNew/MTLHeaderBridge.hpp
+--- Metal/MTLHeaderBridge.hpp	2024-04-15 07:12:10
++++ MetalNew/MTLHeaderBridge.hpp	2024-04-15 07:16:15
+@@ -1918,6 +1918,9 @@
+     "setShouldMaximizeConcurrentCompilation:");
+ _MTL_PRIVATE_DEF_SEL(setSignaledValue_,
+     "setSignaledValue:");
++_MTL_PRIVATE_DEF_SEL(
++    waitUntilSignaledValue_timeoutMS_,
++    "waitUntilSignaledValue:timeoutMS:");
+ _MTL_PRIVATE_DEF_SEL(setSize_,
+     "setSize:");
+ _MTL_PRIVATE_DEF_SEL(setSlice_,

--- a/mlx/array.cpp
+++ b/mlx/array.cpp
@@ -93,7 +93,9 @@ void array::detach() {
 }
 
 void array::eval() {
-  if (!is_evaled()) {
+  if (is_async_evaled()) {
+    event().wait();
+  } else if (!is_evaled()) {
     mlx::core::eval({*this});
   }
 }

--- a/mlx/array.cpp
+++ b/mlx/array.cpp
@@ -93,9 +93,11 @@ void array::detach() {
 }
 
 void array::eval() {
-  if (is_async_evaled()) {
+  // Ensure the array is ready to be read
+  if (status() == Status::scheduled) {
     event().wait();
-  } else if (!is_evaled()) {
+    set_status(Status::available);
+  } else if (status() == Status::unscheduled) {
     mlx::core::eval({*this});
   }
 }
@@ -178,7 +180,7 @@ void array::ArrayDesc::init() {
 }
 
 array::ArrayDesc::ArrayDesc(std::vector<int> shape, Dtype dtype)
-    : shape(std::move(shape)), dtype(dtype) {
+    : shape(std::move(shape)), dtype(dtype), status(Status::available) {
   init();
 }
 
@@ -189,6 +191,7 @@ array::ArrayDesc::ArrayDesc(
     std::vector<array> inputs)
     : shape(std::move(shape)),
       dtype(dtype),
+      status(Status::unscheduled),
       primitive(std::move(primitive)),
       inputs(std::move(inputs)) {
   init();

--- a/mlx/array.cpp
+++ b/mlx/array.cpp
@@ -176,7 +176,7 @@ void array::ArrayDesc::init() {
 }
 
 array::ArrayDesc::ArrayDesc(std::vector<int> shape, Dtype dtype)
-    : shape(std::move(shape)), dtype(dtype), evaled(true) {
+    : shape(std::move(shape)), dtype(dtype) {
   init();
 }
 

--- a/mlx/array.cpp
+++ b/mlx/array.cpp
@@ -176,7 +176,7 @@ void array::ArrayDesc::init() {
 }
 
 array::ArrayDesc::ArrayDesc(std::vector<int> shape, Dtype dtype)
-    : shape(std::move(shape)), dtype(dtype) {
+    : shape(std::move(shape)), dtype(dtype), evaled(true) {
   init();
 }
 

--- a/mlx/array.h
+++ b/mlx/array.h
@@ -9,6 +9,7 @@
 
 #include "mlx/allocator.h"
 #include "mlx/dtype.h"
+#include "mlx/event.h"
 
 namespace mlx::core {
 
@@ -330,6 +331,14 @@ class array {
     return array_desc_->async_evaled = true;
   }
 
+  Event& event() const {
+    return array_desc_->event;
+  }
+
+  void attach_event(Event e) const {
+    array_desc_->event = std::move(e);
+  }
+
   // Mark the array as a tracer array (true) or not.
   void set_tracer(bool is_tracer) {
     array_desc_->is_tracer = is_tracer;
@@ -382,6 +391,9 @@ class array {
 
     // Whether or not the array has been asynchronously evaluated
     bool async_evaled{false};
+
+    //
+    Event event;
 
     // Indicates an array is being used in a graph transform
     // and should not be detached from the graph

--- a/mlx/array.h
+++ b/mlx/array.h
@@ -317,7 +317,11 @@ class array {
 
   // Check if the array has been evaluated
   bool is_evaled() const {
-    return array_desc_->data != nullptr;
+    return array_desc_->evaled;
+  }
+  // Mark the array as evaluated
+  bool set_evaled() const {
+    return array_desc_->evaled = true;
   }
 
   // Mark the array as a tracer array (true) or not.
@@ -369,6 +373,9 @@ class array {
     size_t size;
     Dtype dtype;
     std::shared_ptr<Primitive> primitive;
+
+    // Whether or not the array is evaluated
+    bool evaled{false};
 
     // Indicates an array is being used in a graph transform
     // and should not be detached from the graph

--- a/mlx/array.h
+++ b/mlx/array.h
@@ -331,10 +331,12 @@ class array {
     return array_desc_->async_evaled = true;
   }
 
+  // Get the array's shared event
   Event& event() const {
     return array_desc_->event;
   }
 
+  // Attach an event to a not yet evaluated array
   void attach_event(Event e) const {
     array_desc_->event = std::move(e);
   }
@@ -392,7 +394,7 @@ class array {
     // Whether or not the array has been asynchronously evaluated
     bool async_evaled{false};
 
-    //
+    // An event on the array used for synchronization
     Event event;
 
     // Indicates an array is being used in a graph transform

--- a/mlx/array.h
+++ b/mlx/array.h
@@ -317,11 +317,17 @@ class array {
 
   // Check if the array has been evaluated
   bool is_evaled() const {
-    return array_desc_->evaled;
+    return array_desc_->data_ptr != nullptr;
   }
+
+  // Check if the array has been async evaluated
+  bool is_async_evaled() const {
+    return array_desc_->async_evaled;
+  }
+
   // Mark the array as evaluated
-  bool set_evaled() const {
-    return array_desc_->evaled = true;
+  bool set_async_evaled() const {
+    return array_desc_->async_evaled = true;
   }
 
   // Mark the array as a tracer array (true) or not.
@@ -374,8 +380,8 @@ class array {
     Dtype dtype;
     std::shared_ptr<Primitive> primitive;
 
-    // Whether or not the array is evaluated
-    bool evaled{false};
+    // Whether or not the array has been asynchronously evaluated
+    bool async_evaled{false};
 
     // Indicates an array is being used in a graph transform
     // and should not be detached from the graph

--- a/mlx/array.h
+++ b/mlx/array.h
@@ -317,7 +317,7 @@ class array {
 
   // Check if the array has been evaluated
   bool is_evaled() const {
-    return array_desc_->data_ptr != nullptr;
+    return array_desc_->data != nullptr;
   }
 
   // Check if the array has been async evaluated

--- a/mlx/backend/metal/CMakeLists.txt
+++ b/mlx/backend/metal/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(
   ${CMAKE_CURRENT_SOURCE_DIR}/conv.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/copy.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/device.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/event.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/fft.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/indexing.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/matmul.cpp

--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -544,11 +544,12 @@ Device& device(mlx::core::Device) {
   return metal_device;
 }
 
-std::shared_ptr<void> new_scoped_memory_pool() {
+std::unique_ptr<void, std::function<void(void*)>> new_scoped_memory_pool() {
   auto dtor = [](void* ptr) {
     static_cast<NS::AutoreleasePool*>(ptr)->release();
   };
-  return std::shared_ptr<void>(NS::AutoreleasePool::alloc()->init(), dtor);
+  return std::unique_ptr<void, std::function<void(void*)>>(
+      NS::AutoreleasePool::alloc()->init(), dtor);
 }
 
 void new_stream(Stream stream) {

--- a/mlx/backend/metal/event.cpp
+++ b/mlx/backend/metal/event.cpp
@@ -2,11 +2,16 @@
 
 #include "mlx/event.h"
 #include "mlx/backend/metal/device.h"
+#include "mlx/backend/metal/metal_impl.h"
 
 namespace mlx::core {
 
 Event::Event(const Stream& stream) : stream_(stream) {
-  auto dtor = [](void* ptr) { static_cast<MTL::SharedEvent*>(ptr)->release(); };
+  auto dtor = [](void* ptr) {
+    auto p = metal::new_scoped_memory_pool();
+    static_cast<MTL::SharedEvent*>(ptr)->release();
+  };
+  auto p = metal::new_scoped_memory_pool();
   event_ = std::shared_ptr<void>(
       metal::device(stream.device).mtl_device()->newSharedEvent(), dtor);
 }

--- a/mlx/backend/metal/event.cpp
+++ b/mlx/backend/metal/event.cpp
@@ -1,0 +1,25 @@
+// Copyright © 2024 Apple Inc.
+
+#include "mlx/event.h"
+#include "mlx/backend/metal/device.h"
+
+namespace mlx::core {
+
+Event::Event(const Stream& stream) : stream_(stream) {
+  auto dtor = [](void* ptr) { static_cast<MTL::SharedEvent*>(ptr)->release(); };
+  event_ = std::shared_ptr<void>(
+      metal::device(stream.device).mtl_device()->newSharedEvent(), dtor);
+}
+
+void Event::wait() {
+  if (!static_cast<MTL::SharedEvent*>(raw_event().get())
+           ->waitUntilSignaledValue(value(), -1)) {
+    throw std::runtime_error("[Event::wait] Timed out");
+  }
+}
+
+void Event::signal() {
+  static_cast<MTL::SharedEvent*>(raw_event().get())->setSignaledValue(value());
+}
+
+} // namespace mlx::core

--- a/mlx/backend/metal/metal.cpp
+++ b/mlx/backend/metal/metal.cpp
@@ -55,17 +55,19 @@ inline void check_error(MTL::CommandBuffer* cbuf) {
   }
 }
 
-std::function<void()> make_task(
-    array& arr,
-    std::vector<std::shared_future<void>> deps,
-    std::shared_ptr<std::promise<void>> p) {
-  auto task = [arr, deps = std::move(deps), p = std::move(p)]() mutable {
+std::function<void()> make_task(array arr, bool signal) {
+  auto task = [arr = std::move(arr), signal]() mutable {
     auto pool = new_scoped_memory_pool();
-    for (auto& d : deps) {
-      d.wait();
-    }
     auto s = arr.primitive().stream();
     auto command_buffer = increment_command_buffer(s);
+    for (auto& i : arr.inputs()) {
+      if (i.event().valid() && i.event().stream() != arr.primitive().stream()) {
+        // TODO, consider committing the buffer and encoding a wait in the new
+        // buffer rather than on the task thread
+        i.event().wait();
+      }
+    }
+
     auto outputs = arr.outputs();
     {
       // If the array is a tracer hold a reference
@@ -88,20 +90,26 @@ std::function<void()> make_task(
     if (!arr.is_tracer()) {
       arr.detach();
     }
-    if (p) {
+
+    if (signal) {
+      // Make sure this buffer had at least one command encoder on it.
+      auto id = arr.id();
       metal::device(s.device).end_encoding(s.index);
+      command_buffer->encodeSignalEvent(
+          static_cast<MTL::Event*>(arr.event().raw_event().get()),
+          arr.event().value());
       scheduler::notify_new_task(s);
       command_buffer->addCompletedHandler(
-          [s, buffers = std::move(buffers), p = std::move(p)](
+          [s, buffers = std::move(buffers), event = arr.event()](
               MTL::CommandBuffer* cbuf) {
-            p->set_value();
             scheduler::notify_task_completion(s);
             check_error(cbuf);
           });
       metal::device(s.device).commit_command_buffer(s.index);
     } else {
+      auto id = arr.id();
       command_buffer->addCompletedHandler(
-          [s, buffers = std::move(buffers)](MTL::CommandBuffer* cbuf) {
+          [s, buffers = std::move(buffers), id](MTL::CommandBuffer* cbuf) {
             check_error(cbuf);
           });
     }

--- a/mlx/backend/metal/metal_impl.h
+++ b/mlx/backend/metal/metal_impl.h
@@ -13,6 +13,6 @@ void new_stream(Stream stream);
 
 std::unique_ptr<void, std::function<void(void*)>> new_scoped_memory_pool();
 
-std::function<void()> make_task(array arr, bool flush);
+std::function<void()> make_task(array arr, bool signal);
 
 } // namespace mlx::core::metal

--- a/mlx/backend/metal/metal_impl.h
+++ b/mlx/backend/metal/metal_impl.h
@@ -2,9 +2,7 @@
 
 #pragma once
 
-#include <future>
 #include <memory>
-#include <vector>
 
 #include "mlx/array.h"
 #include "mlx/stream.h"
@@ -14,9 +12,6 @@ namespace mlx::core::metal {
 void new_stream(Stream stream);
 std::shared_ptr<void> new_scoped_memory_pool();
 
-std::function<void()> make_task(
-    array& arr,
-    std::vector<std::shared_future<void>> deps,
-    std::shared_ptr<std::promise<void>> p);
+std::function<void()> make_task(array arr, bool flush);
 
 } // namespace mlx::core::metal

--- a/mlx/backend/metal/metal_impl.h
+++ b/mlx/backend/metal/metal_impl.h
@@ -10,7 +10,8 @@
 namespace mlx::core::metal {
 
 void new_stream(Stream stream);
-std::shared_ptr<void> new_scoped_memory_pool();
+
+std::unique_ptr<void, std::function<void(void*)>> new_scoped_memory_pool();
 
 std::function<void()> make_task(array arr, bool flush);
 

--- a/mlx/backend/no_metal/CMakeLists.txt
+++ b/mlx/backend/no_metal/CMakeLists.txt
@@ -2,6 +2,7 @@ target_sources(
   mlx
   PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/allocator.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/event.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/metal.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/primitives.cpp
 )

--- a/mlx/backend/no_metal/event.cpp
+++ b/mlx/backend/no_metal/event.cpp
@@ -1,0 +1,40 @@
+// Copyright © 2024 Apple Inc.
+
+#include "mlx/event.h"
+
+#include <condition_variable>
+#include <mutex>
+
+namespace mlx::core {
+
+struct EventCounter {
+  uint64_t value{0};
+  std::mutex mtx;
+  std::condition_variable cv;
+}
+
+Event::Event(const Stream& stream)
+    : stream(stream) {
+  auto dtor = [](void* ptr) { delete static_cast<EventCounter*>(ptr); };
+  event = std::shared_ptr<void>(new EventCounter{}, dtor);
+}
+
+void Event::wait() {
+  auto ec = static_cast<EventCounter*>(event.get());
+  std::unique_lock<std::mutex> lk(ec->mtx);
+  if (ec.value >= value) {
+    return;
+  }
+  cond.wait(lk, [value, ec] { return ec->value >= value; });
+}
+
+void Event::signal() {
+  auto ec = static_cast<EventCounter*>(event.get());
+  {
+    std::lock_guard<std::mutex> lk(ec->mtx);
+    ec->value = value;
+  }
+  cond.notify_all();
+}
+
+} // namespace mlx::core

--- a/mlx/backend/no_metal/metal.cpp
+++ b/mlx/backend/no_metal/metal.cpp
@@ -12,7 +12,8 @@ bool is_available() {
 }
 
 void new_stream(Stream) {}
-std::shared_ptr<void> new_scoped_memory_pool() {
+
+std::unique_ptr<void, std::function<void(void*)>> new_scoped_memory_pool() {
   return nullptr;
 }
 

--- a/mlx/backend/no_metal/metal.cpp
+++ b/mlx/backend/no_metal/metal.cpp
@@ -16,10 +16,7 @@ std::shared_ptr<void> new_scoped_memory_pool() {
   return nullptr;
 }
 
-std::function<void()> make_task(
-    array& arr,
-    std::vector<std::shared_future<void>> deps,
-    std::shared_ptr<std::promise<void>> p) {
+std::function<void()> make_task(array arr, bool flush) {
   throw std::runtime_error(
       "[metal::make_task] Cannot make GPU task without metal backend");
 }

--- a/mlx/backend/no_metal/metal.cpp
+++ b/mlx/backend/no_metal/metal.cpp
@@ -17,7 +17,7 @@ std::unique_ptr<void, std::function<void(void*)>> new_scoped_memory_pool() {
   return nullptr;
 }
 
-std::function<void()> make_task(array arr, bool flush) {
+std::function<void()> make_task(array arr, bool signal) {
   throw std::runtime_error(
       "[metal::make_task] Cannot make GPU task without metal backend");
 }

--- a/mlx/compile.cpp
+++ b/mlx/compile.cpp
@@ -352,7 +352,9 @@ void compile_simplify(
   // Helpers to identify identical scalars
   std::map<std::pair<uint64_t, Dtype::Val>, array> scalars;
   auto is_scalar = [](const array& a) {
-    return a.is_evaled() && a.ndim() == 0;
+    // Condition for when it's safe to read an array
+    return !a.is_async_evaled() && a.data_shared_ptr() != nullptr &&
+        a.ndim() == 0;
   };
   auto get_scalar_rep = [](const array& a) {
     uint64_t v = 0;

--- a/mlx/compile.cpp
+++ b/mlx/compile.cpp
@@ -353,8 +353,7 @@ void compile_simplify(
   std::map<std::pair<uint64_t, Dtype::Val>, array> scalars;
   auto is_scalar = [](const array& a) {
     // Condition for when it's safe to read an array
-    return !a.is_async_evaled() && a.data_shared_ptr() != nullptr &&
-        a.ndim() == 0;
+    return a.is_available() && a.ndim() == 0;
   };
   auto get_scalar_rep = [](const array& a) {
     uint64_t v = 0;

--- a/mlx/event.h
+++ b/mlx/event.h
@@ -2,6 +2,8 @@
 #pragma once
 
 #include <memory>
+#include <stdexcept>
+
 #include "mlx/stream.h"
 
 namespace mlx::core {

--- a/mlx/event.h
+++ b/mlx/event.h
@@ -1,6 +1,7 @@
 // Copyright © 2024 Apple Inc.
 #pragma once
 
+#include <memory>
 #include "mlx/stream.h"
 
 namespace mlx::core {

--- a/mlx/event.h
+++ b/mlx/event.h
@@ -1,0 +1,53 @@
+// Copyright © 2024 Apple Inc.
+#pragma once
+
+#include "mlx/stream.h"
+
+namespace mlx::core {
+
+class Event {
+ public:
+  Event(){};
+
+  Event(const Stream& steam);
+
+  // Wait for the event to be signaled at it's curent value
+  void wait();
+
+  // Signal the event at it's current value
+  void signal();
+
+  // Check if the event is valid
+  bool valid() {
+    return event_ != nullptr;
+  };
+
+  uint64_t value() {
+    return value_;
+  };
+
+  void set_value(uint64_t v) {
+    value_ = v;
+  };
+
+  const Stream& stream() {
+    if (!valid()) {
+      throw std::runtime_error(
+          "[Event::stream] Cannot access stream on invalid event.");
+    }
+    return stream_;
+  };
+
+  const std::shared_ptr<void>& raw_event() {
+    return event_;
+  };
+
+ private:
+  // Default constructed stream should never be used
+  // since the event is not yet valid
+  Stream stream_{0, Device::cpu};
+  std::shared_ptr<void> event_{nullptr};
+  uint64_t value_{0};
+};
+
+} // namespace mlx::core

--- a/mlx/event.h
+++ b/mlx/event.h
@@ -14,10 +14,10 @@ class Event {
 
   Event(const Stream& steam);
 
-  // Wait for the event to be signaled at it's curent value
+  // Wait for the event to be signaled at its curent value
   void wait();
 
-  // Signal the event at it's current value
+  // Signal the event at its current value
   void signal();
 
   // Check if the event is valid

--- a/mlx/transforms.cpp
+++ b/mlx/transforms.cpp
@@ -80,15 +80,14 @@ std::shared_future<void> async_eval(std::vector<array> outputs) {
           }
         }
 
-    cache.insert(id);
-    for (auto& s : a.siblings()) {
-      cache.insert(s.id());
-    }
-
-    if (!a.is_evaled() || (!a.is_tracer() && a.has_primitive())) {
-      if (!a.has_primitive()) {
-        throw std::invalid_argument(
-            "[eval] Attempting to eval an array without a primitive.");
+        if (cache.find(in.id()) == cache.end()) {
+          dfs.emplace(in, 0);
+          cache.insert(in.id());
+          for (auto& s : in.siblings()) {
+            cache.insert(s.id());
+          }
+        }
+        continue;
       }
 
       // All inputs are done being processed, process this array

--- a/mlx/transforms.cpp
+++ b/mlx/transforms.cpp
@@ -149,12 +149,11 @@ array eval_impl(std::vector<array> outputs, bool async) {
       }
       scheduler::enqueue(stream, metal::make_task(std::move(arr), signal));
     } else {
-      bool flush = needs_signal.find(arr.id()) != needs_signal.end();
       auto task = [arr = std::move(arr), stream, signal]() mutable {
-        for (auto& i : arr.inputs()) {
-          if (i.event().valid() &&
-              i.event().stream() != arr.primitive().stream()) {
-            i.event().wait();
+        for (auto& input : arr.inputs()) {
+          if (input.event().valid() &&
+              input.event().stream() != arr.primitive().stream()) {
+            input.event().wait();
           }
         }
         scheduler::notify_new_task(stream);

--- a/mlx/transforms.cpp
+++ b/mlx/transforms.cpp
@@ -62,10 +62,18 @@ std::shared_future<void> eval_impl(std::vector<array> outputs, bool async) {
       if (idx < a.inputs().size()) {
         // Add an input, and continue
         auto& in = a.inputs()[idx++];
+
+        // Async evaled arrays could not have been tracers and are safe to
+        // ignore
         if (in.is_async_evaled()) {
           continue;
         }
+
         if (!in.is_evaled()) {
+          if (async && in.is_tracer()) {
+            throw std::invalid_argument(
+                "[async_eval] Not allowed inside a graph transfomration.");
+          }
           if (!in.has_primitive()) {
             throw std::invalid_argument(
                 "[eval] Attempting to eval an array without a primitive.");

--- a/mlx/transforms.h
+++ b/mlx/transforms.h
@@ -2,12 +2,11 @@
 
 #pragma once
 
-#include <future>
 #include "mlx/array.h"
 
 namespace mlx::core {
 
-std::shared_future<void> async_eval(std::vector<array> outputs);
+void async_eval(std::vector<array> outputs);
 
 void eval(std::vector<array> outputs);
 

--- a/mlx/utils.cpp
+++ b/mlx/utils.cpp
@@ -264,9 +264,7 @@ std::ostream& operator<<(std::ostream& os, const Dtype::Kind& k) {
 }
 
 std::ostream& operator<<(std::ostream& os, array a) {
-  if (!a.is_evaled()) {
-    a.eval();
-  }
+  a.eval();
   switch (a.dtype()) {
     case bool_:
       print_array<bool>(os, a);

--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -946,10 +946,7 @@ void init_array(nb::module_& m) {
       .def(
           "__repr__",
           [](array& a) {
-            if (!a.is_evaled()) {
-              nb::gil_scoped_release nogil;
-              a.eval();
-            }
+            nb::gil_scoped_release nogil;
             std::ostringstream os;
             os << a;
             return os.str();

--- a/python/src/buffer.h
+++ b/python/src/buffer.h
@@ -86,7 +86,7 @@ extern "C" inline int getbuffer(PyObject* obj, Py_buffer* view, int flags) {
   std::memset(view, 0, sizeof(Py_buffer));
   auto a = nb::cast<array>(nb::handle(obj));
 
-  if (!a.is_evaled()) {
+  {
     nb::gil_scoped_release nogil;
     a.eval();
   }

--- a/python/src/convert.cpp
+++ b/python/src/convert.cpp
@@ -104,8 +104,7 @@ template <typename Lib, typename T>
 nb::ndarray<Lib> mlx_to_nd_array(
     array a,
     std::optional<nb::dlpack::dtype> t = {}) {
-  // Eval if not already evaled
-  if (!a.is_evaled()) {
+  {
     nb::gil_scoped_release nogil;
     a.eval();
   }

--- a/python/src/transforms.cpp
+++ b/python/src/transforms.cpp
@@ -654,6 +654,20 @@ void init_transforms(nb::module_& m) {
 
         Returns:
             Synchronizer: A synchronization object.
+
+        Example:
+            >>> x = mx.array(1.0)
+            >>> y = mx.exp(x)
+            >>> sync = mx.async_eval(y)
+            >>> sync.wait() # wait for y to be computed
+            >>> print(y)
+            >>>
+            >>> y = mx.exp(x)
+            >>> mx.async_eval(y)
+            >>> z = y + 3
+            >>> sync = mx.async_eval(z)
+            >>> sync.wait() # wait for z (and y) to be computed
+            >>> print(z)
       )pbdoc");
   m.def(
       "jvp",

--- a/python/src/transforms.cpp
+++ b/python/src/transforms.cpp
@@ -595,14 +595,6 @@ class PyCheckpointedFun {
 };
 
 void init_transforms(nb::module_& m) {
-  nb::class_<std::shared_future<void>>(
-      m,
-      "Synchronizer",
-      R"pbdoc(
-      A synchronization object returned by :func:`async_eval`.
-      )pbdoc")
-      .def("wait", [](const std::shared_future<void>& f) { f.wait(); });
-
   m.def(
       "eval",
       [](const nb::args& args) {
@@ -629,18 +621,13 @@ void init_transforms(nb::module_& m) {
         std::vector<array> arrays = tree_flatten(args, false);
         {
           nb::gil_scoped_release nogil;
-          return async_eval(arrays);
+          async_eval(arrays);
         }
       },
       nb::arg(),
-      nb::sig("def async_eval(*args) -> Synchronizer"),
+      nb::sig("def async_eval(*args)"),
       R"pbdoc(
         Asynchronously evaluate an :class:`array` or tree of :class:`array`.
-
-        .. warning::
-
-          You must call ``wait`` on the returned synchronization object before
-          using any arrays that are asynchronously evaluated.
 
         .. note::
 
@@ -652,21 +639,16 @@ void init_transforms(nb::module_& m) {
               :class:`list`, :class:`tuple` or :class:`dict`. Leaves which are not
               arrays are ignored.
 
-        Returns:
-            Synchronizer: A synchronization object.
-
         Example:
             >>> x = mx.array(1.0)
             >>> y = mx.exp(x)
-            >>> sync = mx.async_eval(y)
-            >>> sync.wait() # wait for y to be computed
+            >>> mx.async_eval(y)
             >>> print(y)
             >>>
             >>> y = mx.exp(x)
             >>> mx.async_eval(y)
             >>> z = y + 3
-            >>> sync = mx.async_eval(z)
-            >>> sync.wait() # wait for z (and y) to be computed
+            >>> mx.async_eval(z)
             >>> print(z)
       )pbdoc");
   m.def(

--- a/python/tests/test_eval.py
+++ b/python/tests/test_eval.py
@@ -44,6 +44,15 @@ class TestEval(mlx_tests.MLXTestCase):
         sync = mx.async_eval(x)
         self.assertEqual(x.item(), 3)
 
+        x = mx.array([1, 2, 3])
+        y = 2 * x
+        s1 = mx.async_eval(y)
+        z = 2 * y
+        s2 = mx.async_eval(z)
+        s2.wait()
+        self.assertTrue(mx.array_equal(y, mx.array([2, 4, 6])))
+        self.assertTrue(mx.array_equal(z, mx.array([4, 8, 12])))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/test_eval.py
+++ b/python/tests/test_eval.py
@@ -87,6 +87,22 @@ class TestEval(mlx_tests.MLXTestCase):
         z = mx.abs(y, stream=s)
         self.assertEqual(z.item(), 5)
 
+    def test_eval_slow_fast_multi_stream(self):
+        x = mx.ones((8000,))
+        y = mx.abs(mx.array(-1.0))
+        for _ in range(20):
+            x = x + mx.array(1.0)
+        z = mx.add(x, y, stream=mx.cpu)
+        self.assertTrue(mx.allclose(z, mx.full((8000,), 22.0)))
+
+        # Switch eval order
+        x = mx.ones((8000,))
+        y = mx.abs(mx.array(-1.0))
+        for _ in range(20):
+            x = x + mx.array(1.0)
+        z = mx.add(y, x, stream=mx.cpu)
+        self.assertTrue(mx.allclose(z, mx.full((8000,), 22.0)))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/test_eval.py
+++ b/python/tests/test_eval.py
@@ -34,35 +34,28 @@ class TestEval(mlx_tests.MLXTestCase):
 
     def test_async_eval(self):
         x = mx.array(1) + mx.array(1) + mx.array(1)
-        sync = mx.async_eval(x)
-        sync.wait()
+        mx.async_eval(x)
         self.assertEqual(x.item(), 3)
 
         # It should be safe to call eval on the array which has been async
         # eval'ed
         x = mx.array(1) + mx.array(1) + mx.array(1)
-        sync = mx.async_eval(x)
         self.assertEqual(x.item(), 3)
 
         x = mx.array([1, 2, 3])
         y = 2 * x
-        s1 = mx.async_eval(y)
+        mx.async_eval(y)
         z = 2 * y
-        s2 = mx.async_eval(z)
-        s2.wait()
+        mx.async_eval(z)
         self.assertTrue(mx.array_equal(y, mx.array([2, 4, 6])))
         self.assertTrue(mx.array_equal(z, mx.array([4, 8, 12])))
 
     def test_async_eval_twice(self):
         x = mx.array(1) + mx.array(1) + mx.array(1)
-        sync = mx.async_eval(x)
-        sync2 = mx.async_eval(x)
-        # Calling either synchronizer is fine
-        sync.wait()
+        mx.async_eval(x)
+        y = x + 1
+        mx.async_eval(y)
         self.assertEqual(x.item(), 3)
-
-        # Calling sync2 should be a no-op
-        sync2.wait()
 
     def test_async_eval_in_trace(self):
         def fun(x):
@@ -81,9 +74,8 @@ class TestEval(mlx_tests.MLXTestCase):
     def test_async_eval_into_eval(self):
         x = mx.array(1)
         y = x + 1
-        sync = mx.async_eval(y)
+        mx.async_eval(y)
         a = y - 10
-        sync.wait()
         b = mx.abs(a)
         self.assertEqual(b.item(), 8)
 
@@ -91,8 +83,7 @@ class TestEval(mlx_tests.MLXTestCase):
         s = mx.new_stream(mx.cpu)
         x = mx.array(0)
         y = x - 5
-        sync = mx.async_eval(y)
-        sync.wait()
+        mx.async_eval(y)
         z = mx.abs(y, stream=s)
         self.assertEqual(z.item(), 5)
 

--- a/python/tests/test_metal.py
+++ b/python/tests/test_metal.py
@@ -24,12 +24,12 @@ class TestMetal(mlx_tests.MLXTestCase):
         self.assertTrue(mx.metal.set_memory_limit(old_limit), old_limit)
 
         # Query active and peak memory
-        a = mx.zeros((4096,))
+        a = mx.zeros((4096,), stream=mx.cpu)
         mx.eval(a)
         active_mem = mx.metal.get_active_memory()
         self.assertTrue(active_mem >= 4096 * 4)
 
-        b = mx.zeros((4096,))
+        b = mx.zeros((4096,), stream=mx.cpu)
         mx.eval(b)
         del b
 

--- a/tests/arg_reduce_tests.cpp
+++ b/tests/arg_reduce_tests.cpp
@@ -49,7 +49,6 @@ TEST_CASE("test arg reduce small") {
       {0, 2, 1, 7, 5, -5, 0, 2, 1, 7, 5, -5,
        0, 2, 1, 7, 5, -5, 0, 2, 1, 7, 5, -5},
       {2, 3, 4});
-  x.eval();
   test_arg_reduce_small(
       Device::cpu, x, ArgReduce::ArgMin, {2, 3}, 2, {0, 1, 3, 0, 1, 3});
   test_arg_reduce_small(

--- a/tests/autograd_tests.cpp
+++ b/tests/autograd_tests.cpp
@@ -100,7 +100,7 @@ TEST_CASE("test jvp") {
     auto fun1 = [](const array& x) {
       auto y = 3 * x;
       eval(y);
-      CHECK(y.is_evaled());
+      CHECK(y.is_available());
       CHECK(y.has_primitive());
       CHECK(y.is_tracer());
       return 2 * y;
@@ -253,7 +253,7 @@ TEST_CASE("test grad") {
       eval(y);
       CHECK(x.is_tracer());
       CHECK(!y.is_tracer());
-      CHECK(y.is_evaled());
+      CHECK(y.is_available());
       CHECK(!y.has_primitive());
       return square(x);
     };
@@ -265,7 +265,7 @@ TEST_CASE("test grad") {
       x = x + 2.0f;
       eval(x);
       CHECK(x.is_tracer());
-      CHECK(x.is_evaled());
+      CHECK(x.is_available());
       CHECK(x.has_primitive());
       return square(x);
     };
@@ -1259,7 +1259,7 @@ TEST_CASE("test update state") {
   grad(fn)(y);
   eval(state);
   CHECK(!state.has_primitive());
-  CHECK(state.is_evaled());
+  CHECK(state.is_available());
   CHECK(array_equal(state, array({1.0, 1.0})).item<bool>());
 }
 

--- a/tests/eval_tests.cpp
+++ b/tests/eval_tests.cpp
@@ -56,13 +56,13 @@ TEST_CASE("test eval with tracer when not tracing") {
   CHECK(!x.is_tracer());
   eval(x);
   CHECK(!x.has_primitive());
-  CHECK(x.is_evaled());
+  CHECK(x.is_available());
 
   x = ones({2, 3});
   x.set_tracer(true);
   eval(x);
   CHECK(!x.has_primitive());
-  CHECK(x.is_evaled());
+  CHECK(x.is_available());
 }
 
 TEST_CASE("test eval graph retention when not tracing") {
@@ -74,20 +74,20 @@ TEST_CASE("test eval graph retention when not tracing") {
   auto z = x + y;
   eval(z);
   CHECK(!z.has_primitive());
-  CHECK(z.is_evaled());
+  CHECK(z.is_available());
   CHECK_EQ(z.item<int>(), 3);
 
   z.set_tracer(false);
   CHECK_EQ(z.item<int>(), 3);
   CHECK(!z.has_primitive());
-  CHECK(z.is_evaled());
+  CHECK(z.is_available());
 
   z = x + y;
   auto a = z + x;
   auto b = a + y;
   eval(b);
   CHECK(!z.has_primitive());
-  CHECK(z.is_evaled());
+  CHECK(z.is_available());
   CHECK(!a.has_primitive());
-  CHECK(a.is_evaled());
+  CHECK(a.is_available());
 }

--- a/tests/metal_tests.cpp
+++ b/tests/metal_tests.cpp
@@ -495,12 +495,14 @@ TEST_CASE("test metal memory info") {
 
   // Query active and peak memory
   {
-    auto a = zeros({4096});
+    // Do these tests on the CPU since deallocation is synchronized
+    // with the main thread.
+    auto a = zeros({4096}, Device::cpu);
     eval(a);
     auto active_mem = metal::get_active_memory();
     CHECK(active_mem >= 4096 * 4);
     {
-      auto b = zeros({4096});
+      auto b = zeros({4096}, Device::cpu);
       eval(b);
     }
     auto new_active_mem = metal::get_active_memory();


### PR DESCRIPTION
- Use Metal shared event for synchronization between the CPU and GPU
- Enable `async_eval` without returning a future
- Attach events to `array` in order to synchronize on possibly async evaluated arrays

For example:

```python
a = mx.array(1.0)
b = a + 1
mx.async_eval(b)
print(b) # No need to wait here.. handled automatically
```

Non-async benchmarks on M1 Max so far not much changed:

Bench | Pre | Post
----  | --- | ---
MNIST 2 CPU |  Time 0.345 (s) | Time 0.329 (s) |
MNIST 10 CPU | Time 0.628 (s)| Time 0.608 (s) |
MNIST 10 GPU | Time 1.278 (s) |  Time 1.276 (s) |
MNIST 100 GPU | Time 7.422 (s) | Time 7.448 (s) |
Transformer GPU | It/sec 2.670 | It/sec 2.671 |


Generating with Gemma on M1 Max:

```
MLX_MAX_OPS_PER_BUFFER=50 python -m mlx_lm.generate --model mlx_model --prompt "Write a story about Einstein" --temp 0.0 --max-tokens 256
```

Pre: `128.018 tokens-per-sec`
Post: `140.112 tokens-per-sec`

Pre + Max Ops 80: `143.687 tokens-per-sec`
Post + Max Ops 80: `164.307 tokens-per-sec`