### PR TITLE
Fix quantization of all 0s

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -3275,7 +3275,7 @@ std::tuple<array, array, array> quantize(
   array w_max = max(packed_w, /* axis= */ -1, /* keepdims= */ true, s);
   array w_min = min(packed_w, /* axis= */ -1, /* keepdims= */ true, s);
   array delta = divide(subtract(w_max, w_min, s), array(n_bins, w.dtype()), s);
-  array scales = squeeze(delta, -1, s);
+  array scales = maximum(squeeze(delta, -1, s), array(1e-7, w.dtype()), s);
   array biases = squeeze(w_min, -1, s);
 
   // making sure that 0 is represented exactly in the resulting quantization

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -18,6 +18,14 @@ class TestQuantized(mlx_tests.MLXTestCase):
                 eps = 1e-6
                 self.assertTrue((errors <= (scales[..., None] + eps)).all())
 
+        # test quantize/dequantize 0s
+        a = mx.zeros((256, 512))
+        for gs in [32, 64, 128]:
+            for b in [2, 4, 8]:
+                w_q, scales, biases = mx.quantize(a, gs, b)
+                a_hat = mx.dequantize(w_q, scales, biases, gs, b)
+                self.assertTrue(mx.all(a_hat == 0))
+
     def test_qmm(self):
         key = mx.random.key(0)
         k1, k2 = mx.random.split(key)


### PR DESCRIPTION
Set the minimum scale to 1e-7 so that the bias doesn't become nan if the scale is 0.