### PR TITLE
Add split_k `qvm` for long context

### DIFF
--- a/mlx/backend/metal/kernels/quantized.metal
+++ b/mlx/backend/metal/kernels/quantized.metal
@@ -95,7 +95,6 @@
 
 #define instantiate_quantized_all_splitk(type, group_size, bits)   \
   instantiate_quantized_split_k(qvm_split_k, type, group_size, bits, 8)   \
-  instantiate_quantized_split_k(qvm_split_k, type, group_size, bits, 16)  \
   instantiate_quantized_split_k(qvm_split_k, type, group_size, bits, 32)
 
 #define instantiate_quantized_funcs(type, group_size, bits) \

--- a/mlx/backend/metal/kernels/quantized.metal
+++ b/mlx/backend/metal/kernels/quantized.metal
@@ -51,6 +51,15 @@
       D,                                                            \
       batched)
 
+#define instantiate_quantized_split_k(name, type, group_size, bits, split_k)     \
+  instantiate_kernel(                                                            \
+      #name "_" #type "_gs_" #group_size "_b_" #bits "_spk_" #split_k, \
+      name,                                                         \
+      type,                                                         \
+      group_size,                                                   \
+      bits,                                                         \
+      split_k)
+
 #define instantiate_quantized_batched_wrap(name, type, group_size, bits) \
   instantiate_quantized_batched(name, type, group_size, bits, 1)      \
   instantiate_quantized_batched(name, type, group_size, bits, 0)
@@ -84,11 +93,17 @@
   instantiate_quantized_quad(qmv_quad, type, group_size, bits, 128, 1)  \
   instantiate_quantized_quad(qmv_quad, type, group_size, bits, 128, 0)
 
+#define instantiate_quantized_all_splitk(type, group_size, bits)   \
+  instantiate_quantized_split_k(qvm_split_k, type, group_size, bits, 8)   \
+  instantiate_quantized_split_k(qvm_split_k, type, group_size, bits, 16)  \
+  instantiate_quantized_split_k(qvm_split_k, type, group_size, bits, 32)
+
 #define instantiate_quantized_funcs(type, group_size, bits) \
   instantiate_quantized_all_single(type, group_size, bits)  \
   instantiate_quantized_all_batched(type, group_size, bits) \
   instantiate_quantized_all_aligned(type, group_size, bits) \
-  instantiate_quantized_all_quad(type, group_size, bits)
+  instantiate_quantized_all_quad(type, group_size, bits)    \
+  instantiate_quantized_all_splitk(type, group_size, bits)
 
 #define instantiate_quantized_types(group_size, bits)       \
   instantiate_quantized_funcs(float, group_size, bits)      \

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -6,6 +6,7 @@
 #include "mlx/backend/metal/copy.h"
 #include "mlx/backend/metal/device.h"
 #include "mlx/backend/metal/kernels.h"
+#include "mlx/backend/metal/reduce.h"
 #include "mlx/backend/metal/utils.h"
 #include "mlx/fast_primitives.h"
 #include "mlx/primitives.h"
@@ -13,11 +14,10 @@
 namespace mlx::core {
 
 void launch_qmm(
-    std::string name,
     const std::vector<array>& inputs,
     array& out,
-    int group_size,
-    int bits,
+    std::string kernel_name,
+    std::string template_def,
     int D,
     int O,
     int B,
@@ -27,8 +27,6 @@ void launch_qmm(
     bool batched,
     bool matrix,
     bool gather,
-    bool aligned,
-    bool quad,
     const Stream& s) {
   auto& x_pre = inputs[0];
   auto& w_pre = inputs[1];
@@ -64,41 +62,9 @@ void launch_qmm(
   auto& s_strides = scales.strides();
   auto& b_strides = biases.strides();
 
-  std::string aligned_n = (O % 32) == 0 ? "true" : "false";
-
-  std::ostringstream kname;
-  auto type_string = get_type_string(x.dtype());
-  kname << name << "_" << type_string << "_gs_" << group_size << "_b_" << bits;
-  if (quad) {
-    kname << "_d_" << D;
-  }
-  if (aligned) {
-    kname << "_alN_" << aligned_n;
-  }
-  if (!gather) {
-    kname << "_batch_" << batched;
-  }
-
   // Encode and dispatch kernel
-  std::string template_def;
-  if (quad) {
-    template_def = get_template_definition(
-        kname.str(), name, type_string, group_size, bits, D, batched);
-  } else if (aligned && !gather) {
-    template_def = get_template_definition(
-        kname.str(), name, type_string, group_size, bits, aligned_n, batched);
-  } else if (!gather && !aligned) {
-    template_def = get_template_definition(
-        kname.str(), name, type_string, group_size, bits, batched);
-  } else if (aligned && gather) {
-    template_def = get_template_definition(
-        kname.str(), name, type_string, group_size, bits, aligned_n);
-  } else {
-    template_def = get_template_definition(
-        kname.str(), name, type_string, group_size, bits);
-  }
   auto& d = metal::device(s.device);
-  auto kernel = get_quantized_kernel(d, kname.str(), template_def);
+  auto kernel = get_quantized_kernel(d, kernel_name, template_def);
   auto& compute_encoder = d.get_command_encoder(s.index);
   compute_encoder->setComputePipelineState(kernel);
 
@@ -148,6 +114,120 @@ void launch_qmm(
   d.add_temporaries(std::move(copies), s.index);
 }
 
+void qvm_split_k(
+    const std::vector<array>& inputs,
+    array& out,
+    std::string kernel_name,
+    std::string template_def,
+    int D,
+    int O,
+    int B,
+    int N,
+    const Stream& s) {
+  int bo = 64;
+  int bd = 32;
+  int split_k = 32;
+
+  // Split the k
+  int split_D = (D + split_k - 1) / split_k;
+  N *= split_k;
+
+  MTL::Size group_dims = MTL::Size(bd, 2, 1);
+  MTL::Size grid_dims = MTL::Size(O / bo, B, N);
+
+  auto& x_pre = inputs[0];
+  auto& w_pre = inputs[1];
+  auto& scales_pre = inputs[2];
+  auto& biases_pre = inputs[3];
+
+  // Ensure that the last two dims are row contiguous.
+  // TODO: Check if we really need this for x as well...
+  std::vector<array> copies;
+  auto ensure_row_contiguous_last_dims = [&copies, &s](const array& arr) {
+    auto stride_0 = arr.strides()[arr.ndim() - 2];
+    auto stride_1 = arr.strides()[arr.ndim() - 1];
+    if (stride_0 == arr.shape(-1) && stride_1 == 1) {
+      return arr;
+    } else {
+      array arr_copy(arr.shape(), arr.dtype(), nullptr, {});
+      copy_gpu(arr, arr_copy, CopyType::General, s);
+      copies.push_back(arr_copy);
+      return arr_copy;
+    }
+  };
+  auto x = ensure_row_contiguous_last_dims(x_pre);
+  auto w = ensure_row_contiguous_last_dims(w_pre);
+  auto scales = ensure_row_contiguous_last_dims(scales_pre);
+  auto biases = ensure_row_contiguous_last_dims(biases_pre);
+
+  int x_batch_ndims = x.ndim() - 2;
+  auto x_shape = x.shape();
+  auto x_strides = x.strides();
+  int w_batch_ndims = w.ndim() - 2;
+  auto w_shape = w.shape();
+  auto w_strides = w.strides();
+  auto s_strides = scales.strides();
+  auto b_strides = biases.strides();
+
+  // Add split_k dim with reshapes
+  x_shape.insert(x_shape.end() - 2, split_k);
+  x_shape.back() /= split_k;
+  x_strides.insert(x_strides.end() - 2, split_D);
+  x_strides[x.ndim() - 1] = split_D;
+  x_batch_ndims += 1;
+
+  w_shape.insert(w_shape.end() - 2, split_k);
+  w_shape[w.ndim() - 1] /= split_k;
+  w_strides.insert(w_strides.end() - 2, split_D * w.shape(-1));
+  w_batch_ndims += 1;
+  s_strides.insert(s_strides.end() - 2, split_D * scales.shape(-1));
+  b_strides.insert(b_strides.end() - 2, split_D * biases.shape(-1));
+
+  int final_block_size = D - (split_k - 1) * split_D;
+
+  auto& d = metal::device(s.device);
+
+  auto temp_shape = out.shape();
+  temp_shape.insert(temp_shape.end() - 2, split_k);
+  array intermediate(temp_shape, x.dtype(), nullptr, {});
+  intermediate.set_data(allocator::malloc_or_wait(intermediate.nbytes()));
+  d.add_temporary(intermediate, s.index);
+
+  // Encode and dispatch kernel
+  auto kernel = get_quantized_kernel(d, kernel_name, template_def);
+  auto& compute_encoder = d.get_command_encoder(s.index);
+  compute_encoder->setComputePipelineState(kernel);
+
+  compute_encoder.set_input_array(w, 0);
+  compute_encoder.set_input_array(scales, 1);
+  compute_encoder.set_input_array(biases, 2);
+  compute_encoder.set_input_array(x, 3);
+  compute_encoder.set_output_array(intermediate, 4);
+  compute_encoder->setBytes(&split_D, sizeof(int), 5);
+  compute_encoder->setBytes(&O, sizeof(int), 6);
+
+  compute_encoder->setBytes(&x_batch_ndims, sizeof(int), 7);
+  set_vector_bytes(compute_encoder, x_shape, 8);
+  set_vector_bytes(compute_encoder, x_strides, 9);
+  compute_encoder->setBytes(&w_batch_ndims, sizeof(int), 10);
+  set_vector_bytes(compute_encoder, w_shape, 11);
+  set_vector_bytes(compute_encoder, w_strides, 12);
+  set_vector_bytes(compute_encoder, s_strides, 13);
+  set_vector_bytes(compute_encoder, b_strides, 14);
+  compute_encoder->setBytes(&final_block_size, sizeof(int), 15);
+
+  compute_encoder.dispatchThreadgroups(grid_dims, group_dims);
+  d.add_temporaries(std::move(copies), s.index);
+
+  int axis = intermediate.ndim() - 3;
+  ReductionPlan plan(
+      ReductionOpType::ContiguousStridedReduce,
+      {intermediate.shape(axis)},
+      {intermediate.strides(axis)});
+  strided_reduce_general_dispatch(
+      intermediate, out, "sum", plan, {axis}, compute_encoder, d, s);
+}
+
 void qmm_op(
     const std::vector<array>& inputs,
     array& out,
@@ -174,51 +254,96 @@ void qmm_op(
 
   std::string name = gather ? "bs_" : "";
   bool matrix = false;
-  bool aligned = false;
-  bool quad = false;
+
+  std::ostringstream kname;
+  std::string template_def;
+  auto type_string = get_type_string(x.dtype());
 
   if (transpose) {
     if (B < 6 && (D == 128 || D == 64)) {
       name += "qmv_quad";
+      kname << name << "_" << type_string << "_gs_" << group_size << "_b_"
+            << bits;
       constexpr int quads_per_simd = 8;
       constexpr int results_per_quadgroup = 8;
       int bo = quads_per_simd * results_per_quadgroup;
       int simdgroup_size = 32;
       group_dims = MTL::Size(simdgroup_size, 1, 1);
       grid_dims = MTL::Size((O + bo - 1) / bo, B, N);
-      quad = true;
+      kname << "_d_" << D;
+      if (gather) {
+        template_def = get_template_definition(
+            kname.str(), name, type_string, group_size, bits, D);
+      } else {
+        kname << "_batch_" << batched;
+        template_def = get_template_definition(
+            kname.str(), name, type_string, group_size, bits, D, batched);
+      }
     } else if (B < 6 && O % 8 == 0 && D % 512 == 0 && D >= 512) {
       name += "qmv_fast";
+      kname << name << "_" << type_string << "_gs_" << group_size << "_b_"
+            << bits;
       int bo = 8;
       int bd = 32;
       group_dims = MTL::Size(bd, 2, 1);
       grid_dims = MTL::Size(O / bo, B, N);
+      if (gather) {
+        template_def = get_template_definition(
+            kname.str(), name, type_string, group_size, bits);
+      } else {
+        kname << "_batch_" << batched;
+        template_def = get_template_definition(
+            kname.str(), name, type_string, group_size, bits, batched);
+      }
     } else if (B < 6) {
       name += "qmv";
+      kname << name << "_" << type_string << "_gs_" << group_size << "_b_"
+            << bits;
       int bo = 8;
       int bd = 32;
       group_dims = MTL::Size(bd, 2, 1);
       grid_dims = MTL::Size((O + bo - 1) / bo, B, N);
+      if (gather) {
+        template_def = get_template_definition(
+            kname.str(), name, type_string, group_size, bits);
+      } else {
+        kname << "_batch_" << batched;
+        template_def = get_template_definition(
+            kname.str(), name, type_string, group_size, bits, batched);
+      }
     } else {
+      name += "qmm_t";
+      kname << name << "_" << type_string << "_gs_" << group_size << "_b_"
+            << bits;
       int wn = 2;
       int wm = 2;
       int bm = 32;
       int bn = 32;
       group_dims = MTL::Size(32, wn, wm);
       grid_dims = MTL::Size((O + bn - 1) / bn, (B + bm - 1) / bm, N);
-      name += "qmm_t";
       matrix = true;
-      aligned = true;
+      std::string aligned_n = (O % 32) == 0 ? "true" : "false";
+      kname << "_alN_" << aligned_n;
+      if (gather) {
+        template_def = get_template_definition(
+            kname.str(), name, type_string, group_size, bits, aligned_n);
+      } else {
+        kname << "_batch_" << batched;
+        template_def = get_template_definition(
+            kname.str(),
+            name,
+            type_string,
+            group_size,
+            bits,
+            aligned_n,
+            batched);
+      }
     }
   } else {
-    if (B < 4) {
-      name += "qvm";
-      int bo = 64;
-      int bd = 32;
-      group_dims = MTL::Size(bd, 2, 1);
-      grid_dims = MTL::Size(O / bo, B, N);
-    } else {
+    if (B >= 4) {
       name += "qmm_n";
+      kname << name << "_" << type_string << "_gs_" << group_size << "_b_"
+            << bits;
       int wn = 2;
       int wm = 2;
       int bm = 32;
@@ -232,14 +357,45 @@ void qmm_op(
             << bn << " but received " << O << ".";
         throw std::runtime_error(msg.str());
       }
+      if (gather) {
+        template_def = get_template_definition(
+            kname.str(), name, type_string, group_size, bits);
+      } else {
+        kname << "_batch_" << batched;
+        template_def = get_template_definition(
+            kname.str(), name, type_string, group_size, bits, batched);
+      }
+    } else if (B == 1 && D > 8192 && !gather) {
+      name += "qvm_split_k";
+      kname << name << "_" << type_string << "_gs_" << group_size << "_b_"
+            << bits;
+      template_def = get_template_definition(
+          kname.str(), name, type_string, group_size, bits);
+      return qvm_split_k(inputs, out, kname.str(), template_def, D, O, B, N, s);
+    } else {
+      name += "qvm";
+      kname << name << "_" << type_string << "_gs_" << group_size << "_b_"
+            << bits;
+      int bo = 64;
+      int bd = 32;
+      group_dims = MTL::Size(bd, 2, 1);
+      grid_dims = MTL::Size(O / bo, B, N);
+      if (gather) {
+        template_def = get_template_definition(
+            kname.str(), name, type_string, group_size, bits);
+      } else {
+        kname << "_batch_" << batched;
+        template_def = get_template_definition(
+            kname.str(), name, type_string, group_size, bits, batched);
+      }
     }
   }
+
   launch_qmm(
-      name,
       inputs,
       out,
-      group_size,
-      bits,
+      kname.str(),
+      template_def,
       D,
       O,
       B,
@@ -249,8 +405,6 @@ void qmm_op(
       batched,
       matrix,
       gather,
-      aligned,
-      quad,
       s);
 }
 

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -123,10 +123,10 @@ void qvm_split_k(
     int O,
     int B,
     int N,
+    int split_k,
     const Stream& s) {
   int bo = 64;
   int bd = 32;
-  int split_k = 32;
 
   // Split the k
   int split_D = (D + split_k - 1) / split_k;
@@ -365,13 +365,15 @@ void qmm_op(
         template_def = get_template_definition(
             kname.str(), name, type_string, group_size, bits, batched);
       }
-    } else if (B == 1 && D > 8192 && !gather) {
+    } else if (B == 1 && D >= 1024 && !gather) {
+      int split_k = D > 4096 ? 32 : 16;
       name += "qvm_split_k";
       kname << name << "_" << type_string << "_gs_" << group_size << "_b_"
-            << bits;
+            << bits << "_spk_" << split_k;
       template_def = get_template_definition(
-          kname.str(), name, type_string, group_size, bits);
-      return qvm_split_k(inputs, out, kname.str(), template_def, D, O, B, N, s);
+          kname.str(), name, type_string, group_size, bits, split_k);
+      return qvm_split_k(
+          inputs, out, kname.str(), template_def, D, O, B, N, split_k, s);
     } else {
       name += "qvm";
       kname << name << "_" << type_string << "_gs_" << group_size << "_b_"

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -365,8 +365,8 @@ void qmm_op(
         template_def = get_template_definition(
             kname.str(), name, type_string, group_size, bits, batched);
       }
-    } else if (B == 1 && D >= 1024 && !gather) {
-      int split_k = D > 4096 ? 32 : 16;
+    } else if (D >= 1024 && !gather) {
+      int split_k = D > 8192 ? 32 : 8;
       name += "qvm_split_k";
       kname << name << "_" << type_string << "_gs_" << group_size << "_b_"
             << bits << "_spk_" << split_k;

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -144,9 +144,34 @@ class TestQuantized(mlx_tests.MLXTestCase):
         tests = product(
             [128, 64, 32],  # group_size
             [2, 4, 8],  # bits
-            [128, 512, 1024],  # M
-            [512, 1024, 67, 16384],  # N
+            [512, 1024],  # M
+            [512, 1024, 67],  # N
             [0, 1, 3, 8],  # B
+        )
+        for group_size, bits, M, N, B in tests:
+            with self.subTest(shape=(B, M, N), group_size=group_size, bits=bits):
+                x_shape = (1, N) if B == 0 else (B, 1, N)
+                w_shape = (N, M) if B == 0 else (B, N, M)
+                x = mx.random.normal(shape=x_shape, key=k1)
+                w = mx.random.normal(shape=w_shape, key=k2)
+                w_q, scales, biases = mx.quantize(w, group_size, bits)
+                w_hat = mx.dequantize(w_q, scales, biases, group_size, bits)
+                y_q = mx.quantized_matmul(
+                    x, w_q, scales, biases, False, group_size, bits
+                )
+                y_hat = x @ w_hat
+                self.assertEqual(y_q.shape, y_hat.shape)
+                self.assertLess((y_q - y_hat).abs().max(), 1e-3)
+
+    def test_qvm_splitk(self):
+        key = mx.random.key(0)
+        k1, k2 = mx.random.split(key)
+        tests = product(
+            [128, 64, 32],  # group_size
+            [2, 4, 8],  # bits
+            [128],  # M
+            [16384],  # N
+            [1, 3],  # B
         )
         for group_size, bits, M, N, B in tests:
             with self.subTest(shape=(B, M, N), group_size=group_size, bits=bits):

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -144,8 +144,8 @@ class TestQuantized(mlx_tests.MLXTestCase):
         tests = product(
             [128, 64, 32],  # group_size
             [2, 4, 8],  # bits
-            [512, 1024],  # M
-            [512, 1024, 67],  # N
+            [128, 512, 1024],  # M
+            [512, 1024, 67, 16384],  # N
             [0, 1, 3, 8],  # B
         )
         for group_size, bits, M, N, B in tests:

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -186,7 +186,7 @@ class TestQuantized(mlx_tests.MLXTestCase):
                 )
                 y_hat = x @ w_hat
                 self.assertEqual(y_q.shape, y_hat.shape)
-                self.assertLess((y_q - y_hat).abs().max(), 1e-3)
+                self.assertLess((y_q - y_hat).abs().max(), 2e-3)
 
     def test_throw(self):
         x = mx.random.normal(shape=(10, 512))


### PR DESCRIPTION
The `qvm` in [quantized_scaled_dot_product_attention](https://github.com/ml-explore/mlx-examples/blob/6fd1f70f7366a1e55f14e2b4cd885b86875ab56c/llms/mlx_lm/models/base.py#L82) gets quite slow for long contexts due to it's big inner loop over the context length.

This PR adds a `split_k` specialization for `qvm` that parallelizes across the context length dimension and then reduces with a separate kernel launch.

In practice this is much faster for LLM generation with a quantized KV cache:

M2 Ultra 76 Core GPU

## Before:
![Screenshot 2024-11-05 at 01 58 42](https://github.com/user-attachments/assets/169e768d-dc54-48fa-96b4-abddf2c9c253)

## After:
![Screenshot 2024-11-05 at 01 54 19](https://github.com/user-attachments/assets/e62058bf-6dde-4ac2-ac5b-46368e047250)



