### PR TITLE
C++20 compatibility for fmt

### DIFF
--- a/mlx/backend/metal/indexing.cpp
+++ b/mlx/backend/metal/indexing.cpp
@@ -262,7 +262,7 @@ void Scatter::eval_gpu(const std::vector<array>& inputs, array& out) {
         break;
     }
     if (reduce_type_ != Scatter::None) {
-      op_type = fmt::format(op_type, out_type_str);
+      op_type = fmt::format(fmt::runtime(op_type), out_type_str);
     }
     auto [idx_args, idx_arr] = make_index_args(idx_type_str, nidx);
 

--- a/mlx/backend/metal/jit_kernels.cpp
+++ b/mlx/backend/metal/jit_kernels.cpp
@@ -445,8 +445,9 @@ MTL::ComputePipelineState* get_steel_gemm_splitk_accum_kernel(
     kernel_source << metal::utils() << metal::gemm()
                   << metal::steel_gemm_splitk()
                   << fmt::format(
-                         axbpy ? steel_gemm_splitk_accum_axbpy_kernels
-                               : steel_gemm_splitk_accum_kernels,
+                         fmt::runtime(
+                             axbpy ? steel_gemm_splitk_accum_axbpy_kernels
+                                   : steel_gemm_splitk_accum_kernels),
                          "name"_a = lib_name,
                          "atype"_a = get_type_string(in.dtype()),
                          "otype"_a = get_type_string(out.dtype()));
@@ -481,7 +482,7 @@ MTL::ComputePipelineState* get_steel_gemm_masked_kernel(
     kernel_source << metal::utils() << metal::gemm()
                   << metal::steel_gemm_masked()
                   << fmt::format(
-                         steel_gemm_masked_kernels,
+                         fmt::runtime(steel_gemm_masked_kernels),
                          "name"_a = lib_name,
                          "itype"_a = get_type_string(out.dtype()),
                          "outmasktype"_a = out_mask_type,

--- a/mlx/backend/metal/jit_kernels.cpp
+++ b/mlx/backend/metal/jit_kernels.cpp
@@ -482,7 +482,7 @@ MTL::ComputePipelineState* get_steel_gemm_masked_kernel(
     kernel_source << metal::utils() << metal::gemm()
                   << metal::steel_gemm_masked()
                   << fmt::format(
-                         fmt::runtime(steel_gemm_masked_kernels),
+                         steel_gemm_masked_kernels,
                          "name"_a = lib_name,
                          "itype"_a = get_type_string(out.dtype()),
                          "outmasktype"_a = out_mask_type,

--- a/mlx/backend/metal/kernels.h
+++ b/mlx/backend/metal/kernels.h
@@ -210,9 +210,12 @@ get_template_definition(std::string name, std::string func, Args... args) {
   (add_arg(args), ...);
   s << ">";
   std::string base_string = R"(
-template [[host_name("{0}")]] [[kernel]] decltype({1}) {1};
+
   )";
-  return fmt::format(fmt::runtime(base_string), name, s.str());
+  return fmt::format(
+      "template [[host_name(\"{0}\")]] [[kernel]] decltype({1}) {1};",
+      name,
+      s.str());
 }
 
 } // namespace mlx::core

--- a/mlx/backend/metal/kernels.h
+++ b/mlx/backend/metal/kernels.h
@@ -210,7 +210,7 @@ get_template_definition(std::string name, std::string func, Args... args) {
   (add_arg(args), ...);
   s << ">";
   return fmt::format(
-      "template [[host_name(\"{0}\")]] [[kernel]] decltype({1}) {1};",
+      "\ntemplate [[host_name(\"{0}\")]] [[kernel]] decltype({1}) {1};\n",
       name,
       s.str());
 }

--- a/mlx/backend/metal/kernels.h
+++ b/mlx/backend/metal/kernels.h
@@ -209,9 +209,6 @@ get_template_definition(std::string name, std::string func, Args... args) {
   };
   (add_arg(args), ...);
   s << ">";
-  std::string base_string = R"(
-
-  )";
   return fmt::format(
       "template [[host_name(\"{0}\")]] [[kernel]] decltype({1}) {1};",
       name,

--- a/mlx/backend/metal/kernels.h
+++ b/mlx/backend/metal/kernels.h
@@ -212,7 +212,7 @@ get_template_definition(std::string name, std::string func, Args... args) {
   std::string base_string = R"(
 template [[host_name("{0}")]] [[kernel]] decltype({1}) {1};
   )";
-  return fmt::format(base_string, name, s.str());
+  return fmt::format(fmt::runtime(base_string), name, s.str());
 }
 
 } // namespace mlx::core


### PR DESCRIPTION
## Proposed changes

Before this change, if you try to compile MLX in C++20 mode, you will get errors along the lines of:

```
mlx/backend/metal/jit_kernels.cpp:459:26: error: call to consteval function 'fmt::basic_format_string<char, fmt::detail::statically_named_arg<const std::string &, char, 5, detail_exported::fixed_string<char, 5>{"name"}>, fmt::detail::statically_named_arg<std::string, char, 6, detail_exported::fixed_string<char, 6>{"atype"}>, fmt::detail::statically_named_arg<std::string, char, 6, detail_exported::fixed_string<char, 6>{"otype"}>>::basic_format_string<std::string_view, 0>' is not a constant expression
```

The solution is proposed here: https://github.com/fmtlib/fmt/issues/2438.

With these changes, code builds in C++20 mode.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
