### PR TITLE
Fix extension metal library finding

### DIFF
--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -1,8 +1,6 @@
 // Copyright © 2023-2024 Apple Inc.
 
-#include <dlfcn.h>
 #include <cstdlib>
-#include <filesystem>
 #include <sstream>
 
 #include <sys/sysctl.h>
@@ -15,8 +13,6 @@
 #include "mlx/backend/metal/metal.h"
 #include "mlx/backend/metal/metal_impl.h"
 #include "mlx/backend/metal/utils.h"
-
-namespace fs = std::filesystem;
 
 namespace mlx::core::metal {
 
@@ -36,20 +32,6 @@ constexpr auto get_metal_version() {
 #else
   return MTL::LanguageVersion3_0;
 #endif
-}
-
-std::string get_colocated_mtllib_path(const std::string& lib_name) {
-  Dl_info info;
-  std::string mtllib_path;
-  std::string lib_ext = lib_name + ".metallib";
-
-  int success = dladdr((void*)get_colocated_mtllib_path, &info);
-  if (success) {
-    auto mtllib = fs::path(info.dli_fname).remove_filename() / lib_ext;
-    mtllib_path = mtllib.c_str();
-  }
-
-  return mtllib_path;
 }
 
 auto load_device() {
@@ -308,12 +290,6 @@ void Device::register_library(
   if (auto it = library_map_.find(lib_name); it == library_map_.end()) {
     auto new_lib = load_library(device_, lib_name, lib_path.c_str());
     library_map_.insert({lib_name, new_lib});
-  }
-}
-
-void Device::register_library(const std::string& lib_name) {
-  if (auto it = library_map_.find(lib_name); it == library_map_.end()) {
-    register_library(lib_name, get_colocated_mtllib_path(lib_name));
   }
 }
 


### PR DESCRIPTION
I broke this in https://github.com/ml-explore/mlx/pull/1310.. didn't catch the library path finding was dependent on the way the function was linked 😅 .