### PR TITLE
[WIP] Adding `mlx.distributions`

### DIFF
--- a/python/mlx/distributions/normal.py
+++ b/python/mlx/distributions/normal.py
@@ -1,0 +1,29 @@
+import math
+from typing import Optional, Tuple, Union
+
+import mlx.core as mx
+
+
+class Normal:
+    def __init__(self, mu: mx.array, sigma: mx.array):
+        super().__init__()
+        self.mu = mu
+        self.sigma = sigma
+
+    def sample(
+        self, sample_shape: Union[int, Tuple[int, ...]], key: Optional[mx.array] = None
+    ):
+        return mx.random.normal(sample_shape, key=key) * self.sigma + self.mu
+
+    def log_prob(self, x: mx.array):
+        return (
+            -0.5 * math.log(2 * math.pi)
+            - mx.log(self.sigma)
+            - 0.5 * ((x - self.mu) / self.sigma) ** 2
+        )
+
+    def sample_and_log_prob(
+        self, sample_shape: Union[int, Tuple[int, ...]], key: Optional[mx.array] = None
+    ):
+        x = self.sample(sample_shape, key=key)
+        return x, self.log_prob(x)


### PR DESCRIPTION
This PR aims to propose the `mlx.distributions` API similar to that of `torch.distributions`.

The PyTorch API seems to have the two main things:
- A [`Constraints`](https://github.com/pytorch/pytorch/blob/main/torch/distributions/constraints.py) API, that helps in enforcing constraints to the random variables.
- The [`Distribution`](https://github.com/pytorch/pytorch/blob/main/torch/distributions/distribution.py) API, which serves as the base template for all the distributions there are.

At the current stage, I have copied the `Normal` distribution implementation from [mlx-examples repository](https://github.com/ml-explore/mlx-examples/blob/main/normalizing_flow/distributions.py). The idea would be to be able to add more distributions to mlx and align them as closely as possible to the PyTorch API.

What do you folks think? And what would be the best way to approach this?

CC: [Kashif](https://github.com/kashif)
