### PR TITLE
Fix deep recursion with siblings

### DIFF
--- a/mlx/array.cpp
+++ b/mlx/array.cpp
@@ -245,7 +245,7 @@ array::ArrayDesc::~ArrayDesc() {
   std::vector<std::shared_ptr<ArrayDesc>> for_deletion;
 
   for (array& a : inputs) {
-    if (a.array_desc_.use_count() == 1) {
+    if (a.array_desc_ && a.array_desc_.use_count() <= a.siblings().size() + 1) {
       for_deletion.push_back(std::move(a.array_desc_));
     }
   }
@@ -257,7 +257,8 @@ array::ArrayDesc::~ArrayDesc() {
     for_deletion.pop_back();
 
     for (array& a : top->inputs) {
-      if (a.array_desc_.use_count() == 1) {
+      if (a.array_desc_ &&
+          a.array_desc_.use_count() <= a.siblings().size() + 1) {
         for_deletion.push_back(std::move(a.array_desc_));
       }
     }


### PR DESCRIPTION
This should fix recursing during destruction with siblings creating a very deep recursion.

Close https://github.com/ml-explore/mlx-swift/issues/139

Added some tests to the long running CI:

```python
def deep_graph():
    # Deep graph destroyed without eval
    x = mx.array([1.0, 2.0])
    for _ in range(100_000):
        x = mx.sin(x)
    del x

    # Deep graph with siblings destroyed without eval
    x = mx.array([1, 2])
    for _ in range(100_000):
        x = mx.concatenate(mx.split(x, 2))
    del x

    # Deep graph with eval
    x = mx.array([1.0, 2.0])
    for _ in range(100_000):
        x = mx.sin(x)
    mx.eval(x)
```