### PR TITLE
Even Even Faster IO

### DIFF
--- a/mlx/io/load.cpp
+++ b/mlx/io/load.cpp
@@ -303,6 +303,11 @@ array load(std::string file, StreamOrDevice s) {
 
 namespace io {
 
+ThreadPool& thread_pool() {
+  static ThreadPool pool_{4};
+  return pool_;
+}
+
 void ParallelFileReader::read(char* data, size_t n) {
   while (n != 0) {
     auto m = ::read(fd_, data, std::min(n, static_cast<size_t>(INT32_MAX)));

--- a/mlx/io/load.cpp
+++ b/mlx/io/load.cpp
@@ -298,7 +298,7 @@ array load(std::shared_ptr<io::Reader> in_stream, StreamOrDevice s) {
 
 /** Load array from file in .npy format */
 array load(std::string file, StreamOrDevice s) {
-  return load(std::make_shared<io::ParallelFileReader>(std::move(file), 4), s);
+  return load(std::make_shared<io::ParallelFileReader>(std::move(file)), s);
 }
 
 namespace io {
@@ -307,6 +307,8 @@ ThreadPool& thread_pool() {
   static ThreadPool pool_{4};
   return pool_;
 }
+
+ThreadPool ParallelFileReader::thread_pool_{4};
 
 void ParallelFileReader::read(char* data, size_t n) {
   while (n != 0) {

--- a/mlx/io/load.h
+++ b/mlx/io/load.h
@@ -14,6 +14,8 @@ namespace mlx::core {
 
 namespace io {
 
+ThreadPool& thread_pool();
+
 class Reader {
  public:
   virtual bool is_open() const = 0;
@@ -79,8 +81,7 @@ class ParallelFileReader : public Reader {
   }
 
  private:
-  // 4MB
-  static constexpr size_t batch_size_ = (1 << 22);
+  static constexpr size_t batch_size_ = 1 << 25;
   int fd_;
   std::string label_;
   ThreadPool thread_pool_;

--- a/mlx/io/load.h
+++ b/mlx/io/load.h
@@ -45,10 +45,8 @@ class Writer {
 
 class ParallelFileReader : public Reader {
  public:
-  explicit ParallelFileReader(std::string file_path, int num_threads)
-      : fd_(open(file_path.c_str(), O_RDONLY)),
-        label_(std::move(file_path)),
-        thread_pool_(ThreadPool(num_threads)) {}
+  explicit ParallelFileReader(std::string file_path)
+      : fd_(open(file_path.c_str(), O_RDONLY)), label_(std::move(file_path)) {}
 
   ~ParallelFileReader() override {
     close(fd_);
@@ -82,9 +80,9 @@ class ParallelFileReader : public Reader {
 
  private:
   static constexpr size_t batch_size_ = 1 << 25;
+  static ThreadPool thread_pool_;
   int fd_;
   std::string label_;
-  ThreadPool thread_pool_;
 };
 
 class FileWriter : public Writer {

--- a/mlx/io/safetensors.cpp
+++ b/mlx/io/safetensors.cpp
@@ -147,7 +147,7 @@ SafetensorsLoad load_safetensors(
 }
 
 SafetensorsLoad load_safetensors(const std::string& file, StreamOrDevice s) {
-  return load_safetensors(std::make_shared<io::ParallelFileReader>(file, 4), s);
+  return load_safetensors(std::make_shared<io::ParallelFileReader>(file), s);
 }
 
 void save_safetensors(

--- a/mlx/io/threadpool.h
+++ b/mlx/io/threadpool.h
@@ -1,3 +1,25 @@
+// This code was modified from https://github.com/progschj/ThreadPool
+// The original License is copied below:
+//
+// Copyright (c) 2012 Jakob Progsch, Václav Zeman
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+//    1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+//
+//    2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+//
+//    3. This notice may not be removed or altered from any source
+//    distribution.
 #pragma once
 
 #include <condition_variable>
@@ -19,12 +41,8 @@ class ThreadPool {
   ~ThreadPool();
 
  private:
-  // need to keep track of threads so we can join them
   std::vector<std::thread> workers;
-  // the task queue
   std::queue<std::function<void()>> tasks;
-
-  // synchronization
   std::mutex queue_mutex;
   std::condition_variable condition;
   bool stop;
@@ -63,7 +81,6 @@ auto ThreadPool::enqueue(F&& f, Args&&... args)
   {
     std::unique_lock<std::mutex> lock(queue_mutex);
 
-    // don't allow enqueueing after stopping the pool
     if (stop) {
       throw std::runtime_error(
           "[ThreadPool::enqueue] Not allowed on stopped ThreadPool");

--- a/python/src/load.cpp
+++ b/python/src/load.cpp
@@ -138,6 +138,21 @@ class PyFileReader : public io::Reader {
 
   void read(char* data, size_t n) override {
     nb::gil_scoped_acquire gil;
+    _read(data, n);
+  }
+
+  void read(char* data, size_t n, size_t offset) override {
+    nb::gil_scoped_acquire gil;
+    seek_func_(offset, (int)std::ios_base::beg);
+    _read(data, n);
+  }
+
+  std::string label() const override {
+    return "python file object";
+  }
+
+ private:
+  void _read(char* data, size_t n) {
     auto memview = PyMemoryView_FromMemory(data, n, PyBUF_WRITE);
     nb::object bytes_read = readinto_func_(nb::handle(memview));
 
@@ -146,16 +161,6 @@ class PyFileReader : public io::Reader {
     }
   }
 
-  void read(char* data, size_t n, size_t offset) override {
-    seek(offset);
-    read(data, n);
-  }
-
-  std::string label() const override {
-    return "python file object";
-  }
-
- private:
   nb::object pyistream_;
   nb::object readinto_func_;
   nb::object seek_func_;


### PR DESCRIPTION
A couple changes:

- Add static io in the thread pool. The GPU load now submits to this thread pool. In order to keep the event signaling in the correct order, the tasks from this thread pool are waited on in the io stream before signaling the GPU.
- Make the parallel file reader static to protect against the now potential situation with lots of files simultaneously being read creating an explosion of threads. 
- The maximum number of active threads (from thread pools) is now 8 - 4 for each of the inner and out thread pools.

M2 Ultra:

Bench | 0.17.1 | Main | Post
--- | ---- | --- | ---
4-bit Gemma 27B | 2.20 | 1.47 | 0.75 |
Flux Generation | 8.61 |   7.08 | 6.53

M1 Max:

Bench | 0.17.1 | Main | Post
--- | ---- | --- | ---
4-bit Llama 8B | 0.64 | 0.46 | 0.26


