### PR TITLE
Remove use of vector<const T>

### DIFF
--- a/mlx/backend/metal/custom_kernel.cpp
+++ b/mlx/backend/metal/custom_kernel.cpp
@@ -32,7 +32,7 @@ void CustomKernel::eval_gpu(
       return copies.back();
     }
   };
-  std::vector<const array> checked_inputs;
+  std::vector<array> checked_inputs;
   for (const array& in : inputs) {
     checked_inputs.push_back(check_input(in));
   }


### PR DESCRIPTION
## Proposed changes

LLVM/Clang upstream have stopped supporting `std::vector<const T>` as documented here https://reviews.llvm.org/D120996

This was not accepted by other compilers anyway, since vectors can't truly have const members. 
This PR makes MLX compatible with the change in the above link.

## Checklist

Put an `x` in the boxes that apply.

- [X] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [X] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
