### PR TITLE
Fix NumPy 2.0 pickle test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           command: |
             pip install --upgrade cmake
             pip install git+https://github.com/wjakob/nanobind.git@2f04eac452a6d9142dedb957701bdb20125561e4
-            pip install "numpy<2.0.0"
+            pip install numpy
             sudo apt-get update
             sudo apt-get install libblas-dev liblapack-dev liblapacke-dev
       - run:
@@ -77,7 +77,7 @@ jobs:
             pip install --upgrade pip
             pip install --upgrade cmake
             pip install git+https://github.com/wjakob/nanobind.git@2f04eac452a6d9142dedb957701bdb20125561e4
-            pip install "numpy<2.0.0"
+            pip install numpy
             pip install torch
             pip install tensorflow
             pip install unittest-xml-reporting
@@ -151,7 +151,7 @@ jobs:
             pip install --upgrade cmake
             pip install git+https://github.com/wjakob/nanobind.git@2f04eac452a6d9142dedb957701bdb20125561e4
             pip install --upgrade setuptools
-            pip install "numpy<2.0.0"
+            pip install numpy
             pip install twine
             pip install build
       - run:
@@ -215,7 +215,7 @@ jobs:
             pip install --upgrade cmake
             pip install git+https://github.com/wjakob/nanobind.git@2f04eac452a6d9142dedb957701bdb20125561e4
             pip install --upgrade setuptools
-            pip install "numpy<2.0.0"
+            pip install numpy
             pip install auditwheel
             pip install patchelf
             pip install build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           command: |
             pip install --upgrade cmake
             pip install git+https://github.com/wjakob/nanobind.git@2f04eac452a6d9142dedb957701bdb20125561e4
-            pip install numpy
+            pip install numpy<2.0.0
             sudo apt-get update
             sudo apt-get install libblas-dev liblapack-dev liblapacke-dev
       - run:
@@ -77,7 +77,7 @@ jobs:
             pip install --upgrade pip
             pip install --upgrade cmake
             pip install git+https://github.com/wjakob/nanobind.git@2f04eac452a6d9142dedb957701bdb20125561e4
-            pip install numpy
+            pip install numpy<2.0.0
             pip install torch
             pip install tensorflow
             pip install unittest-xml-reporting
@@ -151,7 +151,7 @@ jobs:
             pip install --upgrade cmake
             pip install git+https://github.com/wjakob/nanobind.git@2f04eac452a6d9142dedb957701bdb20125561e4
             pip install --upgrade setuptools
-            pip install numpy
+            pip install numpy<2.0.0
             pip install twine
             pip install build
       - run:
@@ -215,7 +215,7 @@ jobs:
             pip install --upgrade cmake
             pip install git+https://github.com/wjakob/nanobind.git@2f04eac452a6d9142dedb957701bdb20125561e4
             pip install --upgrade setuptools
-            pip install numpy
+            pip install numpy<2.0.0
             pip install auditwheel
             pip install patchelf
             pip install build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           command: |
             pip install --upgrade cmake
             pip install git+https://github.com/wjakob/nanobind.git@2f04eac452a6d9142dedb957701bdb20125561e4
-            pip install numpy<2.0.0
+            pip install "numpy<2.0.0"
             sudo apt-get update
             sudo apt-get install libblas-dev liblapack-dev liblapacke-dev
       - run:
@@ -77,7 +77,7 @@ jobs:
             pip install --upgrade pip
             pip install --upgrade cmake
             pip install git+https://github.com/wjakob/nanobind.git@2f04eac452a6d9142dedb957701bdb20125561e4
-            pip install numpy<2.0.0
+            pip install "numpy<2.0.0"
             pip install torch
             pip install tensorflow
             pip install unittest-xml-reporting
@@ -151,7 +151,7 @@ jobs:
             pip install --upgrade cmake
             pip install git+https://github.com/wjakob/nanobind.git@2f04eac452a6d9142dedb957701bdb20125561e4
             pip install --upgrade setuptools
-            pip install numpy<2.0.0
+            pip install "numpy<2.0.0"
             pip install twine
             pip install build
       - run:
@@ -215,7 +215,7 @@ jobs:
             pip install --upgrade cmake
             pip install git+https://github.com/wjakob/nanobind.git@2f04eac452a6d9142dedb957701bdb20125561e4
             pip install --upgrade setuptools
-            pip install numpy<2.0.0
+            pip install "numpy<2.0.0"
             pip install auditwheel
             pip install patchelf
             pip install build

--- a/python/src/convert.cpp
+++ b/python/src/convert.cpp
@@ -122,7 +122,7 @@ nb::ndarray<NDParams...> mlx_to_nd_array_impl(
       a.data<T>(),
       a.ndim(),
       shape.data(),
-      nullptr,
+      /* owner= */ nb::none(),
       strides.data(),
       t.value_or(nb::dtype<T>()));
 }
@@ -151,7 +151,8 @@ nb::ndarray<NDParams...> mlx_to_nd_array(const array& a) {
     case float16:
       return mlx_to_nd_array_impl<float16_t, NDParams...>(a);
     case bfloat16:
-      return mlx_to_nd_array_impl<bfloat16_t, NDParams...>(a, nb::bfloat16);
+      throw nb::type_error(
+          "bfloat16 arrays cannot be converted directly to NumPy.");
     case float32:
       return mlx_to_nd_array_impl<float, NDParams...>(a);
     case complex64:

--- a/python/src/convert.cpp
+++ b/python/src/convert.cpp
@@ -122,7 +122,7 @@ nb::ndarray<NDParams...> mlx_to_nd_array_impl(
       a.data<T>(),
       a.ndim(),
       shape.data(),
-      nb::none(),
+      nullptr,
       strides.data(),
       t.value_or(nb::dtype<T>()));
 }


### PR DESCRIPTION
NumPy updated to 2.0 in CircleCI which broke one of our tests.

`np.array(x, copy=False)` now errors instead of silently copying the array if the no-copy path is not possible.
This means we get a different error when pickling a `bfloat16` array so our `with self.assertRaises(TypeError)` doesn't trigger.

We fix by explicitly raising the type error in the `bfloat16` template.


