### PR TITLE
Fix `inner()` throws when one argument is an one element array

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -3631,7 +3631,8 @@ array outer(const array& a, const array& b, StreamOrDevice s /* = {} */) {
 }
 
 array inner(const array& a, const array& b, StreamOrDevice s /* = {} */) {
-  if (a.ndim() == 0 || b.ndim() == 0) {
+  if (a.ndim() == 0 || b.ndim() == 0 || 
+      a.shape() == std::vector({1}) || b.shape() == std::vector({1})) {
     return multiply(a, b, s);
   }
   if (a.shape(-1) != b.shape(-1)) {

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -3631,8 +3631,8 @@ array outer(const array& a, const array& b, StreamOrDevice s /* = {} */) {
 }
 
 array inner(const array& a, const array& b, StreamOrDevice s /* = {} */) {
-  if (a.ndim() == 0 || b.ndim() == 0 || 
-      a.shape() == std::vector({1}) || b.shape() == std::vector({1})) {
+  if (a.ndim() == 0 || b.ndim() == 0 || a.shape() == std::vector({1}) ||
+      b.shape() == std::vector({1})) {
     return multiply(a, b, s);
   }
   if (a.shape(-1) != b.shape(-1)) {

--- a/tests/ops_tests.cpp
+++ b/tests/ops_tests.cpp
@@ -2781,6 +2781,10 @@ TEST_CASE("inner") {
   z = inner(eye(2), array(7.));
   expected = array({7., 0., 0., 7.}, {2, 2});
   CHECK(array_equal(z, expected).item<bool>());
+
+  z = inner(eye(2), array({7.}, {1}));
+  expected = array({7., 0., 0., 7.}, {2, 2});
+  CHECK(array_equal(z, expected).item<bool>());
 }
 
 TEST_CASE("test divmod") {


### PR DESCRIPTION
## Proposed changes

This PR addresses the issue #1223 by checking if `a` or `b` is a one-element array by adding the following checks to the if statement `a.shape() == std::vector({1}) || b.shape() == std::vector({1})` (Is there a better way for comparing vectors in cpp?). A new test case is also added to the end of `ops_tests.cpp/TEST_CASE("inner")`.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
