### PR TITLE
Add optional headers to ``mx.fast.metal_kernel``

### DIFF
--- a/mlx/fast.cpp
+++ b/mlx/fast.cpp
@@ -1128,7 +1128,7 @@ std::map<std::string, array> MetalKernel::operator()(
   std::string kernel_name = func_name.str();
 
   std::ostringstream kernel_source;
-  kernel_source << includes_ << std::endl;
+  kernel_source << header_ << std::endl;
 
   std::vector<CustomKernelShapeInfo> shape_infos;
   write_signature(

--- a/mlx/fast.cpp
+++ b/mlx/fast.cpp
@@ -1128,7 +1128,7 @@ std::map<std::string, array> MetalKernel::operator()(
   std::string kernel_name = func_name.str();
 
   std::ostringstream kernel_source;
-  kernel_source << headers_ << std::endl;
+  kernel_source << includes_ << std::endl;
 
   std::vector<CustomKernelShapeInfo> shape_infos;
   write_signature(

--- a/mlx/fast.cpp
+++ b/mlx/fast.cpp
@@ -1112,7 +1112,6 @@ std::map<std::string, array> MetalKernel::operator()(
         "[metal_kernel] MetalKernel only works on GPU.");
   }
 
-  std::ostringstream kernel_source;
   std::ostringstream func_name;
 
   std::string template_def = "";
@@ -1127,6 +1126,9 @@ std::map<std::string, array> MetalKernel::operator()(
 
   func_name << "custom_kernel_" << name_ << hash_key;
   std::string kernel_name = func_name.str();
+
+  std::ostringstream kernel_source;
+  kernel_source << headers_ << std::endl;
 
   std::vector<CustomKernelShapeInfo> shape_infos;
   write_signature(

--- a/mlx/fast.h
+++ b/mlx/fast.h
@@ -71,10 +71,12 @@ class MetalKernel {
   MetalKernel(
       const std::string& name,
       const std::string& source,
-      bool ensure_row_contiguous,
-      bool atomic_outputs)
+      const std::string& headers = "",
+      bool ensure_row_contiguous = true,
+      bool atomic_outputs = false)
       : name_(name),
         source_(source),
+        headers_(headers),
         ensure_row_contiguous_(ensure_row_contiguous),
         atomic_outputs_(atomic_outputs) {}
 
@@ -93,7 +95,8 @@ class MetalKernel {
  private:
   std::string name_;
   std::string source_;
-  bool ensure_row_contiguous_ = true;
-  bool atomic_outputs_ = false;
+  std::string headers_;
+  bool ensure_row_contiguous_;
+  bool atomic_outputs_;
 };
 } // namespace mlx::core::fast

--- a/mlx/fast.h
+++ b/mlx/fast.h
@@ -71,12 +71,12 @@ class MetalKernel {
   MetalKernel(
       const std::string& name,
       const std::string& source,
-      const std::string& includes = "",
+      const std::string& header = "",
       bool ensure_row_contiguous = true,
       bool atomic_outputs = false)
       : name_(name),
         source_(source),
-        includes_(includes),
+        header_(header),
         ensure_row_contiguous_(ensure_row_contiguous),
         atomic_outputs_(atomic_outputs) {}
 
@@ -95,7 +95,7 @@ class MetalKernel {
  private:
   std::string name_;
   std::string source_;
-  std::string includes_;
+  std::string header_;
   bool ensure_row_contiguous_;
   bool atomic_outputs_;
 };

--- a/mlx/fast.h
+++ b/mlx/fast.h
@@ -71,12 +71,12 @@ class MetalKernel {
   MetalKernel(
       const std::string& name,
       const std::string& source,
-      const std::string& headers = "",
+      const std::string& includes = "",
       bool ensure_row_contiguous = true,
       bool atomic_outputs = false)
       : name_(name),
         source_(source),
-        headers_(headers),
+        includes_(includes),
         ensure_row_contiguous_(ensure_row_contiguous),
         atomic_outputs_(atomic_outputs) {}
 
@@ -95,7 +95,7 @@ class MetalKernel {
  private:
   std::string name_;
   std::string source_;
-  std::string headers_;
+  std::string includes_;
   bool ensure_row_contiguous_;
   bool atomic_outputs_;
 };

--- a/python/src/fast.cpp
+++ b/python/src/fast.cpp
@@ -208,7 +208,7 @@ void init_fast(nb::module_& parent_module) {
               bool>(),
           "name"_a,
           "source"_a,
-          "includes"_a = "",
+          "header"_a = "",
           "ensure_row_contiguous"_a = true,
           "atomic_outputs"_a = false,
           R"pbdoc(
@@ -220,7 +220,7 @@ void init_fast(nb::module_& parent_module) {
             the function signature will be generated for you. The names of the inputs/outputs
             are determined by the ``inputs`` and ``output_shapes``/``output_dtypes``
             used when the kernel is called.
-        includes (str): Source code to include before the main function. 
+        header (str): Header source code to include before the main function.
             Useful for helper functions or includes that should live outside of the main function body.
         ensure_row_contiguous (bool): Whether to ensure the inputs are row contiguous
             before the kernel runs. Default: ``True``.

--- a/python/src/fast.cpp
+++ b/python/src/fast.cpp
@@ -102,12 +102,11 @@ void init_fast(nb::module_& parent_module) {
               implementation which rotates consecutive dimensions.
             base (float, optional): The base used to compute angular frequency for
               each dimension in the positional encodings. Exactly one of ``base`` and
-              ``freqs`` must be ``None``.
+             ``freqs`` must be ``None``.
             scale (float): The scale used to scale the positions.
             offset (int): The position offset to start at.
             freqs (array, optional): Optional frequencies to use with RoPE.
-              If set, the ``base`` parameter must be ``None``. Default: ``None``.
-
+              If set, the ``base`` parameter must be ``None``. ``Default: None``.
         Returns:
             array: The output array.
       )pbdoc");
@@ -200,9 +199,15 @@ void init_fast(nb::module_& parent_module) {
       A jit-compiled custom Metal kernel defined from a source string.
       )pbdoc")
       .def(
-          nb::init<const std::string&, const std::string&, bool, bool>(),
+          nb::init<
+              const std::string&,
+              const std::string&,
+              const std::string&,
+              bool,
+              bool>(),
           "name"_a,
           "source"_a,
+          "headers"_a = "",
           "ensure_row_contiguous"_a = true,
           "atomic_outputs"_a = false,
           R"pbdoc(
@@ -214,6 +219,8 @@ void init_fast(nb::module_& parent_module) {
             the function signature will be generated for you. The names of the inputs/outputs
             are determined by the ``inputs`` and ``output_shapes``/``output_dtypes``
             used when the kernel is called.
+        headers (str): Header source code. Useful for helper functions or includes
+            that should live outside of the main function body.
         ensure_row_contiguous (bool): Whether to ensure the inputs are row contiguous
             before the kernel runs. Default: ``True``.
         atomic_outputs (bool): Whether to use atomic outputs in the function signature

--- a/python/src/fast.cpp
+++ b/python/src/fast.cpp
@@ -208,7 +208,7 @@ void init_fast(nb::module_& parent_module) {
               bool>(),
           "name"_a,
           "source"_a,
-          "headers"_a = "",
+          "includes"_a = "",
           "ensure_row_contiguous"_a = true,
           "atomic_outputs"_a = false,
           R"pbdoc(
@@ -220,8 +220,8 @@ void init_fast(nb::module_& parent_module) {
             the function signature will be generated for you. The names of the inputs/outputs
             are determined by the ``inputs`` and ``output_shapes``/``output_dtypes``
             used when the kernel is called.
-        headers (str): Header source code. Useful for helper functions or includes
-            that should live outside of the main function body.
+        includes (str): Source code to include before the main function. 
+            Useful for helper functions or includes that should live outside of the main function body.
         ensure_row_contiguous (bool): Whether to ensure the inputs are row contiguous
             before the kernel runs. Default: ``True``.
         atomic_outputs (bool): Whether to use atomic outputs in the function signature

--- a/python/src/fast.cpp
+++ b/python/src/fast.cpp
@@ -102,11 +102,12 @@ void init_fast(nb::module_& parent_module) {
               implementation which rotates consecutive dimensions.
             base (float, optional): The base used to compute angular frequency for
               each dimension in the positional encodings. Exactly one of ``base`` and
-             ``freqs`` must be ``None``.
+              ``freqs`` must be ``None``.
             scale (float): The scale used to scale the positions.
             offset (int): The position offset to start at.
             freqs (array, optional): Optional frequencies to use with RoPE.
-              If set, the ``base`` parameter must be ``None``. ``Default: None``.
+              If set, the ``base`` parameter must be ``None``. Default: ``None``.
+
         Returns:
             array: The output array.
       )pbdoc");

--- a/python/tests/test_fast.py
+++ b/python/tests/test_fast.py
@@ -651,7 +651,7 @@ class TestFast(mlx_tests.MLXTestCase):
         mx.random.seed(7)
         a = mx.random.normal(shape=(2, 2))
         kernel = mx.fast.metal_kernel(
-            name="basic",
+            name="helper",
             header="""
             template <typename T>
             T do_exp(T x) {

--- a/python/tests/test_fast.py
+++ b/python/tests/test_fast.py
@@ -551,7 +551,7 @@ class TestFast(mlx_tests.MLXTestCase):
     @unittest.skipIf(not mx.metal.is_available(), "Metal is not available")
     def test_custom_kernel_basic(self):
         mx.random.seed(7)
-        a = mx.random.normal(shape=(3, 6))
+        a = mx.random.normal(shape=(2, 2))
         kernel = mx.fast.metal_kernel(
             name="basic",
             source="""
@@ -567,7 +567,7 @@ class TestFast(mlx_tests.MLXTestCase):
             output_dtypes={"out1": mx.float32},
             stream=mx.gpu,
         )
-        mx.allclose(out["out1"], a[:2, :2])
+        self.assertTrue(mx.allclose(out["out1"], a))
 
     @unittest.skipIf(not mx.metal.is_available(), "Metal is not available")
     def test_custom_kernel_args(self):
@@ -649,10 +649,10 @@ class TestFast(mlx_tests.MLXTestCase):
     @unittest.skipIf(not mx.metal.is_available(), "Metal is not available")
     def test_custom_kernel_helper(self):
         mx.random.seed(7)
-        a = mx.random.normal(shape=(3, 6))
+        a = mx.random.normal(shape=(2, 2))
         kernel = mx.fast.metal_kernel(
             name="basic",
-            includes="""
+            header="""
             template <typename T>
             T do_exp(T x) {
                 return exp(x);
@@ -671,8 +671,7 @@ class TestFast(mlx_tests.MLXTestCase):
             output_dtypes={"out1": mx.float32},
             stream=mx.gpu,
         )
-        print(out["out1"])
-        mx.allclose(out["out1"], mx.exp(a[:2, :2]))
+        self.assertTrue(mx.allclose(out["out1"], mx.exp(a)))
 
 
 if __name__ == "__main__":

--- a/python/tests/test_fast.py
+++ b/python/tests/test_fast.py
@@ -618,12 +618,12 @@ class TestFast(mlx_tests.MLXTestCase):
             uint elem = thread_position_in_grid.x;
             uint loc = elem_to_loc(elem, inp_shape, inp_strides, inp_ndim);
             T tmp = inp[loc];
-            out[elem] = metal::exp(tmp) * threads_per_simdgroup;
+            out[elem] = metal::precise::exp(tmp) * threads_per_simdgroup;
         """
         source_contig = """
             uint elem = thread_position_in_grid.x;
             T tmp = inp[elem];
-            out[elem] = metal::exp(tmp) * threads_per_simdgroup;
+            out[elem] = metal::precise::exp(tmp) * threads_per_simdgroup;
         """
 
         # non contiguous
@@ -655,7 +655,7 @@ class TestFast(mlx_tests.MLXTestCase):
             header="""
             template <typename T>
             T do_exp(T x) {
-                return exp(x);
+                return metal::precise::exp(x);
             }
             """,
             source="""

--- a/python/tests/test_fast.py
+++ b/python/tests/test_fast.py
@@ -652,7 +652,7 @@ class TestFast(mlx_tests.MLXTestCase):
         a = mx.random.normal(shape=(3, 6))
         kernel = mx.fast.metal_kernel(
             name="basic",
-            headers="""
+            includes="""
             template <typename T>
             T do_exp(T x) {
                 return exp(x);


### PR DESCRIPTION
Resolves #1357

One question here:
I was thinking about allowing a `Path` or `Sequence[Path]` as well as a string in the headers argument. Do you think that's worth having? Feels a bit more natural in the python API than C++.