### PR TITLE
Bfs width limit

### DIFF
--- a/mlx/transforms.cpp
+++ b/mlx/transforms.cpp
@@ -26,7 +26,7 @@ int bfs_max_width() {
       return 10;
     }
   };
-  static int bfs_max_width_ get_val();
+  static int bfs_max_width_ = get_val();
   return bfs_max_width_;
 }
 

--- a/mlx/transforms.cpp
+++ b/mlx/transforms.cpp
@@ -23,7 +23,7 @@ int bfs_max_width() {
     if (const char* buff_str = std::getenv("MLX_BFS_MAX_WIDTH")) {
       return atoi(buff_str);
     } else {
-      return 10;
+      return 50;
     }
   };
   static int bfs_max_width_ = get_val();

--- a/mlx/transforms.cpp
+++ b/mlx/transforms.cpp
@@ -1,6 +1,5 @@
 // Copyright © 2023-2024 Apple Inc.
 #include <algorithm>
-#include <cstdlib>
 #include <deque>
 #include <future>
 #include <numeric>
@@ -17,18 +16,6 @@
 #include "mlx/transforms.h"
 #include "mlx/transforms_impl.h"
 #include "mlx/utils.h"
-
-int bfs_max_width() {
-  auto get_val = []() {
-    if (const char* buff_str = std::getenv("MLX_BFS_MAX_WIDTH")) {
-      return atoi(buff_str);
-    } else {
-      return 50;
-    }
-  };
-  static int bfs_max_width_ = get_val();
-  return bfs_max_width_;
-}
 
 namespace mlx::core {
 
@@ -146,7 +133,7 @@ array eval_impl(std::vector<array> outputs, bool async) {
     }
 
     // Build the tape in BFS order with a width limit
-    int max_width = bfs_max_width();
+    int max_width = env::bfs_max_width();
     dfs = std::stack<std::pair<std::reference_wrapper<array>, int>>();
     tape.push_back(synchronizer);
     for (int i = 0; !cache.empty() && (i < tape.size() || !dfs.empty());) {

--- a/mlx/utils.cpp
+++ b/mlx/utils.cpp
@@ -1,9 +1,10 @@
 // Copyright © 2023 Apple Inc.
 
+#include <cstdlib>
 #include <sstream>
 #include <vector>
 
-#include "utils.h"
+#include "mlx/utils.h"
 
 namespace mlx::core {
 
@@ -335,5 +336,17 @@ std::ostream& operator<<(std::ostream& os, const std::vector<int64_t>& v) {
   os << ")";
   return os;
 }
+
+namespace env {
+
+int get_var(const char* name, int default_value) {
+  if (const char* buff_str = std::getenv(name)) {
+    return atoi(buff_str);
+  } else {
+    return default_value;
+  }
+}
+
+} // namespace env
 
 } // namespace mlx::core

--- a/mlx/utils.h
+++ b/mlx/utils.h
@@ -120,4 +120,20 @@ inline int next_power_of_2(int n) {
   return pow(2, std::ceil(std::log2(n)));
 }
 
+namespace env {
+
+int get_var(const char* name, int default_value);
+
+inline int bfs_max_width() {
+  static int bfs_max_width_ = get_var("MLX_BFS_MAX_WIDTH", 20);
+  return bfs_max_width_;
+}
+
+inline int max_ops_per_buffer() {
+  static int max_ops_per_buffer_ = get_var("MLX_MAX_OPS_PER_BUFFER", 10);
+  return max_ops_per_buffer_;
+}
+
+} // namespace env
+
 } // namespace mlx::core


### PR DESCRIPTION
Add a width limit to the BFS. Made it configurable with an env var `MLX_BFS_MAX_WIDTH` to facilitate benchmarking and keep it flexible.

The default is temporarily 10 but that needs to be validated on benchmarks:

A simple benchmark like the following which is worst case for BFS will use way less RAM:

```python
arrs = [mx.zeros((4096, 128), mx.int64) for _ in range(1000)]
arrs = [x.astype(mx.int8) for x in arrs]
mx.eval(arrs)
print(mx.metal.get_peak_memory() / 1e6)
```

Before the width limit:  4,251 MB
width 1: 689 MB
width 10: 729 MB
width 50: 792 MB

### Benchmarks M3 Max

LLM inference Llama 3.2 1B 4-bit, 512 tokens

Width | toks/sec | RAM
--- | --- | ---
1 | 357.2 | 0.724 GB
5 | 373.2 | 0.723 GB
10 | 374.0 | 0.724 GB
inf | 375.0 | 0.724 GB

Transformer Training

Width | it/sec | RAM
--- | --- | ---
1 | 3.32 | 5.204
10 | 3.47 | 5.222
50 | 3.48 | 5.48
inf | 3.48 | 5.48

CIFAR ResNet

Width | im/sec | RAM
--- | --- | ---
1 | 3152 | 1.468 GB
10 | 3087 | 1.515 GB
20 | 3168 | 1.671 GB
50 | 3887 | 1.895 GB 
inf | 4023 | 2.264  GB

Quantizing Llama 8B to 4-bit
Width | Time (s) | RAM (GB)
--- | --- | ---
1 | 2.92 | 9.37 
10 | 2.83 | 9.59
20 | 2.89 | 10.20
50 |  2.90 | 10.22
inf | 3.14 | 18.17

