### PR TITLE
Add favicon to docs

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -62,7 +62,6 @@ html_theme_options = {
 
 html_favicon=html_theme_options["logo"]["image_light"]
 
-
 # -- Options for HTMLHelp output ---------------------------------------------
 
 htmlhelp_basename = "mlx_doc"

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -60,7 +60,7 @@ html_theme_options = {
     },
 }
 
-html_favicon=html_theme_options["logo"]["image_light"]
+html_favicon = html_theme_options["logo"]["image_light"]
 
 # -- Options for HTMLHelp output ---------------------------------------------
 

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -60,6 +60,8 @@ html_theme_options = {
     },
 }
 
+html_favicon=html_theme_options["logo"]["image_light"]
+
 
 # -- Options for HTMLHelp output ---------------------------------------------
 


### PR DESCRIPTION
## Proposed changes

Use sphinx's "html_favicon" config option to make it generate a link tag with rel="icon" for google's bots to correctly get the docs icon.

Fixes #1544 

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
