### PR TITLE
Support for 1D and 2D grid in mx.fast.metal_kernel

### DIFF
--- a/mlx/fast.cpp
+++ b/mlx/fast.cpp
@@ -1011,7 +1011,7 @@ void write_signature(
       {"threadgroups_per_grid", grid_dtype},
       {"threads_per_grid", grid_dtype},
       {"threads_per_simdgroup", "uint"},
-      {"thread_per_threadgroup", grid_dtype},
+      {"threads_per_threadgroup", grid_dtype},
   };
   std::vector<std::pair<std::string, std::string>> attrs;
   for (const auto& [attr, dtype] : metal_attributes) {

--- a/mlx/fast.h
+++ b/mlx/fast.h
@@ -65,6 +65,9 @@ array affine_dequantize(
     StreamOrDevice s = {});
 
 typedef std::variant<int, bool, Dtype> TemplateArg;
+typedef int MetalGrid1D;
+typedef std::tuple<int, int> MetalGrid2D;
+typedef std::tuple<int, int, int> MetalGrid3D;
 
 class MetalKernel {
  public:
@@ -80,12 +83,18 @@ class MetalKernel {
         ensure_row_contiguous_(ensure_row_contiguous),
         atomic_outputs_(atomic_outputs) {}
 
+  template <
+      typename T,
+      std::enable_if_t<
+          std::is_same_v<T, MetalGrid1D> || std::is_same_v<T, MetalGrid2D> ||
+              std::is_same_v<T, MetalGrid3D>,
+          bool> = true>
   std::map<std::string, array> operator()(
       std::map<std::string, array>& inputs,
       std::map<std::string, std::vector<int>> output_shapes,
       std::map<std::string, Dtype> output_dtypes,
-      std::tuple<int, int, int> grid,
-      std::tuple<int, int, int> threadgroup,
+      T grid,
+      T threadgroup,
       std::optional<std::map<std::string, TemplateArg>> template_args =
           std::nullopt,
       std::optional<float> init_value = std::nullopt,

--- a/python/tests/test_fast.py
+++ b/python/tests/test_fast.py
@@ -570,6 +570,48 @@ class TestFast(mlx_tests.MLXTestCase):
         self.assertTrue(mx.allclose(out["out1"], a))
 
     @unittest.skipIf(not mx.metal.is_available(), "Metal is not available")
+    def test_custom_kernel_1d_grid(self):
+        mx.random.seed(7)
+        a = mx.random.normal(shape=(2,))
+        kernel = mx.fast.metal_kernel(
+            name="basic_1d",
+            source="""
+                uint elem = thread_position_in_grid;
+                out1[elem] = a[elem];
+            """,
+        )
+        out = kernel(
+            inputs={"a": a},
+            grid=4,
+            threadgroup=2,
+            output_shapes={"out1": (2,)},
+            output_dtypes={"out1": mx.float32},
+            stream=mx.gpu,
+        )
+        self.assertTrue(mx.allclose(out["out1"], a))
+
+    @unittest.skipIf(not mx.metal.is_available(), "Metal is not available")
+    def test_custom_kernel_2d_grid(self):
+        mx.random.seed(7)
+        a = mx.random.normal(shape=(2, 2))
+        kernel = mx.fast.metal_kernel(
+            name="basic_2d",
+            source="""
+                uint elem = thread_position_in_grid.x;
+                out1[elem] = a[elem];
+            """,
+        )
+        out = kernel(
+            inputs={"a": a},
+            grid=(4, 1),
+            threadgroup=(2, 1),
+            output_shapes={"out1": (2, 2)},
+            output_dtypes={"out1": mx.float32},
+            stream=mx.gpu,
+        )
+        self.assertTrue(mx.allclose(out["out1"], a))
+
+    @unittest.skipIf(not mx.metal.is_available(), "Metal is not available")
     def test_custom_kernel_args(self):
         mx.random.seed(7)
         a = mx.random.normal(shape=(3, 6))


### PR DESCRIPTION
## Proposed changes

This change allows using metal kernels with 1D and 2D grids, in addition to 3D grids. Previously, `grid` and `threadgroup` argument had to be 3 element tuples of integers. With this change, they can be one of `int` (1D), `tuple[int, int]` (2D) and `tuple[int, int, int]` (3D).

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
