### PR TITLE
Add synchronize function

### DIFF
--- a/docs/src/dev/metal_debugger.rst
+++ b/docs/src/dev/metal_debugger.rst
@@ -32,10 +32,9 @@ work.
 
     trace_file = "mlx_trace.gputrace"
 
-    if not mx.metal.start_capture(trace_file):
-      print("Make sure to run with MTL_CAPTURE_ENABLED=1 and "
-            f"that the path {trace_file} does not already exist.")
-      exit(1)
+    # Make sure to run with MTL_CAPTURE_ENABLED=1 and
+    # that the path trace_file does not already exist.
+    mx.metal.start_capture(trace_file)
 
     for _ in range(10):
       mx.eval(mx.add(a, b))

--- a/docs/src/python/devices_and_streams.rst
+++ b/docs/src/python/devices_and_streams.rst
@@ -16,3 +16,4 @@ Devices and Streams
    new_stream
    set_default_stream
    stream
+   synchronize

--- a/docs/src/python/metal.rst
+++ b/docs/src/python/metal.rst
@@ -7,6 +7,7 @@ Metal
   :toctree: _autosummary
 
   is_available
+  synchronize
   get_active_memory
   get_peak_memory
   get_cache_memory

--- a/docs/src/python/metal.rst
+++ b/docs/src/python/metal.rst
@@ -7,7 +7,6 @@ Metal
   :toctree: _autosummary
 
   is_available
-  synchronize
   get_active_memory
   get_peak_memory
   get_cache_memory

--- a/examples/cpp/metal_capture.cpp
+++ b/examples/cpp/metal_capture.cpp
@@ -11,7 +11,7 @@ int main() {
   // To use Metal debugging and profiling:
   // 1. Build with the MLX_METAL_DEBUG CMake option (i.e. -DMLX_METAL_DEBUG=ON).
   // 2. Run with MTL_CAPTURE_ENABLED=1.
-  assert(metal::start_capture("mlx_trace.gputrace"));
+  metal::start_capture("mlx_trace.gputrace");
 
   // Start at index two because the default GPU and CPU streams have indices
   // zero and one, respectively. This naming matches the label assigned to each

--- a/mlx/backend/metal/metal.cpp
+++ b/mlx/backend/metal/metal.cpp
@@ -115,13 +115,39 @@ std::function<void()> make_task(array arr, bool signal) {
   return task;
 }
 
-bool start_capture(std::string path, id object) {
+void synchronize(Stream s) {
+  if (s.device == mlx::core::Device::cpu) {
+    return;
+  }
+  auto p = std::make_shared<std::promise<void>>();
+  std::future<void> f = p->get_future();
+  scheduler::enqueue(s, [s, p = std::move(p)]() {
+    auto& d = metal::device(s.device);
+    auto cb = d.get_command_buffer(s.index);
+    if (cb == nullptr) {
+      cb = d.new_command_buffer(s.index);
+    } else {
+      d.end_encoding(s.index);
+    }
+    d.commit_command_buffer(s.index);
+    cb->waitUntilCompleted();
+    check_error(cb);
+    p->set_value();
+  });
+  f.wait();
+}
+
+void synchronize() {
+  synchronize(default_stream(default_device()));
+}
+
+void start_capture(std::string path, id object) {
   auto pool = new_scoped_memory_pool();
 
   auto descriptor = MTL::CaptureDescriptor::alloc()->init();
   descriptor->setCaptureObject(object);
 
-  if (path.length() > 0) {
+  if (!path.empty()) {
     auto string = NS::String::string(path.c_str(), NS::UTF8StringEncoding);
     auto url = NS::URL::fileURLWithPath(string);
     descriptor->setDestination(MTL::CaptureDestinationGPUTraceDocument);
@@ -129,15 +155,24 @@ bool start_capture(std::string path, id object) {
   }
 
   auto manager = MTL::CaptureManager::sharedCaptureManager();
-  return manager->startCapture(descriptor, nullptr);
+  NS::Error* error;
+  bool started = manager->startCapture(descriptor, &error);
+  descriptor->release();
+  if (!started) {
+    std::ostringstream msg;
+    msg << "[metal::start_capture] Failed to start: "
+        << error->localizedDescription()->utf8String();
+    throw std::runtime_error(msg.str());
+  }
 }
 
-bool start_capture(std::string path) {
+void start_capture(std::string path) {
   auto& device = metal::device(mlx::core::Device::gpu);
   return start_capture(path, device.mtl_device());
 }
 
 void stop_capture() {
+  auto pool = new_scoped_memory_pool();
   auto manager = MTL::CaptureManager::sharedCaptureManager();
   manager->stopCapture();
 }

--- a/mlx/backend/metal/metal.h
+++ b/mlx/backend/metal/metal.h
@@ -9,12 +9,6 @@ namespace mlx::core::metal {
 /* Check if the Metal backend is available. */
 bool is_available();
 
-/* Synchronize with the default stream. */
-void synchronize();
-
-/* Synchronize with the provided stream. */
-void synchronize(Stream);
-
 /* Get the actively used memory in bytes.
  *
  * Note, this will not always match memory use reported by the system because

--- a/mlx/backend/metal/metal.h
+++ b/mlx/backend/metal/metal.h
@@ -9,6 +9,12 @@ namespace mlx::core::metal {
 /* Check if the Metal backend is available. */
 bool is_available();
 
+/* Synchronize with the default stream. */
+void synchronize();
+
+/* Synchronize with the provided stream. */
+void synchronize(Stream);
+
 /* Get the actively used memory in bytes.
  *
  * Note, this will not always match memory use reported by the system because
@@ -55,7 +61,7 @@ size_t set_memory_limit(size_t limit, bool relaxed = true);
 size_t set_cache_limit(size_t limit);
 
 /** Capture a GPU trace, saving it to an absolute file `path` */
-bool start_capture(std::string path = "");
+void start_capture(std::string path = "");
 void stop_capture();
 
 } // namespace mlx::core::metal

--- a/mlx/backend/metal/metal_impl.h
+++ b/mlx/backend/metal/metal_impl.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <future>
 #include <memory>
 
 #include "mlx/array.h"
@@ -14,5 +15,9 @@ void new_stream(Stream stream);
 std::unique_ptr<void, std::function<void(void*)>> new_scoped_memory_pool();
 
 std::function<void()> make_task(array arr, bool signal);
+
+std::function<void()> make_synchronize_task(
+    Stream s,
+    std::shared_ptr<std::promise<void>> p);
 
 } // namespace mlx::core::metal

--- a/mlx/backend/no_metal/metal.cpp
+++ b/mlx/backend/no_metal/metal.cpp
@@ -11,11 +11,6 @@ bool is_available() {
   return false;
 }
 
-void synchronize() {}
-
-/* Synchronize with the provided stream. */
-void synchronize(Stream) {}
-
 void new_stream(Stream) {}
 
 std::unique_ptr<void, std::function<void(void*)>> new_scoped_memory_pool() {
@@ -25,6 +20,14 @@ std::unique_ptr<void, std::function<void(void*)>> new_scoped_memory_pool() {
 std::function<void()> make_task(array arr, bool signal) {
   throw std::runtime_error(
       "[metal::make_task] Cannot make GPU task without metal backend");
+}
+
+std::function<void()> make_synchronize_task(
+    Stream s,
+    std::shared_ptr<std::promise<void>> p) {
+  throw std::runtime_error(
+      "[metal::make_synchronize_task] Cannot synchronize GPU"
+      " without metal backend");
 }
 
 // No-ops when Metal is not available.

--- a/mlx/backend/no_metal/metal.cpp
+++ b/mlx/backend/no_metal/metal.cpp
@@ -4,7 +4,6 @@
 
 #include "mlx/backend/metal/metal.h"
 #include "mlx/backend/metal/metal_impl.h"
-#include "mlx/stream.h"
 
 namespace mlx::core::metal {
 
@@ -15,7 +14,7 @@ bool is_available() {
 void synchronize() {}
 
 /* Synchronize with the provided stream. */
-void synchronize(Stream);
+void synchronize(Stream) {}
 
 void new_stream(Stream) {}
 

--- a/mlx/backend/no_metal/metal.cpp
+++ b/mlx/backend/no_metal/metal.cpp
@@ -11,6 +11,11 @@ bool is_available() {
   return false;
 }
 
+void synchronize() {}
+
+/* Synchronize with the provided stream. */
+void synchronize(Stream);
+
 void new_stream(Stream) {}
 
 std::unique_ptr<void, std::function<void(void*)>> new_scoped_memory_pool() {
@@ -38,9 +43,7 @@ size_t set_memory_limit(size_t, bool) {
 size_t set_cache_limit(size_t) {
   return 0;
 }
-bool start_capture(std::string path) {
-  return false;
-}
+void start_capture(std::string path) {}
 void stop_capture() {}
 
 } // namespace mlx::core::metal

--- a/mlx/backend/no_metal/metal.cpp
+++ b/mlx/backend/no_metal/metal.cpp
@@ -4,6 +4,7 @@
 
 #include "mlx/backend/metal/metal.h"
 #include "mlx/backend/metal/metal_impl.h"
+#include "mlx/stream.h"
 
 namespace mlx::core::metal {
 

--- a/mlx/scheduler.h
+++ b/mlx/scheduler.h
@@ -27,6 +27,7 @@ struct StreamThread {
       : stop(false), stream(stream), thread(&StreamThread::thread_fn, this) {}
 
   ~StreamThread() {
+    metal::synchronize(stream);
     {
       std::unique_lock<std::mutex> lk(mtx);
       stop = true;

--- a/mlx/scheduler.h
+++ b/mlx/scheduler.h
@@ -27,7 +27,7 @@ struct StreamThread {
       : stop(false), stream(stream), thread(&StreamThread::thread_fn, this) {}
 
   ~StreamThread() {
-    metal::synchronize(stream);
+    synchronize(stream);
     {
       std::unique_lock<std::mutex> lk(mtx);
       stop = true;

--- a/mlx/stream.h
+++ b/mlx/stream.h
@@ -29,4 +29,10 @@ inline bool operator!=(const Stream& lhs, const Stream& rhs) {
   return !(lhs == rhs);
 }
 
+/* Synchronize with the default stream. */
+void synchronize();
+
+/* Synchronize with the provided stream. */
+void synchronize(Stream);
+
 } // namespace mlx::core

--- a/python/src/metal.cpp
+++ b/python/src/metal.cpp
@@ -19,19 +19,6 @@ void init_metal(nb::module_& m) {
       Check if the Metal back-end is available.
       )pbdoc");
   metal.def(
-      "synchronize",
-      [](const std::optional<Stream>& s) {
-        s ? metal::synchronize(s.value()) : metal::synchronize();
-      },
-      "stream"_a = nb::none(),
-      R"pbdoc(
-      Synchronize with the given stream.
-
-      Args:
-        (Stream, optional): The stream to synchronize with. If ``None`` then
-           the default stream of the default device is used. Default: ``None``.
-      )pbdoc");
-  metal.def(
       "get_active_memory",
       &metal::get_active_memory,
       R"pbdoc(

--- a/python/src/metal.cpp
+++ b/python/src/metal.cpp
@@ -2,6 +2,7 @@
 
 #include "mlx/backend/metal/metal.h"
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
 #include <nanobind/stl/string.h>
 
 namespace nb = nanobind;
@@ -16,6 +17,19 @@ void init_metal(nb::module_& m) {
       &metal::is_available,
       R"pbdoc(
       Check if the Metal back-end is available.
+      )pbdoc");
+  metal.def(
+      "synchronize",
+      [](const std::optional<Stream>& s) {
+        s ? metal::synchronize(s.value()) : metal::synchronize();
+      },
+      "stream"_a = nb::none(),
+      R"pbdoc(
+      Synchronize with the given stream.
+
+      Args:
+        (Stream, optional): The stream to synchronize with. If ``None`` then
+           the default stream of the default device is used. Default: ``None``.
       )pbdoc");
   metal.def(
       "get_active_memory",
@@ -99,9 +113,6 @@ void init_metal(nb::module_& m) {
       Args:
         path (str): The path to save the capture which should have
           the extension ``.gputrace``.
-
-      Returns:
-        bool: Whether the capture was successfully started.
       )pbdoc");
   metal.def(
       "stop_capture",

--- a/python/src/stream.cpp
+++ b/python/src/stream.cpp
@@ -129,4 +129,17 @@ void init_stream(nb::module_& m) {
               # Operations here will use mx.cpu by default.
               pass
       )pbdoc");
+  m.def(
+      "synchronize",
+      [](const std::optional<Stream>& s) {
+        s ? synchronize(s.value()) : synchronize();
+      },
+      "stream"_a = nb::none(),
+      R"pbdoc(
+      Synchronize with the given stream.
+
+      Args:
+        (Stream, optional): The stream to synchronize with. If ``None`` then
+           the default stream of the default device is used. Default: ``None``.
+      )pbdoc");
 }

--- a/python/tests/test_metal.py
+++ b/python/tests/test_metal.py
@@ -26,14 +26,14 @@ class TestMetal(mlx_tests.MLXTestCase):
         # Query active and peak memory
         a = mx.zeros((4096,))
         mx.eval(a)
-        mx.metal.synchronize()
+        mx.synchronize()
         active_mem = mx.metal.get_active_memory()
         self.assertTrue(active_mem >= 4096 * 4)
 
         b = mx.zeros((4096,))
         mx.eval(b)
         del b
-        mx.metal.synchronize()
+        mx.synchronize()
 
         new_active_mem = mx.metal.get_active_memory()
         self.assertEqual(new_active_mem, active_mem)

--- a/python/tests/test_metal.py
+++ b/python/tests/test_metal.py
@@ -24,14 +24,16 @@ class TestMetal(mlx_tests.MLXTestCase):
         self.assertTrue(mx.metal.set_memory_limit(old_limit), old_limit)
 
         # Query active and peak memory
-        a = mx.zeros((4096,), stream=mx.cpu)
+        a = mx.zeros((4096,))
         mx.eval(a)
+        mx.metal.synchronize()
         active_mem = mx.metal.get_active_memory()
         self.assertTrue(active_mem >= 4096 * 4)
 
-        b = mx.zeros((4096,), stream=mx.cpu)
+        b = mx.zeros((4096,))
         mx.eval(b)
         del b
+        mx.metal.synchronize()
 
         new_active_mem = mx.metal.get_active_memory()
         self.assertEqual(new_active_mem, active_mem)

--- a/tests/metal_tests.cpp
+++ b/tests/metal_tests.cpp
@@ -499,6 +499,7 @@ TEST_CASE("test metal memory info") {
     // with the main thread.
     auto a = zeros({4096});
     eval(a);
+    metal::synchronize();
     auto active_mem = metal::get_active_memory();
     CHECK(active_mem >= 4096 * 4);
     {

--- a/tests/metal_tests.cpp
+++ b/tests/metal_tests.cpp
@@ -497,14 +497,15 @@ TEST_CASE("test metal memory info") {
   {
     // Do these tests on the CPU since deallocation is synchronized
     // with the main thread.
-    auto a = zeros({4096}, Device::cpu);
+    auto a = zeros({4096});
     eval(a);
     auto active_mem = metal::get_active_memory();
     CHECK(active_mem >= 4096 * 4);
     {
-      auto b = zeros({4096}, Device::cpu);
+      auto b = zeros({4096});
       eval(b);
     }
+    metal::synchronize();
     auto new_active_mem = metal::get_active_memory();
     CHECK_EQ(new_active_mem, active_mem);
     auto peak_mem = metal::get_peak_memory();

--- a/tests/metal_tests.cpp
+++ b/tests/metal_tests.cpp
@@ -495,18 +495,16 @@ TEST_CASE("test metal memory info") {
 
   // Query active and peak memory
   {
-    // Do these tests on the CPU since deallocation is synchronized
-    // with the main thread.
     auto a = zeros({4096});
     eval(a);
-    metal::synchronize();
+    synchronize();
     auto active_mem = metal::get_active_memory();
     CHECK(active_mem >= 4096 * 4);
     {
       auto b = zeros({4096});
       eval(b);
     }
-    metal::synchronize();
+    synchronize();
     auto new_active_mem = metal::get_active_memory();
     CHECK_EQ(new_active_mem, active_mem);
     auto peak_mem = metal::get_peak_memory();


### PR DESCRIPTION
- Add `mx.synchronize(stream=None)` for synchronizing with a given stream.
- Updated `mx.metal.start_capture` function to throw on failure and print the error message rather than silently do nothing