### PR TITLE
Fix row reduce

### DIFF
--- a/mlx/backend/metal/reduce.cpp
+++ b/mlx/backend/metal/reduce.cpp
@@ -450,7 +450,7 @@ void row_reduce_general_dispatch(
 
   // Case 2: Contiguous reduce without non-row reductions
   if (plan.type == ContiguousReduce && args.reduce_ndim == 0 &&
-      in.size() / args.row_size >= 4) {
+      in.size() / args.row_size >= 32) {
     return row_reduce_simple(in, out, op_name, args, compute_encoder, d, s);
   }
 

--- a/mlx/backend/metal/reduce.cpp
+++ b/mlx/backend/metal/reduce.cpp
@@ -449,7 +449,8 @@ void row_reduce_general_dispatch(
   }
 
   // Case 2: Contiguous reduce without non-row reductions
-  if (plan.type == ContiguousReduce && args.reduce_ndim == 0) {
+  if (plan.type == ContiguousReduce && args.reduce_ndim == 0 &&
+      in.size() / args.row_size >= 4) {
     return row_reduce_simple(in, out, op_name, args, compute_encoder, d, s);
   }
 


### PR DESCRIPTION
Fixes OOB write in the `row_reduce_simple` kernel. Reductions with very few rows shouldn't have been routing to that kernel anyway because it is noticeably slower than the general one row per thread group one.

| Size     |  Before  | Now  |
| -------- | -------- | ---- |
|  2 x 1M  |  0.79    | 0.17 |
|  4 x 1M  |  0.53    | 0.17 |
|  6 x 1M  |  0.50    | 0.18 |
|  8 x 1M  |  0.60    | 0.19 |
| 12 x 1M  |  0.63    | 0.30 |
| 16 x 1M  |  0.66    | 0.48 |
| 24 x 1M  |  0.83    | 0.79 |
| 32 x 1M  |  1.03    | 1.03 |
 