### PR TITLE
Removed redundant coefficient in neon_fast_exp, added more softmax tests

### DIFF
--- a/mlx/backend/accelerate/softmax.cpp
+++ b/mlx/backend/accelerate/softmax.cpp
@@ -70,7 +70,6 @@ inline float16x8_t neon_fast_exp(float16x8_t x) {
 
   x = vdupq_n_f16(float16_t(1.535336188319500e-4f));
   x = vfmaq_f16(vdupq_n_f16(float16_t(1.339887440266574e-3f)), x, fpart);
-  x = vfmaq_f16(vdupq_n_f16(float16_t(1.339887440266574e-3f)), x, fpart);
   x = vfmaq_f16(vdupq_n_f16(float16_t(9.618437357674640e-3f)), x, fpart);
   x = vfmaq_f16(vdupq_n_f16(float16_t(5.550332471162809e-2f)), x, fpart);
   x = vfmaq_f16(vdupq_n_f16(float16_t(2.402264791363012e-1f)), x, fpart);

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -2927,6 +2927,10 @@ array softmax(
     const std::vector<int>& axes,
     bool precise /* = false */,
     StreamOrDevice s /* = {}*/) {
+  if (a.size() == 0) {
+    return a;
+  }
+
   if (axes.size() == 1 && (a.ndim() == axes[0] + 1 || axes[0] == -1)) {
     auto dtype = at_least_float(a.dtype());
     return array(


### PR DESCRIPTION
## Proposed changes

I found the same coefficient repeated twice in `neon_fast_exp`. This is most likely a typo, since both [`simd_fast_exp`](https://github.com/ml-explore/mlx/blob/cdb59faea64383474fdb769b4c0e131408a99060/mlx/backend/accelerate/softmax.cpp#L36) (from same file) and [`fm_exp2f`](https://github.com/akohlmey/fastermath/blob/master/src/exp.c#L110-L138) from fastermath (mentioned in the comments) don't do this. This change shaves  off a few cycles (An FMLA and VDUP instructions, amongst others) and seems to result in a modest performance improvement with a [tiny microbenchmark](https://gist.github.com/jeethu/e4b4d988620cb9031afbbcdcbed9c3f8) that I tried. 

```bash
./benchmark_neon_exp
Unable to determine clock rate from sysctl: hw.cpufrequency: No such file or directory
This does not affect benchmark measurements, only the metadata output.
***WARNING*** Failed to set thread affinity. Estimated CPU frequency may be incorrect.
2024-08-27T20:55:47+01:00
Running ./benchmark_neon_exp
Run on (16 X 24 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB
  L1 Instruction 128 KiB
  L2 Unified 4096 KiB (x16)
Load Average: 1.72, 2.22, 2.29
------------------------------------------------------------------------------
Benchmark                                    Time             CPU   Iterations
------------------------------------------------------------------------------
BM_NeonFastExp<neon_fast_exp>            0.249 ns        0.249 ns   2789233558
BM_NeonFastExp<neon_fast_exp_fixed>      0.248 ns        0.248 ns   2815145483
```

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
