### PR TITLE
The tile op does not accept None as reps

### DIFF
--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -3824,7 +3824,9 @@ void init_ops(nb::module_& m) {
     )pbdoc");
   m.def(
       "tile",
-      [](const array& a, const IntOrVec& reps, StreamOrDevice s) {
+      [](const array& a,
+         const std::variant<int, std::vector<int>>& reps,
+         StreamOrDevice s) {
         if (auto pv = std::get_if<int>(&reps); pv) {
           return tile(a, {*pv}, s);
         } else {


### PR DESCRIPTION
## Proposed changes

The `IntOrVec` type implies accepting `None` as input.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
