### PR TITLE
Fix reduce edge case

### DIFF
--- a/mlx/backend/common/reduce_utils.cpp
+++ b/mlx/backend/common/reduce_utils.cpp
@@ -32,7 +32,7 @@ ReductionPlan get_reduction_plan(const array& x, const std::vector<int>& axes) {
     std::vector<int> shape = {x.shape(axes[0])};
     std::vector<size_t> strides = {x.strides()[axes[0]]};
     for (int i = 1; i < axes.size(); i++) {
-      if (axes[i] - 1 == axes[i - 1]) {
+      if (axes[i] - 1 == axes[i - 1] && x.shape(axes[i]) > 1) {
         shape.back() *= x.shape(axes[i]);
         strides.back() = x.strides()[axes[i]];
       } else {

--- a/python/tests/test_reduce.py
+++ b/python/tests/test_reduce.py
@@ -10,21 +10,21 @@ import numpy as np
 
 class TestReduce(mlx_tests.MLXTestCase):
     def test_axis_permutation_sums(self):
-        x_npy = np.random.randn(5, 5, 5, 5, 5).astype(np.float32)
-        x_mlx = mx.array(x_npy)
-        for t in permutations(range(5)):
-            with self.subTest(t=t):
-                y_npy = np.transpose(x_npy, t)
-                y_mlx = mx.transpose(x_mlx, t)
-                for n in range(1, 6):
-                    for a in combinations(range(5), n):
-                        with self.subTest(a=a):
-                            z_npy = np.sum(y_npy, axis=a)
-                            z_mlx = mx.sum(y_mlx, axis=a)
-                            mx.eval(z_mlx)
-                            self.assertTrue(
-                                np.allclose(z_npy, np.array(z_mlx), atol=1e-4)
-                            )
+        for shape in [(5, 5, 1, 5, 5), (65, 65, 1, 65)]:
+            with self.subTest(shape=shape):
+                x_npy = (np.random.randn(*shape) * 128).astype(np.int32)
+                x_mlx = mx.array(x_npy)
+                for t in permutations(range(len(shape))):
+                    with self.subTest(t=t):
+                        y_npy = np.transpose(x_npy, t)
+                        y_mlx = mx.transpose(x_mlx, t)
+                        for n in range(1, len(shape) + 1):
+                            for a in combinations(range(len(shape)), n):
+                                with self.subTest(a=a):
+                                    z_npy = np.sum(y_npy, axis=a)
+                                    z_mlx = mx.sum(y_mlx, axis=a)
+                                    mx.eval(z_mlx)
+                                    self.assertTrue(np.all(z_npy == z_mlx))
 
     def test_expand_sums(self):
         x_npy = np.random.randn(5, 1, 5, 1, 5, 1).astype(np.float32)


### PR DESCRIPTION
There is currently a bug when reducing an axis that is a transposed singleton axis and the axis just before that.

Basically the following:

```python
x = mx.random.normal((5, 5, 1, 5))

# fixed in this PR
x.transpose(0, 2, 1, 3).sum((0, 1))

# all the following are fine
x.transpose(0, 2, 1, 3).sum(0)
x.transpose(0, 2, 1, 3).sum((0, 2))
x.transpose(0, 2, 1, 3).sum((0, 3))
x.transpose(0, 2, 1, 3).sum((1, 2))
x.transpose(0, 2, 1, 3).sum((1, 3))
...
```
