### PR TITLE
[Fix] minor typo in default argument for argpartition's "axis" parameter

### DIFF
--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -2527,7 +2527,7 @@ void init_ops(nb::module_& m) {
       },
       nb::arg(),
       "kth"_a,
-      "axis"_a = -1,
+      "axis"_a.none() = -1,
       nb::kw_only(),
       "stream"_a = nb::none(),
       nb::sig(


### PR DESCRIPTION
## Proposed changes

According to the document, argpartition's axis parameter can be None, but due to a previous typo it can't really accepts a None value.

Fixes #1121 

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
