### PR TITLE
Create CITATION.cff for mlx

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,24 @@
+cff-version: 1.2.0
+title: mlx
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Awni
+    family-names: Hannun
+    affiliation: Apple
+  - given-names: Jagrit
+    family-names: Digani
+    affiliation: Apple
+  - given-names: Angelos
+    family-names: Katharopoulos
+    affiliation: Apple
+  - given-names: Ronan
+    family-names: Collobert
+    affiliation: Apple
+repository-code: 'https://github.com/ml-explore'
+abstract: >-
+  MLX: efficient and flexible machine learning on Apple
+  silicon
+license: MIT


### PR DESCRIPTION
## Proposed changes

Adding a `CITATION.cff` enables GitHub and other apps to automatically detect the correct way to cite `mlx`. This file contains the same semantic content as the BibTex citation in the README. You can take a look at how other repos implement their `CITATION.cff` for more info, like [pytorch/CITATION.cff](https://github.com/pytorch/pytorch/blob/main/CITATION.cff)

It also adds new views on the GitHub site, for example:
<img width="466" alt="Screenshot 2024-09-15 at 6 36 04 PM" src="https://github.com/user-attachments/assets/87fa59b2-3608-4183-aa26-ac0417fae751">




## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
