### PR TITLE
Improvements in the quantizer and dequantization kernel

### DIFF
--- a/mlx/backend/metal/kernels/quantized.metal
+++ b/mlx/backend/metal/kernels/quantized.metal
@@ -205,13 +205,10 @@ qouter(const thread uint8_t* w, U x, U scale, U bias, thread U* result) {
   }
 
   else if (bits == 4) {
-    const thread uint16_t* ws = (const thread uint16_t*)w;
-    U s[4] = {scale, scale / 16.0f, scale / 256.0f, scale / 4096.0f};
-    for (int i = 0; i < (values_per_thread / 4); i++) {
-      result[4 * i] += x * (s[0] * (ws[i] & 0x000f) + bias);
-      result[4 * i + 1] += x * (s[1] * (ws[i] & 0x00f0) + bias);
-      result[4 * i + 2] += x * (s[2] * (ws[i] & 0x0f00) + bias);
-      result[4 * i + 3] += x * (s[3] * (ws[i] & 0xf000) + bias);
+    U s[2] = {scale, scale / 16.0f};
+    for (int i = 0; i < (values_per_thread / 2); i++) {
+      result[2 * i] += x * (s[0] * (w[i] & 0x0f) + bias);
+      result[2 * i + 1] += x * (s[1] * (w[i] & 0xf0) + bias);
     }
   }
 
@@ -244,17 +241,10 @@ dequantize(const device uint8_t* w, U scale, U bias, threadgroup U* w_local) {
   }
 
   else if (bits == 4) {
-    const device uint16_t* ws = (const device uint16_t*)w;
-    U s[4] = {
-        scale,
-        scale / static_cast<U>(16.0f),
-        scale / static_cast<U>(256.0f),
-        scale / static_cast<U>(4096.0f)};
-    for (int i = 0; i < (N / 4); i++) {
-      w_local[4 * i] = s[0] * (ws[i] & 0x000f) + bias;
-      w_local[4 * i + 1] = s[1] * (ws[i] & 0x00f0) + bias;
-      w_local[4 * i + 2] = s[2] * (ws[i] & 0x0f00) + bias;
-      w_local[4 * i + 3] = s[3] * (ws[i] & 0xf000) + bias;
+    U s[2] = {scale, scale / static_cast<U>(16.0f)};
+    for (int i = 0; i < (N / 2); i++) {
+      w_local[2 * i] = s[0] * (w[i] & 0x0f) + bias;
+      w_local[2 * i + 1] = s[1] * (w[i] & 0xf0) + bias;
     }
   }
 

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -16,7 +16,7 @@ class TestQuantized(mlx_tests.MLXTestCase):
                 w_hat = mx.dequantize(w_q, scales, biases, gs, b)
                 errors = (w - w_hat).abs().reshape(*scales.shape, -1)
                 eps = 1e-6
-                self.assertTrue((2 * errors <= (scales[..., None] + eps)).all())
+                self.assertTrue((errors <= (scales[..., None] + eps).abs()).all())
 
         # test quantize/dequantize 0s
         a = mx.zeros((256, 512))


### PR DESCRIPTION
This PR has two contributions both working together for what is hopefully better quantization performance across the board.

1. We change the way we compute the scale and bias for the block as follows.
    a. We set the bias to the min or max value depending on which has the higher absolute value.
    b. We set the scale to go from min to max or max to min respectively.
    c. We adjust the scale to make sure that 0 is quantized as 0.
2. For the dequantization, since the scale is usually a float16, dividing it by 4096 destroys significant information and causes quantization errors. We change it so that it is divided by 16. The same issue does not happen in `qmv` where everything is float32.

Quantization performance
---------------------------

This is the quantization performance on Wikitext-2 test set. The Q4_0 performance is computed by quantizing and dequantizing the weights in place with absmax quantization and block size 32.

![quant](https://github.com/ml-explore/mlx/assets/1242043/8c528e3e-e4f1-4185-a0ff-2990306a4c0f)

Regarding the block size discussion (which I cannot find now @ivanfioravanti) I think 64 is a good compromise for a default and 32 should be evaluated and used if the 64 performance is not adequate. Wdyt @awni and @jagrit06 ?

![quant-blocks](https://github.com/ml-explore/mlx/assets/1242043/8dc3ef0d-5000-4d29-9f52-ccf878fc6abd)

Throughput
-------------

The kernel change actually has no performance degradation whatsoever

Before
```
$ python benchmarks/python/comparative/bench_mlx.py quant_matmul_t_64_4 --size 4096x4096 --size 4096x512 --size 4096x64 --size 4096x64 --dtype float16 --dtype uint32 --dtype float16 --dtype float16
6.557293891906738
$ python -m mlx_lm.lora --model mlx-community/NeuralBeagle14-7B-4bit-mlx --train --data ../../lora/data/
...
...
Iter 1: Val loss 2.866, Val took 8.981s
Iter 10: Train loss 2.323, Learning Rate 1.000e-05, It/sec 1.882, Tokens/sec 752.791, Trained Tokens 3999, Peak mem 6.265 GB
Iter 20: Train loss 1.691, Learning Rate 1.000e-05, It/sec 1.732, Tokens/sec 698.554, Trained Tokens 8032, Peak mem 6.265 GB
```

After
```
$ python benchmarks/python/comparative/bench_mlx.py quant_matmul_t_64_4 --size 4096x4096 --size 4096x512 --size 4096x64 --size 4096x64 --dtype float16 --dtype uint32 --dtype float16 --dtype float16
6.5276172161102295
$ python -m mlx_lm.lora --model mlx-community/NeuralBeagle14-7B-4bit-mlx --train --data ../../lora/data/
...
...
Iter 1: Val loss 2.834, Val took 8.946s
Iter 10: Train loss 2.334, Learning Rate 1.000e-05, It/sec 1.880, Tokens/sec 751.839, Trained Tokens 3999, Peak mem 6.265 GB
Iter 20: Train loss 1.699, Learning Rate 1.000e-05, It/sec 1.741, Tokens/sec 702.182, Trained Tokens 8032, Peak mem 6.265 GB
```