### PR TITLE
Async load

### DIFF
--- a/mlx/backend/common/load.cpp
+++ b/mlx/backend/common/load.cpp
@@ -5,10 +5,8 @@
 #include <utility>
 
 #include "mlx/allocator.h"
-#include "mlx/io/load.h"
+#include "mlx/backend/common/load.h"
 #include "mlx/primitives.h"
-
-namespace mlx::core {
 
 namespace {
 
@@ -29,11 +27,14 @@ void swap_endianness(uint8_t* data_bytes, size_t N) {
 
 } // namespace
 
-void Load::eval(const std::vector<array>& inputs, array& out) {
-  assert(inputs.size() == 0);
-  out.set_data(allocator::malloc_or_wait(out.nbytes()));
+namespace mlx::core {
 
-  reader_->read(out.data<char>(), out.nbytes(), offset_);
+void load(
+    array& out,
+    size_t offset,
+    const std::shared_ptr<io::Reader>& reader,
+    bool swap_endianness_) {
+  reader->read(out.data<char>(), out.nbytes(), offset);
 
   if (swap_endianness_) {
     switch (out.itemsize()) {
@@ -48,6 +49,13 @@ void Load::eval(const std::vector<array>& inputs, array& out) {
         break;
     }
   }
+}
+
+void Load::eval(const std::vector<array>& inputs, array& out) {
+  assert(inputs.size() == 0);
+  out.set_data(allocator::malloc_or_wait(out.nbytes()));
+
+  load(out, offset_, reader_, swap_endianness_);
 }
 
 } // namespace mlx::core

--- a/mlx/backend/common/load.h
+++ b/mlx/backend/common/load.h
@@ -1,0 +1,14 @@
+// Copyright © 2024 Apple Inc.
+
+#include "mlx/array.h"
+#include "mlx/io/load.h"
+
+namespace mlx::core {
+
+void load(
+    array& out,
+    size_t offset,
+    const std::shared_ptr<io::Reader>& reader,
+    bool swap_endianess);
+
+} // namespace mlx::core

--- a/mlx/backend/metal/primitives.cpp
+++ b/mlx/backend/metal/primitives.cpp
@@ -198,21 +198,6 @@ void Full::eval_gpu(const std::vector<array>& inputs, array& out) {
   copy_gpu(in, out, ctype);
 }
 
-template <const uint8_t scalar_size>
-void swap_endianness(uint8_t* data_bytes, size_t N) {
-  struct Elem {
-    uint8_t bytes[scalar_size];
-  };
-
-  Elem* data = reinterpret_cast<Elem*>(data_bytes);
-
-  for (size_t i = 0; i < N; i++) {
-    for (size_t j = 0; j < (scalar_size / 2); j++) {
-      std::swap(data[i].bytes[j], data[i].bytes[scalar_size - j - 1]);
-    }
-  }
-}
-
 void Load::eval_gpu(const std::vector<array>& inputs, array& out) {
   static Stream io_stream = new_stream(Device::cpu);
   out.set_data(allocator::malloc_or_wait(out.nbytes()));


### PR DESCRIPTION
This uses the same trick as the comms to put Load ops in their own stream.

A simple benchmark shows that this can enable pipelining Loading with GPU work:

Bench | Pre | Post |
---- | --- | --- |
op_and_load | 12.26343 msec | 6.74928 msec
op | 6.50007 msec | 6.48391 msec
load | 4.63016 msec | 4.60564 msec

The code for the benchmark:

```python
import mlx.core as mx
import time

def time_fn(fn, *args, **kwargs):
    print(f"Timing {fn.__name__} ...", end=" ")

    # warmup
    for _ in range(5):
        mx.eval(fn(*args, **kwargs))

    num_iters = 100
    tic = time.perf_counter()
    for _ in range(num_iters):
        x = mx.eval(fn(*args, **kwargs))
    toc = time.perf_counter()

    msec = 1e3 * (toc - tic) / num_iters
    print(f"{msec:.5f} msec")

def op_and_load(x, y):
    z = x @ y
    a = mx.load("model.safetensors")["a"]
    return z + a

def op(x, y):
    return x @ y

def load():
    return mx.load("model.safetensors")


n = 4096
#a = mx.random.uniform(shape=(n, n))
#mx.save_safetensors("model.safetensors", {"a": a})
x = mx.random.uniform(shape=(n, n))
y = mx.random.uniform(shape=(n, n))

time_fn(op_and_load, x, y)
time_fn(op, x, y)
time_fn(load)
```