### PR TITLE
Fix reshape copy bug

### DIFF
--- a/mlx/backend/common/primitives.cpp
+++ b/mlx/backend/common/primitives.cpp
@@ -405,7 +405,17 @@ void Reshape::eval(const std::vector<array>& inputs, array& out) {
   auto [copy_necessary, out_strides] = prepare_reshape(in, out);
 
   if (copy_necessary) {
-    copy(in, out, in.data_size() == 1 ? CopyType::Scalar : CopyType::General);
+    out.set_data(allocator::malloc_or_wait(out.nbytes()));
+    auto out_strides = make_contiguous_strides<size_t>(in.shape());
+    copy_inplace<size_t>(
+        in,
+        out,
+        in.shape(),
+        in.strides(),
+        out_strides,
+        0,
+        0,
+        CopyType::General);
   } else {
     shared_buffer_reshape(in, out_strides, out);
   }

--- a/mlx/backend/common/utils.h
+++ b/mlx/backend/common/utils.h
@@ -29,6 +29,15 @@ inline size_t elem_to_loc(int elem, const array& a) {
   return elem_to_loc(elem, a.shape(), a.strides());
 }
 
+template <typename stride_t>
+std::vector<stride_t> make_contiguous_strides(const std::vector<int>& shape) {
+  std::vector<stride_t> strides(shape.size(), 1);
+  for (int i = shape.size() - 1; i > 0; i--) {
+    strides[i - 1] = strides[i] * shape[i];
+  }
+  return strides;
+}
+
 // Collapse dims that are contiguous to possibly route to a better kernel
 // e.g. for x = transpose(array({0, 1, 2, 3, 4, 5, 6, 7}, {2, 2, 2}), {2, 0, 1})
 // should return {{2, 4}, {{1, 2}}}.

--- a/mlx/backend/metal/copy.cpp
+++ b/mlx/backend/metal/copy.cpp
@@ -154,11 +154,8 @@ void copy_gpu_inplace(
     array& out,
     CopyType ctype,
     const Stream& s) {
-  std::vector<size_t> out_strides = (in.shape() == out.shape())
-      ? out.strides()
-      : make_contiguous_strides<size_t>(in.shape());
   return copy_gpu_inplace(
-      in, out, in.shape(), in.strides(), out_strides, 0, 0, ctype, s);
+      in, out, in.shape(), in.strides(), out.strides(), 0, 0, ctype, s);
 }
 
 void copy_gpu_inplace(
@@ -168,9 +165,7 @@ void copy_gpu_inplace(
     int64_t ioffset,
     CopyType ctype,
     const Stream& s) {
-  std::vector<int64_t> ostrides = (in.shape() == out.shape())
-      ? std::vector<int64_t>{out.strides().begin(), out.strides().end()}
-      : make_contiguous_strides<int64_t>(in.shape());
+  std::vector<int64_t> ostrides{out.strides().begin(), out.strides().end()};
   return copy_gpu_inplace(
       in, out, in.shape(), istride, ostrides, ioffset, 0, ctype, s);
 }

--- a/mlx/backend/metal/copy.cpp
+++ b/mlx/backend/metal/copy.cpp
@@ -154,8 +154,11 @@ void copy_gpu_inplace(
     array& out,
     CopyType ctype,
     const Stream& s) {
+  std::vector<size_t> out_strides = (in.shape() == out.shape())
+      ? out.strides()
+      : make_contiguous_strides<size_t>(in.shape());
   return copy_gpu_inplace(
-      in, out, in.shape(), in.strides(), out.strides(), 0, 0, ctype, s);
+      in, out, in.shape(), in.strides(), out_strides, 0, 0, ctype, s);
 }
 
 void copy_gpu_inplace(
@@ -165,7 +168,9 @@ void copy_gpu_inplace(
     int64_t ioffset,
     CopyType ctype,
     const Stream& s) {
-  std::vector<int64_t> ostrides{out.strides().begin(), out.strides().end()};
+  std::vector<int64_t> ostrides = (in.shape() == out.shape())
+      ? std::vector<int64_t>{out.strides().begin(), out.strides().end()}
+      : make_contiguous_strides<int64_t>(in.shape());
   return copy_gpu_inplace(
       in, out, in.shape(), istride, ostrides, ioffset, 0, ctype, s);
 }

--- a/mlx/backend/metal/primitives.cpp
+++ b/mlx/backend/metal/primitives.cpp
@@ -273,7 +273,18 @@ void Reshape::eval_gpu(const std::vector<array>& inputs, array& out) {
   auto [copy_necessary, out_strides] = prepare_reshape(in, out);
 
   if (copy_necessary) {
-    copy_gpu(in, out, CopyType::General);
+    out.set_data(allocator::malloc_or_wait(out.nbytes()));
+    auto out_strides = make_contiguous_strides<size_t>(in.shape());
+    copy_gpu_inplace(
+        in,
+        out,
+        in.shape(),
+        in.strides(),
+        out_strides,
+        0,
+        0,
+        CopyType::General,
+        stream());
   } else {
     shared_buffer_reshape(in, out_strides, out);
   }


### PR DESCRIPTION
Fixes https://github.com/ml-explore/mlx-swift/issues/104 and potentially https://github.com/ml-explore/mlx-examples/issues/642 .

The two first commits in the PR have two different fixes. The later one is what I consider a better choice. The bug is because the code in `Reshape` assumed that `copy` copies arrays of same total size but different shapes. That is not true, it is not checked but copy assumes `in.shape() == out.shape()`. I did not add this as an assertion but we could... let me know.

The fix in the previous PR was just allowing to copy from any shape to any shape assuming that the total number of elements is the same.

The current fix just fixes reshape to allocate and copy in place passing the correct output strides. I also updated the cpu copy to use `collapse_contiguous_dims` so we should get signficantly faster many-dimensional copies on the cpu.