### PR TITLE
Fix overflow in quantize/dequantize

### DIFF
--- a/mlx/backend/metal/kernels/quantized.h
+++ b/mlx/backend/metal/kernels/quantized.h
@@ -1505,7 +1505,7 @@ template <typename T, const int group_size, const int bits>
   T bias = at_zero ? T(0) : edge;
 
   // Write out the scales and biases
-  int gindex = in_index / group_size;
+  size_t gindex = in_index / group_size;
   if (in_index % group_size == 0) {
     scales[gindex] = scale;
     biases[gindex] = bias;

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -584,8 +584,19 @@ void fast::AffineQuantize::eval_gpu(
       dequantize_ ? w.size() * uint8_per_uint32 : w.size() / per_thread;
 
   NS::UInteger thread_group_size = kernel->maxTotalThreadsPerThreadgroup();
+  if (thread_group_size > nthreads) {
+    thread_group_size = nthreads;
+  }
   auto group_dims = MTL::Size(thread_group_size, 1, 1);
-  auto grid_dims = MTL::Size(nthreads, 1, 1);
+  bool use_2d = out.data_size() > UINT_MAX;
+  auto grid_shape = w.shape();
+  if (dequantize_) {
+    grid_shape.back() *= uint8_per_uint32;
+  } else {
+    grid_shape.back() /= per_thread;
+  }
+  MTL::Size grid_dims = use_2d ? get_2d_grid_dims(grid_shape, w.strides())
+                               : MTL::Size(nthreads, 1, 1);
   compute_encoder.dispatchThreads(grid_dims, group_dims);
 
   d.get_command_buffer(s.index)->addCompletedHandler(

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -588,7 +588,7 @@ void fast::AffineQuantize::eval_gpu(
     thread_group_size = nthreads;
   }
   auto group_dims = MTL::Size(thread_group_size, 1, 1);
-  bool use_2d = out.data_size() > UINT_MAX;
+  bool use_2d = nthreads > UINT_MAX;
   auto grid_shape = w.shape();
   if (dequantize_) {
     grid_shape.back() *= uint8_per_uint32;


### PR DESCRIPTION
Resolves https://github.com/ml-explore/mlx-examples/issues/967

Doesn't seem to make any speed difference when quantizing an 8B model:

Before: 1.62 sec
After: 1.60 sec