### PR TITLE
Speedup `qvm`

### DIFF
--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -137,10 +137,10 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
       auto kernel = d.get_kernel(kname.str());
       compute_encoder->setComputePipelineState(kernel);
 
-      int bo = 8;
+      int bo = 64;
       int bd = 32;
-      MTL::Size group_dims = MTL::Size(bd, bo, 1);
-      MTL::Size grid_dims = MTL::Size((O + bo - 1) / bo, B, 1);
+      MTL::Size group_dims = MTL::Size(bd, 2, 1);
+      MTL::Size grid_dims = MTL::Size(O / bo, B, 1);
 
       compute_encoder.set_input_array(x, 0);
       compute_encoder.set_input_array(w, 1);
@@ -393,10 +393,10 @@ void BlockSparseQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
       auto kernel = d.get_kernel(kname.str());
       compute_encoder->setComputePipelineState(kernel);
 
-      int bo = 8;
+      int bo = 64;
       int bd = 32;
-      MTL::Size group_dims = MTL::Size(bd, bo, 1);
-      MTL::Size grid_dims = MTL::Size((O + bo - 1) / bo, B, N);
+      MTL::Size group_dims = MTL::Size(bd, 2, 1);
+      MTL::Size grid_dims = MTL::Size(O / bo, B, N);
 
       compute_encoder.set_input_array(x, 0);
       compute_encoder.set_input_array(w, 1);


### PR DESCRIPTION
As title.

This kernel was quite a bit slower than `qmv` and needed some love.

For example on the block-mask-moe branch of mlx-examples we have the following before and after speeds:

Before
```
$ python -m mlx_lm.lora --model /tmp/qwen-moe-q8-128/ --train --data lora/data/
Loading pretrained model
Trainable parameters: 0.032% (1.581M/4938.955M)
Loading datasets
Training
Starting training..., iters: 1000
Iter 1: Val loss 2.412, Val took 9.038s
Iter 10: Train loss 2.051, Learning Rate 1.000e-05, It/sec 0.508, Tokens/sec 187.652, Trained Tokens 3692, Peak mem 17.277 GB
Iter 20: Train loss 1.458, Learning Rate 1.000e-05, It/sec 0.485, Tokens/sec 179.789, Trained Tokens 7396, Peak mem 17.277 GB
```

After
```
python -m mlx_lm.lora --model /tmp/qwen-moe-q8-128/ --train --data lora/data/
Loading pretrained model
Trainable parameters: 0.032% (1.581M/4938.955M)
Loading datasets
Training
Starting training..., iters: 1000
Iter 1: Val loss 2.413, Val took 8.970s
Iter 10: Train loss 2.057, Learning Rate 1.000e-05, It/sec 1.566, Tokens/sec 578.108, Trained Tokens 3692, Peak mem 17.277 GB
Iter 20: Train loss 1.461, Learning Rate 1.000e-05, It/sec 1.505, Tokens/sec 557.471, Trained Tokens 7396, Peak mem 17.277 GB
```