### PR TITLE
[Type annotations] Add type hints to `mlx.nn.layers.dropout`.

### DIFF
--- a/python/mlx/nn/layers/dropout.py
+++ b/python/mlx/nn/layers/dropout.py
@@ -23,10 +23,10 @@ class Dropout(Module):
 
         self._p_1 = 1 - p
 
-    def _extra_repr(self):
+    def _extra_repr(self) -> str:
         return f"p={1-self._p_1}"
 
-    def __call__(self, x):
+    def __call__(self, x: mx.array) -> mx.array:
         if self._p_1 == 1 or not self.training:
             return x
 
@@ -66,10 +66,10 @@ class Dropout2d(Module):
 
         self._p_1 = 1 - p
 
-    def _extra_repr(self):
+    def _extra_repr(self) -> str:
         return f"p={1-self._p_1}"
 
-    def __call__(self, x):
+    def __call__(self, x: mx.array) -> mx.array:
         if x.ndim not in (3, 4):
             raise ValueError(
                 f"Received input with {x.ndim} dimensions. Expected 3 or 4 dimensions."
@@ -115,10 +115,10 @@ class Dropout3d(Module):
 
         self._p_1 = 1 - p
 
-    def _extra_repr(self):
+    def _extra_repr(self) -> str:
         return f"p={1-self._p_1}"
 
-    def __call__(self, x):
+    def __call__(self, x: mx.array) -> mx.array:
         if x.ndim not in (4, 5):
             raise ValueError(
                 f"Received input with {x.ndim} dimensions. Expected 4 or 5 dimensions."


### PR DESCRIPTION
## Proposed changes
> [!important]
> Refer issue: #1240 

### Description

As a student with an AI background, I'm initially focusing on the implementations under `python/mlx/nn/layers`. I'll use `Dropout` as an example ([code link](https://github.com/ml-explore/mlx/blob/main/python/mlx/nn/layers/dropout.py#L7-L35)):

```python
class Dropout(Module):
    r"""Randomly zero a portion of the elements during training.

    The remaining elements are multiplied with :math:`\frac{1}{1-p}` where
    :math:`p` is the probability of zeroing an element. This is done so the
    expected value of a given element will remain the same.

    Args:
        p (float): The probability to zero an element
    """

    def __init__(self, p: float = 0.5):
        super().__init__()

        if p < 0 or p >= 1:
            raise ValueError(f"The dropout probability {p} is not in [0, 1)")

        self._p_1 = 1 - p

    def _extra_repr(self):
        return f"p={1-self._p_1}"

    def __call__(self, x):
        if self._p_1 == 1 or not self.training:
            return x

        mask = mx.random.bernoulli(self._p_1, x.shape)

        return (mask * x) * (1 / self._p_1)
```

To add typing annotations, a straightforward approach would be to reference PyTorch's implementation ([code link](https://github.com/pytorch/pytorch/blob/main/torch/nn/modules/dropout.py#L35-L70)):

```python
from torch import Tensor

class Dropout(_DropoutNd):
    ...

    def forward(self, input: Tensor) -> Tensor:
        return F.dropout(input, self.p, self.training, self.inplace)
```

Aligning with PyTorch, we might do something like this:

```diff
class Dropout(Module):
    r"""Randomly zero a portion of the elements during training.

    The remaining elements are multiplied with :math:`\frac{1}{1-p}` where
    :math:`p` is the probability of zeroing an element. This is done so the
    expected value of a given element will remain the same.

    Args:
        p (float): The probability to zero an element
    """

    def __init__(self, p: float = 0.5):
        super().__init__()

        if p < 0 or p >= 1:
            raise ValueError(f"The dropout probability {p} is not in [0, 1)")

        self._p_1 = 1 - p

-   def _extra_repr(self):
+   def _extra_repr(self) -> str:
        return f"p={1-self._p_1}"

-   def __call__(self, x):
+   def __call__(self, x: mx.array) -> mx.array:
        if self._p_1 == 1 or not self.training:
            return x

        mask = mx.random.bernoulli(self._p_1, x.shape)

        return (mask * x) * (1 / self._p_1)
```

### **Issue Encountered**

> [!NOTE]
> This conclusion represents only my personal understanding. It may be incorrect.

Although this appears to complete the task, I've noticed that PyTorch wraps a `Tensor` Python implementation on top of C++, while MLX doesn't. Consequently, despite these changes, in IDEs (like VSCode), it's equivalent to `def __call__(self, x: Any) -> Any:`.

Regarding this issue, I'd like to ask: **how can we improve the readability and type hinting experience for MLX?**

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
