### PR TITLE
Use fewer barriers

### DIFF
--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -164,7 +164,7 @@ void CommandEncoder::maybeInsertBarrier() {
   if (needs_barrier_) {
     enc_->memoryBarrier(MTL::BarrierScopeBuffers);
     needs_barrier_ = false;
-    prev_outputs_ = next_outputs_;
+    prev_outputs_ = std::move(next_outputs_);
   } else {
     prev_outputs_.insert(next_outputs_.begin(), next_outputs_.end());
   }

--- a/mlx/backend/metal/device.h
+++ b/mlx/backend/metal/device.h
@@ -49,7 +49,7 @@ struct CommandEncoder {
     }
     ~ConcurrentContext() {
       enc.concurrent_ = false;
-      enc.outputs_.insert(
+      enc.prev_outputs_.insert(
           enc.concurrent_outputs_.begin(), enc.concurrent_outputs_.end());
       enc.concurrent_outputs_.clear();
     }
@@ -66,6 +66,7 @@ struct CommandEncoder {
   void set_output_array(array& a, int idx, int64_t offset = 0);
   void dispatchThreadgroups(MTL::Size grid_dims, MTL::Size group_dims);
   void dispatchThreads(MTL::Size grid_dims, MTL::Size group_dims);
+  void maybeInsertBarrier();
 
   ConcurrentContext start_concurrent() {
     return ConcurrentContext(*this);
@@ -84,8 +85,10 @@ struct CommandEncoder {
 
  private:
   MTL::ComputeCommandEncoder* enc_;
+  bool needs_barrier_{false};
   bool concurrent_{false};
-  std::unordered_set<MTL::Resource*> outputs_;
+  std::unordered_set<MTL::Resource*> prev_outputs_;
+  std::unordered_set<MTL::Resource*> next_outputs_;
   std::unordered_set<MTL::Resource*> concurrent_outputs_;
   std::unordered_set<const void*> all_inputs_;
   std::unordered_set<const void*> all_outputs_;


### PR DESCRIPTION
Everything after a barrier waits on everything before so we don't need to synchronize on anything that happened before a barrier. This change implements that.

Some benchmarks on M2 Ultra:

Bench | Pre | Post
----- | ---- | ----
4-bit Mistral 7B generating 512 toks | 122.0 | 123.8
4-bit Llama 1B generating 512 toks | 420.2  | 431.3
Transformer training | 6.237 | 6.265 |

On LeNet and MNIST no change observed.

With this change we can hit > 130 toks/sec for 4-bit Mistral 7B by increasing ops per buffer:

```
MLX_MAX_OPS_PER_BUFFER=80 mlx_lm.generate --model mlx-community/Mistral-7B-Instruct-v0.3-4bit --prompt "Write a story about Einstein"  --temp 0.0 --max-tokens 512
```

Pre: `125.939 tokens-per-sec`
Post: `130.900 tokens-per-sec`