### PR TITLE
Add zero VJPs for bitwise ops and gather w.r.t. index

### DIFF
--- a/mlx/primitives.h
+++ b/mlx/primitives.h
@@ -471,6 +471,7 @@ class BitwiseBinary : public UnaryPrimitive {
   void eval_gpu(const std::vector<array>& inputs, array& out) override;
 
   DEFINE_VMAP()
+  DEFINE_GRADS()
   bool is_equivalent(const Primitive& other) const override;
   void print(std::ostream& os) override;
   DEFINE_INPUT_OUTPUT_SHAPE()

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -1043,6 +1043,19 @@ class TestArray(mlx_tests.MLXTestCase):
         a_mlx = mx.array(a_np)
         self.assertTrue(np.array_equal(a_np[2:-1, 0], np.array(a_mlx[2:-1, 0])))
 
+    def test_indexing_grad(self):
+        x = mx.array([[1, 2], [3, 4]]).astype(mx.float32)
+        ind = mx.array([0, 1, 0]).astype(mx.float32)
+
+        def index_fn(x, ind):
+            return x[ind.astype(mx.int32)].sum()
+
+        grad_x, grad_ind = mx.grad(index_fn, argnums=(0, 1))(x, ind)
+        expected = mx.array([[2, 2], [1, 1]])
+
+        self.assertTrue(mx.array_equal(grad_x, expected))
+        self.assertTrue(mx.array_equal(grad_ind, mx.zeros(ind.shape)))
+
     def test_setitem(self):
         a = mx.array(0)
         a[None] = 1

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -2373,6 +2373,21 @@ class TestOps(mlx_tests.MLXTestCase):
         self.assertEqual(c.shape, (3, 2, 5))
         self.assertTrue(mx.array_equal(c, mx.ones((3, 2, 5), dtype=mx.bool_)))
 
+    def test_bitwise_grad(self):
+        a = np.random.randint(0, 10, size=(4, 3))
+        b = np.random.randint(0, 10, size=(4, 3))
+        cotangent = np.random.randint(0, 10, size=(4, 3))
+        a = mx.array(a)
+        b = mx.array(b)
+        cotangent = mx.array(cotangent)
+
+        def bitwise(a, b):
+            return a.astype(mx.int32) & b.astype(mx.int32)
+
+        _, vjps = mx.vjp(bitwise, [a, b], [cotangent])
+        for vjp in vjps:
+            self.assertFalse(np.any(np.array(vjp)))
+
     def test_conjugate(self):
         shape = (3, 5, 7)
         a = np.random.normal(size=shape) + 1j * np.random.normal(size=shape)


### PR DESCRIPTION
Motivated by implementing `torch.nn.functional.grid_sample` in MLX since it requires differentiating through indexing and bounds checks.

(see #1213)
