### PR TITLE
Doc error for default for scale in SinusoidalPositionalEncoding

### DIFF
--- a/python/mlx/nn/layers/positional_encoding.py
+++ b/python/mlx/nn/layers/positional_encoding.py
@@ -67,7 +67,7 @@ class SinusoidalPositionalEncoding(Module):
         max_freq (float, optional): The maximum frequency expected. Default:
             ``1``.
         scale (float, optional): A multiplicative scale for the embeddings.
-            Default: ``sqrt(dims//2)``.
+            Default: ``sqrt(2/dims)``.
         cos_first (bool, optional): If ``True`` embed using ``[cos(x); sin(x)]``
             instead of the reverse. Default: ``False``.
         full_turns (bool, optional): If ``True`` multiply the frequencies with


### PR DESCRIPTION
Code uses the inverse, which is correct.

## Proposed changes

Documentation fix, made consistent with code for scale = sqrt(2/dims) default.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
