### PR TITLE
Move args in conv_general

### DIFF
--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -3353,13 +3353,15 @@ void init_ops(nb::module_& m) {
         }
 
         return conv_general(
-            /* const array& input = */ input,
-            /* const array& weight = */ weight,
-            /* std::vector<int> stride = */ stride_vec,
-            /* std::vector<int> padding_lo = */ padding_lo_vec,
-            /* std::vector<int> padding_hi = */ padding_lo_vec,
-            /* std::vector<int> kernel_dilation = */ kernel_dilation_vec,
-            /* std::vector<int> input_dilation = */ input_dilation_vec,
+            /* array input = */ std::move(input),
+            /* array weight = */ std::move(weight),
+            /* std::vector<int> stride = */ std::move(stride_vec),
+            /* std::vector<int> padding_lo = */ std::move(padding_lo_vec),
+            /* std::vector<int> padding_hi = */ std::move(padding_hi_vec),
+            /* std::vector<int> kernel_dilation = */
+            std::move(kernel_dilation_vec),
+            /* std::vector<int> input_dilation = */
+            std::move(input_dilation_vec),
             /* int groups = */ groups,
             /* bool flip = */ flip,
             s);


### PR DESCRIPTION
## Proposed changes

C++ conv_general API takes args by value so we can just move them.

Also fix a typo that padding_lo is passed as padding_hi.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
