### PR TITLE
BFS graph evaluation order

### DIFF
--- a/mlx/transforms.cpp
+++ b/mlx/transforms.cpp
@@ -40,7 +40,7 @@ int detail::InTracing::tracing_counter{0};
 int detail::RetainGraph::tracing_counter{0};
 
 array eval_impl(std::vector<array> outputs, bool async) {
-  std::queue<array> tape;
+  std::vector<array> tape;
 
   // stream events to use for synchronization
   std::unordered_map<uint32_t, Event> events;
@@ -64,7 +64,9 @@ array eval_impl(std::vector<array> outputs, bool async) {
   events.emplace(stream.index, Event{stream});
 
   {
-    std::unordered_set<std::uintptr_t> cache;
+    // Record the degree of each input
+    std::unordered_map<std::uintptr_t, int> cache;
+
     std::stack<std::pair<std::reference_wrapper<array>, int>> dfs;
     dfs.emplace(synchronizer, 0);
     while (!dfs.empty()) {
@@ -104,23 +106,27 @@ array eval_impl(std::vector<array> outputs, bool async) {
           }
         }
 
-        if (cache.find(in.id()) == cache.end()) {
+        // All siblings have the same degree
+        auto cache_it = cache.find(in.id());
+        if (cache_it == cache.end()) {
           dfs.emplace(in, 0);
-          cache.insert(in.id());
+          cache.insert({in.id(), 1});
           for (auto& s : in.siblings()) {
-            cache.insert(s.id());
+            cache.insert({s.id(), 1});
+          }
+        } else {
+          cache_it->second++;
+          for (auto& s : in.siblings()) {
+            cache[s.id()]++;
           }
         }
         continue;
       }
-
-      // All inputs are done being processed, process this array
       if ((a.status() != array::Status::unscheduled) && !a.is_tracer() &&
           a.has_primitive()) {
         // If the array is evaluated and is no longer a tracer, detach it
         a.detach();
       } else if (a.status() == array::Status::unscheduled) {
-        tape.push(a);
         // Lookup corresponding event and increment counter
         auto& stream = a.primitive().stream();
         auto e = events.find(stream.index);
@@ -135,11 +141,39 @@ array eval_impl(std::vector<array> outputs, bool async) {
       }
       dfs.pop();
     }
+
+    // Build the tape in BFS order
+    tape.push_back(synchronizer);
+    for (int i = 0; !cache.empty() && i < tape.size(); ++i) {
+      auto& a = tape[i];
+      for (auto& in : a.inputs()) {
+        if (in.status() != array::Status::unscheduled) {
+          continue;
+        }
+        auto it = cache.find(in.id());
+        it->second -= 1;
+
+        if (it->second != 0) {
+          for (auto& s : in.siblings()) {
+            cache[s.id()] -= 1;
+          }
+          continue;
+        }
+
+        // Remove input and siblings from cache
+        cache.erase(it);
+        for (auto& s : in.siblings()) {
+          cache.erase(s.id());
+        }
+
+        tape.push_back(in);
+      }
+    }
   }
 
   while (!tape.empty()) {
-    auto arr = std::move(tape.front());
-    tape.pop();
+    auto arr = std::move(tape.back());
+    tape.pop_back();
 
     // Set the status of the array and siblings.
     arr.set_status(array::Status::scheduled);


### PR DESCRIPTION
This is a draft implementation of changing the graph evaluation order from DFS to BFS. So far results are promising, more benchmarks forth-coming.

There might be a faster/simpler way to do the traversal, this also needs some scrutiny.


### Benchmarks:

On M2 Ultra

Benchmark | DFS  | BFS 
----- | ---- | ----
Simple matmul + unary | 1.725 ms | 1.023 ms
Mistral 7B 4-bit, 512 tokens | 113.0  toks/sec | 120.5 toks/sec
Transformer train 153 M |   5.9 its/sec | 6.22 its/sec
MNIST | 0.608 seconds | 0.565 seconds
LeNet | 7.241 seconds | 5.212 seconds
ResNet 22 Training CIFAR | 1021.85 samples/second | 1175.79 samples/second

Memory Use

Benchmark | DFS | BFS
---- | --- | -----
Mistral 7B 4-bit, 512 tokens | 3.900 GB	| 3.900 GB
Transformer train 153 M	| 5.534 GB | 5.480 GB
ResNet 22 Training CIFAR |1.643 GB |	2.264 GB

Simple benchmark code:

```python
a = mx.random.uniform(shape=(256, 256))
b = mx.random.uniform(shape=(256, 256))

def fun():
    outs = []
    for _ in range(100):
        x = a @ b
        x = mx.abs(x)
        outs.append(x)
    return outs
```