### PR TITLE
remove hazard tracking

### DIFF
--- a/mlx/backend/metal/allocator.cpp
+++ b/mlx/backend/metal/allocator.cpp
@@ -205,7 +205,7 @@ Buffer MetalAllocator::malloc(size_t size, bool allow_swap /* = false */) {
 
     // Allocate new buffer if needed
     size_t res_opt = MTL::ResourceStorageModeShared;
-    res_opt |= MTL::ResourceHazardTrackingModeTracked;
+    res_opt |= MTL::ResourceHazardTrackingModeUntracked;
     lk.unlock();
     buf = device_->newBuffer(size, res_opt);
     lk.lock();

--- a/mlx/backend/metal/device.h
+++ b/mlx/backend/metal/device.h
@@ -173,6 +173,7 @@ class Device {
   std::unordered_map<int32_t, MTL::CommandQueue*> queue_map_;
   std::unordered_map<int32_t, std::pair<int, MTL::CommandBuffer*>> buffer_map_;
   std::unordered_map<int32_t, std::unique_ptr<CommandEncoder>> encoder_map_;
+  std::unordered_map<int32_t, MTL::Fence*> fence_map_;
 
   std::shared_mutex kernel_mtx_;
   std::unordered_map<std::string, MTL::ComputePipelineState*> kernel_map_;


### PR DESCRIPTION
Draft PR to turn off hazard tracking. Removing hazard tracking opens a bunch of doos including using heaps efficiently, residency sets.

This is a draft because I'm not 100% sure it's right and I'd also like to do some benchmarking to see if it affects perf at all.

Basically we use MTL::Fence to put command buffers in order. We could of course try to do something more clever.. but so far I don't see any performance impact doing it the simple way suggesting we aren't getting much out of command buffers running in parallel.