### PR TITLE
[Fix] expand axes for dimension with integer indices in mlx_slice_update

### DIFF
--- a/python/src/indexing.cpp
+++ b/python/src/indexing.cpp
@@ -845,9 +845,7 @@ auto mlx_slice_update(
       st = (st < 0) ? st + src.shape(ax) : st;
       starts[ax] = st;
       stops[ax] = st + 1;
-      if (src.ndim() - ax < up.ndim()) {
-        upd_expand_dims.push_back(ax - src.ndim());
-      }
+      upd_expand_dims.push_back(ax);
       ax++;
     }
   }

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -1251,12 +1251,7 @@ class TestArray(mlx_tests.MLXTestCase):
             slice(None, None, 2),
         )
 
-        check_slices(
-            np.zeros((2, 4)),
-            np.ones((2)),
-            slice(None),
-            1
-        )
+        check_slices(np.zeros((2, 4)), np.ones((2)), slice(None), 1)
 
     def test_array_at(self):
         a = mx.array(1)

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -1255,19 +1255,9 @@ class TestArray(mlx_tests.MLXTestCase):
             slice(None, None, 2),
         )
 
-        check_slices(
-            np.zeros((5, 4, 3)),
-            np.ones((5, 3)),
-            slice(None),
-            0
-        )
+        check_slices(np.zeros((5, 4, 3)), np.ones((5, 3)), slice(None), 0)
 
-        check_slices(
-            np.zeros((5, 4, 3)),
-            np.ones((5, 1, 3)),
-            slice(None),
-            slice(0, 1)
-        )
+        check_slices(np.zeros((5, 4, 3)), np.ones((5, 1, 3)), slice(None), slice(0, 1))
 
     def test_array_at(self):
         a = mx.array(1)

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -1194,6 +1194,10 @@ class TestArray(mlx_tests.MLXTestCase):
             a = mx.zeros((2, 2))
             a[0, 0, 0] = 1
 
+        with self.assertRaises(ValueError):
+            a = mx.zeros((5, 4, 3))
+            a[:, 0] = mx.ones((5, 1, 3))
+
         check_slices(np.zeros((2, 2, 2, 2)), 1, None, Ellipsis, None)
         check_slices(
             np.zeros((2, 2, 2, 2)), 1, np.array([0, 1]), Ellipsis, np.array([0, 1])

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -1258,6 +1258,9 @@ class TestArray(mlx_tests.MLXTestCase):
         check_slices(np.zeros((5, 4, 3)), np.ones((5, 3)), slice(None), 0)
 
         check_slices(np.zeros((5, 4, 3)), np.ones((5, 1, 3)), slice(None), slice(0, 1))
+        check_slices(
+            np.ones((3, 4, 4, 4)), np.zeros((4, 4)), 0, slice(0, 4), 3, slice(0, 4)
+        )
 
     def test_array_at(self):
         a = mx.array(1)

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -1251,7 +1251,19 @@ class TestArray(mlx_tests.MLXTestCase):
             slice(None, None, 2),
         )
 
-        check_slices(np.zeros((2, 4)), np.ones((2)), slice(None), 1)
+        check_slices(
+            np.zeros((5, 4, 3)),
+            np.ones((5, 3)),
+            slice(None),
+            0
+        )
+
+        check_slices(
+            np.zeros((5, 4, 3)),
+            np.ones((5, 1, 3)),
+            slice(None),
+            slice(0, 1)
+        )
 
     def test_array_at(self):
         a = mx.array(1)

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -1251,6 +1251,13 @@ class TestArray(mlx_tests.MLXTestCase):
             slice(None, None, 2),
         )
 
+        check_slices(
+            np.zeros((2, 4)),
+            np.ones((2)),
+            slice(None),
+            1
+        )
+
     def test_array_at(self):
         a = mx.array(1)
         a = a.at[None].add(1)


### PR DESCRIPTION
## Proposed changes

Fix #1015 

For dimensions with integer indices, `src` should squeeze these dimensions.
For example, an array `a = mx.zeros(5, 4, 3)` indexed by `a[:, 0]` should end up with shape (5, 3), and the second dimension is squeezed, as the implementation in `mlx_get_item`. 

However it's a bit complex for `mlx_set_item` since the array returned by `mlx_slice_update` should have the original, unsqueezed shape. To achieve the same effect and make it easier, we could expand new axes in the update array on these dimensions that are supposed to be squeezed. 
For example, to update `a[:, 0] = mx.ones((5, 3))`, instead of squeezing a to shape (5, 3), we expand a new axis for the update array, so its shape becomes (5, 1, 3), which is broadcast compatible with a's unsqueezed shape (5, 4, 3). In other words, `a[:, 0] = mx.ones((5, 3))` now achieve the same effect as `a[:, 0:1] = mx.ones((5, 3))[:, None]`

I'm a bit unsure if this is the correct way to implement it, and I don't really understand the old dimension expansion logic
```
if (src.ndim() - ax < up.ndim()) {
    upd_expand_dims.push_back(ax - src.ndim());
}
```
maybe @jagrit06 can explain it a bit? I guess this tries to do something similar but can't see how it's done.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
