### PR TITLE
Fix module attribute set, reset, set

### DIFF
--- a/python/mlx/nn/layers/base.py
+++ b/python/mlx/nn/layers/base.py
@@ -112,6 +112,7 @@ class Module(dict):
             self[key] = val
         else:
             super(Module, self).__setattr__(key, val)
+            self.pop(key, None)
 
     def load_weights(
         self,

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -67,6 +67,12 @@ class TestBase(mlx_tests.MLXTestCase):
         model = Model()
         self.assertTrue(mx.array_equal(model.val, mx.array(1.0)))
 
+        model.val = None
+        self.assertEqual(model.val, None)
+
+        model.val = mx.array([3])
+        self.assertEqual(model.val.item(), 3)
+
     def test_model_with_dict(self):
         class DictModule(nn.Module):
             def __init__(self):


### PR DESCRIPTION
Pretty bad bug when doing something like:

```python
model.attribute = mx.array([1])
model.attribute = None
model.attribute = mx.array([2])
assert model.attribute == None # <- would be true
````