### PR TITLE
Bug fix in quantize

### DIFF
--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -16,7 +16,7 @@ class TestQuantized(mlx_tests.MLXTestCase):
                 w_hat = mx.dequantize(w_q, scales, biases, gs, b)
                 errors = (w - w_hat).abs().reshape(*scales.shape, -1)
                 eps = 1e-6
-                self.assertTrue((errors <= (scales[..., None] + eps)).all())
+                self.assertTrue((2 * errors <= (scales[..., None] + eps)).all())
 
         # test quantize/dequantize 0s
         a = mx.zeros((256, 512))


### PR DESCRIPTION
Quantize was using different scales and biases to pack the weights than the returned ones. Not sure if this was introduced when we fixed the NaNs when quantizing a block of 0s.