### PR TITLE
Fixes segfault when compiling checkpointed functions

### DIFF
--- a/mlx/compile.cpp
+++ b/mlx/compile.cpp
@@ -266,8 +266,8 @@ class CompilerCache {
     cache_.erase(fun_id);
   }
 
-  std::unordered_map<std::uintptr_t, std::vector<CacheEntry>>& entries() {
-    return cache_;
+  void clear() {
+    cache_.clear();
   }
 
  private:
@@ -863,6 +863,10 @@ void compile_erase(std::uintptr_t fun_id) {
   detail::compiler_cache().erase(fun_id);
 }
 
+void compile_clear_cache() {
+  detail::compiler_cache().clear();
+}
+
 } // namespace detail
 
 std::function<std::vector<array>(const std::vector<array>&)> compile(
@@ -885,10 +889,6 @@ void enable_compile() {
 
 void set_compile_mode(CompileMode mode) {
   detail::compile_mode() = mode;
-}
-
-void clear_compiler_cache() {
-  detail::compiler_cache().entries().clear();
 }
 
 } // namespace mlx::core

--- a/mlx/compile.cpp
+++ b/mlx/compile.cpp
@@ -266,6 +266,10 @@ class CompilerCache {
     cache_.erase(fun_id);
   }
 
+  std::unordered_map<std::uintptr_t, std::vector<CacheEntry>>& entries() {
+    return cache_;
+  }
+
  private:
   CompilerCache() {
     // Make sure the allocator is fully
@@ -881,6 +885,10 @@ void enable_compile() {
 
 void set_compile_mode(CompileMode mode) {
   detail::compile_mode() = mode;
+}
+
+void clear_compiler_cache() {
+  detail::compiler_cache().entries().clear();
 }
 
 } // namespace mlx::core

--- a/mlx/compile.h
+++ b/mlx/compile.h
@@ -24,11 +24,6 @@ void disable_compile();
  */
 void enable_compile();
 
-/** Clear the compiler cache causing a recompilation of all compiled functions
- * when called again.
- */
-void clear_compiler_cache();
-
 /** Set the compiler mode to the given value. */
 void set_compile_mode(CompileMode mode);
 } // namespace mlx::core

--- a/mlx/compile.h
+++ b/mlx/compile.h
@@ -24,6 +24,11 @@ void disable_compile();
  */
 void enable_compile();
 
+/** Clear the compiler cache causing a recompilation of all compiled functions
+ * when called again.
+ */
+void clear_compiler_cache();
+
 /** Set the compiler mode to the given value. */
 void set_compile_mode(CompileMode mode);
 } // namespace mlx::core

--- a/mlx/transforms_impl.h
+++ b/mlx/transforms_impl.h
@@ -27,6 +27,10 @@ std::function<std::vector<array>(const std::vector<array>&)> compile(
 // Erase cached compile functions
 void compile_erase(std::uintptr_t fun_id);
 
+// Clear the compiler cache causing a recompilation of all compiled functions
+// when called again.
+void compile_clear_cache();
+
 // Create an InTracing object during tracing operations to signify to the rest
 // of the codebase that we are during tracing so evals should not throw away
 // the graph.

--- a/python/src/transforms.cpp
+++ b/python/src/transforms.cpp
@@ -961,13 +961,6 @@ void init_transforms(nb::module_& m) {
         variable ``MLX_DISABLE_COMPILE`` if set.
       )pbdoc");
   m.def(
-      "clear_compiler_cache",
-      &clear_compiler_cache,
-      R"pbdoc(
-        Clear the compiler cache causing all compiled function to recompile if
-        they are called again.
-      )pbdoc");
-  m.def(
       "checkpoint",
       [](nb::callable fun) { return nb::cpp_function(PyCheckpointedFun{fun}); },
       "fun"_a);
@@ -976,6 +969,6 @@ void init_transforms(nb::module_& m) {
   auto atexit = nb::module_::import_("atexit");
   atexit.attr("register")(nb::cpp_function([]() {
     tree_cache().clear();
-    clear_compiler_cache();
+    detail::compile_clear_cache();
   }));
 }


### PR DESCRIPTION
Closes #1162.

See title. It exposes a `clear_compiler_cache` method in C++ and Python which is also registered `atexit`.