### PR TITLE
Change initial memory limits and add memory size to device info

### DIFF
--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -5,6 +5,8 @@
 #include <filesystem>
 #include <sstream>
 
+#include <sys/sysctl.h>
+
 #define NS_PRIVATE_IMPLEMENTATION
 #define CA_PRIVATE_IMPLEMENTATION
 #define MTL_PRIVATE_IMPLEMENTATION
@@ -560,11 +562,19 @@ std::unordered_map<std::string, std::variant<std::string, size_t>>
 device_info() {
   auto raw_device = device(default_device()).mtl_device();
   auto arch = std::string(raw_device->architecture()->name()->utf8String());
+
+  int mib[] = {CTL_HW, HW_MEMSIZE};
+  size_t memsize = 0;
+  size_t length = sizeof(memsize);
+
+  sysctl(mib, 2, &memsize, &length, NULL, 0);
+
   return {
       {"architecture", arch},
       {"max_buffer_length", raw_device->maxBufferLength()},
       {"max_recommended_working_set_size",
-       raw_device->recommendedMaxWorkingSetSize()}};
+       raw_device->recommendedMaxWorkingSetSize()},
+      {"memory_size", memsize}};
 }
 
 } // namespace mlx::core::metal

--- a/python/src/metal.cpp
+++ b/python/src/metal.cpp
@@ -129,6 +129,7 @@ void init_metal(nb::module_& m) {
       * ``architecture``
       * ``max_buffer_size``
       * ``max_recommended_working_set_size``
+      * ``memory_size``
 
       Returns:
           dict: A dictionary with string keys and string or integer values.


### PR DESCRIPTION
1. Add a `memory_size` field to the `device_info` dictionary
2. Change the allocator memory limits to be more sensible. Previously on devices with large machines the memory limit is set to well over the total physical memory which is not a very sensible default.

LLM generation / transformer training timings did not change on M2 Ultra.