### PR TITLE
feat: Added "tanh" option to GELU approximation

### DIFF
--- a/python/mlx/nn/layers/activations.py
+++ b/python/mlx/nn/layers/activations.py
@@ -532,19 +532,21 @@ class GELU(Module):
 
     where :math:`\Phi(x)` is the Gaussian CDF.
 
-    However, if ``approx`` is set to 'precise'/'tanh' or 'fast' it applies
+    However, if ``approx`` is set to 'precise' or 'fast' it applies
 
     .. math::
         \textrm{GELUApprox}(x) &= 0.5 * x * \left(1 + \text{Tanh}\left((\sqrt{2 / \pi} * \left(x + 0.044715 * x^3\right)\right)\right) \\
         \textrm{GELUFast}(x) &= x * \sigma\left(1.773 * x\right)
 
-    respectively.
+    respectively. Note, that 'tanh' is an alias for 'precise' to follow the 
+    Pytorch API.
 
     See :func:`gelu`, :func:`gelu_approx` and :func:`gelu_fast_approx` for the
     functional equivalents and information regarding error bounds.
+    
 
     Args:
-        approx ('none' | 'precise'/'tanh' | 'fast'): Which approximation to gelu to use if any.
+        approx ('none' | 'precise' | 'fast'): Which approximation to gelu to use if any.
     """
 
     def __init__(self, approx="none"):

--- a/python/mlx/nn/layers/activations.py
+++ b/python/mlx/nn/layers/activations.py
@@ -536,10 +536,13 @@ class GELU(Module):
 
     .. math::
         \textrm{GELUApprox}(x) &= 0.5 * x * \left(1 + \text{Tanh}\left((\sqrt{2 / \pi} * \left(x + 0.044715 * x^3\right)\right)\right) \\
-        \textrm{GELUFast}(x) &= x * \sigma\left(1.773 * x\right)
+        \textrm{GELUFast}(x) &= x * \sigma\left(1.702 * x\right)
 
-    respectively. Note, that 'tanh' is an alias for 'precise' to follow the 
-    Pytorch API.
+    respectively.
+
+    .. note::
+       For compatibility with the PyTorch API, 'tanh' can be used as an alias
+       for 'precise'.
 
     See :func:`gelu`, :func:`gelu_approx` and :func:`gelu_fast_approx` for the
     functional equivalents and information regarding error bounds.
@@ -560,7 +563,7 @@ class GELU(Module):
             self._act = gelu_fast_approx
         else:
             raise ValueError(
-                f"The approximation should be in ['none', 'precise'/'tanh', 'fast'] but '{approx}' was given"
+                f"The approximation should be in ['none', 'precise', 'tanh', 'fast'] but '{approx}' was given"
             )
 
     def __call__(self, x):

--- a/python/mlx/nn/layers/activations.py
+++ b/python/mlx/nn/layers/activations.py
@@ -532,7 +532,7 @@ class GELU(Module):
 
     where :math:`\Phi(x)` is the Gaussian CDF.
 
-    However, if ``approx`` is set to 'precise' or 'fast' it applies
+    However, if ``approx`` is set to 'precise'/'tanh' or 'fast' it applies
 
     .. math::
         \textrm{GELUApprox}(x) &= 0.5 * x * \left(1 + \text{Tanh}\left((\sqrt{2 / \pi} * \left(x + 0.044715 * x^3\right)\right)\right) \\
@@ -544,7 +544,7 @@ class GELU(Module):
     functional equivalents and information regarding error bounds.
 
     Args:
-        approx ('none' | 'precise' | 'fast'): Which approximation to gelu to use if any.
+        approx ('none' | 'precise'/'tanh' | 'fast'): Which approximation to gelu to use if any.
     """
 
     def __init__(self, approx="none"):
@@ -552,13 +552,13 @@ class GELU(Module):
 
         if approx == "none":
             self._act = gelu
-        elif approx == "precise":
+        elif approx == "precise" or approx == "tanh":
             self._act = gelu_approx
         elif approx == "fast":
             self._act = gelu_fast_approx
         else:
             raise ValueError(
-                f"The approximation should be in ['none', 'precise', 'fast'] but '{approx}' was given"
+                f"The approximation should be in ['none', 'precise'/'tanh', 'fast'] but '{approx}' was given"
             )
 
     def __call__(self, x):

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -722,8 +722,13 @@ class TestLayers(mlx_tests.MLXTestCase):
 
         out = nn.GELU()(mx.array(inputs))
         self.assertTrue(np.allclose(out, expected))
+
+        # Test the precise/tanh approximation
         out_approx = nn.GELU(approx="precise")(mx.array(inputs))
+        out_approx_tanh = nn.GELU(approx="tanh")(mx.array(inputs))
         self.assertTrue(np.allclose(out_approx, expected_approx))
+        self.assertTrue(np.allclose(out_approx_tanh, expected_approx))
+        self.assertTrue(np.allclose(out_approx, out_approx_tanh))
 
         # Crudely check the approximations
         x = mx.arange(-6.0, 6.0, 12 / 100)


### PR DESCRIPTION
## Proposed changes

This PR closes issue #1265. In the initialisation of GELU, the approximation options are `precise` and `fast`. The `precise` implementation is equivalent to PyTorch's `tanh`. I've added the option to initialise with `tanh` as well as `precise`.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
