### PR TITLE
No extra reshape

### DIFF
--- a/python/src/indexing.cpp
+++ b/python/src/indexing.cpp
@@ -803,9 +803,9 @@ auto mlx_slice_update(
   // Pre process tuple
   auto upd = to_array(v, src.dtype());
 
-  // Remove leading singletons dimensions from the update
+  // Remove extra leading singletons dimensions from the update
   int s = 0;
-  for (; s < upd.ndim() && upd.shape(s) == 1; s++) {
+  for (; s < upd.ndim() && upd.shape(s) == 1 && (upd.ndim() - s) > src.ndim(); s++) {
   };
   auto up_shape = std::vector<int>(upd.shape().begin() + s, upd.shape().end());
   up_shape = up_shape.empty() ? std::vector{1} : up_shape;

--- a/python/src/indexing.cpp
+++ b/python/src/indexing.cpp
@@ -805,7 +805,8 @@ auto mlx_slice_update(
 
   // Remove extra leading singletons dimensions from the update
   int s = 0;
-  for (; s < upd.ndim() && upd.shape(s) == 1 && (upd.ndim() - s) > src.ndim(); s++) {
+  for (; s < upd.ndim() && upd.shape(s) == 1 && (upd.ndim() - s) > src.ndim();
+       s++) {
   };
   auto up_shape = std::vector<int>(upd.shape().begin() + s, upd.shape().end());
   up_shape = up_shape.empty() ? std::vector{1} : up_shape;


### PR DESCRIPTION
Previously the slice update below would resolve to two reshapes + the update itself. This removes the two reshapes when possible.

```python
c = mx.zeros([1, 8, 256, 128])
k = mx.zeros([1, 8, 1, 128])
mx.eval(c, k)

c[..., 2:3, :] = k
```

Gives a very small improvement to toks/sec for 4-bit Llama 3.1 1B on M3 Max:

```
mlx_lm.generate --model mlx-community/Llama-3.2-1B-Instruct-4bit  --prompt "Write a story about Einstein" -m 200
```

Pre: `Generation: 200 tokens, 371.306 tokens-per-sec`
Post: `Generation: 200 tokens, 375.838 tokens-per-sec`
