### PR TITLE
Fix submodule stubs

### DIFF
--- a/python/mlx/_stub_patterns.txt
+++ b/python/mlx/_stub_patterns.txt
@@ -1,0 +1,20 @@
+mlx.core.distributed.__prefix__:
+  from mlx.core import array, Dtype, Device, Stream
+  from mlx.core.distributed import Group
+  from typing import Sequence, Optional, Union
+
+mlx.core.fast.__prefix__:
+  from mlx.core import array, Dtype, Device, Stream
+  from typing import Sequence, Optional, Union
+
+mlx.core.linalg.__prefix__:
+  from mlx.core import array, Dtype, Device, Stream
+  from typing import Sequence, Optional, Tuple, Union
+
+mlx.core.metal.__prefix__:
+  from mlx.core import array, Dtype, Device, Stream
+  from typing import Sequence, Optional, Union
+
+mlx.core.random.__prefix__:
+  from mlx.core import array, Dtype, Device, Stream
+  from typing import Sequence, Optional, Union

--- a/python/src/linalg.cpp
+++ b/python/src/linalg.cpp
@@ -187,7 +187,7 @@ void init_linalg(nb::module_& parent_module) {
       nb::kw_only(),
       "stream"_a = nb::none(),
       nb::sig(
-          "def qr(a: array, *, stream: Union[None, Stream, Device] = None) -> tuple(array, array)"),
+          "def qr(a: array, *, stream: Union[None, Stream, Device] = None) -> Tuple[array, array]"),
       R"pbdoc(
         The QR factorization of the input matrix.
 
@@ -220,7 +220,7 @@ void init_linalg(nb::module_& parent_module) {
       nb::kw_only(),
       "stream"_a = nb::none(),
       nb::sig(
-          "def svd(a: array, *, stream: Union[None, Stream, Device] = None) -> tuple(array, array, array)"),
+          "def svd(a: array, *, stream: Union[None, Stream, Device] = None) -> Tuple[array, array, array]"),
       R"pbdoc(
         The Singular Value Decomposition (SVD) of the input matrix.
 

--- a/setup.py
+++ b/setup.py
@@ -141,6 +141,8 @@ class GenerateStubs(Command):
             "nanobind.stubgen",
             "-m",
             "mlx.core",
+            "-p",
+            "python/mlx/_stub_patterns.txt",
         ]
         subprocess.run(stub_cmd + ["-r", "-O", out_path])
         # Run again without recursive to specify output file name


### PR DESCRIPTION
The submodules stubs don't import the packages they need so the types in the signatures previously would show up as `Any`.

This fixes that by adding the imports.

Some comments for future fixes here:
- Nanobind has some facility to auto-detect and include imports but it would require writing the signatures with fully qualified names (e.g. `typing.Union` instead of just `Union`) which gets quite verbose and annoying. 

- The alternative would be to let nanobind auto-generate the signatures.. this is not a bad option. The only downside is some of the variants can be extremely long / verbose and I don't see a way to have aliases for those.