### PR TITLE
Add ConvTransposed layers

### DIFF
--- a/docs/src/python/nn/layers.rst
+++ b/docs/src/python/nn/layers.rst
@@ -16,6 +16,9 @@ Layers
    Conv1d
    Conv2d
    Conv3d
+   ConvTransposed1d
+   ConvTransposed2d
+   ConvTransposed3d
    Dropout
    Dropout2d
    Dropout3d

--- a/python/mlx/nn/layers/__init__.py
+++ b/python/mlx/nn/layers/__init__.py
@@ -54,7 +54,14 @@ from mlx.nn.layers.activations import (
 )
 from mlx.nn.layers.base import Module
 from mlx.nn.layers.containers import Sequential
-from mlx.nn.layers.convolution import Conv1d, Conv2d, Conv3d
+from mlx.nn.layers.convolution import (
+    Conv1d,
+    Conv2d,
+    Conv3d,
+    ConvTranspose1d,
+    ConvTranspose2d,
+    ConvTranspose3d,
+)
 from mlx.nn.layers.dropout import Dropout, Dropout2d, Dropout3d
 from mlx.nn.layers.embedding import Embedding
 from mlx.nn.layers.linear import Bilinear, Identity, Linear

--- a/python/mlx/nn/layers/convolution.py
+++ b/python/mlx/nn/layers/convolution.py
@@ -200,3 +200,168 @@ class Conv3d(Module):
         if "bias" in self:
             y = y + self.bias
         return y
+
+
+class ConvTranspose1d(Module):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        stride: int = 1,
+        padding: int = 0,
+        dilation: int = 1,
+        bias: bool = True,
+    ):
+        super().__init__()
+        # Add +1 to padding to match the behavior of PyTorch
+        padding += 1
+
+        scale = math.sqrt(1 / (in_channels * kernel_size))
+        self.weight = mx.random.uniform(
+            low=-scale,
+            high=scale,
+            shape=(out_channels, kernel_size, in_channels),
+        )
+        if bias:
+            self.bias = mx.zeros((out_channels,))
+
+        self.padding = padding
+        self.stride = stride
+        self.dilation = dilation
+
+    def _extra_repr(self):
+        return (
+            f"{self.weight.shape[-1]}, {self.weight.shape[0]}, "
+            f"kernel_size={self.weight.shape[1:2]}, stride={self.stride}, "
+            f"padding={self.padding}, dilation={self.dilation}, "
+            f"bias={'bias' in self}"
+        )
+
+    def __call__(self, x):
+        y = mx.conv_general(
+            x,
+            self.weight,
+            stride=1,
+            padding=self.padding,
+            kernel_dilation=self.dilation,
+            input_dilation=self.stride,
+            flip=True,
+        )
+        if "bias" in self:
+            y = y + self.bias
+        return y
+
+
+class ConvTranspose2d(Module):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: Union[int, tuple],
+        stride: Union[int, tuple] = 1,
+        padding: Union[int, tuple] = 0,
+        dilation: Union[int, tuple] = 1,
+        bias: bool = True,
+    ):
+        super().__init__()
+
+        kernel_size, stride, padding = map(
+            lambda x: (x, x) if isinstance(x, int) else x,
+            (kernel_size, stride, padding),
+        )
+        # Add +1 to padding to match the behavior of PyTorch
+        padding = (padding[0] + 1, padding[1] + 1)
+
+        scale = math.sqrt(1 / (in_channels * kernel_size[0] * kernel_size[1]))
+        self.weight = mx.random.uniform(
+            low=-scale,
+            high=scale,
+            shape=(out_channels, *kernel_size, in_channels),
+        )
+        if bias:
+            self.bias = mx.zeros((out_channels,))
+
+        self.padding = padding
+        self.stride = stride
+        self.dilation = dilation
+
+    def _extra_repr(self):
+        return (
+            f"{self.weight.shape[-1]}, {self.weight.shape[0]}, "
+            f"kernel_size={self.weight.shape[1:2]}, stride={self.stride}, "
+            f"padding={self.padding}, dilation={self.dilation}, "
+            f"bias={'bias' in self}"
+        )
+
+    def __call__(self, x):
+        y = mx.conv_general(
+            x,
+            self.weight,
+            stride=1,
+            padding=self.padding,
+            kernel_dilation=self.dilation,
+            input_dilation=self.stride,
+            flip=True,
+        )
+        if "bias" in self:
+            y = y + self.bias
+        return y
+
+
+class ConvTranspose3d(Module):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: Union[int, tuple],
+        stride: Union[int, tuple] = 1,
+        padding: Union[int, tuple] = 0,
+        dilation: Union[int, tuple] = 1,
+        bias: bool = True,
+    ):
+        super().__init__()
+
+        kernel_size, stride, padding = map(
+            lambda x: (x, x, x) if isinstance(x, int) else x,
+            (kernel_size, stride, padding),
+        )
+        # Add +1 to padding to match the behavior of PyTorch
+        padding = (padding[0] + 1, padding[1] + 1, padding[2] + 1)
+
+        scale = math.sqrt(
+            1 / (in_channels * kernel_size[0] * kernel_size[1] * kernel_size[2])
+        )
+        self.weight = mx.random.uniform(
+            low=-scale,
+            high=scale,
+            shape=(out_channels, *kernel_size, in_channels),
+        )
+        if bias:
+            self.bias = mx.zeros((out_channels,))
+
+        self.padding = padding
+        self.stride = stride
+        self.dilation = dilation
+
+    def _extra_repr(self):
+        return (
+            f"{self.weight.shape[-1]}, {self.weight.shape[0]}, "
+            f"kernel_size={self.weight.shape[1:2]}, stride={self.stride}, "
+            f"padding={self.padding}, dilation={self.dilation}, "
+            f"bias={'bias' in self}"
+        )
+
+    def __call__(self, x):
+        y = mx.conv_general(
+            x,
+            self.weight,
+            stride=1,
+            padding=self.padding,
+            kernel_dilation=self.dilation,
+            input_dilation=self.stride,
+            flip=True,
+        )
+        if "bias" in self:
+            y = y + self.bias
+        return y

--- a/python/mlx/nn/layers/convolution.py
+++ b/python/mlx/nn/layers/convolution.py
@@ -203,6 +203,25 @@ class Conv3d(Module):
 
 
 class ConvTranspose1d(Module):
+    """
+    Applies 1-dimensional transposed convolution to the multi-channel input sequence.
+
+    The channels are expected to be last i.e. the input shape should be ``NLC`` where:
+
+    * ``N`` is the batch dimension
+    * ``L`` is the sequence length
+    * ``C`` is the number of input channels
+
+    Args:
+        in_channels (int): Number of input channels.
+        out_channels (int): Number of output channels.
+        kernel_size (int): Size of the convolution kernel.
+        stride (int, optional): Stride of the convolution. Defaults to 1.
+        padding (int, optional): Padding added to the input. Defaults to 0.
+        dilation (int, optional): Spacing between kernel elements. Defaults to 1.
+        bias (bool, optional): Whether to include a bias term. Defaults to True.
+    """
+
     def __init__(
         self,
         in_channels: int,
@@ -254,6 +273,26 @@ class ConvTranspose1d(Module):
 
 
 class ConvTranspose2d(Module):
+    """
+    Applies 2-dimensional transposed convolution to the multi-channel input image.
+
+    The channels are expected to be last i.e. the input shape should be ``NHWC`` where:
+
+    * ``N`` is the batch dimension
+    * ``H`` is the input image height
+    * ``W`` is the input image width
+    * ``C`` is the number of input channels
+
+    Args:
+        in_channels (int): Number of input channels.
+        out_channels (int): Number of output channels.
+        kernel_size (int or tuple): Size of the convolution kernel.
+        stride (int or tuple, optional): Stride of the convolution. Defaults to 1.
+        padding (int or tuple, optional): Padding added to the input. Defaults to 0.
+        dilation (int or tuple, optional): Spacing between kernel elements. Defaults to 1.
+        bias (bool, optional): Whether to include a bias term. Defaults to True.
+    """
+
     def __init__(
         self,
         in_channels: int,
@@ -310,6 +349,26 @@ class ConvTranspose2d(Module):
 
 
 class ConvTranspose3d(Module):
+    """
+    Applies 3-dimensional transposed convolution to the multi-channel input image.
+
+    The channels are expected to be last i.e. the input shape should be ``NDHWC`` where:
+
+    * ``N`` is the batch dimension
+    * ``D`` is the input image depth
+    * ``H`` is the input image height
+    * ``W`` is the input image width
+    * ``C`` is the number of input channels
+
+    Args:
+        in_channels (int): Number of input channels.
+        out_channels (int): Number of output channels.
+        kernel_size (int or tuple): Size of the convolution kernel.
+        stride (int or tuple, optional): Stride of the convolution. Defaults to 1.
+        padding (int or tuple, optional): Padding added to the input. Defaults to 0.
+        bias (bool, optional): Whether to include a bias term. Defaults to True.
+    """
+
     def __init__(
         self,
         in_channels: int,


### PR DESCRIPTION
## Proposed changes

This PR adds `ConvTranspose1d`, `ConvTranspose2d`, and `ConvTranspose3d` to `mlx.nn`, following interest expressed in https://github.com/ml-explore/mlx/discussions/1001. Additionally, equivalence tests were included to compare the outputs with PyTorch's implementations, as the [example implementation](https://github.com/ml-explore/mlx-examples/blob/main/segment_anything/segment_anything/mask_decoder.py#L202-L252) referenced in the discussion did not match PyTorch outputs upon comparison.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
