### PR TITLE
Fix leak with multi-output primitives

### DIFF
--- a/mlx/array.cpp
+++ b/mlx/array.cpp
@@ -175,7 +175,7 @@ array::~array() {
     return;
   }
 
-  // Ignore arrays that will be detached during async eval
+  // Ignore arrays that might be detached during eval
   if (status() == array::Status::scheduled) {
     return;
   }

--- a/mlx/array.cpp
+++ b/mlx/array.cpp
@@ -175,10 +175,11 @@ array::~array() {
     return;
   }
 
-  // Ignore arrays that will be detached
-  if (status() != array::Status::unscheduled) {
+  // Ignore arrays that will be detached during async eval
+  if (status() == array::Status::scheduled) {
     return;
   }
+
   // Break circular reference for non-detached arrays with siblings
   if (auto n = siblings().size(); n > 0) {
     bool do_detach = true;

--- a/mlx/backend/metal/metal.cpp
+++ b/mlx/backend/metal/metal.cpp
@@ -75,6 +75,9 @@ std::function<void()> make_task(array arr, bool signal) {
     if (!arr.is_tracer()) {
       arr.detach();
     }
+    for (auto& out : outputs) {
+      out.set_status(array::Status::available);
+    }
 
     if (signal || d.get_command_buffer_ops(s.index) >= MAX_OPS_PER_BUFFER) {
       d.end_encoding(s.index);

--- a/mlx/transforms.cpp
+++ b/mlx/transforms.cpp
@@ -141,10 +141,9 @@ array eval_impl(std::vector<array> outputs, bool async) {
     tape.pop();
 
     // Set the status of the array and siblings.
-    auto status = async ? array::Status::scheduled : array::Status::available;
-    arr.set_status(status);
+    arr.set_status(array::Status::scheduled);
     for (auto& s : arr.siblings()) {
-      s.set_status(status);
+      s.set_status(array::Status::scheduled);
     }
 
     auto stream = arr.primitive().stream();
@@ -170,6 +169,10 @@ array eval_impl(std::vector<array> outputs, bool async) {
         if (!arr.is_tracer()) {
           arr.detach();
         }
+        for (auto& out : outputs) {
+          out.set_status(array::Status::available);
+        }
+
         if (signal) {
           arr.event().signal();
         }


### PR DESCRIPTION
The test case shows how this was happening. I think the fix is safe since the only case where we could have a race is in the asynchronous eval in which case:

- No eval is allowed during transforms so the array will be detached during eval
- Hence, we don't go into the multi-output destructor since it will be handled by the detach.