### PR TITLE
remove fmt dependencies from MLX install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,7 +203,7 @@ FetchContent_Declare(fmt
   EXCLUDE_FROM_ALL
 )
 FetchContent_MakeAvailable(fmt)
-target_link_libraries(mlx PRIVATE fmt::fmt-header-only)
+target_link_libraries(mlx PRIVATE $<BUILD_INTERFACE:fmt::fmt-header-only>)
 
 if (MLX_BUILD_PYTHON_BINDINGS)
   message(STATUS "Building Python bindings.")
@@ -251,6 +251,7 @@ install(
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     COMPONENT headers
     FILES_MATCHING PATTERN "*.h"
+    PATTERN "backend/metal/kernels.h" EXCLUDE
 )
 
 # Install metal dependencies


### PR DESCRIPTION
This PR fixes the below problem when using MLX install
```
CMake Error at /Users/jjuang/test_install/share/cmake/MLX/MLXTargets.cmake:61 (set_target_properties):
  The link interface of target "mlx" contains:

    fmt::fmt-header-only

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.
```