### PR TITLE
Fixes teardown of program while GPU is running

### DIFF
--- a/mlx/array.h
+++ b/mlx/array.h
@@ -205,7 +205,12 @@ class array {
     Data(const Data& d) = delete;
     Data& operator=(const Data& d) = delete;
     ~Data() {
-      d(buffer);
+      try {
+        d(buffer);
+      } catch (...) {
+        // Deletion failed likely because we were in the middle of the
+        // program's destruction.
+      }
     }
   };
 

--- a/mlx/scheduler.h
+++ b/mlx/scheduler.h
@@ -117,11 +117,16 @@ class Scheduler {
   }
 
   void notify_task_completion(const Stream& stream) {
-    {
-      std::unique_lock<std::mutex> lk(mtx);
-      n_active_tasks_--;
+    try {
+      {
+        std::unique_lock<std::mutex> lk(mtx);
+        n_active_tasks_--;
+      }
+      completion_cv.notify_all();
+    } catch (...) {
+      // Getting the lock failed likely because we were in the middle of the
+      // program's destruction.
     }
-    completion_cv.notify_all();
   }
 
   int n_active_tasks() const {


### PR DESCRIPTION
Guards the `Data` deleter and the `notify_task_completion` with `try ... catch` blocks because they are called from the command buffer completion handlers which may be called after the destruction of the main thread (now that we have `async_eval`).