### PR TITLE
Pass missing stream arg in array.flatten

### DIFF
--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -1139,7 +1139,7 @@ void init_array(nb::module_& m) {
              int start_axis,
              int end_axis,
              const StreamOrDevice& s) {
-            return flatten(a, start_axis, end_axis);
+            return flatten(a, start_axis, end_axis, s);
           },
           "start_axis"_a = 0,
           "end_axis"_a = -1,


### PR DESCRIPTION
## Proposed changes

The `s` arg is missing in the `array.flatten` implementation.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
