### PR TITLE
Update cosine decay to not clamp output, match other implementations

### DIFF
--- a/python/mlx/optimizers/schedulers.py
+++ b/python/mlx/optimizers/schedulers.py
@@ -58,14 +58,14 @@ def step_decay(init: float, decay_rate: float, step_size: int) -> Callable:
     return schedule
 
 
-def cosine_decay(init: float, decay_steps: int, minimum: float = 0.0) -> Callable:
+def cosine_decay(init: float, decay_steps: int, end: float = 0.0) -> Callable:
     r"""Make a cosine decay scheduler.
 
     Args:
         init (float): Initial value.
         decay_steps (int): Number of steps to decay over. The decayed
             value is constant for steps beyond ``decay_steps``.
-        minimum (float, optional): Minimal value to decay to. Default: ``0``.
+        end (float, optional): Final value to decay to. Default: ``0``.
 
     Example:
 
@@ -83,7 +83,7 @@ def cosine_decay(init: float, decay_steps: int, minimum: float = 0.0) -> Callabl
     def scheduler(step):
         s = mx.minimum(step, decay_steps)
         decay = 0.5 * (1.0 + mx.cos((math.pi / decay_steps) * s))
-        return mx.maximum(init * decay, minimum)
+        return end + decay * (init - end)
 
     return scheduler
 

--- a/python/tests/test_optimizers.py
+++ b/python/tests/test_optimizers.py
@@ -329,9 +329,11 @@ class TestSchedulers(unittest.TestCase):
         self.assertAlmostEqual(lr, expected_lr, delta=1e-7)
 
         lr_schedule = opt.cosine_decay(0.1, 10, 0.05)
+        lr = lr_schedule(9)
+        expected_end_lr = 0.05
+        self.assertGreater(lr, expected_end_lr)
         lr = lr_schedule(20)
-        expected_lr = 0.05
-        self.assertEqual(lr, expected_lr)
+        self.assertEqual(lr, expected_end_lr)
 
     def test_schedule_joiner(self):
         boundaries = [2, 3, 4]


### PR DESCRIPTION
## Proposed changes

This change updates how the 'minimum' value is treated by the cosine decay scheduler. The existing implementation clamps the output to the provided minimum and the new implementation instead smoothly transitions from the initial to final learning rate. This picture clarifies the difference between these two when decaying from 1.0 to 0.5 over 100 steps:
![image](https://github.com/ml-explore/mlx/assets/5405091/f44d6f18-3451-46f1-aa3d-c3afada0f82e)


With this change the behavior will also match that of [pytorch](https://pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.CosineAnnealingLR.html), [optax](https://github.com/google-deepmind/optax/blob/702e6d2ed849f0507b2f30c1984d5a30541c7666/optax/schedules/_schedule.py#L311), and [keras](https://github.com/keras-team/keras/blob/20bc26771ca64fe6874a6b856b812b71b1ed7f59/keras/src/optimizers/schedules/learning_rate_schedule.py#L698)

Also renamed 'minimum' to 'end' because this implementation can 'decay' upwards.

EDIT: I'm also not completely sold that removing `minimum` is the right move because it still might be useful to someone. Could  be best to keep that and also add `end` as a separate parameter. If anyone has opinions about that I'd be happy to change it.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
