### PR TITLE
Fix typo in transformer docs

### DIFF
--- a/python/mlx/nn/layers/transformer.py
+++ b/python/mlx/nn/layers/transformer.py
@@ -314,7 +314,7 @@ class Transformer(Module):
         norm_first (bool, optional): if ``True``, encoder and decoder layers
             will perform layer normalization before attention and MLP
             operations, otherwise after. Default: ``True``.
-        chekpoint (bool, optional): if ``True`` perform gradient checkpointing
+        checkpoint (bool, optional): if ``True`` perform gradient checkpointing
             to reduce the memory usage at the expense of more computation.
             Default: ``False``.
     """


### PR DESCRIPTION
## Proposed changes

There's a small typo in the nn.Transformer docs, `chekpoint`. This changes it to say `checkpoint`. It's just a docs fix.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

(I didn't run pre-commit since this was done in the github webui)