### PR TITLE
Add support for grouped 1D convolutions to the nn API

### DIFF
--- a/python/mlx/nn/layers/convolution.py
+++ b/python/mlx/nn/layers/convolution.py
@@ -25,6 +25,8 @@ class Conv1d(Module):
         padding (int, optional): How many positions to 0-pad the input with.
             Default: ``0``.
         dilation (int, optional): The dilation of the convolution.
+        groups (int, optional): The number of groups for the convolution.
+            Default: ``1``.
         bias (bool, optional): If ``True`` add a learnable bias to the output.
             Default: ``True``
     """
@@ -44,7 +46,8 @@ class Conv1d(Module):
 
         if groups > 1 and in_channels % groups != 0:
             raise ValueError(
-                f"The number of input channels ({in_channels}) must be divisible by the number of groups ({groups})"
+                f"The number of input channels ({in_channels}) must be "
+                f"divisible by the number of groups ({groups})"
             )
 
         scale = math.sqrt(1 / (in_channels * kernel_size))

--- a/python/mlx/nn/layers/convolution.py
+++ b/python/mlx/nn/layers/convolution.py
@@ -66,7 +66,9 @@ class Conv1d(Module):
         )
 
     def __call__(self, x):
-        y = mx.conv1d(x, self.weight, self.stride, self.padding, self.dilation, self.groups)
+        y = mx.conv1d(
+            x, self.weight, self.stride, self.padding, self.dilation, self.groups
+        )
         if "bias" in self:
             y = y + self.bias
         return y

--- a/python/mlx/nn/layers/convolution.py
+++ b/python/mlx/nn/layers/convolution.py
@@ -42,6 +42,11 @@ class Conv1d(Module):
     ):
         super().__init__()
 
+        if groups > 1 and in_channels % groups != 0:
+            raise ValueError(
+                f"The number of input channels ({in_channels}) must be divisible by the number of groups ({groups})"
+            )
+
         scale = math.sqrt(1 / (in_channels * kernel_size))
         self.weight = mx.random.uniform(
             low=-scale,

--- a/python/mlx/nn/layers/convolution.py
+++ b/python/mlx/nn/layers/convolution.py
@@ -44,7 +44,7 @@ class Conv1d(Module):
     ):
         super().__init__()
 
-        if groups > 1 and in_channels % groups != 0:
+        if in_channels % groups != 0:
             raise ValueError(
                 f"The number of input channels ({in_channels}) must be "
                 f"divisible by the number of groups ({groups})"

--- a/python/mlx/nn/layers/convolution.py
+++ b/python/mlx/nn/layers/convolution.py
@@ -51,7 +51,7 @@ class Conv1d(Module):
         self.weight = mx.random.uniform(
             low=-scale,
             high=scale,
-            shape=(out_channels, kernel_size, int(in_channels / groups)),
+            shape=(out_channels, kernel_size, in_channels // groups),
         )
         if bias:
             self.bias = mx.zeros((out_channels,))

--- a/python/mlx/nn/layers/convolution.py
+++ b/python/mlx/nn/layers/convolution.py
@@ -37,6 +37,7 @@ class Conv1d(Module):
         stride: int = 1,
         padding: int = 0,
         dilation: int = 1,
+        groups: int = 1,
         bias: bool = True,
     ):
         super().__init__()
@@ -45,7 +46,7 @@ class Conv1d(Module):
         self.weight = mx.random.uniform(
             low=-scale,
             high=scale,
-            shape=(out_channels, kernel_size, in_channels),
+            shape=(out_channels, kernel_size, int(in_channels / groups)),
         )
         if bias:
             self.bias = mx.zeros((out_channels,))
@@ -53,17 +54,19 @@ class Conv1d(Module):
         self.padding = padding
         self.dilation = dilation
         self.stride = stride
+        self.groups = groups
 
     def _extra_repr(self):
         return (
             f"{self.weight.shape[-1]}, {self.weight.shape[0]}, "
             f"kernel_size={self.weight.shape[1]}, stride={self.stride}, "
             f"padding={self.padding}, dilation={self.dilation}, "
+            f"groups={self.groups}, "
             f"bias={'bias' in self}"
         )
 
     def __call__(self, x):
-        y = mx.conv1d(x, self.weight, self.stride, self.padding, self.dilation)
+        y = mx.conv1d(x, self.weight, self.stride, self.padding, self.dilation, self.groups)
         if "bias" in self:
             y = y + self.bias
         return y

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -655,7 +655,7 @@ class TestLayers(mlx_tests.MLXTestCase):
             in_channels=C_in, out_channels=C_out, kernel_size=ks, groups=groups
         )
         y = c(x)
-        self.assertEqual(c.weight.shape, (C_out, ks, int(C_in / groups)))
+        self.assertEqual(c.weight.shape, (C_out, ks, C_in // groups))
         self.assertEqual(y.shape, (N, L - ks + 1, C_out))
 
     def test_conv2d(self):

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -649,9 +649,11 @@ class TestLayers(mlx_tests.MLXTestCase):
 
         c = nn.Conv1d(in_channels=C_in, out_channels=C_out, kernel_size=ks, bias=False)
         self.assertTrue("bias" not in c.parameters())
-        
+
         groups = C_in
-        c = nn.Conv1d(in_channels=C_in, out_channels=C_out, kernel_size=ks, groups=groups)
+        c = nn.Conv1d(
+            in_channels=C_in, out_channels=C_out, kernel_size=ks, groups=groups
+        )
         y = c(x)
         self.assertEqual(c.weight.shape, (C_out, ks, int(C_in / groups)))
         self.assertEqual(y.shape, (N, L - ks + 1, C_out))

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -649,6 +649,12 @@ class TestLayers(mlx_tests.MLXTestCase):
 
         c = nn.Conv1d(in_channels=C_in, out_channels=C_out, kernel_size=ks, bias=False)
         self.assertTrue("bias" not in c.parameters())
+        
+        groups = C_in
+        c = nn.Conv1d(in_channels=C_in, out_channels=C_out, kernel_size=ks, groups=groups)
+        y = c(x)
+        self.assertEqual(c.weight.shape, (C_out, ks, int(C_in / groups)))
+        self.assertEqual(y.shape, (N, L - ks + 1, C_out))
 
     def test_conv2d(self):
         x = mx.ones((4, 8, 8, 3))


### PR DESCRIPTION
## Proposed changes

This enables the groups parameter for nn.Conv1D and fixes the weights creation to handle the groups.

I realize the backwards pass isn't supported with groups > 1, but this API is already exposed through the functional API so I don't think it's necessarily a worse user experience to have the forward pass available in the nn API as well.

## Checklist

Put an `x` in the boxes that apply.

- [X] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [X] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have updated the necessary documentation (if needed)
