### PR TITLE
Improve stability of BCE loss calculation for input probabilities close to or exactly 0 or 1

### DIFF
--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -17,7 +17,7 @@ MLX was developed with contributions from the following individuals:
 - Brian Keene & Atila Orhon, with Argmax Inc.: Added `fast.scaled_dot_product_attention`
 - AmirHossein Razlighi: Added chaining support for some of the ops in `nn.Module`. Comparison works for non array objects in `mlx.core.array`. Exception handling for invalid operations in `mlx.core.array`.
 - Gleb Pobudzey: Added the `where` primitive, and groups in 1D and 2D convolutions.
-- Paul Paczuski: improved stability of BCE loss calculation
+- Paul Paczuski: Improved stability of BCE loss calculation
 
 <a href="https://github.com/ml-explore/mlx/graphs/contributors">
   <img class="dark-light" src="https://contrib.rocks/image?repo=ml-explore/mlx&anon=0&columns=20&max=100&r=true" />

--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -17,6 +17,7 @@ MLX was developed with contributions from the following individuals:
 - Brian Keene & Atila Orhon, with Argmax Inc.: Added `fast.scaled_dot_product_attention`
 - AmirHossein Razlighi: Added chaining support for some of the ops in `nn.Module`. Comparison works for non array objects in `mlx.core.array`. Exception handling for invalid operations in `mlx.core.array`.
 - Gleb Pobudzey: Added the `where` primitive, and groups in 1D and 2D convolutions.
+- Paul Paczuski: improved stability of BCE loss calculation
 
 <a href="https://github.com/ml-explore/mlx/graphs/contributors">
   <img class="dark-light" src="https://contrib.rocks/image?repo=ml-explore/mlx&anon=0&columns=20&max=100&r=true" />

--- a/python/mlx/nn/losses.py
+++ b/python/mlx/nn/losses.py
@@ -124,6 +124,10 @@ def binary_cross_entropy(
     """
     Computes the binary cross entropy loss.
 
+    In order to always return a finite loss for input probabilities close to or
+    exactly 0 or 1, this loss calculation clips log function outputs to be
+    greater than or equal to -100.
+
     Args:
         inputs (array): The predicted values. If ``with_logits`` is ``True``, then
             ``inputs`` are unnormalized logits. Otherwise, ``inputs`` are probabilities.
@@ -159,7 +163,9 @@ def binary_cross_entropy(
     if with_logits:
         loss = mx.logaddexp(0.0, inputs) - inputs * targets
     else:
-        loss = -(targets * mx.log(inputs) + (1 - targets) * mx.log(1 - inputs))
+        log_inputs_clip = mx.clip(mx.log(inputs), a_min=-100, a_max=None)
+        log_inputs_inv_clip = mx.clip(mx.log(1 - inputs), a_min=-100, a_max=None)
+        loss = -(targets * log_inputs_clip + (1 - targets) * log_inputs_inv_clip)
 
     # Apply weights if provided
     if weights is not None:

--- a/python/mlx/nn/losses.py
+++ b/python/mlx/nn/losses.py
@@ -124,11 +124,10 @@ def binary_cross_entropy(
     """
     Computes the binary cross entropy loss.
 
-    In order to always return a finite loss for input probabilities close to or
-    exactly 0 or 1, this loss calculation clips log function outputs to be
-    greater than or equal to -100. However, in this case, consider passing the
-    logits as inputs and `with_logits=True` for a more direct and precise loss
-    calculation.
+    By default, this function takes the pre-sigmoid logits, which results in a faster
+    and more precise loss. For improved numerical stability when ``with_logits=False``,
+    the loss calculation clips the input probabilities (in log-space) to a minimum value
+    of ``-100``.
 
     Args:
         inputs (array): The predicted values. If ``with_logits`` is ``True``, then

--- a/python/mlx/nn/losses.py
+++ b/python/mlx/nn/losses.py
@@ -126,7 +126,9 @@ def binary_cross_entropy(
 
     In order to always return a finite loss for input probabilities close to or
     exactly 0 or 1, this loss calculation clips log function outputs to be
-    greater than or equal to -100.
+    greater than or equal to -100. However, in this case, consider passing the
+    logits as inputs and `with_logits=True` for a more direct and precise loss
+    calculation.
 
     Args:
         inputs (array): The predicted values. If ``with_logits`` is ``True``, then

--- a/python/tests/test_losses.py
+++ b/python/tests/test_losses.py
@@ -127,7 +127,7 @@ class TestLosses(mlx_tests.MLXTestCase):
 
         def _test_tiny_probs_as_inputs():
             TINY_PROB = 1e-59
-            probs = mx.array([0, TINY_PROB, 1-TINY_PROB, 1])
+            probs = mx.array([0, TINY_PROB, 1 - TINY_PROB, 1])
             targets = mx.array([0, 0, 1, 1])
 
             losses_none = nn.losses.binary_cross_entropy(

--- a/python/tests/test_losses.py
+++ b/python/tests/test_losses.py
@@ -125,8 +125,34 @@ class TestLosses(mlx_tests.MLXTestCase):
             expected_sum = mx.sum(expected_none)
             self.assertTrue(mx.allclose(losses_sum, expected_sum))
 
+        def _test_tiny_probs_as_inputs():
+            TINY_PROB = 1e-59
+            probs = mx.array([0, TINY_PROB, 1-TINY_PROB, 1])
+            targets = mx.array([0, 0, 1, 1])
+
+            losses_none = nn.losses.binary_cross_entropy(
+                probs, targets, with_logits=False, reduction="none"
+            )
+            expected_none = mx.array([0.0, TINY_PROB, TINY_PROB, 0.0])
+            self.assertTrue(mx.allclose(losses_none, expected_none))
+
+            # Test with reduction 'mean'
+            losses_mean = nn.losses.binary_cross_entropy(
+                probs, targets, with_logits=False, reduction="mean"
+            )
+            expected_mean = mx.mean(expected_none)
+            self.assertTrue(mx.allclose(losses_mean, expected_mean))
+
+            # Test with reduction 'sum'
+            losses_sum = nn.losses.binary_cross_entropy(
+                probs, targets, with_logits=False, reduction="sum"
+            )
+            expected_sum = mx.sum(expected_none)
+            self.assertTrue(mx.allclose(losses_sum, expected_sum))
+
         _test_logits_as_inputs()
         _test_probs_as_inputs()
+        _test_tiny_probs_as_inputs()
 
     def test_l1_loss(self):
         predictions = mx.array([0.5, 0.2, 0.9, 0.0])


### PR DESCRIPTION
## Proposed changes

Predicted probabilities that are close to, or exactly 0 or 1, may result in
numerical instabilities or undefined values in a Binary Cross-Entropy (BCE)
loss calculation.

Currently, our BCE function will return `nan` in such scenarios.

If we clip the logs in the BCE loss calculation, we can always return a finite
loss value. 

This is indeed the PyTorch approach [1]: 

> Our solution is that BCELoss clamps its log function outputs to be greater
> than or equal to -100. This way, we can always have a finite loss value and a
> linear backward method.

[1] https://pytorch.org/docs/stable/generated/torch.nn.BCELoss.html

This PR suggests and implements this log clipping in the BCE formula.

### Implementation

Apply `mx.clip(..., a_min=-100)` to the `mx.log()` calculations in
the BCE loss function.

Following `pytorch`, and to always obtain a finite loss, clipping is always
done (and uses the same `pytorch` clip value of -100).

But if desired, we can add a parameter like `clip=True`

Note: both before and after this implementation, a `nan` will still be returned
for negative input probabilites.

### Example

Current behavior:

```python
TINY_PROB = 1e-59
probs = mx.array([0, TINY_PROB, 1-TINY_PROB, 1])
targets = mx.array([0, 0, 1, 1])

# array([nan, nan, nan, nan], dtype=float32)
nn.losses.binary_cross_entropy(probs, targets, with_logits=False, reduction="none")

# array(nan, dtype=float32)
nn.losses.binary_cross_entropy(probs, targets, with_logits=False, reduction="mean")

# array(nan, dtype=float32)
nn.losses.binary_cross_entropy(probs, targets, with_logits=False, reduction="sum")
```

New behavior:

```python
TINY_PROB = 1e-59
probs = mx.array([0, TINY_PROB, 1-TINY_PROB, 1])
targets = mx.array([0, 0, 1, 1])

# array([-0, -0, -0, -0], dtype=float32)
nn.losses.binary_cross_entropy(probs, targets, with_logits=False, reduction="none")

# array(0, dtype=float32)
nn.losses.binary_cross_entropy(probs, targets, with_logits=False, reduction="mean")

# array(0, dtype=float32)
nn.losses.binary_cross_entropy(probs, targets, with_logits=False, reduction="sum")
```

New behavior matches `pytorch`:

```python
import numpy as np
import torch
import torch.nn.functional as F


# tensor([0., 0., -0., -0.])
F.binary_cross_entropy(
    torch.tensor(np.array(probs), dtype=torch.float32),
    torch.tensor(np.array(targets), dtype=torch.float32),
    reduction="none")

# tensor(0.)
F.binary_cross_entropy(
    torch.tensor(np.array(probs), dtype=torch.float32),
    torch.tensor(np.array(targets), dtype=torch.float32),
    reduction="mean")

# tensor(0.)
F.binary_cross_entropy(
    torch.tensor(np.array(probs), dtype=torch.float32),
    torch.tensor(np.array(targets), dtype=torch.float32),
    reduction="sum")
```

### References

PR that added support for probabilities: #492

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
