### PR TITLE
Ensure io/comm streams are active before eval

### DIFF
--- a/mlx/backend/metal/primitives.cpp
+++ b/mlx/backend/metal/primitives.cpp
@@ -199,7 +199,6 @@ void Full::eval_gpu(const std::vector<array>& inputs, array& out) {
 }
 
 void Load::eval_gpu(const std::vector<array>& inputs, array& out) {
-  static Stream io_stream = new_stream(Device::cpu);
   out.set_data(allocator::malloc_or_wait(out.nbytes()));
 
   auto read_task = [out = out,
@@ -213,7 +212,7 @@ void Load::eval_gpu(const std::vector<array>& inputs, array& out) {
     fut.wait();
     out.event().signal();
   };
-  scheduler::enqueue(io_stream, std::move(signal_task));
+  scheduler::enqueue(io_stream(), std::move(signal_task));
   auto& d = metal::device(stream().device);
   d.end_encoding(stream().index);
   auto command_buffer = d.get_command_buffer(stream().index);

--- a/mlx/distributed/mpi/mpi.cpp
+++ b/mlx/distributed/mpi/mpi.cpp
@@ -255,6 +255,9 @@ Group init(bool strict /* = false */) {
     }
   }
 
+  // Ensure the communication stream is alive before
+  // the graph is evaluated
+  detail::communication_stream();
   return Group(global_group);
 }
 


### PR DESCRIPTION
Previously seeing occasional segfaults due to new stream creation in the scheduler not being thread safe. This resolves that (not seeing a segfault in 20 runs now). I didn't come up with a good way to test this reliably.. so not new tests added.