### PR TITLE
Fix typo in a variable name in example code.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,10 +11,9 @@ possible.
    and after the change. Examples of benchmarks can be found in `benchmarks/python/`.
 4. If you've changed APIs, update the documentation.
 5. Every PR should have passing tests and at least one review. 
-6. For code formatting install `pre-commit`, `black` and `clang-format` using something like `pip install pre-commit black clang-format` and run `pre-commit install`.
+6. For code formatting install `pre-commit` using something like `pip install pre-commit` and run `pre-commit install`.
    This should install hooks for running `black` and `clang-format` to ensure
    consistent style for C++ and python code.
-   For convenience, you can set up the repository-specific Python virtualenv inside the `venv` directory at the root of the repository - it is ignored by git.
  
    You can also run the formatters manually as follows:
  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,9 +11,10 @@ possible.
    and after the change. Examples of benchmarks can be found in `benchmarks/python/`.
 4. If you've changed APIs, update the documentation.
 5. Every PR should have passing tests and at least one review. 
-6. For code formatting install `pre-commit` using something like `pip install pre-commit` and run `pre-commit install`.
+6. For code formatting install `pre-commit`, `black` and `clang-format` using something like `pip install pre-commit black clang-format` and run `pre-commit install`.
    This should install hooks for running `black` and `clang-format` to ensure
    consistent style for C++ and python code.
+   For convenience, you can set up the repository-specific Python virtualenv inside the `venv` directory at the root of the repository - it is ignored by git.
  
    You can also run the formatters manually as follows:
  

--- a/examples/cpp/tutorial.cpp
+++ b/examples/cpp/tutorial.cpp
@@ -89,8 +89,10 @@ void automatic_differentiation() {
   // dfdx is 2 * x
 
   // Get the second derivative by composing grad with grad
-  auto df2dx2 = grad(grad(fn))(x);
-  // df2dx2 is 2
+  auto d2fdx2 = grad(grad(fn))(x);
+  // d2fdx2 is 2
+  std::cout << d2fdx2 << std::endl;
+  assert(d2fdx2.item<float>() - 2.0 <= std::numeric_limits<float>::epsilon());
 }
 
 int main() {

--- a/examples/cpp/tutorial.cpp
+++ b/examples/cpp/tutorial.cpp
@@ -89,10 +89,8 @@ void automatic_differentiation() {
   // dfdx is 2 * x
 
   // Get the second derivative by composing grad with grad
-  auto d2fdx2 = grad(grad(fn))(x);
-  // d2fdx2 is 2
-  std::cout << d2fdx2 << std::endl;
-  assert(d2fdx2.item<float>() - 2.0 <= std::numeric_limits<float>::epsilon());
+  auto df2dx2 = grad(grad(fn))(x);
+  // df2dx2 is 2
 }
 
 int main() {

--- a/examples/cpp/tutorial.cpp
+++ b/examples/cpp/tutorial.cpp
@@ -89,8 +89,8 @@ void automatic_differentiation() {
   // dfdx is 2 * x
 
   // Get the second derivative by composing grad with grad
-  auto df2dx2 = grad(grad(fn))(x);
-  // df2dx2 is 2
+  auto d2fdx2 = grad(grad(fn))(x);
+  // d2fdx2 is 2
 }
 
 int main() {


### PR DESCRIPTION
* Rename df2dx2 to d2fdx2 - the appropriate naming for the second derivative

* Update CONTRIBUTING.md - add needed python packages, and a virtual-env hint

## Proposed changes

Renamed a variable to appropriately denote the second order derivative
- Added an assert on the value, but I've been away from C++ for some time, so do suggest if a different approach for float equality assertion is needed

Also added a few instructions in `CONTRIBUTING.md` - which I hope is helpful.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
