### PR TITLE
Skip using Residency sets in VMs

### DIFF
--- a/mlx/backend/metal/resident.cpp
+++ b/mlx/backend/metal/resident.cpp
@@ -1,33 +1,14 @@
 // Copyright © 2024 Apple Inc.
 
-#include <sys/sysctl.h>
-#include <cstddef>
-
 #include "mlx/backend/metal/resident.h"
 #include "mlx/backend/metal/metal_impl.h"
 
 namespace mlx::core::metal {
 
-// TODO maybe worth including tvos / visionos
-#define supported __builtin_available(macOS 15, iOS 18, *)
-
-// Trying to create a residency set in a VM leads to errors.
-static bool in_vm() {
-  auto check_vm = []() {
-    int hv_vmm_present = 0;
-
-    std::size_t len = sizeof(hv_vmm_present);
-    sysctlbyname("kern.hv_vmm_present", &hv_vmm_present, &len, NULL, 0);
-
-    return hv_vmm_present;
-  };
-
-  static int in_vm = check_vm();
-  return in_vm;
-}
-
 ResidencySet::ResidencySet(MTL::Device* d) {
-  if (supported && !in_vm()) {
+  if (!d->supportsFamily(MTL::GPUFamilyMetal3)) {
+    return;
+  } else if (__builtin_available(macOS 15, iOS 18, *)) {
     auto pool = new_scoped_memory_pool();
     auto desc = MTL::ResidencySetDescriptor::alloc()->init();
     NS::Error* error;
@@ -45,68 +26,72 @@ ResidencySet::ResidencySet(MTL::Device* d) {
 }
 
 void ResidencySet::insert(MTL::Allocation* buf) {
-  if (supported && !in_vm()) {
-    if (wired_set_->allocatedSize() + buf->allocatedSize() <= capacity_) {
-      wired_set_->addAllocation(buf);
-      wired_set_->commit();
-      wired_set_->requestResidency();
-    } else {
-      unwired_set_.insert(buf);
-    }
+  if (!wired_set_) {
+    return;
+  }
+  if (wired_set_->allocatedSize() + buf->allocatedSize() <= capacity_) {
+    wired_set_->addAllocation(buf);
+    wired_set_->commit();
+    wired_set_->requestResidency();
+  } else {
+    unwired_set_.insert(buf);
   }
 }
 
 void ResidencySet::erase(MTL::Allocation* buf) {
-  if (supported && !in_vm()) {
-    if (auto it = unwired_set_.find(buf); it != unwired_set_.end()) {
-      unwired_set_.erase(it);
-    } else {
-      wired_set_->removeAllocation(buf);
-      wired_set_->commit();
-    }
+  if (!wired_set_) {
+    return;
+  }
+  if (auto it = unwired_set_.find(buf); it != unwired_set_.end()) {
+    unwired_set_.erase(it);
+  } else {
+    wired_set_->removeAllocation(buf);
+    wired_set_->commit();
   }
 }
 
 void ResidencySet::resize(size_t size) {
-  if (supported && !in_vm()) {
-    if (capacity_ == size) {
-      return;
-    }
-    capacity_ = size;
+  if (!wired_set_) {
+    return;
+  }
 
-    size_t current_size = wired_set_->allocatedSize();
+  if (capacity_ == size) {
+    return;
+  }
+  capacity_ = size;
 
-    if (current_size < size) {
-      // Add unwired allocations to the set
-      for (auto it = unwired_set_.begin(); it != unwired_set_.end();) {
-        auto buf_size = (*it)->allocatedSize();
-        if (current_size + buf_size > size) {
-          it++;
-        } else {
-          current_size += buf_size;
-          wired_set_->addAllocation(*it);
-          unwired_set_.erase(it++);
-        }
+  size_t current_size = wired_set_->allocatedSize();
+
+  if (current_size < size) {
+    // Add unwired allocations to the set
+    for (auto it = unwired_set_.begin(); it != unwired_set_.end();) {
+      auto buf_size = (*it)->allocatedSize();
+      if (current_size + buf_size > size) {
+        it++;
+      } else {
+        current_size += buf_size;
+        wired_set_->addAllocation(*it);
+        unwired_set_.erase(it++);
       }
-      wired_set_->commit();
-      wired_set_->requestResidency();
-    } else if (current_size > size) {
-      // Remove wired allocations until under capacity
-      auto allocations = wired_set_->allAllocations();
-      auto num_allocations = wired_set_->allocationCount();
-      for (int i = 0; i < num_allocations && current_size > size; ++i) {
-        auto buf = static_cast<const MTL::Allocation*>(allocations->object(i));
-        wired_set_->removeAllocation(buf);
-        current_size -= buf->allocatedSize();
-        unwired_set_.insert(buf);
-      }
-      wired_set_->commit();
     }
+    wired_set_->commit();
+    wired_set_->requestResidency();
+  } else if (current_size > size) {
+    // Remove wired allocations until under capacity
+    auto allocations = wired_set_->allAllocations();
+    auto num_allocations = wired_set_->allocationCount();
+    for (int i = 0; i < num_allocations && current_size > size; ++i) {
+      auto buf = static_cast<const MTL::Allocation*>(allocations->object(i));
+      wired_set_->removeAllocation(buf);
+      current_size -= buf->allocatedSize();
+      unwired_set_.insert(buf);
+    }
+    wired_set_->commit();
   }
 }
 
 ResidencySet::~ResidencySet() {
-  if (supported && !in_vm()) {
+  if (wired_set_) {
     wired_set_->release();
   }
 }


### PR DESCRIPTION
## Proposed changes

Attempting to use residency sets in a VM throws[^1]

    libc++abi: terminating due to uncaught exception of type std::runtime_error: [metal::Device] Unable to construct residency set.

Not quite sure if this is the best fix, but it does make the error go
away.

Note that it was previously possible to run simple programs that used
mlx in a VM prior to 0eb56d5be02a826b13519a1418e345150f5e9526. See
related discussion at Homebrew/homebrew-core#195627.

[^1]: https://github.com/Homebrew/homebrew-core/actions/runs/11525831492/job/32105148462#step:3:56

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)

I didn't run `pre-commit`, but it did run `clang-format` on the single file I changed. It reordered some existing includes, which didn't seem correct to me so I dropped that change. I can commit it again if desired.
