### PR TITLE
Buffer size

### DIFF
--- a/mlx/allocator.cpp
+++ b/mlx/allocator.cpp
@@ -35,6 +35,9 @@ void CommonAllocator::free(Buffer buffer) {
 }
 
 size_t CommonAllocator::size(Buffer buffer) const {
+  if (buffer.ptr() == nullptr) {
+    return 0;
+  }
   return *static_cast<size_t*>(buffer.ptr());
 }
 

--- a/mlx/allocator.cpp
+++ b/mlx/allocator.cpp
@@ -23,11 +23,19 @@ void free(Buffer buffer) {
 }
 
 Buffer CommonAllocator::malloc(size_t size, bool) {
-  return Buffer{std::malloc(size)};
+  void* ptr = std::malloc(size + sizeof(size_t));
+  if (ptr != nullptr) {
+    *static_cast<size_t*>(ptr) = size;
+  }
+  return Buffer{ptr};
 }
 
 void CommonAllocator::free(Buffer buffer) {
-  std::free(buffer.raw_ptr());
+  std::free(buffer.ptr());
+}
+
+size_t CommonAllocator::size(Buffer buffer) const {
+  return *static_cast<size_t*>(buffer.ptr());
 }
 
 Buffer malloc_or_wait(size_t size) {

--- a/mlx/allocator.h
+++ b/mlx/allocator.h
@@ -41,6 +41,7 @@ class Allocator {
  public:
   virtual Buffer malloc(size_t size, bool allow_swap = false) = 0;
   virtual void free(Buffer buffer) = 0;
+  virtual size_t size(Buffer buffer) const = 0;
 
   Allocator() = default;
   Allocator(const Allocator& other) = delete;
@@ -57,6 +58,7 @@ class CommonAllocator : public Allocator {
  public:
   virtual Buffer malloc(size_t size, bool allow_swap = false) override;
   virtual void free(Buffer buffer) override;
+  virtual size_t size(Buffer buffer) const override;
 
  private:
   CommonAllocator() = default;

--- a/mlx/array.h
+++ b/mlx/array.h
@@ -324,6 +324,10 @@ class array {
     return array_desc_->data->buffer;
   }
 
+  size_t buffer_size() const {
+    return allocator::allocator().size(buffer());
+  }
+
   // Return a copy of the shared pointer
   // to the array::Data struct
   std::shared_ptr<Data> data_shared_ptr() const {

--- a/mlx/backend/common/binary.h
+++ b/mlx/backend/common/binary.h
@@ -43,11 +43,8 @@ void set_binary_op_output_data(
     array& out,
     BinaryOpType bopt,
     bool donate_with_move = false) {
-  constexpr size_t donation_extra = 16384;
-  bool b_donatable = b.is_donatable() && b.itemsize() == out.itemsize() &&
-      b.buffer_size() <= out.nbytes() + donation_extra;
-  bool a_donatable = a.is_donatable() && a.itemsize() == out.itemsize() &&
-      a.buffer_size() <= out.nbytes() + donation_extra;
+  bool b_donatable = is_donatable(b, out);
+  bool a_donatable = is_donatable(a, out);
   switch (bopt) {
     case BinaryOpType::ScalarScalar:
       out.set_data(

--- a/mlx/backend/common/ternary.h
+++ b/mlx/backend/common/ternary.h
@@ -41,7 +41,7 @@ void set_ternary_op_output_data(
     TernaryOpType topt,
     bool donate_with_move = false) {
   auto maybe_donate = [&out, donate_with_move](const array& x) {
-    if (x.is_donatable() && x.itemsize() == out.itemsize()) {
+    if (is_donatable(x, out)) {
       if (donate_with_move) {
         out.move_shared_buffer(x);
       } else {

--- a/mlx/backend/common/unary.h
+++ b/mlx/backend/common/unary.h
@@ -12,7 +12,7 @@ namespace mlx::core {
 namespace {
 
 void set_unary_output_data(const array& in, array& out) {
-  if (in.is_donatable() && in.itemsize() == out.itemsize()) {
+  if (is_donatable(in, out)) {
     out.copy_shared_buffer(in);
   } else {
     auto size = in.data_size();

--- a/mlx/backend/common/utils.h
+++ b/mlx/backend/common/utils.h
@@ -155,4 +155,11 @@ inline auto check_contiguity(
       no_broadcast_data_size, is_row_contiguous, is_col_contiguous);
 }
 
+inline bool is_donatable(const array& in, const array& out) {
+  constexpr size_t donation_extra = 16384;
+
+  return in.is_donatable() && in.itemsize() == out.itemsize() &&
+      in.buffer_size() <= out.nbytes() + donation_extra;
+}
+
 } // namespace mlx::core

--- a/mlx/backend/metal/allocator.cpp
+++ b/mlx/backend/metal/allocator.cpp
@@ -241,6 +241,10 @@ void MetalAllocator::free(Buffer buffer) {
   }
 }
 
+size_t MetalAllocator::size(Buffer buffer) const {
+  return static_cast<MTL::Buffer*>(buffer.ptr())->length();
+}
+
 MetalAllocator& allocator() {
   // By creating the |allocator_| on heap, the destructor of MetalAllocator will
   // not be called on exit and all the buffers will be leaked. This is necessary

--- a/mlx/backend/metal/allocator.h
+++ b/mlx/backend/metal/allocator.h
@@ -56,6 +56,7 @@ class MetalAllocator : public allocator::Allocator {
  public:
   virtual Buffer malloc(size_t size, bool allow_swap = false) override;
   virtual void free(Buffer buffer) override;
+  virtual size_t size(Buffer buffer) const override;
   size_t get_active_memory() {
     return active_memory_;
   };

--- a/mlx/backend/no_metal/allocator.cpp
+++ b/mlx/backend/no_metal/allocator.cpp
@@ -10,7 +10,7 @@ Allocator& allocator() {
 }
 
 void* Buffer::raw_ptr() {
-  return ptr_;
+  return static_cast<size_t*>(ptr_) + 1;
 }
 
 } // namespace mlx::core::allocator


### PR DESCRIPTION
Adds the ability to query the allocator for the size of a buffer which enables us to add donation heuristics to limit memory abuse by donating a huge buffer while only a small portion of it is used.

The metal allocator already tracks the size of the buffer so this PR simply exposes that. It also adds the same functionality to the common allocator by allocating an extra `size_t` per buffer which holds the size of the buffer.

Finally in the binary ops I added a heuristic that doesn't allow donation if the buffer is more than 16KB bigger than needed. In the allocator we have set this to one VM page which is typically ~8KB so this heuristic mimics that one only a bit more permissive.