### PR TITLE
Bump mac tests to use python 3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,9 +77,9 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            brew install python@3.8
+            brew install python@3.9
             brew install openmpi
-            python3.8 -m venv env
+            python3.9 -m venv env
             source env/bin/activate
             pip install --upgrade pip
             pip install --upgrade cmake


### PR DESCRIPTION
Brew deprecated python 3.8. This seems like the simplest fix. I don't think we've ever run into issues from differences between 3.8 and 3.9 (?) so testing in 3.9 seems fine (maybe with the intention of deprecating 3.8 at some point in the future)