### PR TITLE
Optimization for general ND copies

### DIFF
--- a/mlx/backend/metal/copy.cpp
+++ b/mlx/backend/metal/copy.cpp
@@ -73,9 +73,11 @@ void copy_gpu_inplace(
         }
       };
   auto [shape, strides_in_, strides_out_] = maybe_collapse();
+  int ndim = shape.size();
 
   bool use_2d = out.data_size() > UINT32_MAX;
   auto& d = metal::device(s.device);
+  int work_per_thread = 1;
   std::string kernel_name;
   {
     std::ostringstream kname;
@@ -93,9 +95,16 @@ void copy_gpu_inplace(
         kname << "gg";
         break;
     }
-    if ((ctype == CopyType::General || ctype == CopyType::GeneralGeneral) &&
-        shape.size() <= MAX_COPY_SPECIALIZED_DIMS) {
-      kname << shape.size();
+    if (ctype == CopyType::General || ctype == CopyType::GeneralGeneral) {
+      if (shape.size() <= MAX_COPY_SPECIALIZED_DIMS) {
+        kname << shape.size();
+      } else if (shape[ndim - 1] % 4 == 0) {
+        work_per_thread = 4;
+        kname << "_n4";
+      } else if (shape[ndim - 1] % 2 == 0) {
+        work_per_thread = 2;
+        kname << "_n2";
+      }
     }
     kname << "_copy";
     kname << type_to_name(in) << type_to_name(out);
@@ -115,20 +124,14 @@ void copy_gpu_inplace(
   compute_encoder.set_output_array(out, 1, out_offset);
 
   if (ctype == CopyType::General || ctype == CopyType::GeneralGeneral) {
-    int ndim = shape.size();
     std::vector<int64_t> strides_in{strides_in_.begin(), strides_in_.end()};
     std::vector<int64_t> strides_out{strides_out_.begin(), strides_out_.end()};
-
     if (ndim > 3) {
       set_vector_bytes(compute_encoder, shape, ndim, 2);
     }
     set_vector_bytes(compute_encoder, strides_in, ndim, 3);
     if (ctype == CopyType::GeneralGeneral) {
       set_vector_bytes(compute_encoder, strides_out, ndim, 4);
-    }
-
-    if (ndim > MAX_COPY_SPECIALIZED_DIMS) {
-      compute_encoder->setBytes(&ndim, sizeof(int), 5);
     }
 
     int dim0 = ndim > 0 ? shape[ndim - 1] : 1;
@@ -138,6 +141,11 @@ void copy_gpu_inplace(
     for (auto& s : shape)
       data_size *= s;
     int rest = data_size / (dim0 * dim1);
+
+    if (ndim > MAX_COPY_SPECIALIZED_DIMS) {
+      compute_encoder->setBytes(&ndim, sizeof(int), 5);
+      dim0 /= work_per_thread;
+    }
 
     // NB assuming thread_group_size is a power of 2 larger than 32 x 32
     NS::UInteger thread_group_size = kernel->maxTotalThreadsPerThreadgroup();

--- a/mlx/backend/metal/copy.cpp
+++ b/mlx/backend/metal/copy.cpp
@@ -100,7 +100,7 @@ void copy_gpu_inplace(
         kname << shape.size();
       } else if (shape[ndim - 1] >= 4) {
         work_per_thread = 4;
-        kname << "_n4";
+        kname << "n4";
       }
     }
     kname << "_copy";

--- a/mlx/backend/metal/copy.cpp
+++ b/mlx/backend/metal/copy.cpp
@@ -98,12 +98,9 @@ void copy_gpu_inplace(
     if (ctype == CopyType::General || ctype == CopyType::GeneralGeneral) {
       if (shape.size() <= MAX_COPY_SPECIALIZED_DIMS) {
         kname << shape.size();
-      } else if (shape[ndim - 1] % 4 == 0) {
+      } else if (shape[ndim - 1] >= 4) {
         work_per_thread = 4;
         kname << "_n4";
-      } else if (shape[ndim - 1] % 2 == 0) {
-        work_per_thread = 2;
-        kname << "_n2";
       }
     }
     kname << "_copy";
@@ -144,7 +141,7 @@ void copy_gpu_inplace(
 
     if (ndim > MAX_COPY_SPECIALIZED_DIMS) {
       compute_encoder->setBytes(&ndim, sizeof(int), 5);
-      dim0 /= work_per_thread;
+      dim0 = (dim0 + work_per_thread - 1) / work_per_thread;
     }
 
     // NB assuming thread_group_size is a power of 2 larger than 32 x 32

--- a/mlx/backend/metal/jit_kernels.cpp
+++ b/mlx/backend/metal/jit_kernels.cpp
@@ -177,7 +177,7 @@ MTL::ComputePipelineState* get_copy_kernel(
                "g3_" + lib_name, "copy_g_nd3", in_type, out_type)
         << get_template_definition("g_" + lib_name, "copy_g", in_type, out_type)
         << get_template_definition(
-               "g_n4_" + lib_name, "copy_g", in_type, out_type, 4)
+               "gn4_" + lib_name, "copy_g", in_type, out_type, 4)
         << get_template_definition(
                "gg1_" + lib_name, "copy_gg_nd1", in_type, out_type)
         << get_template_definition(
@@ -187,7 +187,7 @@ MTL::ComputePipelineState* get_copy_kernel(
         << get_template_definition(
                "gg_" + lib_name, "copy_gg", in_type, out_type)
         << get_template_definition(
-               "gg_n4_" + lib_name, "copy_gg", in_type, out_type, 4);
+               "ggn4_" + lib_name, "copy_gg", in_type, out_type, 4);
     lib = d.get_library(lib_name, kernel_source.str());
   }
   return d.get_kernel(kernel_name, lib);

--- a/mlx/backend/metal/jit_kernels.cpp
+++ b/mlx/backend/metal/jit_kernels.cpp
@@ -177,16 +177,17 @@ MTL::ComputePipelineState* get_copy_kernel(
                "g3_" + lib_name, "copy_g_nd3", in_type, out_type)
         << get_template_definition("g_" + lib_name, "copy_g", in_type, out_type)
         << get_template_definition(
-               "g_n4_" + lib_name, "copy_g", in_type, out_type, 4);
-    << get_template_definition(
-           "gg1_" + lib_name, "copy_gg_nd1", in_type, out_type)
-    << get_template_definition(
-           "gg2_" + lib_name, "copy_gg_nd2", in_type, out_type)
-    << get_template_definition(
-           "gg3_" + lib_name, "copy_gg_nd3", in_type, out_type)
-    << get_template_definition("gg_" + lib_name, "copy_gg", in_type, out_type)
-    << get_template_definition(
-           "gg_n4_" + lib_name, "copy_gg", in_type, out_type, 4);
+               "g_n4_" + lib_name, "copy_g", in_type, out_type, 4)
+        << get_template_definition(
+               "gg1_" + lib_name, "copy_gg_nd1", in_type, out_type)
+        << get_template_definition(
+               "gg2_" + lib_name, "copy_gg_nd2", in_type, out_type)
+        << get_template_definition(
+               "gg3_" + lib_name, "copy_gg_nd3", in_type, out_type)
+        << get_template_definition(
+               "gg_" + lib_name, "copy_gg", in_type, out_type)
+        << get_template_definition(
+               "gg_n4_" + lib_name, "copy_gg", in_type, out_type, 4);
     lib = d.get_library(lib_name, kernel_source.str());
   }
   return d.get_kernel(kernel_name, lib);

--- a/mlx/backend/metal/jit_kernels.cpp
+++ b/mlx/backend/metal/jit_kernels.cpp
@@ -177,13 +177,16 @@ MTL::ComputePipelineState* get_copy_kernel(
                "g3_" + lib_name, "copy_g_nd3", in_type, out_type)
         << get_template_definition("g_" + lib_name, "copy_g", in_type, out_type)
         << get_template_definition(
-               "gg1_" + lib_name, "copy_gg_nd1", in_type, out_type)
-        << get_template_definition(
-               "gg2_" + lib_name, "copy_gg_nd2", in_type, out_type)
-        << get_template_definition(
-               "gg3_" + lib_name, "copy_gg_nd3", in_type, out_type)
-        << get_template_definition(
-               "gg_" + lib_name, "copy_gg", in_type, out_type);
+               "g_n4_" + lib_name, "copy_g", in_type, out_type, 4);
+    << get_template_definition(
+           "gg1_" + lib_name, "copy_gg_nd1", in_type, out_type)
+    << get_template_definition(
+           "gg2_" + lib_name, "copy_gg_nd2", in_type, out_type)
+    << get_template_definition(
+           "gg3_" + lib_name, "copy_gg_nd3", in_type, out_type)
+    << get_template_definition("gg_" + lib_name, "copy_gg", in_type, out_type)
+    << get_template_definition(
+           "gg_n4_" + lib_name, "copy_gg", in_type, out_type, 4);
     lib = d.get_library(lib_name, kernel_source.str());
   }
   return d.get_kernel(kernel_name, lib);

--- a/mlx/backend/metal/kernels/copy.h
+++ b/mlx/backend/metal/kernels/copy.h
@@ -71,7 +71,7 @@ template <typename T, typename U>
   dst[dst_idx] = static_cast<U>(src[src_idx]);
 }
 
-template <typename T, typename U>
+template <typename T, typename U, int N = 1>
 [[kernel]] void copy_g(
     device const T* src [[buffer(0)]],
     device U* dst [[buffer(1)]],
@@ -80,10 +80,15 @@ template <typename T, typename U>
     constant const int& ndim [[buffer(5)]],
     uint3 index [[thread_position_in_grid]],
     uint3 grid_dim [[threads_per_grid]]) {
-  auto src_idx = elem_to_loc(index, src_shape, src_strides, ndim);
+  auto src_idx = elem_to_loc(
+      {N * index.x, index.y, index.z}, src_shape, src_strides, ndim);
   int64_t dst_idx =
-      index.x + (int64_t)grid_dim.x * (index.y + (int64_t)grid_dim.y * index.z);
-  dst[dst_idx] = static_cast<U>(src[src_idx]);
+      N * (index.x + grid_dim.x * (index.y + int64_t(grid_dim.y) * index.z));
+  auto src_xstride = src_strides[ndim - 1];
+  for (int i = 0; i < N; ++i) {
+    dst[dst_idx + i] = static_cast<U>(src[src_idx]);
+    src_idx += src_xstride;
+  }
 }
 
 template <typename T, typename U>
@@ -122,7 +127,7 @@ template <typename T, typename U>
   dst[dst_idx] = static_cast<U>(src[src_idx]);
 }
 
-template <typename T, typename U>
+template <typename T, typename U, int N = 1>
 [[kernel]] void copy_gg(
     device const T* src [[buffer(0)]],
     device U* dst [[buffer(1)]],
@@ -131,7 +136,17 @@ template <typename T, typename U>
     constant const int64_t* dst_strides [[buffer(4)]],
     constant const int& ndim [[buffer(5)]],
     uint3 index [[thread_position_in_grid]]) {
-  auto src_idx = elem_to_loc(index, src_shape, src_strides, ndim);
-  auto dst_idx = elem_to_loc(index, src_shape, dst_strides, ndim);
-  dst[dst_idx] = static_cast<U>(src[src_idx]);
+  auto idx = elem_to_loc_2_nd(
+      {N * index.x, index.y, index.z},
+      src_shape,
+      src_strides,
+      dst_strides,
+      ndim);
+  auto src_xstride = src_strides[ndim - 1];
+  auto dst_xstride = dst_strides[ndim - 1];
+  for (int i = 0; i < N; ++i) {
+    dst[idx.y] = static_cast<U>(src[idx.x]);
+    idx.x += src_xstride;
+    idx.y += dst_xstride;
+  }
 }

--- a/mlx/backend/metal/kernels/copy.metal
+++ b/mlx/backend/metal/kernels/copy.metal
@@ -17,9 +17,9 @@
   instantiate_kernel("gg2_copy" #tname, copy_gg_nd2, itype, otype) \
   instantiate_kernel("gg3_copy" #tname, copy_gg_nd3, itype, otype) \
   instantiate_kernel("g_copy" #tname, copy_g, itype, otype) \
-  instantiate_kernel("g_n4_copy" #tname, copy_g, itype, otype, 4) \
+  instantiate_kernel("gn4_copy" #tname, copy_g, itype, otype, 4) \
   instantiate_kernel("gg_copy" #tname, copy_gg, itype, otype) \
-  instantiate_kernel("gg_n4_copy" #tname, copy_gg, itype, otype, 4)
+  instantiate_kernel("ggn4_copy" #tname, copy_gg, itype, otype, 4)
 
 #define instantiate_copy_itype(itname, itype)                \
   instantiate_copy_all(itname ##bool_, itype, bool)          \

--- a/mlx/backend/metal/kernels/copy.metal
+++ b/mlx/backend/metal/kernels/copy.metal
@@ -17,10 +17,8 @@
   instantiate_kernel("gg2_copy" #tname, copy_gg_nd2, itype, otype) \
   instantiate_kernel("gg3_copy" #tname, copy_gg_nd3, itype, otype) \
   instantiate_kernel("g_copy" #tname, copy_g, itype, otype) \
-  instantiate_kernel("g_n2_copy" #tname, copy_g, itype, otype, 2) \
   instantiate_kernel("g_n4_copy" #tname, copy_g, itype, otype, 4) \
   instantiate_kernel("gg_copy" #tname, copy_gg, itype, otype) \
-  instantiate_kernel("gg_n2_copy" #tname, copy_gg, itype, otype, 2) \
   instantiate_kernel("gg_n4_copy" #tname, copy_gg, itype, otype, 4)
 
 #define instantiate_copy_itype(itname, itype)                \

--- a/mlx/backend/metal/kernels/copy.metal
+++ b/mlx/backend/metal/kernels/copy.metal
@@ -17,7 +17,11 @@
   instantiate_kernel("gg2_copy" #tname, copy_gg_nd2, itype, otype) \
   instantiate_kernel("gg3_copy" #tname, copy_gg_nd3, itype, otype) \
   instantiate_kernel("g_copy" #tname, copy_g, itype, otype) \
-  instantiate_kernel("gg_copy" #tname, copy_gg, itype, otype)
+  instantiate_kernel("g_n2_copy" #tname, copy_g, itype, otype, 2) \
+  instantiate_kernel("g_n4_copy" #tname, copy_g, itype, otype, 4) \
+  instantiate_kernel("gg_copy" #tname, copy_gg, itype, otype) \
+  instantiate_kernel("gg_n2_copy" #tname, copy_gg, itype, otype, 2) \
+  instantiate_kernel("gg_n4_copy" #tname, copy_gg, itype, otype, 4)
 
 #define instantiate_copy_itype(itname, itype)                \
   instantiate_copy_all(itname ##bool_, itype, bool)          \

--- a/mlx/backend/metal/kernels/utils.h
+++ b/mlx/backend/metal/kernels/utils.h
@@ -149,15 +149,16 @@ elem_to_loc_3(uint3 elem, constant const stride_t strides[3]) {
 ///////////////////////////////////////////////////////////////////////////////
 // Multiple Arrays with generic dims
 
+template <typename stride_t>
 METAL_FUNC ulong2 elem_to_loc_2_nd(
     uint3 elem,
     constant const int* shape,
-    constant const size_t* a_strides,
-    constant const size_t* b_strides,
+    constant const stride_t* a_strides,
+    constant const stride_t* b_strides,
     int ndim) {
   ulong2 loc = {
-      elem.x * a_strides[ndim - 1] + elem.y * a_strides[ndim - 2],
-      elem.x * b_strides[ndim - 1] + elem.y * b_strides[ndim - 2]};
+      ulong(elem.x * a_strides[ndim - 1] + elem.y * a_strides[ndim - 2]),
+      ulong(elem.x * b_strides[ndim - 1] + elem.y * b_strides[ndim - 2])};
   for (int d = ndim - 3; d >= 0; --d) {
     uint l = elem.z % shape[d];
     loc.x += l * a_strides[d];


### PR DESCRIPTION
- Add specializations for more work per thread to amortize cost of indexing
- Use 2-array index computation for gg copy to save a bunch of divides (helps a lot)

Benchmarking general and gg copy for 5D arrays:

bench | pre | post
---- | ---- | ----
general | 118.26 ms  |  79.3 ms
gg | 230.2 ms |  107.0 ms

Benchmark below:

```python
D = 64

a = mx.zeros((D, D, D, D, D))
a = mx.transpose(a, (1, 0, 4, 2, 3))

def fn_g(a):
    return [a[..., ::-1] for _ in range(5)]

def fn_gg(a):
    return [mx.pad(a, ((0, 0), (0, 0), (0, 0), (0, 0), (4, 0))) for _ in range(5)]
```
