### PR TITLE
add keyword positonal

### DIFF
--- a/python/src/transforms.cpp
+++ b/python/src/transforms.cpp
@@ -87,7 +87,7 @@ auto py_value_and_grad(
       std::ostringstream msg;
       msg << error_msg_tag << " Can't compute the gradient of argument index "
           << argnums.back() << " because the function is called with only "
-          << args.size() << " arguments.";
+          << args.size() << " positional arguments.";
       throw std::invalid_argument(msg.str());
     }
 


### PR DESCRIPTION
## Proposed changes

Address #1072 

```
(mlx-dev) shubham@Shubhams-MBP mlx % python dummy.py                                   
Traceback (most recent call last):
  File "/Users/shubham/Documents/workspace/forks/mlx/dummy.py", line 5, in <module>
    xent_grad(logits=a, targets=mx.array(0))
ValueError: [grad] Can't compute the gradient of argument index 0 because the function is called with only 0 positional arguments.
```

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
