### PR TITLE
avgpool, not maxpool in `nn.AvgPool2d` example

### DIFF
--- a/python/mlx/nn/layers/pooling.py
+++ b/python/mlx/nn/layers/pooling.py
@@ -317,7 +317,7 @@ class AvgPool2d(_Pool2d):
         >>> import mlx.core as mx
         >>> import mlx.nn.layers as nn
         >>> x = mx.random.normal(shape=(8, 32, 32, 4))
-        >>> pool = nn.MaxPool2d(kernel_size=2, stride=2)
+        >>> pool = nn.AvgPool2d(kernel_size=2, stride=2)
         >>> pool(x)
     """
 


### PR DESCRIPTION
## Proposed changes

self-explanatory

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have updated the necessary documentation (if needed)
