### PR TITLE
In place all-reduce and forgiving init

### DIFF
--- a/mlx/distributed/distributed.h
+++ b/mlx/distributed/distributed.h
@@ -43,8 +43,12 @@ struct Group {
 /**
  * Initialize the distributed backend and return the group containing all
  * discoverable processes.
+ *
+ * If strict is true then throw an error if we couldn't initialize the
+ * distributed subsystem. Otherwise simply return a singleton group which will
+ * render communication operations as no-op.
  */
-Group init();
+Group init(bool strict = false);
 
 namespace detail {
 

--- a/mlx/distributed/mpi/mpi.cpp
+++ b/mlx/distributed/mpi/mpi.cpp
@@ -236,7 +236,7 @@ bool is_available() {
   return mpi().is_available();
 }
 
-Group init(bool strict) {
+Group init(bool strict /* = false */) {
   static std::shared_ptr<MPIGroupImpl> global_group = nullptr;
 
   if (global_group == nullptr) {

--- a/mlx/distributed/mpi/mpi.cpp
+++ b/mlx/distributed/mpi/mpi.cpp
@@ -168,6 +168,7 @@ MPIWrapper& mpi() {
 }
 
 struct MPIGroupImpl {
+  MPIGroupImpl() : comm_(nullptr), global_(true), rank_(0), size_(1) {}
   MPIGroupImpl(MPI_Comm comm, bool global)
       : comm_(comm), global_(global), rank_(-1), size_(-1) {}
   ~MPIGroupImpl() {
@@ -240,9 +241,10 @@ Group init() {
 
   if (global_group == nullptr) {
     if (!mpi().init_safe()) {
-      throw std::runtime_error("Cannot initialize MPI");
+      global_group = std::make_shared<MPIGroupImpl>();
+    } else {
+      global_group = std::make_shared<MPIGroupImpl>(mpi().world(), true);
     }
-    global_group = std::make_shared<MPIGroupImpl>(mpi().world(), true);
   }
 
   return Group(global_group);

--- a/mlx/distributed/mpi/mpi.cpp
+++ b/mlx/distributed/mpi/mpi.cpp
@@ -236,11 +236,14 @@ bool is_available() {
   return mpi().is_available();
 }
 
-Group init() {
+Group init(bool strict) {
   static std::shared_ptr<MPIGroupImpl> global_group = nullptr;
 
   if (global_group == nullptr) {
     if (!mpi().init_safe()) {
+      if (strict) {
+        throw std::runtime_error("Cannot initialize MPI");
+      }
       global_group = std::make_shared<MPIGroupImpl>();
     } else {
       global_group = std::make_shared<MPIGroupImpl>(mpi().world(), true);

--- a/mlx/distributed/mpi/mpi.cpp
+++ b/mlx/distributed/mpi/mpi.cpp
@@ -260,7 +260,8 @@ Stream communication_stream() {
 void all_reduce_sum(Group group, const array& input_, array& output) {
   array input = ensure_row_contiguous(input_);
   mpi().all_reduce(
-      input.data<void>(),
+      (input.data<void>() == output.data<void>()) ? MPI_IN_PLACE
+                                                  : input.data<void>(),
       output.data<void>(),
       input.size(),
       mpi().datatype(input),

--- a/mlx/distributed/no_distributed.cpp
+++ b/mlx/distributed/no_distributed.cpp
@@ -20,7 +20,7 @@ bool is_available() {
   return false;
 }
 
-Group init(bool strict) {
+Group init(bool strict /* = false */) {
   return Group(nullptr);
 }
 

--- a/mlx/distributed/no_distributed.cpp
+++ b/mlx/distributed/no_distributed.cpp
@@ -20,7 +20,7 @@ bool is_available() {
   return false;
 }
 
-Group init() {
+Group init(bool strict) {
   return Group(nullptr);
 }
 

--- a/mlx/distributed/primitives.cpp
+++ b/mlx/distributed/primitives.cpp
@@ -16,7 +16,11 @@ void AllReduce::eval_cpu(
   assert(inputs.size() == 1);
   assert(outputs.size() == 1);
 
-  outputs[0].set_data(allocator::malloc_or_wait(outputs[0].nbytes()));
+  if (inputs[0].is_donatable()) {
+    outputs[0].copy_shared_buffer(inputs[0]);
+  } else {
+    outputs[0].set_data(allocator::malloc_or_wait(outputs[0].nbytes()));
+  }
 
   switch (reduce_type_) {
     case Sum:

--- a/python/src/distributed.cpp
+++ b/python/src/distributed.cpp
@@ -54,8 +54,18 @@ void init_distributed(nb::module_& parent_module) {
   m.def(
       "init",
       &distributed::init,
+      "strict"_a = false,
+      nb::sig("def init(strict: bool = False) -> Group"),
       R"pbdoc(
         Initialize the communication backend and create the global communication group.
+
+        Args:
+          strict (bool, optional): If set to False it returns a singleton group
+            in case ``mx.distributed.is_available()`` returns False otherwise
+            it throws a runtime error. Default: ``False``
+
+        Returns:
+          Group: The group representing all the launched processes.
       )pbdoc");
 
   m.def(


### PR DESCRIPTION
This PR adds an in-place all reduce if the array is donatable. It also makes init return a singleton group if the distributed backend wasn't available (except if otherwise requested).

The latter makes for simpler code as it can be written as if distributed is always available, e.g.

```python
if mx.distributed.is_available():
    foo = mx.distributed.all_reduce(foo)
```

becomes simply

```python
foo = mx.distributed.all_reduce(foo)
```