### PR TITLE
avoid using find_library to make install truly portable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,9 +62,9 @@ cmake_policy(SET CMP0135 NEW)
 add_library(mlx)
 
 if (MLX_BUILD_METAL)
-  find_library(METAL_LIB Metal)
-  find_library(FOUNDATION_LIB Foundation)
-  find_library(QUARTZ_LIB QuartzCore)
+  set(METAL_LIB "-framework Metal")
+  set(FOUNDATION_LIB "-framework Foundation")
+  set(QUARTZ_LIB "-framework QuartzCore")
 endif()
 
 if (MLX_BUILD_METAL AND NOT METAL_LIB)


### PR DESCRIPTION
Without this change, after `make install` in MLXTargets.cmake we will see something like 
```
add_library(mlx STATIC IMPORTED)

set_target_properties(mlx PROPERTIES
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include/metal_cpp;${_IMPORT_PREFIX}/include;${_IMPORT_PREFIX}/include"
  INTERFACE_LINK_LIBRARIES "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/System/Library/Frameworks/Metal.framework;/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/System/Library/Frameworks/Foundation.framework;/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/System/Library/Frameworks/QuartzCore.framework;\$<LINK_ONLY:fmt::fmt-header-only>"
)
```
This will only work on my machine and defeats the purpose of a portable install. 

After this PR, after `make install` in MLXTargets.cmake we will see 
```
# Create imported target mlx
add_library(mlx STATIC IMPORTED)

set_target_properties(mlx PROPERTIES
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include/metal_cpp;${_IMPORT_PREFIX}/include;${_IMPORT_PREFIX}/include"
  INTERFACE_LINK_LIBRARIES "-framework Metal;-framework Foundation;-framework QuartzCore;\$<LINK_ONLY:fmt::fmt-header-only>"
)
``` 
which makes the install truly portable