### PR TITLE
Conv cpu improvements

### DIFF
--- a/benchmarks/python/conv2d_bench_cpu.py
+++ b/benchmarks/python/conv2d_bench_cpu.py
@@ -1,0 +1,127 @@
+import argparse
+import math
+import time
+
+import mlx.core as mx
+import numpy as np
+import torch
+
+N_warmup = 1
+N_iter_bench = 10
+N_iter_func = 5
+mx.set_default_device(mx.DeviceType.cpu)
+
+
+def bench(f, a, b):
+    for i in range(N_warmup):
+        f(a, b)
+
+    s = time.perf_counter_ns()
+    for i in range(N_iter_bench):
+        f(a, b)
+    e = time.perf_counter_ns()
+    return (e - s) * 1e-9
+
+
+def make_mx_conv_2D(strides=(1, 1), padding=(0, 0), groups=1):
+    def mx_conv_2D(a, b):
+        ys = []
+        for i in range(N_iter_func):
+            y = mx.conv2d(a, b, stride=strides, padding=padding, groups=groups)
+            ys.append(y)
+        mx.eval(ys)
+        return ys
+
+    return mx_conv_2D
+
+
+def make_pt_conv_2D(strides=(1, 1), padding=(0, 0), groups=1):
+    @torch.no_grad()
+    def pt_conv_2D(a, b):
+        ys = []
+        for i in range(N_iter_func):
+            y = torch.conv2d(a, b, stride=strides, padding=padding, groups=groups)
+            ys.append(y)
+        return ys
+
+    return pt_conv_2D
+
+
+def bench_shape(N, H, W, C, kH, kW, O, strides, padding, groups, np_dtype):
+    scale = 1.0 / math.sqrt(kH * kH * C)
+    a_np = np.random.uniform(0, 0.5, (N, H, W, C)).astype(np_dtype)
+    b_np = np.random.uniform(-scale, scale, (O, kH, kW, int(C / groups))).astype(
+        np_dtype
+    )
+
+    a_mx = mx.array(a_np)
+    b_mx = mx.array(b_np)
+
+    a_pt = torch.from_numpy(a_np.transpose((0, 3, 1, 2))).to("cpu")
+    b_pt = torch.from_numpy(b_np.transpose((0, 3, 1, 2))).to("cpu")
+
+    f_mx = make_mx_conv_2D(strides, padding, groups)
+    f_pt = make_pt_conv_2D(strides, padding, groups)
+
+    time_torch = bench(f_pt, a_pt, b_pt)
+    time_mlx = bench(f_mx, a_mx, b_mx)
+
+    out_mx = mx.conv2d(a_mx, b_mx, stride=strides, padding=padding, groups=groups)
+    out_pt = torch.conv2d(
+        a_pt.to("cpu"), b_pt.to("cpu"), stride=strides, padding=padding, groups=groups
+    )
+    out_pt = torch.permute(out_pt, (0, 2, 3, 1))
+    out_pt = out_pt.numpy(force=True)
+
+    atol = 2e-5 if np_dtype == np.float32 else 1e-4
+
+    if not np.allclose(out_pt, out_mx, atol=atol):
+        print(
+            f"Failed at {(N, H, W, C)}, {(O, kH, kW, C)} [strides = {strides}, padding = {padding}, groups = {groups}] with max(|a - b|) = {np.max(np.abs(out_pt - out_mx))}"
+        )
+
+    return time_mlx, time_torch
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run conv benchmarks")
+
+    dtypes = ("float32",)
+    shapes = (
+        (4, 32, 32, 32, 5, 5, 32, (1, 1), (2, 2), 1),
+        (4, 32, 32, 64, 5, 5, 64, (1, 1), (2, 2), 1),
+        (4, 32, 32, 128, 5, 5, 128, (1, 1), (2, 2), 1),
+        (4, 32, 32, 256, 5, 5, 256, (1, 1), (2, 2), 1),
+        (4, 32, 32, 512, 5, 5, 512, (1, 1), (2, 2), 1),
+        (4, 64, 64, 32, 5, 5, 32, (1, 1), (2, 2), 1),
+        (4, 64, 64, 64, 5, 5, 64, (1, 1), (2, 2), 1),
+        (4, 64, 64, 128, 5, 5, 128, (1, 1), (2, 2), 1),
+        (4, 64, 64, 256, 5, 5, 256, (1, 1), (2, 2), 1),
+        # (4, 64, 64, 256, 5, 5, 256, (1, 1), (2, 2), 2),
+        # (4, 64, 64, 256, 5, 5, 256, (1, 1), (2, 2), 16),
+        # (4, 64, 64, 256, 5, 5, 256, (1, 1), (2, 2), 64),
+        (4, 128, 128, 32, 5, 5, 32, (1, 1), (2, 2), 1),
+        (4, 128, 128, 64, 5, 5, 64, (1, 1), (2, 2), 1),
+        (4, 128, 128, 128, 5, 5, 128, (1, 1), (2, 2), 1),
+        (4, 256, 256, 32, 5, 5, 3, (1, 1), (2, 2), 1),
+        (4, 256, 256, 3, 5, 5, 32, (1, 1), (2, 2), 1),
+        (4, 128, 128, 64, 5, 5, 3, (1, 1), (2, 2), 1),
+        (4, 128, 128, 3, 5, 5, 64, (1, 1), (2, 2), 1),
+    )
+
+    for dtype in dtypes:
+        print(
+            "(N,   H,   W,   C), (  O, kH, kW,   C),   dtype, stride,   pads,  groups, diff%"
+        )
+        for N, H, W, C, kH, kW, O, strides, padding, groups in shapes:
+            np_dtype = getattr(np, dtype)
+            time_mlx, time_torch = bench_shape(
+                N, H, W, C, kH, kW, O, strides, padding, groups, np_dtype
+            )
+            diff = time_torch / time_mlx - 1.0
+
+            print(
+                f"({N}, {H:3d}, {W:3d}, {C:3d}), ({O:3d}, {kH:2d}, {kW:2d}, {C:3d}), {dtype}, {strides}, {padding}, {groups:7d}, {100. * diff:+5.2f}%"
+            )
+            if time_mlx >= 2.0 * time_torch:
+                print("ATTENTION ^^^^^^^")

--- a/benchmarks/python/conv2d_train_bench_cpu.py
+++ b/benchmarks/python/conv2d_train_bench_cpu.py
@@ -3,7 +3,6 @@ import time
 import mlx.core as mx
 import mlx.nn
 import mlx.optimizers as opt
-
 import torch
 
 
@@ -19,16 +18,22 @@ def bench_mlx(steps: int = 20) -> float:
             self.net = mlx.nn.Sequential(
                 mlx.nn.Conv2d(in_channels, hidden_channels, kernel_size=3, padding=1),
                 mlx.nn.ReLU(),
-                mlx.nn.Conv2d(hidden_channels, 2*hidden_channels, kernel_size=3, padding=1),
+                mlx.nn.Conv2d(
+                    hidden_channels, 2 * hidden_channels, kernel_size=3, padding=1
+                ),
                 mlx.nn.ReLU(),
-                mlx.nn.ConvTranspose2d(2*hidden_channels, hidden_channels, kernel_size=3, padding=1),
+                mlx.nn.ConvTranspose2d(
+                    2 * hidden_channels, hidden_channels, kernel_size=3, padding=1
+                ),
                 mlx.nn.ReLU(),
-                mlx.nn.ConvTranspose2d(hidden_channels, in_channels, kernel_size=3, padding=1),
+                mlx.nn.ConvTranspose2d(
+                    hidden_channels, in_channels, kernel_size=3, padding=1
+                ),
             )
 
         def __call__(self, input):
             return self.net(input)
-    
+
     benchNet = BenchNetMLX(3)
     mx.eval(benchNet.parameters())
     optim = opt.Adam(learning_rate=1e-3)
@@ -43,7 +48,7 @@ def bench_mlx(steps: int = 20) -> float:
     def loss_fn(params, image):
         benchNet.update(params)
         pred_image = benchNet(image)
-        return (pred_image-image).abs().mean()
+        return (pred_image - image).abs().mean()
 
     def step(params, image):
         loss, grads = mx.value_and_grad(loss_fn)(params, image)
@@ -60,7 +65,7 @@ def bench_mlx(steps: int = 20) -> float:
         end_time = time.perf_counter()
 
         print(f"{i:3d}, time={(end_time-start_time) * 1000:7.2f} ms")
-        total_time += (end_time-start_time) * 1000
+        total_time += (end_time - start_time) * 1000
 
     return total_time
 
@@ -77,16 +82,22 @@ def bench_torch(steps: int = 20) -> float:
             self.net = torch.nn.Sequential(
                 torch.nn.Conv2d(in_channels, hidden_channels, kernel_size=3, padding=1),
                 torch.nn.ReLU(),
-                torch.nn.Conv2d(hidden_channels, 2*hidden_channels, kernel_size=3, padding=1),
+                torch.nn.Conv2d(
+                    hidden_channels, 2 * hidden_channels, kernel_size=3, padding=1
+                ),
                 torch.nn.ReLU(),
-                torch.nn.ConvTranspose2d(2*hidden_channels, hidden_channels, kernel_size=3, padding=1),
+                torch.nn.ConvTranspose2d(
+                    2 * hidden_channels, hidden_channels, kernel_size=3, padding=1
+                ),
                 torch.nn.ReLU(),
-                torch.nn.ConvTranspose2d(hidden_channels, in_channels, kernel_size=3, padding=1),
+                torch.nn.ConvTranspose2d(
+                    hidden_channels, in_channels, kernel_size=3, padding=1
+                ),
             )
 
         def forward(self, input):
             return self.net(input)
-    
+
     benchNet = BenchNetTorch(3).to(device)
     optim = torch.optim.Adam(benchNet.parameters(), lr=1e-3)
 
@@ -109,13 +120,13 @@ def bench_torch(steps: int = 20) -> float:
         end_time = time.perf_counter()
 
         print(f"{i:3d}, time={(end_time-start_time) * 1000:7.2f} ms")
-        total_time += (end_time-start_time) * 1000
+        total_time += (end_time - start_time) * 1000
 
     return total_time
 
 
 def main():
-    steps = 20  
+    steps = 20
     time_mlx = bench_mlx(steps)
     time_torch = bench_torch(steps)
 

--- a/benchmarks/python/conv2d_train_bench_cpu.py
+++ b/benchmarks/python/conv2d_train_bench_cpu.py
@@ -1,0 +1,132 @@
+import time
+
+import mlx.core as mx
+import mlx.nn
+import mlx.optimizers as opt
+
+import torch
+
+
+def bench_mlx(steps: int = 20) -> float:
+    mx.set_default_device(mx.DeviceType.cpu)
+
+    class BenchNetMLX(mlx.nn.Module):
+        # simple encoder-decoder net
+
+        def __init__(self, in_channels, hidden_channels=32):
+            super().__init__()
+
+            self.net = mlx.nn.Sequential(
+                mlx.nn.Conv2d(in_channels, hidden_channels, kernel_size=3, padding=1),
+                mlx.nn.ReLU(),
+                mlx.nn.Conv2d(hidden_channels, 2*hidden_channels, kernel_size=3, padding=1),
+                mlx.nn.ReLU(),
+                mlx.nn.ConvTranspose2d(2*hidden_channels, hidden_channels, kernel_size=3, padding=1),
+                mlx.nn.ReLU(),
+                mlx.nn.ConvTranspose2d(hidden_channels, in_channels, kernel_size=3, padding=1),
+            )
+
+        def __call__(self, input):
+            return self.net(input)
+    
+    benchNet = BenchNetMLX(3)
+    mx.eval(benchNet.parameters())
+    optim = opt.Adam(learning_rate=1e-3)
+
+    inputs = mx.random.normal([10, 256, 256, 3])
+
+    params = benchNet.parameters()
+    optim.init(params)
+
+    state = [benchNet.state, optim.state]
+
+    def loss_fn(params, image):
+        benchNet.update(params)
+        pred_image = benchNet(image)
+        return (pred_image-image).abs().mean()
+
+    def step(params, image):
+        loss, grads = mx.value_and_grad(loss_fn)(params, image)
+        optim.update(benchNet, grads)
+        return loss
+
+    total_time = 0.0
+    print("MLX:")
+    for i in range(steps):
+        start_time = time.perf_counter()
+
+        step(benchNet.parameters(), inputs)
+        mx.eval(state)
+        end_time = time.perf_counter()
+
+        print(f"{i:3d}, time={(end_time-start_time) * 1000:7.2f} ms")
+        total_time += (end_time-start_time) * 1000
+
+    return total_time
+
+
+def bench_torch(steps: int = 20) -> float:
+    device = torch.device("cpu")
+
+    class BenchNetTorch(torch.nn.Module):
+        # simple encoder-decoder net
+
+        def __init__(self, in_channels, hidden_channels=32):
+            super().__init__()
+
+            self.net = torch.nn.Sequential(
+                torch.nn.Conv2d(in_channels, hidden_channels, kernel_size=3, padding=1),
+                torch.nn.ReLU(),
+                torch.nn.Conv2d(hidden_channels, 2*hidden_channels, kernel_size=3, padding=1),
+                torch.nn.ReLU(),
+                torch.nn.ConvTranspose2d(2*hidden_channels, hidden_channels, kernel_size=3, padding=1),
+                torch.nn.ReLU(),
+                torch.nn.ConvTranspose2d(hidden_channels, in_channels, kernel_size=3, padding=1),
+            )
+
+        def forward(self, input):
+            return self.net(input)
+    
+    benchNet = BenchNetTorch(3).to(device)
+    optim = torch.optim.Adam(benchNet.parameters(), lr=1e-3)
+
+    inputs = torch.randn(10, 3, 256, 256, device=device)
+
+    def loss_fn(pred_image, image):
+        return (pred_image - image).abs().mean()
+
+    total_time = 0.0
+    print("PyTorch:")
+    for i in range(steps):
+        start_time = time.perf_counter()
+
+        optim.zero_grad()
+        pred_image = benchNet(inputs)
+        loss = loss_fn(pred_image, inputs)
+        loss.backward()
+        optim.step()
+
+        end_time = time.perf_counter()
+
+        print(f"{i:3d}, time={(end_time-start_time) * 1000:7.2f} ms")
+        total_time += (end_time-start_time) * 1000
+
+    return total_time
+
+
+def main():
+    steps = 20  
+    time_mlx = bench_mlx(steps)
+    time_torch = bench_torch(steps)
+
+    print(f"average time of MLX:     {time_mlx/steps:9.2f} ms")
+    print(f"total time of MLX:       {time_mlx:9.2f} ms")
+    print(f"average time of PyTorch: {time_torch/steps:9.2f} ms")
+    print(f"total time of PyTorch:   {time_torch:9.2f} ms")
+
+    diff = time_torch / time_mlx - 1.0
+    print(f"torch/mlx diff: {100. * diff:+5.2f}%")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/python/conv2d_transpose_bench_cpu.py
+++ b/benchmarks/python/conv2d_transpose_bench_cpu.py
@@ -1,0 +1,129 @@
+import argparse
+import math
+import time
+
+import mlx.core as mx
+import numpy as np
+import torch
+
+N_warmup = 1
+N_iter_bench = 10
+N_iter_func = 5
+
+
+def bench(f, a, b):
+    for i in range(N_warmup):
+        f(a, b)
+
+    s = time.perf_counter_ns()
+    for i in range(N_iter_bench):
+        f(a, b)
+    e = time.perf_counter_ns()
+    return (e - s) * 1e-9
+
+
+def make_mx_conv_transpose_2D(strides=(1, 1), padding=(0, 0), groups=1):
+    def mx_conv_transpose_2D(a, b):
+        ys = []
+        for i in range(N_iter_func):
+            y = mx.conv_transpose2d(
+                a, b, stride=strides, padding=padding, groups=groups, stream=mx.cpu
+            )
+            ys.append(y)
+        mx.eval(ys)
+        return ys
+
+    return mx_conv_transpose_2D
+
+
+def make_pt_conv_transpose_2D(strides=(1, 1), padding=(0, 0), groups=1):
+    @torch.no_grad()
+    def pt_conv_transpose_2D(a, b):
+        ys = []
+        for i in range(N_iter_func):
+            y = torch.conv_transpose2d(
+                a, b, stride=strides, padding=padding, groups=groups
+            )
+            ys.append(y)
+        return ys
+
+    return pt_conv_transpose_2D
+
+
+def bench_shape(N, H, W, C, kH, kW, O, strides, padding, groups, np_dtype):
+    scale = 1.0 / math.sqrt(kH * kH * C)
+    a_np = np.random.uniform(0, 0.5, (N, H, W, C)).astype(np_dtype)
+    b_np = np.random.uniform(-scale, scale, (int(O / groups), kH, kW, C)).astype(
+        np_dtype
+    )
+
+    a_mx = mx.array(a_np)
+    b_mx = mx.array(b_np)
+
+    a_pt = torch.from_numpy(a_np.transpose((0, 3, 1, 2))).to("cpu")
+    b_pt = torch.from_numpy(b_np.transpose((3, 0, 1, 2))).to("cpu")
+
+    f_mx = make_mx_conv_transpose_2D(strides, padding, groups)
+    f_pt = make_pt_conv_transpose_2D(strides, padding, groups)
+
+    time_torch = bench(f_pt, a_pt, b_pt)
+    time_mlx = bench(f_mx, a_mx, b_mx)
+
+    out_mx = mx.conv_transpose2d(
+        a_mx, b_mx, stride=strides, padding=padding, groups=groups, stream=mx.cpu
+    )
+    out_pt = torch.conv_transpose2d(
+        a_pt.to("cpu"), b_pt.to("cpu"), stride=strides, padding=padding, groups=groups
+    )
+    out_pt = torch.permute(out_pt, (0, 2, 3, 1))
+    out_pt = out_pt.numpy(force=True)
+
+    atol = 2e-5 if np_dtype == np.float32 else 1e-4
+
+    if not np.allclose(out_pt, out_mx, atol=atol):
+        print(
+            f"Failed at {(N, H, W, C)}, {(O, kH, kW, C)} [strides = {strides}, padding = {padding}, groups = {groups}] with max(|a - b|) = {np.max(np.abs(out_pt - out_mx))}"
+        )
+
+    return time_mlx, time_torch
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run conv benchmarks")
+
+    dtypes = ("float32",)
+    shapes = (
+        (4, 32, 32, 32, 5, 5, 32, (1, 1), (2, 2), 1),
+        (4, 32, 32, 64, 5, 5, 64, (1, 1), (2, 2), 1),
+        (4, 32, 32, 128, 5, 5, 128, (1, 1), (2, 2), 1),
+        (4, 32, 32, 256, 5, 5, 256, (1, 1), (2, 2), 1),
+        (4, 32, 32, 512, 5, 5, 512, (1, 1), (2, 2), 1),
+        (4, 64, 64, 32, 5, 5, 32, (1, 1), (2, 2), 1),
+        (4, 64, 64, 64, 5, 5, 64, (1, 1), (2, 2), 1),
+        (4, 64, 64, 128, 5, 5, 128, (1, 1), (2, 2), 1),
+        (4, 64, 64, 256, 5, 5, 256, (1, 1), (2, 2), 1),
+        (4, 128, 128, 32, 5, 5, 32, (1, 1), (2, 2), 1),
+        (4, 128, 128, 64, 5, 5, 64, (1, 1), (2, 2), 1),
+        (4, 128, 128, 128, 5, 5, 128, (1, 1), (2, 2), 1),
+        (4, 256, 256, 32, 5, 5, 3, (1, 1), (2, 2), 1),
+        (4, 256, 256, 3, 5, 5, 32, (1, 1), (2, 2), 1),
+        (4, 128, 128, 64, 5, 5, 3, (1, 1), (2, 2), 1),
+        (4, 128, 128, 3, 5, 5, 64, (1, 1), (2, 2), 1),
+    )
+
+    for dtype in dtypes:
+        print(
+            "(N,   H,   W,   C), (  O, kH, kW,   C),   dtype, stride,   pads,  groups, diff%"
+        )
+        for N, H, W, C, kH, kW, O, strides, padding, groups in shapes:
+            np_dtype = getattr(np, dtype)
+            time_mlx, time_torch = bench_shape(
+                N, H, W, C, kH, kW, O, strides, padding, groups, np_dtype
+            )
+            diff = time_torch / time_mlx - 1.0
+
+            print(
+                f"({N}, {H:3d}, {W:3d}, {C:3d}), ({O:3d}, {kH:2d}, {kW:2d}, {C:3d}), {dtype}, {strides}, {padding}, {groups:7d}, {100. * diff:+5.2f}%"
+            )
+            if time_mlx >= 2.0 * time_torch:
+                print("ATTENTION ^^^^^^^")

--- a/benchmarks/python/conv3d_bench_cpu.py
+++ b/benchmarks/python/conv3d_bench_cpu.py
@@ -1,0 +1,110 @@
+import argparse
+import math
+import time
+
+import mlx.core as mx
+import numpy as np
+import torch
+
+N_warmup = 1
+N_iter_bench = 10
+N_iter_func = 5
+mx.set_default_device(mx.DeviceType.cpu)
+
+
+def bench(f, a, b):
+    for i in range(N_warmup):
+        f(a, b)
+
+    s = time.perf_counter_ns()
+    for i in range(N_iter_bench):
+        f(a, b)
+    e = time.perf_counter_ns()
+    return (e - s) * 1e-9
+
+
+def make_mx_conv_3D(strides=(1, 1), padding=(0, 0), groups=1):
+    def mx_conv_3D(a, b):
+        ys = []
+        for i in range(N_iter_func):
+            y = mx.conv3d(a, b, stride=strides, padding=padding, groups=groups)
+            ys.append(y)
+        mx.eval(ys)
+        return ys
+
+    return mx_conv_3D
+
+
+def make_pt_conv_3D(strides=(1, 1), padding=(0, 0), groups=1):
+    @torch.no_grad()
+    def pt_conv_3D(a, b):
+        ys = []
+        for i in range(N_iter_func):
+            y = torch.conv3d(a, b, stride=strides, padding=padding, groups=groups)
+            ys.append(y)
+        return ys
+
+    return pt_conv_3D
+
+
+def bench_shape(N, D, H, W, C, kD, kH, kW, O, strides, padding, groups, np_dtype):
+    scale = 1.0 / math.sqrt(kD * kH * kW * C)
+    a_np = np.random.uniform(0, 0.5, (N, D, H, W, C)).astype(np_dtype)
+    b_np = np.random.uniform(-scale, scale, (O, kD, kH, kW, int(C / groups))).astype(
+        np_dtype
+    )
+
+    a_mx = mx.array(a_np)
+    b_mx = mx.array(b_np)
+
+    a_pt = torch.from_numpy(a_np.transpose((0, 4, 1, 2, 3))).to("cpu")
+    b_pt = torch.from_numpy(b_np.transpose((0, 4, 1, 2, 3))).to("cpu")
+
+    f_mx = make_mx_conv_3D(strides, padding, groups)
+    f_pt = make_pt_conv_3D(strides, padding, groups)
+
+    time_torch = bench(f_pt, a_pt, b_pt)
+    time_mlx = bench(f_mx, a_mx, b_mx)
+
+    out_mx = mx.conv3d(a_mx, b_mx, stride=strides, padding=padding, groups=groups)
+    out_pt = torch.conv3d(
+        a_pt.to("cpu"), b_pt.to("cpu"), stride=strides, padding=padding, groups=groups
+    )
+    out_pt = torch.permute(out_pt, (0, 2, 3, 4, 1))
+    out_pt = out_pt.numpy(force=True)
+
+    atol = 2e-5 if np_dtype == np.float32 else 1e-4
+
+    if not np.allclose(out_pt, out_mx, atol=atol):
+        print(
+            f"Failed at {(N, D, H, W, C)}, {(O, kD, kH, kW, C)} [strides = {strides}, padding = {padding}, groups = {groups}] with max(|a - b|) = {np.max(np.abs(out_pt - out_mx))}"
+        )
+
+    return time_mlx, time_torch
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run conv benchmarks")
+
+    dtypes = ("float32",)
+    shapes = (
+        (4, 16, 16, 16, 16, 5, 5, 5, 16, (1, 1, 1), (2, 2, 2), 1),
+        (4, 16, 16, 16, 32, 5, 5, 5, 32, (1, 1, 1), (2, 2, 2), 1),
+    )
+
+    for dtype in dtypes:
+        print(
+            "(N,   D,   H,   W,   C), (  O, kD, kH, kW,   C),   dtype,    stride,      pads,  groups, diff%"
+        )
+        for N, D, H, W, C, kD, kH, kW, O, strides, padding, groups in shapes:
+            np_dtype = getattr(np, dtype)
+            time_mlx, time_torch = bench_shape(
+                N, D, H, W, C, kD, kH, kW, O, strides, padding, groups, np_dtype
+            )
+            diff = time_torch / time_mlx - 1.0
+
+            print(
+                f"({N}, {D:3d}, {H:3d}, {W:3d}, {C:3d}), ({O:3d}, {kD:2d}, {kH:2d}, {kW:2d}, {C:3d}), {dtype}, {strides}, {padding}, {groups:7d}, {100. * diff:+5.2f}%"
+            )
+            if time_mlx >= 2.0 * time_torch:
+                print("ATTENTION ^^^^^^^")

--- a/benchmarks/python/conv3d_train_bench_cpu.py
+++ b/benchmarks/python/conv3d_train_bench_cpu.py
@@ -1,0 +1,132 @@
+import time
+
+import mlx.core as mx
+import mlx.nn
+import mlx.optimizers as opt
+
+import torch
+
+
+def bench_mlx(steps: int = 20, shape=(10, 32, 32, 32, 3)) -> float:
+    mx.set_default_device(mx.DeviceType.cpu)
+
+    class BenchNetMLX(mlx.nn.Module):
+        # simple encoder-decoder net
+
+        def __init__(self, in_channels, hidden_channels=16):
+            super().__init__()
+
+            self.net = mlx.nn.Sequential(
+                mlx.nn.Conv3d(in_channels, hidden_channels, kernel_size=3, padding=1),
+                mlx.nn.ReLU(),
+                mlx.nn.Conv3d(hidden_channels, 2*hidden_channels, kernel_size=3, padding=1),
+                mlx.nn.ReLU(),
+                mlx.nn.ConvTranspose3d(2*hidden_channels, hidden_channels, kernel_size=3, padding=1),
+                mlx.nn.ReLU(),
+                mlx.nn.ConvTranspose3d(hidden_channels, in_channels, kernel_size=3, padding=1),
+            )
+
+        def __call__(self, input):
+            return self.net(input)
+    
+    benchNet = BenchNetMLX(3)
+    mx.eval(benchNet.parameters())
+    optim = opt.Adam(learning_rate=1e-3)
+
+    inputs = mx.random.normal(shape)
+
+    params = benchNet.parameters()
+    optim.init(params)
+
+    state = [benchNet.state, optim.state]
+
+    def loss_fn(params, image):
+        benchNet.update(params)
+        pred_image = benchNet(image)
+        return (pred_image-image).abs().mean()
+
+    def step(params, image):
+        loss, grads = mx.value_and_grad(loss_fn)(params, image)
+        optim.update(benchNet, grads)
+        return loss
+
+    total_time = 0.0
+    print("MLX:")
+    for i in range(steps):
+        start_time = time.perf_counter()
+
+        step(benchNet.parameters(), inputs)
+        mx.eval(state)
+        end_time = time.perf_counter()
+
+        print(f"{i:3d}, time={(end_time-start_time) * 1000:7.2f} ms")
+        total_time += (end_time-start_time) * 1000
+
+    return total_time
+
+
+def bench_torch(steps: int = 20, shape=(10, 3, 32, 32, 32)) -> float:
+    device = torch.device("cpu")
+
+    class BenchNetTorch(torch.nn.Module):
+        # simple encoder-decoder net
+
+        def __init__(self, in_channels, hidden_channels=16):
+            super().__init__()
+
+            self.net = torch.nn.Sequential(
+                torch.nn.Conv3d(in_channels, hidden_channels, kernel_size=3, padding=1),
+                torch.nn.ReLU(),
+                torch.nn.Conv3d(hidden_channels, 2*hidden_channels, kernel_size=3, padding=1),
+                torch.nn.ReLU(),
+                torch.nn.ConvTranspose3d(2*hidden_channels, hidden_channels, kernel_size=3, padding=1),
+                torch.nn.ReLU(),
+                torch.nn.ConvTranspose3d(hidden_channels, in_channels, kernel_size=3, padding=1),
+            )
+
+        def forward(self, input):
+            return self.net(input)
+    
+    benchNet = BenchNetTorch(3).to(device)
+    optim = torch.optim.Adam(benchNet.parameters(), lr=1e-3)
+
+    inputs = torch.randn(*shape, device=device)
+
+    def loss_fn(pred_image, image):
+        return (pred_image - image).abs().mean()
+
+    total_time = 0.0
+    print("PyTorch:")
+    for i in range(steps):
+        start_time = time.perf_counter()
+
+        optim.zero_grad()
+        pred_image = benchNet(inputs)
+        loss = loss_fn(pred_image, inputs)
+        loss.backward()
+        optim.step()
+
+        end_time = time.perf_counter()
+
+        print(f"{i:3d}, time={(end_time-start_time) * 1000:7.2f} ms")
+        total_time += (end_time-start_time) * 1000
+
+    return total_time
+
+
+def main():
+    steps = 10
+    time_mlx = bench_mlx(steps)
+    time_torch = bench_torch(steps)
+
+    print(f"average time of MLX:     {time_mlx/steps:9.2f} ms")
+    print(f"total time of MLX:       {time_mlx:9.2f} ms")
+    print(f"average time of PyTorch: {time_torch/steps:9.2f} ms")
+    print(f"total time of PyTorch:   {time_torch:9.2f} ms")
+
+    diff = time_torch / time_mlx - 1.0
+    print(f"torch/mlx diff: {100. * diff:+5.2f}%")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/python/conv3d_train_bench_cpu.py
+++ b/benchmarks/python/conv3d_train_bench_cpu.py
@@ -3,7 +3,6 @@ import time
 import mlx.core as mx
 import mlx.nn
 import mlx.optimizers as opt
-
 import torch
 
 
@@ -19,16 +18,22 @@ def bench_mlx(steps: int = 20, shape=(10, 32, 32, 32, 3)) -> float:
             self.net = mlx.nn.Sequential(
                 mlx.nn.Conv3d(in_channels, hidden_channels, kernel_size=3, padding=1),
                 mlx.nn.ReLU(),
-                mlx.nn.Conv3d(hidden_channels, 2*hidden_channels, kernel_size=3, padding=1),
+                mlx.nn.Conv3d(
+                    hidden_channels, 2 * hidden_channels, kernel_size=3, padding=1
+                ),
                 mlx.nn.ReLU(),
-                mlx.nn.ConvTranspose3d(2*hidden_channels, hidden_channels, kernel_size=3, padding=1),
+                mlx.nn.ConvTranspose3d(
+                    2 * hidden_channels, hidden_channels, kernel_size=3, padding=1
+                ),
                 mlx.nn.ReLU(),
-                mlx.nn.ConvTranspose3d(hidden_channels, in_channels, kernel_size=3, padding=1),
+                mlx.nn.ConvTranspose3d(
+                    hidden_channels, in_channels, kernel_size=3, padding=1
+                ),
             )
 
         def __call__(self, input):
             return self.net(input)
-    
+
     benchNet = BenchNetMLX(3)
     mx.eval(benchNet.parameters())
     optim = opt.Adam(learning_rate=1e-3)
@@ -43,7 +48,7 @@ def bench_mlx(steps: int = 20, shape=(10, 32, 32, 32, 3)) -> float:
     def loss_fn(params, image):
         benchNet.update(params)
         pred_image = benchNet(image)
-        return (pred_image-image).abs().mean()
+        return (pred_image - image).abs().mean()
 
     def step(params, image):
         loss, grads = mx.value_and_grad(loss_fn)(params, image)
@@ -60,7 +65,7 @@ def bench_mlx(steps: int = 20, shape=(10, 32, 32, 32, 3)) -> float:
         end_time = time.perf_counter()
 
         print(f"{i:3d}, time={(end_time-start_time) * 1000:7.2f} ms")
-        total_time += (end_time-start_time) * 1000
+        total_time += (end_time - start_time) * 1000
 
     return total_time
 
@@ -77,16 +82,22 @@ def bench_torch(steps: int = 20, shape=(10, 3, 32, 32, 32)) -> float:
             self.net = torch.nn.Sequential(
                 torch.nn.Conv3d(in_channels, hidden_channels, kernel_size=3, padding=1),
                 torch.nn.ReLU(),
-                torch.nn.Conv3d(hidden_channels, 2*hidden_channels, kernel_size=3, padding=1),
+                torch.nn.Conv3d(
+                    hidden_channels, 2 * hidden_channels, kernel_size=3, padding=1
+                ),
                 torch.nn.ReLU(),
-                torch.nn.ConvTranspose3d(2*hidden_channels, hidden_channels, kernel_size=3, padding=1),
+                torch.nn.ConvTranspose3d(
+                    2 * hidden_channels, hidden_channels, kernel_size=3, padding=1
+                ),
                 torch.nn.ReLU(),
-                torch.nn.ConvTranspose3d(hidden_channels, in_channels, kernel_size=3, padding=1),
+                torch.nn.ConvTranspose3d(
+                    hidden_channels, in_channels, kernel_size=3, padding=1
+                ),
             )
 
         def forward(self, input):
             return self.net(input)
-    
+
     benchNet = BenchNetTorch(3).to(device)
     optim = torch.optim.Adam(benchNet.parameters(), lr=1e-3)
 
@@ -109,7 +120,7 @@ def bench_torch(steps: int = 20, shape=(10, 3, 32, 32, 32)) -> float:
         end_time = time.perf_counter()
 
         print(f"{i:3d}, time={(end_time-start_time) * 1000:7.2f} ms")
-        total_time += (end_time-start_time) * 1000
+        total_time += (end_time - start_time) * 1000
 
     return total_time
 

--- a/benchmarks/python/conv3d_transpose_bench_cpu.py
+++ b/benchmarks/python/conv3d_transpose_bench_cpu.py
@@ -27,7 +27,9 @@ def make_mx_conv_3D(strides=(1, 1, 1), padding=(0, 0, 0), groups=1):
     def mx_conv_3D(a, b):
         ys = []
         for i in range(N_iter_func):
-            y = mx.conv_transpose3d(a, b, stride=strides, padding=padding, groups=groups)
+            y = mx.conv_transpose3d(
+                a, b, stride=strides, padding=padding, groups=groups
+            )
             ys.append(y)
         mx.eval(ys)
         return ys
@@ -40,7 +42,9 @@ def make_pt_conv_3D(strides=(1, 1, 1), padding=(0, 0, 0), groups=1):
     def pt_conv_3D(a, b):
         ys = []
         for i in range(N_iter_func):
-            y = torch.conv_transpose3d(a, b, stride=strides, padding=padding, groups=groups)
+            y = torch.conv_transpose3d(
+                a, b, stride=strides, padding=padding, groups=groups
+            )
             ys.append(y)
         return ys
 
@@ -66,7 +70,9 @@ def bench_shape(N, D, H, W, C, kD, kH, kW, O, strides, padding, groups, np_dtype
     time_torch = bench(f_pt, a_pt, b_pt)
     time_mlx = bench(f_mx, a_mx, b_mx)
 
-    out_mx = mx.conv_transpose3d(a_mx, b_mx, stride=strides, padding=padding, groups=groups)
+    out_mx = mx.conv_transpose3d(
+        a_mx, b_mx, stride=strides, padding=padding, groups=groups
+    )
     out_pt = torch.conv_transpose3d(
         a_pt.to("cpu"), b_pt.to("cpu"), stride=strides, padding=padding, groups=groups
     )

--- a/benchmarks/python/conv3d_transpose_bench_cpu.py
+++ b/benchmarks/python/conv3d_transpose_bench_cpu.py
@@ -1,0 +1,110 @@
+import argparse
+import math
+import time
+
+import mlx.core as mx
+import numpy as np
+import torch
+
+N_warmup = 1
+N_iter_bench = 10
+N_iter_func = 5
+mx.set_default_device(mx.DeviceType.cpu)
+
+
+def bench(f, a, b):
+    for i in range(N_warmup):
+        f(a, b)
+
+    s = time.perf_counter_ns()
+    for i in range(N_iter_bench):
+        f(a, b)
+    e = time.perf_counter_ns()
+    return (e - s) * 1e-9
+
+
+def make_mx_conv_3D(strides=(1, 1, 1), padding=(0, 0, 0), groups=1):
+    def mx_conv_3D(a, b):
+        ys = []
+        for i in range(N_iter_func):
+            y = mx.conv_transpose3d(a, b, stride=strides, padding=padding, groups=groups)
+            ys.append(y)
+        mx.eval(ys)
+        return ys
+
+    return mx_conv_3D
+
+
+def make_pt_conv_3D(strides=(1, 1, 1), padding=(0, 0, 0), groups=1):
+    @torch.no_grad()
+    def pt_conv_3D(a, b):
+        ys = []
+        for i in range(N_iter_func):
+            y = torch.conv_transpose3d(a, b, stride=strides, padding=padding, groups=groups)
+            ys.append(y)
+        return ys
+
+    return pt_conv_3D
+
+
+def bench_shape(N, D, H, W, C, kD, kH, kW, O, strides, padding, groups, np_dtype):
+    scale = 1.0 / math.sqrt(kD * kH * kW * C)
+    a_np = np.random.uniform(0, 0.5, (N, D, H, W, C)).astype(np_dtype)
+    b_np = np.random.uniform(-scale, scale, (O, kD, kH, kW, int(C / groups))).astype(
+        np_dtype
+    )
+
+    a_mx = mx.array(a_np)
+    b_mx = mx.array(b_np)
+
+    a_pt = torch.from_numpy(a_np.transpose((0, 4, 1, 2, 3))).to("cpu")
+    b_pt = torch.from_numpy(b_np.transpose((4, 0, 1, 2, 3))).to("cpu")
+
+    f_mx = make_mx_conv_3D(strides, padding, groups)
+    f_pt = make_pt_conv_3D(strides, padding, groups)
+
+    time_torch = bench(f_pt, a_pt, b_pt)
+    time_mlx = bench(f_mx, a_mx, b_mx)
+
+    out_mx = mx.conv_transpose3d(a_mx, b_mx, stride=strides, padding=padding, groups=groups)
+    out_pt = torch.conv_transpose3d(
+        a_pt.to("cpu"), b_pt.to("cpu"), stride=strides, padding=padding, groups=groups
+    )
+    out_pt = torch.permute(out_pt, (0, 2, 3, 4, 1))
+    out_pt = out_pt.numpy(force=True)
+
+    atol = 2e-5 if np_dtype == np.float32 else 1e-4
+
+    if not np.allclose(out_pt, out_mx, atol=atol):
+        print(
+            f"Failed at {(N, D, H, W, C)}, {(O, kD, kH, kW, C)} [strides = {strides}, padding = {padding}, groups = {groups}] with max(|a - b|) = {np.max(np.abs(out_pt - out_mx))}"
+        )
+
+    return time_mlx, time_torch
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run conv benchmarks")
+
+    dtypes = ("float32",)
+    shapes = (
+        (4, 16, 16, 16, 16, 5, 5, 5, 16, (1, 1, 1), (2, 2, 2), 1),
+        (4, 16, 16, 16, 32, 5, 5, 5, 32, (1, 1, 1), (2, 2, 2), 1),
+    )
+
+    for dtype in dtypes:
+        print(
+            "(N,   D,   H,   W,   C), (  O, kD, kH, kW,   C),   dtype,    stride,      pads,  groups, diff%"
+        )
+        for N, D, H, W, C, kD, kH, kW, O, strides, padding, groups in shapes:
+            np_dtype = getattr(np, dtype)
+            time_mlx, time_torch = bench_shape(
+                N, D, H, W, C, kD, kH, kW, O, strides, padding, groups, np_dtype
+            )
+            diff = time_torch / time_mlx - 1.0
+
+            print(
+                f"({N}, {D:3d}, {H:3d}, {W:3d}, {C:3d}), ({O:3d}, {kD:2d}, {kH:2d}, {kW:2d}, {C:3d}), {dtype}, {strides}, {padding}, {groups:7d}, {100. * diff:+5.2f}%"
+            )
+            if time_mlx >= 2.0 * time_torch:
+                print("ATTENTION ^^^^^^^")

--- a/mlx/backend/common/conv.cpp
+++ b/mlx/backend/common/conv.cpp
@@ -1112,7 +1112,8 @@ void conv_3D_cpu(
     bool flip) {
   const int groups = in.shape().back() / wt.shape().back();
   if (wt_dilation[0] == 1 && wt_dilation[1] == 1 && wt_dilation[2] == 1 &&
-      in_dilation[0] == 1 && in_dilation[1] == 1 && in_dilation[2] == 1 && groups == 1) {
+      in_dilation[0] == 1 && in_dilation[1] == 1 && in_dilation[2] == 1 &&
+      groups == 1) {
     return explicit_gemm_conv_ND_cpu(
         in, wt, out, padding, wt_strides, wt_dilation, flip);
   }

--- a/mlx/backend/common/copy.cpp
+++ b/mlx/backend/common/copy.cpp
@@ -137,6 +137,165 @@ inline void copy_general_dim4(const array& src, array& dst) {
 }
 
 template <typename SrcT, typename DstT, typename stride_t>
+void copy_general_dim5(
+    const array& src,
+    array& dst,
+    const std::vector<int>& data_shape,
+    const std::vector<stride_t>& i_strides,
+    int64_t i_offset) {
+  const SrcT* src_ptr = src.data<SrcT>() + i_offset;
+  DstT* dst_ptr = dst.data<DstT>();
+  
+  // Pre-compute loop bounds and strides
+  const int d0 = data_shape[0], d1 = data_shape[1], d2 = data_shape[2], d3 = data_shape[3], d4 = data_shape[4];
+  const stride_t s0 = i_strides[0], s1 = i_strides[1], s2 = i_strides[2], s3 = i_strides[3], s4 = i_strides[4];
+
+  // Pre-compute stride adjustments
+  const stride_t s3_adj = s3 - s4 * d4;
+  const stride_t s2_adj = s2 - s3 * d3;
+  const stride_t s1_adj = s1 - s2 * d2;
+  const stride_t s0_adj = s0 - s1 * d1;
+
+  stride_t src_idx = 0;
+  stride_t dst_idx = 0;
+
+  for (int i = 0; i < d0; ++i) {
+    for (int j = 0; j < d1; ++j) {
+      for (int k = 0; k < d2; ++k) {
+        for (int l = 0; l < d3; ++l) {
+          for (int m = 0; m < d4; ++m) {
+            dst_ptr[dst_idx++] = static_cast<DstT>(src_ptr[src_idx]);
+            src_idx += s4;
+          }
+          src_idx += s3_adj;
+        }
+        src_idx += s2_adj;
+      }
+      src_idx += s1_adj;
+    }
+    src_idx += s0_adj;
+  }
+}
+
+template <typename SrcT, typename DstT>
+inline void copy_general_dim5(const array& src, array& dst) {
+  return copy_general_dim5<SrcT, DstT, size_t>(
+      src, dst, src.shape(), src.strides(), 0);
+}
+
+template <typename SrcT, typename DstT, typename stride_t>
+void copy_general_dim6(
+    const array& src,
+    array& dst,
+    const std::vector<int>& data_shape,
+    const std::vector<stride_t>& i_strides,
+    int64_t i_offset) {
+  const SrcT* src_ptr = src.data<SrcT>() + i_offset;
+  DstT* dst_ptr = dst.data<DstT>();
+  
+  // Pre-compute loop bounds and strides
+  const int d0 = data_shape[0], d1 = data_shape[1], d2 = data_shape[2], 
+            d3 = data_shape[3], d4 = data_shape[4], d5 = data_shape[5];
+  const stride_t s0 = i_strides[0], s1 = i_strides[1], s2 = i_strides[2], 
+                 s3 = i_strides[3], s4 = i_strides[4], s5 = i_strides[5];
+
+  // Pre-compute stride adjustments
+  const stride_t s4_adj = s4 - s5 * d5;
+  const stride_t s3_adj = s3 - s4 * d4;
+  const stride_t s2_adj = s2 - s3 * d3;
+  const stride_t s1_adj = s1 - s2 * d2;
+  const stride_t s0_adj = s0 - s1 * d1;
+
+  stride_t src_idx = 0;
+  stride_t dst_idx = 0;
+
+  for (int i = 0; i < d0; ++i) {
+    for (int j = 0; j < d1; ++j) {
+      for (int k = 0; k < d2; ++k) {
+        for (int l = 0; l < d3; ++l) {
+          for (int m = 0; m < d4; ++m) {
+            for (int n = 0; n < d5; ++n) {
+              dst_ptr[dst_idx++] = static_cast<DstT>(src_ptr[src_idx]);
+              src_idx += s5;
+            }
+            src_idx += s4_adj;
+          }
+          src_idx += s3_adj;
+        }
+        src_idx += s2_adj;
+      }
+      src_idx += s1_adj;
+    }
+    src_idx += s0_adj;
+  }
+}
+
+template <typename SrcT, typename DstT>
+inline void copy_general_dim6(const array& src, array& dst) {
+  return copy_general_dim6<SrcT, DstT, size_t>(
+      src, dst, src.shape(), src.strides(), 0);
+}
+
+template <typename SrcT, typename DstT, typename stride_t>
+void copy_general_dim7(
+    const array& src,
+    array& dst,
+    const std::vector<int>& data_shape,
+    const std::vector<stride_t>& i_strides,
+    int64_t i_offset) {
+  const SrcT* src_ptr = src.data<SrcT>() + i_offset;
+  DstT* dst_ptr = dst.data<DstT>();
+  
+  // Pre-compute loop bounds and strides
+  const int d0 = data_shape[0], d1 = data_shape[1], d2 = data_shape[2], 
+            d3 = data_shape[3], d4 = data_shape[4], d5 = data_shape[5],
+            d6 = data_shape[6];
+  const stride_t s0 = i_strides[0], s1 = i_strides[1], s2 = i_strides[2], 
+                 s3 = i_strides[3], s4 = i_strides[4], s5 = i_strides[5],
+                 s6 = i_strides[6];
+
+  // Pre-compute stride adjustments
+  const stride_t s5_adj = s5 - s6 * d6;
+  const stride_t s4_adj = s4 - s5 * d5;
+  const stride_t s3_adj = s3 - s4 * d4;
+  const stride_t s2_adj = s2 - s3 * d3;
+  const stride_t s1_adj = s1 - s2 * d2;
+  const stride_t s0_adj = s0 - s1 * d1;
+
+  stride_t src_idx = 0;
+  stride_t dst_idx = 0;
+
+  for (int i = 0; i < d0; ++i) {
+    for (int j = 0; j < d1; ++j) {
+      for (int k = 0; k < d2; ++k) {
+        for (int l = 0; l < d3; ++l) {
+          for (int m = 0; m < d4; ++m) {
+            for (int n = 0; n < d5; ++n) {
+              for (int p = 0; p < d6; ++p) {
+                dst_ptr[dst_idx++] = static_cast<DstT>(src_ptr[src_idx]);
+                src_idx += s6;
+              }
+              src_idx += s5_adj;
+            }
+            src_idx += s4_adj;
+          }
+          src_idx += s3_adj;
+        }
+        src_idx += s2_adj;
+      }
+      src_idx += s1_adj;
+    }
+    src_idx += s0_adj;
+  }
+}
+
+template <typename SrcT, typename DstT>
+inline void copy_general_dim7(const array& src, array& dst) {
+  return copy_general_dim7<SrcT, DstT, size_t>(
+      src, dst, src.shape(), src.strides(), 0);
+}
+
+template <typename SrcT, typename DstT, typename stride_t>
 void copy_general(
     const array& src,
     array& dst,
@@ -160,6 +319,18 @@ void copy_general(
       return;
     case 4:
       copy_general_dim4<SrcT, DstT, stride_t>(
+          src, dst, new_shape, new_strides[0], i_offset);
+      return;
+    case 5:
+      copy_general_dim5<SrcT, DstT, stride_t>(
+          src, dst, new_shape, new_strides[0], i_offset);
+      return;
+    case 6:
+      copy_general_dim6<SrcT, DstT, stride_t>(
+          src, dst, new_shape, new_strides[0], i_offset);
+      return;
+    case 7:
+      copy_general_dim7<SrcT, DstT, stride_t>(
           src, dst, new_shape, new_strides[0], i_offset);
       return;
   }

--- a/mlx/backend/common/copy.cpp
+++ b/mlx/backend/common/copy.cpp
@@ -145,10 +145,12 @@ void copy_general_dim5(
     int64_t i_offset) {
   const SrcT* src_ptr = src.data<SrcT>() + i_offset;
   DstT* dst_ptr = dst.data<DstT>();
-  
+
   // Pre-compute loop bounds and strides
-  const int d0 = data_shape[0], d1 = data_shape[1], d2 = data_shape[2], d3 = data_shape[3], d4 = data_shape[4];
-  const stride_t s0 = i_strides[0], s1 = i_strides[1], s2 = i_strides[2], s3 = i_strides[3], s4 = i_strides[4];
+  const int d0 = data_shape[0], d1 = data_shape[1], d2 = data_shape[2],
+            d3 = data_shape[3], d4 = data_shape[4];
+  const stride_t s0 = i_strides[0], s1 = i_strides[1], s2 = i_strides[2],
+                 s3 = i_strides[3], s4 = i_strides[4];
 
   // Pre-compute stride adjustments
   const stride_t s3_adj = s3 - s4 * d4;
@@ -192,11 +194,11 @@ void copy_general_dim6(
     int64_t i_offset) {
   const SrcT* src_ptr = src.data<SrcT>() + i_offset;
   DstT* dst_ptr = dst.data<DstT>();
-  
+
   // Pre-compute loop bounds and strides
-  const int d0 = data_shape[0], d1 = data_shape[1], d2 = data_shape[2], 
+  const int d0 = data_shape[0], d1 = data_shape[1], d2 = data_shape[2],
             d3 = data_shape[3], d4 = data_shape[4], d5 = data_shape[5];
-  const stride_t s0 = i_strides[0], s1 = i_strides[1], s2 = i_strides[2], 
+  const stride_t s0 = i_strides[0], s1 = i_strides[1], s2 = i_strides[2],
                  s3 = i_strides[3], s4 = i_strides[4], s5 = i_strides[5];
 
   // Pre-compute stride adjustments
@@ -245,12 +247,12 @@ void copy_general_dim7(
     int64_t i_offset) {
   const SrcT* src_ptr = src.data<SrcT>() + i_offset;
   DstT* dst_ptr = dst.data<DstT>();
-  
+
   // Pre-compute loop bounds and strides
-  const int d0 = data_shape[0], d1 = data_shape[1], d2 = data_shape[2], 
+  const int d0 = data_shape[0], d1 = data_shape[1], d2 = data_shape[2],
             d3 = data_shape[3], d4 = data_shape[4], d5 = data_shape[5],
             d6 = data_shape[6];
-  const stride_t s0 = i_strides[0], s1 = i_strides[1], s2 = i_strides[2], 
+  const stride_t s0 = i_strides[0], s1 = i_strides[1], s2 = i_strides[2],
                  s3 = i_strides[3], s4 = i_strides[4], s5 = i_strides[5],
                  s6 = i_strides[6];
 


### PR DESCRIPTION
## Proposed changes

* changed `conv2d_cpu` and `conv3d_cpu` to use `explicit_gemm_conv_ND_cpu`
* extended `explicit_gemm_conv_ND_cpu` to accept a `flip` flag
  * implemented kernel flipping using `vDSP_vrvrs`
* implemented `copy_general_dim5`, `copy_general_dim6`, and `copy_general_dim7`
* added some benchmarks
  * I included cpu benchmarks in this PR to showcase the improvements for the reviewers. When the PR is ready to merge, we can either remove the benchmarks or refactor them into the existing benchmarks.
  * Results of the benchmarks listed below.
* resolves #1130

### Benefits

* These changes significantly increase the performance of all conv operations on the cpu. We now outperform pytorch in almost all scenarios by a large margin (often more than twice as fast).
* The main gains come from explicitly implementing the missing `copy_general_dimX` variants. Without them, a fallback implementation was used that prevented auto-vectorization.

### Limitations

* Currently, group support is missing in `explicit_gemm_conv_ND_cpu`, which I will add in a second PR. If `groups > 1`, the conv dispatch will fall back to the naive implementation (as it is now anyway).
* In cases where the number of input channels is much larger than the number of output channels (e.g., `w.shape = (3, 5, 5, 64)`), pytorch is still faster. I don’t know exactly why, maybe this is a channels first/channels last thing? It is still much faster than the current naive implementation.

### Benchmark results

<details>
  <summary>Results</summary>
  
```
python conv2d_bench_cpu.py
(N,   H,   W,   C), (  O, kH, kW,   C),   dtype, stride,   pads,  groups, diff%
(4,  32,  32,  32), ( 32,  5,  5,  32), float32, (1, 1), (2, 2),       1, +30.96%
(4,  32,  32,  64), ( 64,  5,  5,  64), float32, (1, 1), (2, 2),       1, +118.00%
(4,  32,  32, 128), (128,  5,  5, 128), float32, (1, 1), (2, 2),       1, +261.26%
(4,  32,  32, 256), (256,  5,  5, 256), float32, (1, 1), (2, 2),       1, +341.74%
(4,  32,  32, 512), (512,  5,  5, 512), float32, (1, 1), (2, 2),       1, +415.97%
(4,  64,  64,  32), ( 32,  5,  5,  32), float32, (1, 1), (2, 2),       1, +60.65%
(4,  64,  64,  64), ( 64,  5,  5,  64), float32, (1, 1), (2, 2),       1, +165.57%
(4,  64,  64, 128), (128,  5,  5, 128), float32, (1, 1), (2, 2),       1, +233.10%
(4,  64,  64, 256), (256,  5,  5, 256), float32, (1, 1), (2, 2),       1, +315.33%
(4, 128, 128,  32), ( 32,  5,  5,  32), float32, (1, 1), (2, 2),       1, +116.07%
(4, 128, 128,  64), ( 64,  5,  5,  64), float32, (1, 1), (2, 2),       1, +168.39%
(4, 128, 128, 128), (128,  5,  5, 128), float32, (1, 1), (2, 2),       1, +241.82%
(4, 256, 256,  32), (  3,  5,  5,  32), float32, (1, 1), (2, 2),       1, +121.82%
(4, 256, 256,   3), ( 32,  5,  5,   3), float32, (1, 1), (2, 2),       1, +69.19%
(4, 128, 128,  64), (  3,  5,  5,  64), float32, (1, 1), (2, 2),       1, +104.81%
(4, 128, 128,   3), ( 64,  5,  5,   3), float32, (1, 1), (2, 2),       1, +97.67%

python conv3d_bench_cpu.py
(N,   D,   H,   W,   C), (  O, kD, kH, kW,   C),   dtype,    stride,      pads,  groups, diff%
(4,  16,  16,  16,  16), ( 16,  5,  5,  5,  16), float32, (1, 1, 1), (2, 2, 2),       1, +331.89%
(4,  16,  16,  16,  32), ( 32,  5,  5,  5,  32), float32, (1, 1, 1), (2, 2, 2),       1, +610.21%

python conv1d_transpose_bench_cpu.py
(N,   L,   C), (  O, kL,   C),   dtype, stride,   pads,  groups, diff%
(4,  32,  32), ( 32,  5,  32), float32,      1,      2,       1, +208.85%
(4,  32,  64), ( 64,  5,  64), float32,      1,      2,       1, +252.78%
(4,  32, 128), (128,  5, 128), float32,      1,      2,       1, +303.15%
(4,  32, 256), (256,  5, 256), float32,      1,      2,       1, +175.76%
(4,  32, 512), (512,  5, 512), float32,      1,      2,       1, +94.74%
(4,  64,  32), ( 32,  5,  32), float32,      1,      2,       1, +261.26%
(4,  64,  64), ( 64,  5,  64), float32,      1,      2,       1, +245.70%
(4,  64, 128), (128,  5, 128), float32,      1,      2,       1, +200.14%
(4,  64, 256), (256,  5, 256), float32,      1,      2,       1, +195.51%
(4, 128,  32), ( 32,  5,  32), float32,      1,      2,       1, +364.18%
(4, 128,  64), ( 64,  5,  64), float32,      1,      2,       1, +244.30%
(4, 128, 128), (128,  5, 128), float32,      1,      2,       1, +263.34%
(4, 256,  32), (  3,  5,  32), float32,      1,      2,       1, +25.47%
(4, 256,   3), ( 32,  5,   3), float32,      1,      2,       1, +651.54%
(4, 128,  64), (  3,  5,  64), float32,      1,      2,       1, +14.00%
(4, 128,   3), ( 64,  5,   3), float32,      1,      2,       1, +709.81%

python conv2d_transpose_bench_cpu.py
(N,   H,   W,   C), (  O, kH, kW,   C),   dtype, stride,   pads,  groups, diff%
(4,  32,  32,  32), ( 32,  5,  5,  32), float32, (1, 1), (2, 2),       1, +37.90%
(4,  32,  32,  64), ( 64,  5,  5,  64), float32, (1, 1), (2, 2),       1, +144.03%
(4,  32,  32, 128), (128,  5,  5, 128), float32, (1, 1), (2, 2),       1, +277.24%
(4,  32,  32, 256), (256,  5,  5, 256), float32, (1, 1), (2, 2),       1, +320.18%
(4,  32,  32, 512), (512,  5,  5, 512), float32, (1, 1), (2, 2),       1, +386.72%
(4,  64,  64,  32), ( 32,  5,  5,  32), float32, (1, 1), (2, 2),       1, +102.91%
(4,  64,  64,  64), ( 64,  5,  5,  64), float32, (1, 1), (2, 2),       1, +172.65%
(4,  64,  64, 128), (128,  5,  5, 128), float32, (1, 1), (2, 2),       1, +229.72%
(4,  64,  64, 256), (256,  5,  5, 256), float32, (1, 1), (2, 2),       1, +316.77%
(4, 128, 128,  32), ( 32,  5,  5,  32), float32, (1, 1), (2, 2),       1, +144.43%
(4, 128, 128,  64), ( 64,  5,  5,  64), float32, (1, 1), (2, 2),       1, +161.99%
(4, 128, 128, 128), (128,  5,  5, 128), float32, (1, 1), (2, 2),       1, +224.38%
(4, 256, 256,  32), (  3,  5,  5,  32), float32, (1, 1), (2, 2),       1, -66.23%
ATTENTION ^^^^^^^
(4, 256, 256,   3), ( 32,  5,  5,   3), float32, (1, 1), (2, 2),       1, +625.42%
(4, 128, 128,  64), (  3,  5,  5,  64), float32, (1, 1), (2, 2),       1, -79.93%
ATTENTION ^^^^^^^
(4, 128, 128,   3), ( 64,  5,  5,   3), float32, (1, 1), (2, 2),       1, +1310.85%

python conv3d_transpose_bench_cpu.py
(N,   D,   H,   W,   C), (  O, kD, kH, kW,   C),   dtype,    stride,      pads,  groups, diff%
(4,  16,  16,  16,  16), ( 16,  5,  5,  5,  16), float32, (1, 1, 1), (2, 2, 2),       1, +626.24%
(4,  16,  16,  16,  32), ( 32,  5,  5,  5,  32), float32, (1, 1, 1), (2, 2, 2),       1, +776.28%

python conv2d_train_bench_cpu.py
MLX:
  0, time=1050.45 ms
  1, time= 790.94 ms
  2, time= 790.76 ms
  3, time= 794.35 ms
  4, time= 790.07 ms
  5, time= 786.00 ms
  6, time= 799.24 ms
  7, time= 797.66 ms
  8, time= 859.17 ms
  9, time= 879.75 ms
 10, time= 837.20 ms
 11, time= 829.94 ms
 12, time= 800.70 ms
 13, time= 848.97 ms
 14, time= 798.10 ms
 15, time= 795.99 ms
 16, time= 792.86 ms
 17, time= 794.46 ms
 18, time= 795.15 ms
 19, time= 789.16 ms
PyTorch:
  0, time=2131.52 ms
  1, time=2018.54 ms
  2, time=2344.00 ms
  3, time=1922.60 ms
  4, time=2177.38 ms
  5, time=2073.02 ms
  6, time=2014.90 ms
  7, time=1794.95 ms
  8, time=2064.72 ms
  9, time=1813.74 ms
 10, time=1383.49 ms
 11, time=1782.65 ms
 12, time=1775.91 ms
 13, time=1730.94 ms
 14, time=1996.80 ms
 15, time=1843.25 ms
 16, time=1922.51 ms
 17, time=1871.03 ms
 18, time=1615.77 ms
 19, time=1956.54 ms
average time of MLX:        821.05 ms
total time of MLX:        16420.92 ms
average time of PyTorch:   1911.71 ms
total time of PyTorch:    38234.25 ms
torch/mlx diff: +132.84%

python conv3d_train_bench_cpu.py
MLX:
  0, time= 543.13 ms
  1, time= 393.77 ms
  2, time= 395.11 ms
  3, time= 394.54 ms
  4, time= 395.68 ms
  5, time= 395.75 ms
  6, time= 395.78 ms
  7, time= 394.02 ms
  8, time= 394.32 ms
  9, time= 394.92 ms
PyTorch:
  0, time=1375.30 ms
  1, time=1312.22 ms
  2, time=1254.90 ms
  3, time=1299.31 ms
  4, time=1274.71 ms
  5, time=1295.90 ms
  6, time=1228.67 ms
  7, time=1250.69 ms
  8, time=1270.63 ms
  9, time=1226.38 ms
average time of MLX:        409.70 ms
total time of MLX:         4097.00 ms
average time of PyTorch:   1278.87 ms
total time of PyTorch:    12788.71 ms
torch/mlx diff: +212.15%
```
  
</details>

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)