### PR TITLE
Add vmap to scatter

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -1,5 +1,4 @@
 // Copyright © 2023-2024 Apple Inc.
-
 #include <algorithm>
 #include <climits>
 #include <cmath>
@@ -1101,6 +1100,9 @@ array moveaxis(
   };
   source = check_ax(source);
   destination = check_ax(destination);
+  if (source == destination) {
+    return a;
+  }
   std::vector<int> reorder(a.ndim());
   std::iota(reorder.begin(), reorder.end(), 0);
   reorder.erase(reorder.begin() + source);
@@ -2745,7 +2747,7 @@ array scatter(
       a.shape(),
       a.dtype(),
       std::make_shared<Scatter>(to_stream(s), mode, axes),
-      inputs);
+      std::move(inputs));
 }
 
 array scatter(

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -2697,9 +2697,8 @@ array scatter(
   if (updates.ndim() != (a.ndim() + idx_shape.size())) {
     std::ostringstream msg;
     msg << "[scatter] Updates with " << updates.ndim()
-        << " dimensions does not match the sum of the array and indices "
-           "dimensions "
-        << a.ndim() + idx_shape.size() << ".";
+        << " dimensions does not match the sum of the array (" << a.ndim()
+        << ") and indices (" << idx_shape.size() << ") dimensions.";
     throw std::invalid_argument(msg.str());
   }
   for (int i = 0; i < idx_shape.size(); ++i) {
@@ -2741,6 +2740,7 @@ array scatter(
   inputs.insert(inputs.begin(), a);
   // TODO promote or cast?
   inputs.push_back(astype(updates, a.dtype(), s));
+
   return array(
       a.shape(),
       a.dtype(),

--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -3026,9 +3026,15 @@ std::pair<std::vector<array>, std::vector<int>> Scatter::vmap(
     // Clone updates along the vmap dimension so they can be applied to each
     // source tensor in the vmap.
     auto& updates = inputs.back();
-    updates =
-        expand_dims(updates, {0, static_cast<int>(inputs[1].ndim())}, stream());
-    updates = repeat(updates, vmap_size, 0, stream());
+    if (vmap_axes.back() < 0) {
+      updates = expand_dims(
+          updates, {0, static_cast<int>(inputs[1].ndim())}, stream());
+      updates = repeat(updates, vmap_size, 0, stream());
+    } else {
+      updates =
+          expand_dims(updates, static_cast<int>(inputs[1].ndim()), stream());
+      updates = moveaxis(updates, vmap_axes.back(), 0, stream());
+    }
   }
 
   auto out = array(

--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -3037,9 +3037,11 @@ std::pair<std::vector<array>, std::vector<int>> Scatter::vmap(
     }
   }
 
+  auto& shape = inputs[0].shape();
+  auto dtype = inputs[0].dtype();
   auto out = array(
-      inputs[0].shape(),
-      inputs[0].dtype(),
+      shape,
+      dtype,
       std::make_shared<Scatter>(stream(), reduce_type_, scatter_axes),
       std::move(inputs));
 

--- a/mlx/primitives.h
+++ b/mlx/primitives.h
@@ -1713,7 +1713,9 @@ class Scatter : public UnaryPrimitive {
   void eval_cpu(const std::vector<array>& inputs, array& out) override;
   void eval_gpu(const std::vector<array>& inputs, array& out) override;
 
+  DEFINE_VMAP();
   DEFINE_GRADS();
+
   void print(std::ostream& os) override {
     os << "Scatter";
     switch (reduce_type_) {

--- a/mlx/transforms.cpp
+++ b/mlx/transforms.cpp
@@ -560,8 +560,10 @@ std::pair<std::vector<array>, std::vector<array>> vmap_trace(
   detail::InTracing in_tracing;
 
   if (in_axes.size() != inputs.size()) {
-    throw std::invalid_argument(
-        "[vmap] The number of in axes must match the number of inputs.");
+    std::stringstream ss;
+    ss << "[vmap] The number of in axes (" << in_axes.size()
+       << ") must match the number of inputs (" << inputs.size() << ").";
+    throw std::invalid_argument(ss.str());
   }
 
   // Some error checking and get the vmap axis size
@@ -617,8 +619,10 @@ std::vector<array> vmap_replace(
     const std::vector<int>& in_axes,
     const std::vector<int>& out_axes) {
   if (out_axes.size() != s_outputs.size()) {
-    throw std::invalid_argument(
-        "[vmap] The number of out axes must match the number of outputs.");
+    std::stringstream msg;
+    msg << "[vmap] The number of out axes (" << out_axes.size()
+        << ") must match the number of outputs (" << s_outputs.size() << ").";
+    throw std::invalid_argument(msg.str());
   }
 
   std::unordered_map<std::uintptr_t, std::pair<array, int>> tmap;

--- a/python/tests/test_vmap.py
+++ b/python/tests/test_vmap.py
@@ -437,6 +437,31 @@ class TestVmap(mlx_tests.MLXTestCase):
         expected[2, 2] = 1
         self.assertTrue(mx.allclose(out, expected))
 
+        # vmap over src, indices, updates
+        def scatter(a, idx, updates):
+            a[idx] = updates
+            return a
+
+        a = mx.zeros((3, 4))
+        idx = mx.array([0, 1, 2])
+        updates = mx.array([1, 2, 3])
+        out = mx.vmap(scatter, in_axes=(0, 0, 0), out_axes=0)(a, idx, updates)
+        expected = mx.diag(mx.array([1, 2, 3]), k=-1)[1:]
+        self.assertTrue(mx.allclose(out, expected))
+
+        # vmap over only updates
+        def scatter(a, idx, updates):
+            a[idx] = updates
+            return a
+
+        a = mx.zeros((3, 4))
+        idx = mx.array([0])
+        updates = mx.array([1, 2, 3])
+        out = mx.vmap(scatter, in_axes=(None, None, 0), out_axes=0)(a, idx, updates)
+        expected = mx.zeros((3, 3, 4))
+        expected[:, 0] = mx.array([1, 2, 3])[:, None]
+        self.assertTrue(mx.allclose(out, expected))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/test_vmap.py
+++ b/python/tests/test_vmap.py
@@ -370,6 +370,73 @@ class TestVmap(mlx_tests.MLXTestCase):
                 mx.allclose(a[:, i, :] @ invs[i], mx.eye(a.shape[0]), rtol=0, atol=1e-5)
             )
 
+    def test_vmap_scatter(self):
+        def scatter(a):
+            a[mx.array(0)] = mx.array(0.0)
+            return a
+
+        a = mx.array([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]])
+        out = mx.vmap(scatter)(a)
+        expected = mx.array([[0.0, 2.0, 3.0], [0.0, 3.0, 4.0]])
+        self.assertTrue(mx.allclose(out, expected))
+
+        out = mx.vmap(scatter, in_axes=(1,), out_axes=1)(a)
+        expected = mx.array([[0.0, 0.0, 0.0], [2.0, 3.0, 4.0]])
+        self.assertTrue(mx.allclose(out, expected))
+
+        def scatter_add(a):
+            return a.at[mx.array(0)].add(mx.array(1.0))
+
+        a = mx.array([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]])
+        out = mx.vmap(scatter_add)(a)
+        expected = mx.array([[2.0, 2.0, 3.0], [3.0, 3.0, 4.0]])
+        self.assertTrue(mx.allclose(out, expected))
+
+        out = mx.vmap(scatter_add, in_axes=(1,), out_axes=1)(a)
+        expected = mx.array([[2.0, 3.0, 4.0], [2.0, 3.0, 4.0]])
+        self.assertTrue(mx.allclose(out, expected))
+
+        # Multiple indices
+        def scatter(a):
+            a[mx.array([0, 1]), mx.array([0, 1])] = mx.array((1.0, 1.0))
+            return a
+
+        a = mx.zeros((3, 3, 3))
+
+        expected = mx.repeat(scatter(mx.zeros((3, 3)))[None], 3, axis=0)
+        out = mx.vmap(scatter, in_axes=(0,), out_axes=0)(a)
+        self.assertTrue(mx.allclose(out, expected))
+
+        expected = mx.zeros((3, 3, 3))
+        expected[0, :, 0] = 1
+        expected[1, :, 1] = 1
+        out = mx.vmap(scatter, in_axes=(1,), out_axes=1)(a)
+        self.assertTrue(mx.allclose(out, expected))
+
+        expected = mx.zeros((3, 3, 3))
+        expected[0, 0, :] = 1
+        expected[1, 1, :] = 1
+        out = mx.vmap(scatter, in_axes=(2,), out_axes=2)(a)
+        self.assertTrue(mx.allclose(out, expected))
+
+        # vmap over src and indices
+        def scatter(a, idx):
+            a[idx] = mx.array(1.0)
+            return a
+
+        a = mx.zeros((3, 4))
+        idx = mx.array([0, 1, 2])
+        out = mx.vmap(scatter, in_axes=(0, 0), out_axes=0)(a, idx)
+        self.assertTrue(mx.allclose(out, mx.eye(n=3, m=4)))
+
+        # vmap over only indices
+        out = mx.vmap(scatter, in_axes=(None, 0), out_axes=0)(a, idx)
+        expected = mx.zeros((3, 3, 4))
+        expected[0, 0] = 1
+        expected[1, 1] = 1
+        expected[2, 2] = 1
+        self.assertTrue(mx.allclose(out, expected))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/vmap_tests.cpp
+++ b/tests/vmap_tests.cpp
@@ -414,6 +414,99 @@ TEST_CASE("test vmap gather") {
   }
 }
 
+TEST_CASE("test vmap scatter") {
+  auto make_scatter_fn = [](const std::vector<array>& indices,
+                            const array& updates,
+                            const std::vector<int>& axes) {
+    return [=](const std::vector<array>& inputs) {
+      REQUIRE_EQ(inputs.size(), 1);
+      auto a = inputs.at(0);
+      return std::vector<array>{scatter(a, indices, updates, axes)};
+    };
+  };
+
+  {
+    // vmap nothing.
+    auto a = zeros({3, 4});
+    auto indices = array({1});
+    auto updates = reshape(array({1, 2}, float32), {1, 1, 2});
+
+    auto func = make_scatter_fn({indices}, updates, std::vector<int>{0});
+    auto out = vmap(func, /* in_axes = */ {-1}, /* out_axes = */ {-1})({a})[0];
+    auto expected =
+        array({0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0}, {3, 4}, float32);
+    // Non-vmapped function output.
+    CHECK(array_equal(func({a}).at(0), expected).item<bool>());
+    CHECK(array_equal(out, expected).item<bool>());
+  }
+
+  {
+    // vmap src on axis 0, scatter on axis 0.
+    auto a = zeros({2, 3, 4});
+    auto indices = array({1});
+    auto updates = reshape(array({1, 2}, float32), {1, 1, 2});
+
+    auto func = make_scatter_fn({indices}, updates, std::vector<int>{0});
+    auto out = vmap(func, /* in_axes = */ {0})({a})[0];
+    auto expected = array(
+        {0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0,
+         0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0},
+        {2, 3, 4},
+        float32);
+    CHECK(array_equal(out, expected).item<bool>());
+  }
+
+  {
+    // vmap src on axis 1, scatter on axis 0.
+    auto a = zeros({3, 2, 4});
+    auto indices = array({1});
+    auto updates = reshape(array({1, 2}, float32), {1, 1, 2});
+
+    auto func = make_scatter_fn({indices}, updates, std::vector<int>{0});
+    auto out = vmap(func, /* in_axes = */ {1}, /* out_axes = */ {1})({a})[0];
+    auto expected = array(
+        {0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 0, 0,
+         1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+        {3, 2, 4},
+        float32);
+    CHECK(array_equal(out, expected).item<bool>());
+  }
+
+  {
+    // vmap src on axis 0, scatter on axis 1.
+    auto a = zeros({2, 3, 4});
+    auto indices = array({1});
+    auto updates = reshape(array({1, 2}, float32), {1, 2, 1});
+
+    auto func = make_scatter_fn({indices}, updates, std::vector<int>{1});
+    auto out = vmap(func, /* in_axes = */ {0})({a})[0];
+    auto expected = array(
+        {0, 1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0,
+         0, 1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0},
+        {2, 3, 4},
+        float32);
+    CHECK(array_equal(out, expected).item<bool>());
+  }
+
+  {
+    // vmap src on axis 2, scatter on axes (0, 1).
+    auto a = zeros({3, 4, 5});
+    auto indices = {array({1}), array({2})};
+    auto axes = {0, 1};
+    auto updates = reshape(array({1, 2}, float32), {1, 1, 2});
+
+    auto func = make_scatter_fn(indices, updates, axes);
+    auto out = vmap(func, /* in_axes = */ {2}, /* out_axes = */ {2})({a})[0];
+    auto expected = array(
+        {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2,
+         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+        {3, 4, 5},
+        float32);
+    CHECK(array_equal(out, expected).item<bool>());
+  }
+}
+
 TEST_CASE("test vmap SVD") {
   auto fun = [](std::vector<array> inputs) {
     return linalg::svd(inputs.at(0), Device::cpu);

--- a/tests/vmap_tests.cpp
+++ b/tests/vmap_tests.cpp
@@ -419,7 +419,6 @@ TEST_CASE("test vmap scatter") {
                             const array& updates,
                             const std::vector<int>& axes) {
     return [=](const std::vector<array>& inputs) {
-      REQUIRE_EQ(inputs.size(), 1);
       auto a = inputs.at(0);
       return std::vector<array>{scatter(a, indices, updates, axes)};
     };
@@ -490,19 +489,15 @@ TEST_CASE("test vmap scatter") {
 
   {
     // vmap src on axis 2, scatter on axes (0, 1).
-    auto a = zeros({3, 4, 5});
+    auto a = zeros({2, 3, 2});
     auto indices = {array({1}), array({2})};
     auto axes = {0, 1};
-    auto updates = reshape(array({1, 2}, float32), {1, 1, 2});
+    auto updates = reshape(array({1}, float32), {1, 1, 1});
 
     auto func = make_scatter_fn(indices, updates, axes);
     auto out = vmap(func, /* in_axes = */ {2}, /* out_axes = */ {2})({a})[0];
-    auto expected = array(
-        {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2,
-         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-        {3, 4, 5},
-        float32);
+    auto expected =
+        array({0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1}, {2, 3, 2}, float32);
     CHECK(array_equal(out, expected).item<bool>());
   }
 }


### PR DESCRIPTION
## Proposed changes

Add `vmap` support to `scatter`.

Closes https://github.com/ml-explore/mlx/issues/909

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
