### PR TITLE
Fix typo in build docs

### DIFF
--- a/docs/src/install.rst
+++ b/docs/src/install.rst
@@ -240,7 +240,7 @@ x86 Shell
 
 .. _build shell:
 
-If the ouptut of ``uname -p``  is ``x86`` then your shell is running as x86 via
+If the output of ``uname -p``  is ``x86`` then your shell is running as x86 via
 Rosetta instead of natively.
 
 To fix this, find the application in Finder (``/Applications`` for iTerm,

--- a/docs/src/install.rst
+++ b/docs/src/install.rst
@@ -264,4 +264,4 @@ Also check that cmake is using the correct architecture:
 
 If you see ``"x86_64"``, try re-installing ``cmake``. If you see ``"arm64"``
 but the build errors out with "Building for x86_64 on macOS is not supported."
-wipe your build cahce with ``rm -rf build/`` and try again.
+wipe your build cache with ``rm -rf build/`` and try again.


### PR DESCRIPTION
fix typos: cahce -> cache, ouptut -> output

## Proposed changes

Please include a description of the problem or feature this PR is addressing. If there is a corresponding issue, include the issue #.

## Checklist

Put an `x` in the boxes that apply.

- [X] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [O] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [O] I have added tests that prove my fix is effective or that my feature works
- [X] I have updated the necessary documentation (if needed)
