### PR TITLE
Faster bits and bernoulli

### DIFF
--- a/mlx/backend/metal/kernels/random.metal
+++ b/mlx/backend/metal/kernels/random.metal
@@ -34,8 +34,8 @@ rbits threefry2x32_hash(const thread uint2& key, uint2 count) {
 [[kernel]] void rbitsc(
     device const uint32_t* keys,
     device char* out,
-    device const bool& odd,
-    device const uint& bytes_per_key,
+    constant const bool& odd,
+    constant const uint& bytes_per_key,
     uint2 grid_dim [[threads_per_grid]],
     uint2 index [[thread_position_in_grid]]) {
   auto kidx = 2 * index.x;
@@ -67,8 +67,8 @@ rbits threefry2x32_hash(const thread uint2& key, uint2 count) {
 [[kernel]] void rbits(
     device const uint32_t* keys,
     device char* out,
-    device const bool& odd,
-    device const uint& bytes_per_key,
+    constant const bool& odd,
+    constant const uint& bytes_per_key,
     constant const int& ndim,
     constant const int* key_shape,
     constant const size_t* key_strides,

--- a/mlx/backend/metal/primitives.cpp
+++ b/mlx/backend/metal/primitives.cpp
@@ -273,7 +273,7 @@ void RandomBits::eval_gpu(const std::vector<array>& inputs, array& out) {
   // organize into grid nkeys x elem_per_key
   MTL::Size grid_dims = MTL::Size(num_keys, half_size + odd, 1);
   NS::UInteger thread_group_size = kernel->maxTotalThreadsPerThreadgroup();
-  MTL::Size group_dims = MTL::Size(thread_group_size, 1, 1);
+  MTL::Size group_dims = MTL::Size(1, thread_group_size, 1);
   auto& compute_encoder = d.get_command_encoder(s.index);
   compute_encoder->setComputePipelineState(kernel);
   compute_encoder.set_input_array(keys, 0);

--- a/mlx/random.cpp
+++ b/mlx/random.cpp
@@ -290,8 +290,14 @@ array bernoulli(
     throw std::invalid_argument(
         "[bernoulli] bernoulli probability `p` must be a float type.");
   }
-  auto res = uniform(shape, p.dtype(), key, s);
-  res = less(res, p, s);
+
+  // Place p on the scale [0, UINT32_MAX]
+  auto p_uint = astype(
+      multiply(p, array(std::numeric_limits<uint32_t>::max(), float32), s),
+      uint32,
+      s);
+  auto res = bits(shape, key, s);
+  res = less(res, p_uint, s);
   if (res.shape() != shape) {
     throw std::invalid_argument(
         "[bernoulli] shape of `p` is incompatible with argument `shape`.");

--- a/mlx/random.cpp
+++ b/mlx/random.cpp
@@ -291,13 +291,14 @@ array bernoulli(
         "[bernoulli] bernoulli probability `p` must be a float type.");
   }
 
-  // Place p on the scale [0, UINT32_MAX]
-  auto p_uint = astype(
-      multiply(p, array(std::numeric_limits<uint32_t>::max(), float32), s),
-      uint32,
-      s);
-  auto res = bits(shape, key, s);
-  res = less(res, p_uint, s);
+  // Place p on the scale [0, nexthigher(UINT32_MAX)] so that if p >= 1.0 we
+  // get all true and if p <= 0.0 we get all false
+  auto upper = array(
+      std::nextafter(
+          static_cast<float>(std::numeric_limits<uint32_t>::max()),
+          std::numeric_limits<float>::max()),
+      float32);
+  auto res = less(bits(shape, key, s), multiply(p, upper, s), s);
   if (res.shape() != shape) {
     throw std::invalid_argument(
         "[bernoulli] shape of `p` is incompatible with argument `shape`.");


### PR DESCRIPTION
- Better grid dim for much faster bits
- Use bits directly for bernoulli

On M1 Max

Benchmark | Pre (ms) | Post (ms)
--- | ---- | ----
Uniform | 21.283 | 4.320 
Bernoulli | 21.791 |  1.911

Statistical test for Bernoulli

P | Pre `abs(p-phat)` | Post `abs(p-phat)
--- | ----- | ----
0.010| 0.0000270 | 0.0000191
0.500| 0.0000430 | 0.0000903
0.990| 0.0000566 | 0.0000239


Code for benchmarks + test:

```python
shape = (32_000_000,)

timeit(lambda : mx.random.uniform(shape=shape))

timeit(lambda : mx.random.bernoulli(0.1, shape))

n = 10_000_000

for p in [0.01, 0.5, 0.99]:
    b = mx.random.bernoulli(p, shape=(n,))
    phat = b.sum() / n
    diff = abs(p - phat)
    print(f"P={p:.3f}, diff = {diff:.7f}")
```