### PR TITLE
Read arrays from files faster

### DIFF
--- a/mlx/backend/common/compiled_cpu.cpp
+++ b/mlx/backend/common/compiled_cpu.cpp
@@ -2,6 +2,7 @@
 
 #include <dlfcn.h>
 #include <filesystem>
+#include <fstream>
 #include <list>
 
 #include "mlx/backend/common/compiled.h"

--- a/mlx/backend/common/load.cpp
+++ b/mlx/backend/common/load.cpp
@@ -33,7 +33,7 @@ void Load::eval(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 0);
   out.set_data(allocator::malloc_or_wait(out.nbytes()));
 
-  reader_->seek(offset_, std::ios_base::beg);
+  reader_->seek(offset_);
   reader_->read(out.data<char>(), out.nbytes());
 
   if (swap_endianness_) {

--- a/mlx/io/gguf.cpp
+++ b/mlx/io/gguf.cpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <fstream>
 #include <numeric>
 
 #include "mlx/io/gguf.h"

--- a/mlx/io/load.h
+++ b/mlx/io/load.h
@@ -22,6 +22,7 @@ class Reader {
       std::ios_base::seekdir way = std::ios_base::beg) = 0;
   virtual void read(char* data, size_t n) = 0;
   virtual std::string label() const = 0;
+  virtual ~Reader() = default;
 };
 
 class Writer {
@@ -34,6 +35,7 @@ class Writer {
       std::ios_base::seekdir way = std::ios_base::beg) = 0;
   virtual void write(const char* data, size_t n) = 0;
   virtual std::string label() const = 0;
+  virtual ~Writer() = default;
 };
 
 class FileReader : public Reader {
@@ -41,7 +43,7 @@ class FileReader : public Reader {
   explicit FileReader(std::string file_path)
       : fd_(open(file_path.c_str(), O_RDONLY)), label_(std::move(file_path)) {}
 
-  ~FileReader() {
+  ~FileReader() override {
     close(fd_);
   }
 
@@ -93,6 +95,10 @@ class FileWriter : public Writer {
   explicit FileWriter(std::string file_path)
       : fd_(open(file_path.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 0644)),
         label_(std::move(file_path)) {}
+
+  ~FileWriter() override {
+    close(fd_);
+  }
 
   bool is_open() const override {
     return fd_ >= 0;

--- a/mlx/io/load.h
+++ b/mlx/io/load.h
@@ -91,7 +91,7 @@ class FileReader : public Reader {
 class FileWriter : public Writer {
  public:
   explicit FileWriter(std::string file_path)
-      : fd_(open(file_path.c_str(), O_CREAT | O_WRONLY)),
+      : fd_(open(file_path.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 0644)),
         label_(std::move(file_path)) {}
 
   bool is_open() const override {


### PR DESCRIPTION
This runs about twice as fast on my laptop:

```python
import mlx.core as mx
from huggingface_hub import snapshot_download
import glob

model_path = snapshot_download(
    repo_id="mlx-community/Meta-Llama-3-8B-Instruct-4bit",
    allow_patterns=["*.safetensors"],
)
weight_files = glob.glob(str(model_path + "/model*.safetensors"))
weights = {}
for wf in weight_files:
    weights.update(mx.load(wf))
mx.eval(weights)
```

Running it with `time`:
Pre: 1.4s
Post: 0.7s