### PR TITLE
Only allow building with OpenMPI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,19 @@ endif()
 
 find_package(MPI)
 if (MPI_FOUND)
+  execute_process(
+    COMMAND zsh "-c" "mpirun --version"
+    OUTPUT_VARIABLE MPI_VERSION
+    COMMAND_ERROR_IS_FATAL ANY
+  )
+  if (${MPI_VERSION} MATCHES ".*Open MPI.*")
     target_include_directories(mlx PRIVATE ${MPI_INCLUDE_PATH})
+  else()
+    message(
+      WARNING
+      "MPI which is not OpenMPI found. Building without MPI."
+    )
+  endif() 
 endif()
 
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/mlx)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 FetchContent_Declare(
   doctest
   GIT_REPOSITORY "https://github.com/onqtam/doctest"
-  GIT_TAG "b7c21ec5ceeadb4951b00396fc1e4642dd347e5f"
+  GIT_TAG "ae7a13539fb71f270b87eb2e874fbac80bc8dda2"
 )
 FetchContent_MakeAvailable(doctest)
 


### PR DESCRIPTION
Sometimes people have MPICH (or another MPI installed) and the build breaks. So this emits an explicit warning about it and builds without MPI.