### PR TITLE
Add GPU Cholesky using MPS

### DIFF
--- a/mlx/backend/metal/CMakeLists.txt
+++ b/mlx/backend/metal/CMakeLists.txt
@@ -53,7 +53,7 @@ make_jit_source(
 make_jit_source(scatter)
 make_jit_source(gather)
 
-if (MLX_METAL_JIT) 
+if (MLX_METAL_JIT)
   target_sources(
     mlx
     PRIVATE
@@ -126,6 +126,7 @@ target_sources(
   PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/allocator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/binary.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/cholesky.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/compiled.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/conv.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/copy.cpp

--- a/mlx/backend/metal/cholesky.cpp
+++ b/mlx/backend/metal/cholesky.cpp
@@ -1,0 +1,91 @@
+// Copyright © 2024 Apple Inc.
+
+#include "mlx/backend/metal/mps/cholesky.h"
+#include "mlx/backend/metal/copy.h"
+#include "mlx/backend/metal/device.h"
+#include "mlx/backend/metal/kernels.h"
+#include "mlx/backend/metal/kernels/defines.h"
+#include "mlx/backend/metal/kernels/steel/gemm/params.h"
+#include "mlx/backend/metal/matmul.h"
+#include "mlx/backend/metal/mps/gemm.h"
+#include "mlx/backend/metal/utils.h"
+#include "mlx/primitives.h"
+#include "mlx/utils.h"
+
+namespace mlx::core {
+
+void Cholesky::eval_gpu(const std::vector<array>& inputs, array& out) {
+  auto& s = stream();
+  auto& d = metal::device(s.device);
+
+  const auto& a = inputs.at(0);
+  if (a.dtype() != float32) {
+    throw std::runtime_error("[Cholesky::eval_gpu] only supports float32.");
+  }
+
+  out.set_data(allocator::malloc_or_wait(out.nbytes()));
+
+  MPS::DataType mps_dtype = MPS::DataTypeFloat32;
+
+  const int num_rows = a.shape(-2);
+  const int row_nbytes = a.shape(-1) * sizeof(float);
+  const int num_matrices = a.size() / (num_rows * num_rows);
+
+  const auto mat_desc = MPS::MatrixDescriptor::matrixDescriptor(
+      /* rows = */ num_rows,
+      /* columns = */ num_rows,
+      /* rowBytes = */ row_nbytes,
+      /* dataType = */ mps_dtype);
+
+  d.end_encoding(s.index);
+
+  // Ensure that the input is contiguous.
+  auto input = a;
+  if (!a.flags().contiguous) {
+    copy(
+        a,
+        input,
+        a.flags().row_contiguous ? CopyType::Vector : CopyType::General);
+  }
+
+  // The kernel does not support batching, so we have to loop explicitly.
+  for (int i = 0; i < num_matrices; i++) {
+    size_t offset = i * num_rows * row_nbytes;
+    auto a_buf = static_cast<const MTL::Buffer*>(input.buffer().ptr());
+    auto a_mat = MPS::Matrix::alloc()->init(a_buf, offset, mat_desc);
+
+    auto out_buf = static_cast<MTL::Buffer*>(out.buffer().ptr());
+    auto out_mat = MPS::Matrix::alloc()->init(out_buf, offset, mat_desc);
+
+    auto kernel = MPS::MatrixDecompositionCholesky::alloc()->init(
+        d.mtl_device(), !upper_, num_rows);
+
+    auto command_buffer = d.get_command_buffer(s.index);
+    kernel->encodeToCommandBuffer(command_buffer, a_mat, out_mat, nullptr);
+    a_mat->release();
+    out_mat->release();
+    command_buffer->addCompletedHandler(
+        [kernel](MTL::CommandBuffer*) mutable { kernel->release(); });
+  }
+
+  // Zero out the unwanted part of the output.
+  auto& compute_encoder = d.get_command_encoder(s.index);
+  auto make_triangular_kernel = d.get_kernel("make_triangular");
+  compute_encoder->setComputePipelineState(make_triangular_kernel);
+  compute_encoder->setBytes(&upper_, sizeof(upper_), 0);
+  compute_encoder->setBytes(&num_rows, sizeof(num_rows), 1);
+  compute_encoder.set_output_array(out, 2);
+
+  const MTL::Size threads_per_grid(num_rows, num_rows, num_matrices);
+  const int threadgroup_width = std::min(
+      threads_per_grid.width, make_triangular_kernel->threadExecutionWidth());
+  const int threadgroup_height = std::min(
+      threads_per_grid.height,
+      make_triangular_kernel->maxTotalThreadsPerThreadgroup() /
+          threadgroup_width);
+  const MTL::Size threads_per_threadgroup(
+      threadgroup_width, threadgroup_height, 1);
+  compute_encoder->dispatchThreads(threads_per_grid, threads_per_threadgroup);
+}
+
+} // namespace mlx::core

--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -14,6 +14,7 @@
 #include "mlx/backend/metal/device.h"
 #include "mlx/backend/metal/metal.h"
 #include "mlx/backend/metal/metal_impl.h"
+#include "mlx/backend/metal/mps/cholesky.h"
 #include "mlx/backend/metal/mps/gemm.h"
 #include "mlx/backend/metal/utils.h"
 

--- a/mlx/backend/metal/kernels/CMakeLists.txt
+++ b/mlx/backend/metal/kernels/CMakeLists.txt
@@ -51,7 +51,7 @@ build_kernel(
 )
 
 set(
-  STEEL_HEADERS 
+  STEEL_HEADERS
   steel/defines.h
   steel/utils.h
   steel/conv/conv.h
@@ -74,6 +74,7 @@ if (NOT MLX_METAL_JIT)
 build_kernel(arange arange.h)
 build_kernel(binary binary.h binary_ops.h)
 build_kernel(binary_two binary_two.h)
+build_kernel(cholesky)
 build_kernel(copy copy.h)
 build_kernel(
   fft

--- a/mlx/backend/metal/kernels/cholesky.metal
+++ b/mlx/backend/metal/kernels/cholesky.metal
@@ -1,0 +1,12 @@
+// Copyright © 2024 Apple Inc.
+
+[[kernel]] void make_triangular(
+    constant const bool& upper,
+    constant const int& m,
+    device float* out,
+    uint3 index [[thread_position_in_grid]]) {
+  const bool should_zero = upper ? index.x > index.y : index.y > index.x;
+  if (should_zero) {
+    out[index.z * m * m + index.x * m + index.y] = 0;
+  }
+}

--- a/mlx/backend/metal/mps/cholesky.h
+++ b/mlx/backend/metal/mps/cholesky.h
@@ -1,0 +1,70 @@
+// Copyright © 2024 Apple Inc.
+
+#pragma once
+
+#include "mlx/backend/metal/mps/gemm.h"
+
+#include <Metal/Metal.hpp>
+
+namespace MTL::Private::Class {
+_MTL_PRIVATE_DEF_CLS(MPSMatrixDecompositionCholesky);
+} // namespace MTL::Private::Class
+
+namespace MTL::Private::Selector {
+_MTL_PRIVATE_DEF_SEL(
+    initWithDevice_lower_order_,
+    "initWithDevice:lower:order:");
+_MTL_PRIVATE_DEF_SEL(
+    encodeToCommandBuffer_sourceMatrix_resultMatrix_status,
+    "encodeToCommandBuffer:sourceMatrix:resultMatrix:status:");
+} // namespace MTL::Private::Selector
+
+namespace MPS {
+
+class MatrixDecompositionCholesky
+    : public NS::Referencing<MatrixDecompositionCholesky, Kernel> {
+ public:
+  static class MatrixDecompositionCholesky* alloc();
+
+  MatrixDecompositionCholesky*
+  init(MTL::Device* device, bool lower, NS::UInteger order);
+
+  void encodeToCommandBuffer(
+      MTL::CommandBuffer* commandBuffer,
+      Matrix* sourceMatrix,
+      Matrix* resultMatrix,
+      MTL::Buffer* status);
+};
+
+_MTL_INLINE MatrixDecompositionCholesky* MatrixDecompositionCholesky::alloc() {
+  return NS::Object::alloc<MatrixDecompositionCholesky>(
+      _MPS_PRIVATE_CLS(MPSMatrixDecompositionCholesky));
+}
+
+_MTL_INLINE MatrixDecompositionCholesky* MatrixDecompositionCholesky::init(
+    MTL::Device* device,
+    bool lower,
+    NS::UInteger order) {
+  return Object::sendMessage<MatrixDecompositionCholesky*>(
+      this,
+      _MPS_PRIVATE_SEL(initWithDevice_lower_order_),
+      device,
+      lower,
+      order);
+}
+
+_MTL_INLINE void MatrixDecompositionCholesky::encodeToCommandBuffer(
+    MTL::CommandBuffer* commandBuffer,
+    Matrix* sourceMatrix,
+    Matrix* resultMatrix,
+    MTL::Buffer* status) {
+  return Object::sendMessage<void>(
+      this,
+      _MPS_PRIVATE_SEL(encodeToCommandBuffer_sourceMatrix_resultMatrix_status),
+      commandBuffer,
+      sourceMatrix,
+      resultMatrix,
+      status);
+}
+
+} // namespace MPS

--- a/mlx/backend/metal/mps/gemm.h
+++ b/mlx/backend/metal/mps/gemm.h
@@ -27,6 +27,9 @@ _MTL_PRIVATE_DEF_SEL(
 _MTL_PRIVATE_DEF_SEL(rows, "rows");
 _MTL_PRIVATE_DEF_SEL(initWithBuffer_descriptor, "initWithBuffer:descriptor:");
 _MTL_PRIVATE_DEF_SEL(
+    initWithBuffer_offset_descriptor,
+    "initWithBuffer:offset:descriptor:");
+_MTL_PRIVATE_DEF_SEL(
     initWithDevice_,
     "initWithDevice:transposeLeft:transposeRight:"
     "resultRows:resultColumns:interiorColumns:alpha:beta:");
@@ -83,7 +86,13 @@ class Matrix : public NS::Referencing<Matrix> {
  public:
   static class Matrix* alloc();
   Matrix* init(MTL::Buffer* buffer, MatrixDescriptor* descriptor);
+  Matrix*
+  init(MTL::Buffer* buffer, NS::UInteger offset, MatrixDescriptor* descriptor);
   Matrix* init(const MTL::Buffer* buffer, MatrixDescriptor* descriptor);
+  Matrix* init(
+      const MTL::Buffer* buffer,
+      NS::UInteger offset,
+      MatrixDescriptor* descriptor);
 };
 
 class Kernel : public NS::Referencing<Kernel> {
@@ -208,9 +217,28 @@ _MTL_INLINE Matrix* Matrix::init(
 }
 
 _MTL_INLINE Matrix* Matrix::init(
+    MTL::Buffer* buffer,
+    NS::UInteger offset,
+    MatrixDescriptor* descriptor) {
+  return Object::sendMessage<Matrix*>(
+      this,
+      _MPS_PRIVATE_SEL(initWithBuffer_offset_descriptor),
+      buffer,
+      offset,
+      descriptor);
+}
+
+_MTL_INLINE Matrix* Matrix::init(
     const MTL::Buffer* buffer,
     MatrixDescriptor* descriptor) {
   return init(const_cast<MTL::Buffer*>(buffer), descriptor);
+}
+
+_MTL_INLINE Matrix* Matrix::init(
+    const MTL::Buffer* buffer,
+    NS::UInteger offset,
+    MatrixDescriptor* descriptor) {
+  return init(const_cast<MTL::Buffer*>(buffer), offset, descriptor);
 }
 
 _MTL_INLINE NS::String* Kernel::label() const {

--- a/mlx/backend/metal/primitives.cpp
+++ b/mlx/backend/metal/primitives.cpp
@@ -358,11 +358,6 @@ void Inverse::eval_gpu(const std::vector<array>& inputs, array& output) {
   throw std::runtime_error("[Inverse::eval_gpu] Metal inversion NYI.");
 }
 
-void Cholesky::eval_gpu(const std::vector<array>& inputs, array& out) {
-  throw std::runtime_error(
-      "[Cholesky::eval_gpu] Metal Cholesky decomposition NYI.");
-}
-
 void View::eval_gpu(const std::vector<array>& inputs, array& out) {
   auto& in = inputs[0];
   auto ibytes = size_of(in.dtype());

--- a/python/tests/test_linalg.py
+++ b/python/tests/test_linalg.py
@@ -155,15 +155,15 @@ class TestLinalg(mlx_tests.MLXTestCase):
             [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]], dtype=mx.float32
         )
         A = sqrtA.T @ sqrtA / 81
-        L = mx.linalg.cholesky(A, stream=mx.cpu)
-        U = mx.linalg.cholesky(A, upper=True, stream=mx.cpu)
+        L = mx.linalg.cholesky(A)
+        U = mx.linalg.cholesky(A, upper=True)
         self.assertTrue(mx.allclose(L @ L.T, A, rtol=1e-5, atol=1e-7))
         self.assertTrue(mx.allclose(U.T @ U, A, rtol=1e-5, atol=1e-7))
 
         # Multiple matrices
         B = A + 1 / 9
         AB = mx.stack([A, B])
-        Ls = mx.linalg.cholesky(AB, stream=mx.cpu)
+        Ls = mx.linalg.cholesky(AB)
         for M, L in zip(AB, Ls):
             self.assertTrue(mx.allclose(L @ L.T, M, rtol=1e-5, atol=1e-7))
 

--- a/tests/linalg_tests.cpp
+++ b/tests/linalg_tests.cpp
@@ -325,26 +325,45 @@ TEST_CASE("test matrix inversion") {
 
 TEST_CASE("test matrix cholesky") {
   // 0D and 1D throw
-  CHECK_THROWS(linalg::cholesky(array(0.0), /* upper = */ false, Device::cpu));
-  CHECK_THROWS(
-      linalg::cholesky(array({0.0, 1.0}), /* upper = */ false, Device::cpu));
+  CHECK_THROWS(linalg::cholesky(array(0.0), /* upper = */ false));
+  CHECK_THROWS(linalg::cholesky(array({0.0, 1.0}), /* upper = */ false));
 
   // Unsupported types throw
-  CHECK_THROWS(linalg::cholesky(
-      array({0, 1}, {1, 2}), /* upper = */ false, Device::cpu));
+  CHECK_THROWS(linalg::cholesky(array({0, 1}, {1, 2}), /* upper = */ false));
 
   // Non-square throws.
-  CHECK_THROWS(linalg::cholesky(
-      array({1, 2, 3, 4, 5, 6}, {2, 3}), /* upper = */ false, Device::cpu));
+  CHECK_THROWS(
+      linalg::cholesky(array({1, 2, 3, 4, 5, 6}, {2, 3}), /* upper = */ false));
 
   const auto prng_key = random::key(220398);
   const auto sqrtA = random::normal({5, 5}, prng_key);
   const auto A = matmul(sqrtA, transpose(sqrtA));
-  const auto L = linalg::cholesky(A, /* upper = */ false, Device::cpu);
-  const auto U = linalg::cholesky(A, /* upper = */ true, Device::cpu);
+  const auto A_noncontiguous = slice(A, {0, 1}, {3, 4}, {1, 1});
 
-  CHECK(allclose(matmul(L, transpose(L)), A, /* rtol = */ 0, /* atol = */ 1e-6)
+  auto tests = std::vector{
+      std::make_tuple(A, true),
+      std::make_tuple(A_noncontiguous, false),
+  };
+
+  for (const auto& [a, expected_contiguous] : tests) {
+    eval(a);
+    CHECK_EQ(a.flags().contiguous, expected_contiguous);
+    CHECK_EQ(a.flags().row_contiguous, expected_contiguous);
+
+    const auto L = linalg::cholesky(a, /* upper = */ false);
+    const auto U = linalg::cholesky(a, /* upper = */ true);
+
+    CHECK_EQ(L.dtype(), float32);
+    CHECK_EQ(U.dtype(), float32);
+
+    CHECK(allclose(tril(U, -1), zeros_like(U)).item<bool>());
+    CHECK(allclose(triu(L, 1), zeros_like(L)).item<bool>());
+
+    CHECK(
+        allclose(matmul(L, transpose(L)), a, /* rtol = */ 0, /* atol = */ 1e-6)
             .item<bool>());
-  CHECK(allclose(matmul(transpose(U), U), A, /* rtol = */ 0, /* atol = */ 1e-6)
+    CHECK(
+        allclose(matmul(transpose(U), U), a, /* rtol = */ 0, /* atol = */ 1e-6)
             .item<bool>());
+  }
 }


### PR DESCRIPTION
## Proposed changes

Add a GPU implementation of Cholesky decomposition based on the MPS kernel. Completes https://github.com/ml-explore/mlx/issues/1026.

Sadly the kernel is slower than the CPU, maybe it's still useful (times in ms):

```
size       cpu     gpu
1000      0.99    7.67
5000     24.44   61.94
10000    79.13  162.09
```

Many of the bindings in `mlx/backend/metal/mps/gemm.h` (eg `Matrix`) could be moved to a standalone header. I can do that in a follow-up if wanted.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
