### PR TITLE
Fix thread group for large arrays

### DIFF
--- a/mlx/backend/metal/binary.cpp
+++ b/mlx/backend/metal/binary.cpp
@@ -110,6 +110,7 @@ void binary_op_gpu_inplace(
     compute_encoder.set_output_array(outputs[1], arg_idx++);
   }
 
+  auto thread_group_size = kernel->maxTotalThreadsPerThreadgroup();
   if (bopt == BinaryOpType::General) {
     // Launch up to 3D grid of threads
     size_t dim0 = ndim > 0 ? shape[ndim - 1] : 1;
@@ -132,7 +133,6 @@ void binary_op_gpu_inplace(
           strides_b.data(), ndim * sizeof(size_t), arg_idx++);
     }
 
-    NS::UInteger thread_group_size = kernel->maxTotalThreadsPerThreadgroup();
     if (thread_group_size != 1024) {
       throw std::runtime_error("[Metal::binary] Must use 1024 sized block");
     }
@@ -142,13 +142,19 @@ void binary_op_gpu_inplace(
   } else {
     // Launch a 1D or 2D grid of threads
     size_t nthreads = out.data_size();
-    MTL::Size grid_dims = use_2d ? get_2d_grid_dims(out.shape(), out.strides())
-                                 : MTL::Size(nthreads, 1, 1);
-    NS::UInteger thread_group_size = kernel->maxTotalThreadsPerThreadgroup();
     if (thread_group_size > nthreads) {
       thread_group_size = nthreads;
     }
+    MTL::Size grid_dims;
     MTL::Size group_dims = MTL::Size(thread_group_size, 1, 1);
+    if (use_2d) {
+      grid_dims = get_2d_grid_dims(out.shape(), out.strides());
+      if (grid_dims.width < thread_group_size) {
+        std::swap(group_dims.width, group_dims.height);
+      }
+    } else {
+      grid_dims = MTL::Size(nthreads, 1, 1);
+    }
     compute_encoder.dispatchThreads(grid_dims, group_dims);
   }
 }

--- a/mlx/backend/metal/binary.cpp
+++ b/mlx/backend/metal/binary.cpp
@@ -1,5 +1,4 @@
 // Copyright © 2024 Apple Inc.
-
 #include "mlx/backend/common/binary.h"
 #include "mlx/backend/metal/device.h"
 #include "mlx/backend/metal/kernels.h"
@@ -145,16 +144,9 @@ void binary_op_gpu_inplace(
     if (thread_group_size > nthreads) {
       thread_group_size = nthreads;
     }
-    MTL::Size grid_dims;
     MTL::Size group_dims = MTL::Size(thread_group_size, 1, 1);
-    if (use_2d) {
-      grid_dims = get_2d_grid_dims(out.shape(), out.strides());
-      if (grid_dims.width < thread_group_size) {
-        std::swap(group_dims.width, group_dims.height);
-      }
-    } else {
-      grid_dims = MTL::Size(nthreads, 1, 1);
-    }
+    MTL::Size grid_dims = use_2d ? get_2d_grid_dims(out.shape(), out.strides())
+                                 : MTL::Size(nthreads, 1, 1);
     compute_encoder.dispatchThreads(grid_dims, group_dims);
   }
 }

--- a/mlx/backend/metal/compiled.cpp
+++ b/mlx/backend/metal/compiled.cpp
@@ -423,15 +423,10 @@ void Compiled::eval_gpu(
     size_t nthreads = outputs[0].data_size();
     MTL::Size group_dims(
         std::min(nthreads, kernel->maxTotalThreadsPerThreadgroup()), 1, 1);
-    MTL::Size grid_dims;
-    if (use_2d) {
-      grid_dims = get_2d_grid_dims(outputs[0].shape(), outputs[0].strides());
-      if (grid_dims.width < group_dims.width) {
-        std::swap(group_dims.width, group_dims.height);
-      }
-    } else {
-      grid_dims = MTL::Size(nthreads, 1, 1);
-    }
+
+    MTL::Size grid_dims = use_2d
+        ? get_2d_grid_dims(outputs[0].shape(), outputs[0].strides())
+        : MTL::Size(nthreads, 1, 1);
     compute_encoder.dispatchThreads(grid_dims, group_dims);
   } else {
     size_t dim0 = ndim > 0 ? shape[ndim - 1] : 1;

--- a/mlx/backend/metal/compiled.cpp
+++ b/mlx/backend/metal/compiled.cpp
@@ -421,11 +421,17 @@ void Compiled::eval_gpu(
   // Launch the kernel
   if (contiguous) {
     size_t nthreads = outputs[0].data_size();
-    MTL::Size grid_dims = use_2d
-        ? get_2d_grid_dims(outputs[0].shape(), outputs[0].strides())
-        : MTL::Size(nthreads, 1, 1);
     MTL::Size group_dims(
         std::min(nthreads, kernel->maxTotalThreadsPerThreadgroup()), 1, 1);
+    MTL::Size grid_dims;
+    if (use_2d) {
+      grid_dims = get_2d_grid_dims(outputs[0].shape(), outputs[0].strides());
+      if (grid_dims.width < group_dims.width) {
+        std::swap(group_dims.width, group_dims.height);
+      }
+    } else {
+      grid_dims = MTL::Size(nthreads, 1, 1);
+    }
     compute_encoder.dispatchThreads(grid_dims, group_dims);
   } else {
     size_t dim0 = ndim > 0 ? shape[ndim - 1] : 1;

--- a/mlx/backend/metal/copy.cpp
+++ b/mlx/backend/metal/copy.cpp
@@ -209,16 +209,9 @@ void fill_gpu(const array& val, array& out, const Stream& s) {
   if (thread_group_size > nthreads) {
     thread_group_size = nthreads;
   }
-  MTL::Size grid_dims;
   MTL::Size group_dims = MTL::Size(thread_group_size, 1, 1);
-  if (use_2d) {
-    grid_dims = get_2d_grid_dims(out.shape(), out.strides());
-    if (grid_dims.width < thread_group_size) {
-      std::swap(group_dims.width, group_dims.height);
-    }
-  } else {
-    grid_dims = MTL::Size(nthreads, 1, 1);
-  }
+  MTL::Size grid_dims = use_2d ? get_2d_grid_dims(out.shape(), out.strides())
+                               : MTL::Size(nthreads, 1, 1);
   compute_encoder.dispatchThreads(grid_dims, group_dims);
 }
 

--- a/mlx/backend/metal/copy.cpp
+++ b/mlx/backend/metal/copy.cpp
@@ -158,16 +158,9 @@ void copy_gpu_inplace(
     if (thread_group_size > nthreads) {
       thread_group_size = nthreads;
     }
-    MTL::Size grid_dims;
     MTL::Size group_dims = MTL::Size(thread_group_size, 1, 1);
-    if (use_2d) {
-      grid_dims = get_2d_grid_dims(out.shape(), out.strides());
-      if (grid_dims.width < thread_group_size) {
-        std::swap(group_dims.width, group_dims.height);
-      }
-    } else {
-      grid_dims = MTL::Size(nthreads, 1, 1);
-    }
+    MTL::Size grid_dims = use_2d ? get_2d_grid_dims(out.shape(), out.strides())
+                                 : MTL::Size(nthreads, 1, 1);
     compute_encoder.dispatchThreads(grid_dims, group_dims);
   }
 }

--- a/mlx/backend/metal/copy.cpp
+++ b/mlx/backend/metal/copy.cpp
@@ -120,6 +120,7 @@ void copy_gpu_inplace(
   compute_encoder.set_input_array(donate_in ? out : in, 0, inp_offset);
   compute_encoder.set_output_array(out, 1, out_offset);
 
+  auto thread_group_size = kernel->maxTotalThreadsPerThreadgroup();
   if (ctype == CopyType::General || ctype == CopyType::GeneralGeneral) {
     std::vector<int64_t> strides_in{strides_in_.begin(), strides_in_.end()};
     std::vector<int64_t> strides_out{strides_out_.begin(), strides_out_.end()};
@@ -145,7 +146,6 @@ void copy_gpu_inplace(
     }
 
     // NB assuming thread_group_size is a power of 2 larger than 32 x 32
-    NS::UInteger thread_group_size = kernel->maxTotalThreadsPerThreadgroup();
     if (thread_group_size != 1024) {
       throw std::runtime_error("[Metal::copy] Must use 1024 sized block");
     }
@@ -155,13 +155,19 @@ void copy_gpu_inplace(
     compute_encoder.dispatchThreads(grid_dims, group_dims);
   } else {
     size_t nthreads = out.data_size();
-    MTL::Size grid_dims = use_2d ? get_2d_grid_dims(out.shape(), out.strides())
-                                 : MTL::Size(nthreads, 1, 1);
-    NS::UInteger thread_group_size = kernel->maxTotalThreadsPerThreadgroup();
     if (thread_group_size > nthreads) {
       thread_group_size = nthreads;
     }
+    MTL::Size grid_dims;
     MTL::Size group_dims = MTL::Size(thread_group_size, 1, 1);
+    if (use_2d) {
+      grid_dims = get_2d_grid_dims(out.shape(), out.strides());
+      if (grid_dims.width < thread_group_size) {
+        std::swap(group_dims.width, group_dims.height);
+      }
+    } else {
+      grid_dims = MTL::Size(nthreads, 1, 1);
+    }
     compute_encoder.dispatchThreads(grid_dims, group_dims);
   }
 }
@@ -205,14 +211,21 @@ void fill_gpu(const array& val, array& out, const Stream& s) {
   compute_encoder.set_input_array(val, 0);
   compute_encoder.set_output_array(out, 1);
 
+  auto thread_group_size = kernel->maxTotalThreadsPerThreadgroup();
   size_t nthreads = out.data_size();
-  MTL::Size grid_dims = use_2d ? get_2d_grid_dims(out.shape(), out.strides())
-                               : MTL::Size(nthreads, 1, 1);
-  NS::UInteger thread_group_size = kernel->maxTotalThreadsPerThreadgroup();
   if (thread_group_size > nthreads) {
     thread_group_size = nthreads;
   }
+  MTL::Size grid_dims;
   MTL::Size group_dims = MTL::Size(thread_group_size, 1, 1);
+  if (use_2d) {
+    grid_dims = get_2d_grid_dims(out.shape(), out.strides());
+    if (grid_dims.width < thread_group_size) {
+      std::swap(group_dims.width, group_dims.height);
+    }
+  } else {
+    grid_dims = MTL::Size(nthreads, 1, 1);
+  }
   compute_encoder.dispatchThreads(grid_dims, group_dims);
 }
 

--- a/mlx/backend/metal/ternary.cpp
+++ b/mlx/backend/metal/ternary.cpp
@@ -106,16 +106,9 @@ void ternary_op_gpu_inplace(
     if (thread_group_size > nthreads) {
       thread_group_size = nthreads;
     }
-    MTL::Size grid_dims;
     MTL::Size group_dims = MTL::Size(thread_group_size, 1, 1);
-    if (use_2d) {
-      grid_dims = get_2d_grid_dims(out.shape(), out.strides());
-      if (grid_dims.width < thread_group_size) {
-        std::swap(group_dims.width, group_dims.height);
-      }
-    } else {
-      grid_dims = MTL::Size(nthreads, 1, 1);
-    }
+    MTL::Size grid_dims = use_2d ? get_2d_grid_dims(out.shape(), out.strides())
+                                 : MTL::Size(nthreads, 1, 1);
     compute_encoder.dispatchThreads(grid_dims, group_dims);
   }
 }

--- a/mlx/backend/metal/ternary.cpp
+++ b/mlx/backend/metal/ternary.cpp
@@ -72,6 +72,7 @@ void ternary_op_gpu_inplace(
   compute_encoder.set_input_array(donate_c ? out : c, 2);
   compute_encoder.set_output_array(out, 3);
 
+  auto thread_group_size = kernel->maxTotalThreadsPerThreadgroup();
   if (topt == TernaryOpType::General) {
     // Launch up to 3D grid of threads
     size_t dim0 = ndim > 0 ? shape[ndim - 1] : 1;
@@ -93,7 +94,6 @@ void ternary_op_gpu_inplace(
       compute_encoder->setBytes(strides_c.data(), ndim * sizeof(size_t), 6);
     }
 
-    NS::UInteger thread_group_size = kernel->maxTotalThreadsPerThreadgroup();
     if (thread_group_size != 1024) {
       throw std::runtime_error("[Metal::ternary] Must use 1024 sized block");
     }
@@ -103,13 +103,19 @@ void ternary_op_gpu_inplace(
   } else {
     // Launch a 1D or 2D grid of threads
     size_t nthreads = out.data_size();
-    MTL::Size grid_dims = use_2d ? get_2d_grid_dims(out.shape(), out.strides())
-                                 : MTL::Size(nthreads, 1, 1);
-    NS::UInteger thread_group_size = kernel->maxTotalThreadsPerThreadgroup();
     if (thread_group_size > nthreads) {
       thread_group_size = nthreads;
     }
+    MTL::Size grid_dims;
     MTL::Size group_dims = MTL::Size(thread_group_size, 1, 1);
+    if (use_2d) {
+      grid_dims = get_2d_grid_dims(out.shape(), out.strides());
+      if (grid_dims.width < thread_group_size) {
+        std::swap(group_dims.width, group_dims.height);
+      }
+    } else {
+      grid_dims = MTL::Size(nthreads, 1, 1);
+    }
     compute_encoder.dispatchThreads(grid_dims, group_dims);
   }
 }

--- a/mlx/backend/metal/unary.cpp
+++ b/mlx/backend/metal/unary.cpp
@@ -72,16 +72,9 @@ void unary_op_gpu_inplace(
     if (thread_group_size > nthreads) {
       thread_group_size = nthreads;
     }
-    MTL::Size grid_dims;
     MTL::Size group_dims = MTL::Size(thread_group_size, 1, 1);
-    if (use_2d) {
-      grid_dims = get_2d_grid_dims(in.shape(), in.strides());
-      if (grid_dims.width < thread_group_size) {
-        std::swap(group_dims.width, group_dims.height);
-      }
-    } else {
-      grid_dims = MTL::Size(nthreads, 1, 1);
-    }
+    MTL::Size grid_dims = use_2d ? get_2d_grid_dims(out.shape(), out.strides())
+                                 : MTL::Size(nthreads, 1, 1);
     compute_encoder.dispatchThreads(grid_dims, group_dims);
   }
 }

--- a/mlx/backend/metal/utils.cpp
+++ b/mlx/backend/metal/utils.cpp
@@ -103,6 +103,9 @@ MTL::Size get_2d_grid_dims(
   if (grid_y > UINT32_MAX || grid_x > UINT32_MAX) {
     throw std::runtime_error("Unable to safely factor shape.");
   }
+  if (grid_y > grid_x) {
+    std::swap(grid_x, grid_y);
+  }
   return MTL::Size(
       static_cast<uint32_t>(grid_x), static_cast<uint32_t>(grid_y), 1);
 }
@@ -144,6 +147,9 @@ MTL::Size get_2d_grid_dims(
   }
   if (grid_y > UINT32_MAX || grid_x > UINT32_MAX || divisor > 1) {
     throw std::runtime_error("Unable to safely factor shape.");
+  }
+  if (grid_y > grid_x) {
+    std::swap(grid_x, grid_y);
   }
   return MTL::Size(
       static_cast<uint32_t>(grid_x), static_cast<uint32_t>(grid_y), 1);


### PR DESCRIPTION
FYI this is an important cliff to be aware of. The following example grid/group dimension is a performance bug:

```python
grid=(10_000_000, 1, 1),
threadgroup=(1, 1024, 1),
```

Bench | Pre | Post
---- | ---- | ----
Unary | 1978.538 (ms) | 43.691 (ms)
Binary | 1979.676 (ms) | 50.079 (ms)
Copy | 1923.015 (ms) | 44.385 (ms)
Compiled |1977.468 (ms) | 43.802 (ms)


Benchmark code:

```python
def big_unary():
    x = mx.zeros((3, 2**31 - 1), mx.int8)
    timeit(mx.abs, x, num_iter=5)

def big_binary():
    x = mx.zeros((3, 2**31 - 1), mx.int8)
    timeit(mx.add, x, x, num_iter=5)

def big_copy():
    x = mx.zeros((3, 2**31 - 1), mx.int8)
    timeit(lambda x: x.astype(mx.uint8), x, num_iter=5)

def big_compiled():
    x = mx.zeros((3, 2**31 - 1), mx.int8)

    @mx.compile
    def fun(x):
        return mx.abs(-x)

    timeit(fun, x, num_iter=5)
```