### PR TITLE
Fix leak for multi-output primitives which are never detached

### DIFF
--- a/mlx/array.cpp
+++ b/mlx/array.cpp
@@ -171,12 +171,16 @@ array::~array() {
     return;
   }
 
-  // Break circular reference for non-detached arrays with siblings
+  // Ignore arrays that will be detached
   if (status() != array::Status::unscheduled) {
     return;
   }
+  // Break circular reference for non-detached arrays with siblings
   if (auto n = siblings().size(); n > 0) {
     bool do_detach = true;
+    // If all siblings have siblings.size() references except
+    // the one we are currently destroying (which has siblings.size() + 1)
+    // then there are no more external references
     do_detach &= (array_desc_.use_count() == (n + 1));
     for (auto& s : siblings()) {
       do_detach &= (s.array_desc_.use_count() == n);

--- a/mlx/array.cpp
+++ b/mlx/array.cpp
@@ -1,5 +1,4 @@
 // Copyright © 2023-2024 Apple Inc.
-
 #include <functional>
 
 #include "mlx/array.h"
@@ -165,6 +164,32 @@ void array::move_shared_buffer(
 
 void array::move_shared_buffer(array other) {
   move_shared_buffer(other, other.strides(), other.flags(), other.data_size());
+}
+
+array::~array() {
+  if (array_desc_ == nullptr) {
+    return;
+  }
+
+  // Break circular reference for non-detached arrays with siblings
+  if (auto n = siblings().size(); n > 0) {
+    bool do_detach = true;
+    do_detach &= (array_desc_.use_count() == (n + 1));
+    for (auto& s : siblings()) {
+      do_detach &= (s.array_desc_.use_count() == n);
+      if (!do_detach) {
+        break;
+      }
+    }
+    if (do_detach) {
+      for (auto& s : siblings()) {
+        for (auto& ss : s.siblings()) {
+          ss.array_desc_ = nullptr;
+        }
+        s.array_desc_->siblings.clear();
+      }
+    }
+  }
 }
 
 void array::ArrayDesc::init() {

--- a/mlx/array.cpp
+++ b/mlx/array.cpp
@@ -172,6 +172,9 @@ array::~array() {
   }
 
   // Break circular reference for non-detached arrays with siblings
+  if (status() != array::Status::unscheduled) {
+    return;
+  }
   if (auto n = siblings().size(); n > 0) {
     bool do_detach = true;
     do_detach &= (array_desc_.use_count() == (n + 1));

--- a/mlx/array.h
+++ b/mlx/array.h
@@ -261,21 +261,15 @@ class array {
     return array_desc_->siblings;
   };
 
+  /** The array's siblings. */
+  std::vector<array>& siblings() {
+    return array_desc_->siblings;
+  };
+
   void set_siblings(std::vector<array> siblings, uint16_t position) {
     array_desc_->siblings = std::move(siblings);
     array_desc_->position = position;
   }
-
-  /** The i-th output of the array's primitive. */
-  const array& output(int i) const {
-    if (i == array_desc_->position) {
-      return *this;
-    } else if (i < array_desc_->position) {
-      return siblings()[i];
-    } else {
-      return siblings()[i + 1];
-    }
-  };
 
   /** The outputs of the array's primitive (i.e. this array and
    * its siblings) in the order the primitive expects. */
@@ -385,6 +379,8 @@ class array {
   void overwrite_descriptor(const array& other) {
     array_desc_ = other.array_desc_;
   }
+
+  ~array();
 
  private:
   // Initialize the arrays data

--- a/mlx/backend/common/make_compiled_preamble.sh
+++ b/mlx/backend/common/make_compiled_preamble.sh
@@ -11,7 +11,7 @@ GCC=$2
 SRCDIR=$3
 CLANG=$4
 
-if [ $CLANG = "TRUE" ]; then
+if [ "$CLANG" = "TRUE" ]; then
   read -r -d '' INCLUDES <<- EOM
   #include <cmath>
   #include <complex>

--- a/mlx/transforms.cpp
+++ b/mlx/transforms.cpp
@@ -1,7 +1,6 @@
 // Copyright © 2023-2024 Apple Inc.
 #include <algorithm>
 #include <future>
-#include <iostream> // TODO
 #include <numeric>
 #include <set>
 #include <sstream>

--- a/mlx/transforms.cpp
+++ b/mlx/transforms.cpp
@@ -1,6 +1,7 @@
 // Copyright © 2023-2024 Apple Inc.
 #include <algorithm>
 #include <future>
+#include <iostream> // TODO
 #include <numeric>
 #include <set>
 #include <sstream>
@@ -246,7 +247,7 @@ std::pair<std::vector<array>, std::vector<array>> vjp(
       return;
     }
     a.set_tracer(false);
-    for (auto s : a.siblings()) {
+    for (auto& s : a.siblings()) {
       s.set_tracer(false);
       cache.insert(s.id());
     }
@@ -403,7 +404,7 @@ std::pair<std::vector<array>, std::vector<array>> jvp(
       return;
     }
     a.set_tracer(false);
-    for (auto s : a.siblings()) {
+    for (auto& s : a.siblings()) {
       s.set_tracer(false);
       cache.insert(s.id());
     }


### PR DESCRIPTION
Closes: https://github.com/ml-explore/mlx-examples/issues/738

No issues destroying very deep graphs, the following still works:

```python
a = mx.array(1.0)
for _ in range(1000000):
    a = mx.abs(a)
```