### PR TITLE
Fix cpu segfault

### DIFF
--- a/mlx/compile_impl.h
+++ b/mlx/compile_impl.h
@@ -6,6 +6,20 @@
 
 namespace mlx::core::detail {
 
-bool compile_available_for_device(const Device& device);
+// This is not part of the general C++ API as calling with a bad id is a bad
+// idea.
+std::function<std::vector<array>(const std::vector<array>&)> compile(
+    const std::function<std::vector<array>(const std::vector<array>&)>& fun,
+    std::uintptr_t fun_id,
+    bool shapeless = false,
+    std::vector<uint64_t> constants = {});
 
-}
+// Erase cached compile functions
+void compile_erase(std::uintptr_t fun_id);
+
+// Clear the compiler cache causing a recompilation of all compiled functions
+// when called again.
+void compile_clear_cache();
+
+bool compile_available_for_device(const Device& device);
+} // namespace mlx::core::detail

--- a/mlx/transforms_impl.h
+++ b/mlx/transforms_impl.h
@@ -16,21 +16,6 @@ std::vector<array> vmap_replace(
     const std::vector<int>& in_axes,
     const std::vector<int>& out_axes);
 
-// This is not part of the general C++ API as calling with a bad id is a bad
-// idea.
-std::function<std::vector<array>(const std::vector<array>&)> compile(
-    const std::function<std::vector<array>(const std::vector<array>&)>& fun,
-    std::uintptr_t fun_id,
-    bool shapeless = false,
-    std::vector<uint64_t> constants = {});
-
-// Erase cached compile functions
-void compile_erase(std::uintptr_t fun_id);
-
-// Clear the compiler cache causing a recompilation of all compiled functions
-// when called again.
-void compile_clear_cache();
-
 // Create an InTracing object during tracing operations to signify to the rest
 // of the codebase that we are during tracing so evals should not throw away
 // the graph.

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -1323,10 +1323,7 @@ void init_ops(nb::module_& m) {
           start (float or int, optional): Starting value which defaults to ``0``.
           stop (float or int): Stopping value.
           step (float or int, optional): Increment which defaults to ``1``.
-          dtype (Dtype, optional): Specifies the data type of the output.
-            If unspecified will default to ``float32`` if any of ``start``,
-            ``stop``, or ``step`` are ``float``. Otherwise will default to
-            ``int32``.
+          dtype (Dtype, optional): Specifies the data type of the output. If unspecified will default to ``float32`` if any of ``start``, ``stop``, or ``step`` are ``float``. Otherwise will default to ``int32``.
 
       Returns:
           array: The range of values.

--- a/python/src/transforms.cpp
+++ b/python/src/transforms.cpp
@@ -13,6 +13,7 @@
 
 #include "mlx/array.h"
 #include "mlx/compile.h"
+#include "mlx/compile_impl.h"
 #include "mlx/graph_utils.h"
 #include "mlx/transforms.h"
 #include "mlx/transforms_impl.h"

--- a/python/tests/test_conv_transpose.py
+++ b/python/tests/test_conv_transpose.py
@@ -171,7 +171,7 @@ class TestConvTranspose(mlx_tests.MLXTestCase):
 
                 # use torch to compute ct
                 out_pt.retain_grad()
-                (out_pt - torch.randn_like(out_pt)).abs().sum().backward()
+                out_pt.sum().backward()
 
                 pt_grad_in = in_pt.grad.permute(0, 2, 1).numpy()
                 pt_grad_wt = wt_pt.grad.permute(1, 2, 0).numpy()
@@ -365,7 +365,7 @@ class TestConvTranspose(mlx_tests.MLXTestCase):
 
                 # use torch to compute ct
                 out_pt.retain_grad()
-                (out_pt - torch.randn_like(out_pt)).abs().sum().backward()
+                out_pt.sum().backward()
 
                 pt_grad_in = in_pt.grad.permute(0, 2, 3, 1).numpy()
                 pt_grad_wt = wt_pt.grad.permute(1, 2, 3, 0).numpy()
@@ -549,7 +549,7 @@ class TestConvTranspose(mlx_tests.MLXTestCase):
 
                 # use torch to compute ct
                 out_pt.retain_grad()
-                (out_pt - torch.randn_like(out_pt)).abs().sum().backward()
+                out_pt.sum().backward()
 
                 pt_grad_in = in_pt.grad.permute(0, 2, 3, 4, 1).numpy()
                 pt_grad_wt = wt_pt.grad.permute(1, 2, 3, 4, 0).numpy()


### PR DESCRIPTION
Closes #1473 

The statics in the cpu compile function were being destroyed before the stream. Moving this to a global static fixes the problem.