### PR TITLE
Fix inconsistent example in "Automatic Vectorization" docs

### DIFF
--- a/docs/src/usage/function_transforms.rst
+++ b/docs/src/usage/function_transforms.rst
@@ -161,7 +161,7 @@ A naive way to add the elements from two sets of vectors is with a loop:
   ys = mx.random.uniform(shape=(100, 4096))
 
   def naive_add(xs, ys):
-      return [xs[i] + ys[:, i] for i in range(xs.shape[1])]
+      return [xs[i] + ys[:, i] for i in range(xs.shape[0])]
 
 Instead you can use :func:`vmap` to automatically vectorize the addition:
 
@@ -169,7 +169,7 @@ Instead you can use :func:`vmap` to automatically vectorize the addition:
 
    # Vectorize over the second dimension of x and the
    # first dimension of y
-   vmap_add = mx.vmap(lambda x, y: x + y, in_axes=(1, 0))
+   vmap_add = mx.vmap(lambda x, y: x + y, in_axes=(0, 1))
 
 The ``in_axes`` parameter can be used to specify which dimensions of the
 corresponding input to vectorize over. Similarly, use ``out_axes`` to specify

--- a/docs/src/usage/indexing.rst
+++ b/docs/src/usage/indexing.rst
@@ -77,7 +77,7 @@ from the GPU. Performing bounds checking for array indices before launching the
 kernel would be extremely inefficient.
 
 Indexing with boolean masks is something that MLX may support in the future. In
-general, MLX has limited support for operations for which outputs
+general, MLX has limited support for operations for which output
 *shapes* are dependent on input *data*. Other examples of these types of
 operations which MLX does not yet support include :func:`numpy.nonzero` and the
 single input version of :func:`numpy.where`.


### PR DESCRIPTION
## Proposed changes

The axes over which the following examples in the documentation iterate strike me as strange:
> ```python
> xs = mx.random.uniform(shape=(4096, 100))
> ys = mx.random.uniform(shape=(100, 4096))
> 
> def naive_add(xs, ys):
>     return [xs[i] + ys[:, i] for i in range(xs.shape[1])]
> ```
> Instead you can use `vmap` to automatically vectorize the addition:
> ```python
> # Vectorize over the second dimension of x and the
> # first dimension of y
>  vmap_add = mx.vmap(lambda x, y: x + y, in_axes=(1, 0))
> ```

The issue is as follows:
- `xs` has 4096 rows and 100 columns.
- `ys` has 100 rows and 4096 columns.
- `naive_add` iterates over `range(xs.shape[1])`, which is 100
- Therefore, `naive_add` only adds the first 100 rows of `xs` to the first 100 columns of `ys` and **ignores** the remaining 3996 rows and columns, respectively.
- The result is a list of 100 arrays with 100 entries each, i.e. equivalent to a `(100, 100)` array.
- I think the intention was to add **each** row of `xs` to its corresponding column in `ys`, producing (the list equivalent of) a `(4096, 100)` array.
- That's why `naive_add` should iterate over `range(xs.shape[0])` instead.
- Also, the existing definition of `vmap_add`, with `in_axes=(1, 0)` is currently not functionally equivalent to that of `naive_add`, since `vmap_add(xs, ys).shape == (100, 4096)`.
- Therefore, `vmap_add` should use `in_axes=(0, 1)` instead.

Maybe `naive_add` should also wrap the list comprehension in an `mx.array` call in order to be functionally equivalent to `vmap_add`, but I have not done this. I also corrected a minor typo in the docs elsewhere.

---

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
