### PR TITLE
Bump extension MLX version

### DIFF
--- a/docs/src/python/ops.rst
+++ b/docs/src/python/ops.rst
@@ -44,6 +44,7 @@ Operations
    convolve
    conv1d
    conv2d
+   conv3d
    conv_general
    cos
    cosh

--- a/examples/extensions/pyproject.toml
+++ b/examples/extensions/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
   "setuptools>=42",
   "cmake>=3.24",
-  "mlx>=0.16.2",
+  "mlx>=0.17.0",
   "nanobind==2.1.0",
 ]
 build-backend = "setuptools.build_meta"

--- a/examples/extensions/requirements.txt
+++ b/examples/extensions/requirements.txt
@@ -1,4 +1,4 @@
 setuptools>=42
 cmake>=3.24
-mlx>=0.16.2
+mlx>=0.17.0
 nanobind==2.1.0

--- a/python/src/fast.cpp
+++ b/python/src/fast.cpp
@@ -102,11 +102,12 @@ void init_fast(nb::module_& parent_module) {
               implementation which rotates consecutive dimensions.
             base (float, optional): The base used to compute angular frequency for
               each dimension in the positional encodings. Exactly one of ``base`` and
-             ``freqs`` must be ``None``.
+              ``freqs`` must be ``None``.
             scale (float): The scale used to scale the positions.
             offset (int): The position offset to start at.
             freqs (array, optional): Optional frequencies to use with RoPE.
-              If set, the ``base`` parameter must be ``None``. ``Default: None``.
+              If set, the ``base`` parameter must be ``None``. Default: ``None``.
+
         Returns:
             array: The output array.
       )pbdoc");


### PR DESCRIPTION
Waiting for 17.0 before bumping this so tests don't break. The extensions need MLX 17 though since it's all nanobind 2.1.0 at this point.

Couple minor fixes in docs.