### PR TITLE
Replace the use of `result_of_t` with `invoke_result_t`

### DIFF
--- a/mlx/io/threadpool.h
+++ b/mlx/io/threadpool.h
@@ -37,7 +37,7 @@ class ThreadPool {
   ThreadPool(size_t);
   template <class F, class... Args>
   auto enqueue(F&& f, Args&&... args)
-      -> std::future<typename std::invoke_result_t<F(Args...)>>;
+      -> std::future<typename std::invoke_result_t<F, Args...>>;
   ~ThreadPool();
 
  private:
@@ -71,8 +71,8 @@ inline ThreadPool::ThreadPool(size_t threads) : stop(false) {
 
 template <class F, class... Args>
 auto ThreadPool::enqueue(F&& f, Args&&... args)
-    -> std::future<typename std::invoke_result_t<F(Args...)>> {
-  using return_type = typename std::invoke_result_t<F(Args...)>;
+    -> std::future<typename std::invoke_result_t<F, Args...>> {
+  using return_type = typename std::invoke_result_t<F, Args...>;
 
   auto task = std::make_shared<std::packaged_task<return_type()>>(
       std::bind(std::forward<F>(f), std::forward<Args>(args)...));

--- a/mlx/io/threadpool.h
+++ b/mlx/io/threadpool.h
@@ -37,7 +37,7 @@ class ThreadPool {
   ThreadPool(size_t);
   template <class F, class... Args>
   auto enqueue(F&& f, Args&&... args)
-      -> std::future<typename std::result_of_t<F(Args...)>>;
+      -> std::future<typename std::invoke_result_t<F(Args...)>>;
   ~ThreadPool();
 
  private:
@@ -71,8 +71,8 @@ inline ThreadPool::ThreadPool(size_t threads) : stop(false) {
 
 template <class F, class... Args>
 auto ThreadPool::enqueue(F&& f, Args&&... args)
-    -> std::future<typename std::result_of_t<F(Args...)>> {
-  using return_type = typename std::result_of_t<F(Args...)>;
+    -> std::future<typename std::invoke_result_t<F(Args...)>> {
+  using return_type = typename std::invoke_result_t<F(Args...)>;
 
   auto task = std::make_shared<std::packaged_task<return_type()>>(
       std::bind(std::forward<F>(f), std::forward<Args>(args)...));


### PR DESCRIPTION
## Proposed changes

Sometime after v0.16.1 code was introduced that uses `result_of_t`. That has been deprecated in C++17 and removed in C++20. This code is in the header, so people using C++20 will not be able to compile with MLX as a dep. The recommended replacement is `invoke_result_t`. It was introduced in C++17. The change is trivial, and it does not change any logic. I have tested this by installing from source, and then building with MLX as a dependency. The compile error is gone.

Note: this change implies C++17 standard will be used to build.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
