### PR TITLE
Make push button linux distribution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,8 +339,7 @@ workflows:
               xcode_version: ["15.0.0", "15.2.0", "16.0.0"]
               build_env: ["DEV_RELEASE=1"]
   linux_test_release:
-    when:
-      - << pipeline.parameters.linux_release >>
+    when: << pipeline.parameters.linux_release >>
     jobs:
       - build_linux_test_release:
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,7 +341,7 @@ workflows:
               xcode_version: ["15.0.0", "15.2.0", "16.0.0"]
               build_env: ["DEV_RELEASE=1"]
   linux_test_release:
-    when: 
+    when:
       and:
         - equal: [ main, << pipeline.git.branch >> ]
         - << pipeline.parameters.linux_release >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,7 +341,9 @@ workflows:
               build_env: ["DEV_RELEASE=1"]
   linux_test_release:
     when: 
-      condition: << pipeline.parameters.linux_release >>
+      and:
+        - equal: [ linux_dist, << pipeline.git.branch >> ]
+        - << pipeline.parameters.linux_release >>
     jobs:
       - build_linux_test_release:
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,7 +261,7 @@ jobs:
           name: Upload package
           command: |
             source env/bin/activate
-            twine upload dist/*
+            twine upload wheelhouse/*
       - store_artifacts:
           path: wheelhouse/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,7 @@ jobs:
       - store_artifacts:
           path: dist/
 
-  build_linux_test_release:
+  build_linux_release:
     parameters:
       python_version:
         type: string
@@ -343,10 +343,10 @@ workflows:
   linux_test_release:
     when: 
       and:
-        - equal: [ linux_dist, << pipeline.git.branch >> ]
+        - equal: [ main, << pipeline.git.branch >> ]
         - << pipeline.parameters.linux_release >>
     jobs:
-      - build_linux_test_release:
+      - build_linux_release:
           matrix:
             parameters:
               python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,11 +253,11 @@ jobs:
               python -m build --wheel
             auditwheel show dist/*
             auditwheel repair dist/* --plat manylinux_2_31_x86_64
-        - run:
-            name: Upload package
-            command: |
-              source env/bin/activate
-              twine upload dist/*
+      - run:
+          name: Upload package
+          command: |
+            source env/bin/activate
+            twine upload dist/*
       - store_artifacts:
           path: wheelhouse/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,6 +246,7 @@ jobs:
             pip install auditwheel
             pip install patchelf
             pip install build
+            pip install twine
             << parameters.extra_env >> \
               CMAKE_BUILD_PARALLEL_LEVEL=`nproc` \
               pip install . -v

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,9 @@ parameters:
   test_release:
     type: boolean
     default: false
+  linux_test_release:
+    type: boolean
+    default: false
 
 jobs:
   linux_build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,6 +253,13 @@ jobs:
               python -m build --wheel
             auditwheel show dist/*
             auditwheel repair dist/* --plat manylinux_2_31_x86_64
+      - when:
+          steps:
+            - run:
+                name: Upload package
+                command: |
+                  source env/bin/activate
+                  twine upload dist/*
       - store_artifacts:
           path: wheelhouse/
 
@@ -333,9 +340,7 @@ workflows:
               build_env: ["DEV_RELEASE=1"]
   linux_test_release:
     when:
-      and:
-        - equal: [ main, << pipeline.git.branch >> ]
-        - << pipeline.parameters.test_release >>
+      - << pipeline.parameters.linux_release >>
     jobs:
       - build_linux_test_release:
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,13 +253,11 @@ jobs:
               python -m build --wheel
             auditwheel show dist/*
             auditwheel repair dist/* --plat manylinux_2_31_x86_64
-      - when:
-          steps:
-            - run:
-                name: Upload package
-                command: |
-                  source env/bin/activate
-                  twine upload dist/*
+        - run:
+            name: Upload package
+            command: |
+              source env/bin/activate
+              twine upload dist/*
       - store_artifacts:
           path: wheelhouse/
 
@@ -339,7 +337,8 @@ workflows:
               xcode_version: ["15.0.0", "15.2.0", "16.0.0"]
               build_env: ["DEV_RELEASE=1"]
   linux_test_release:
-    when: << pipeline.parameters.linux_release >>
+    when: 
+      condition: << pipeline.parameters.linux_release >>
     jobs:
       - build_linux_test_release:
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ parameters:
   test_release:
     type: boolean
     default: false
-  linux_test_release:
+  linux_release:
     type: boolean
     default: false
 


### PR DESCRIPTION
Make it easier to deploy linux to PyPi if needed. Use the trigger pipeline functionality in circle. I deployed a release of 0.18 with this.

<img width="711" alt="Screenshot 2024-10-10 at 8 49 46 AM" src="https://github.com/user-attachments/assets/614e94e8-6854-4690-a5fb-c3b86c3f7eaa">
