### PR TITLE
[RFC] Multithread stream

### DIFF
--- a/mlx/scheduler.cpp
+++ b/mlx/scheduler.cpp
@@ -21,16 +21,12 @@ void set_default_stream(Stream s) {
   return scheduler::scheduler().set_default_stream(s);
 }
 
-Stream new_stream(Device d) {
+Stream new_stream(Device d, int threads /* = 1 */) {
   if (!metal::is_available() && d == Device::gpu) {
     throw std::invalid_argument(
         "[new_stream] Cannot make gpu stream without gpu backend.");
   }
-  return scheduler::scheduler().new_stream(d);
-}
-
-Stream new_stream() {
-  return scheduler::scheduler().new_stream(default_device());
+  return scheduler::scheduler().new_stream(d, threads);
 }
 
 void synchronize(Stream s) {

--- a/mlx/scheduler.cpp
+++ b/mlx/scheduler.cpp
@@ -26,6 +26,10 @@ Stream new_stream(Device d, int threads /* = 1 */) {
     throw std::invalid_argument(
         "[new_stream] Cannot make gpu stream without gpu backend.");
   }
+  if (d == Device::gpu && threads > 1) {
+    throw std::invalid_argument(
+        "[new_stream] Cannot make multi-threaded gpu stream.");
+  }
   return scheduler::scheduler().new_stream(d, threads);
 }
 

--- a/mlx/stream.h
+++ b/mlx/stream.h
@@ -9,7 +9,9 @@ namespace mlx::core {
 struct Stream {
   int index;
   Device device;
-  explicit Stream(int index, Device device) : index(index), device(device) {}
+  int threads;
+  explicit Stream(int index, Device device, int threads = 1)
+      : index(index), device(device), threads(threads) {}
 };
 
 /** Get the default stream for the given device. */
@@ -19,7 +21,7 @@ Stream default_stream(Device d);
 void set_default_stream(Stream s);
 
 /** Make a new stream on the given device. */
-Stream new_stream(Device d);
+Stream new_stream(Device d, int threads = 1);
 
 inline bool operator==(const Stream& lhs, const Stream& rhs) {
   return lhs.index == rhs.index;

--- a/mlx/utils.cpp
+++ b/mlx/utils.cpp
@@ -142,7 +142,7 @@ std::ostream& operator<<(std::ostream& os, const Device& d) {
 std::ostream& operator<<(std::ostream& os, const Stream& s) {
   os << "Stream(";
   os << s.device;
-  os << ", " << s.index << ")";
+  os << ", index=" << s.index << ", threads=" << s.threads << ")";
   return os;
 }
 

--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -184,10 +184,6 @@ void init_array(nb::module_& m) {
       R"pbdoc(
       A helper object to apply updates at specific indices.
       )pbdoc")
-      .def(
-          nb::init<const array&>(),
-          "x"_a,
-          nb::sig("def __init__(self, x: array)"))
       .def("__getitem__", &ArrayAt::set_indices, "indices"_a.none())
       .def("add", &ArrayAt::add, "value"_a)
       .def("subtract", &ArrayAt::subtract, "value"_a)
@@ -202,10 +198,6 @@ void init_array(nb::module_& m) {
       R"pbdoc(
       A helper object to iterate over the 1st dimension of an array.
       )pbdoc")
-      .def(
-          nb::init<const array&>(),
-          "x"_a,
-          nb::sig("def __init__(self, x: array)"))
       .def("__next__", &ArrayPythonIterator::next)
       .def("__iter__", [](const ArrayPythonIterator& it) { return it; });
 

--- a/python/src/stream.cpp
+++ b/python/src/stream.cpp
@@ -47,6 +47,8 @@ void init_stream(nb::module_& m) {
       "Stream",
       R"pbdoc(
       A stream for running operations on a given device.
+
+      Use :func:`new_stream` to create new streams.
       )pbdoc")
       .def(nb::init<int, Device>(), "index"_a, "device"_a)
       .def_ro("device", &Stream::device)
@@ -79,7 +81,7 @@ void init_stream(nb::module_& m) {
         streams device. It will not change the default device.
 
         Args:
-          stream (stream): Stream to make the default.
+          stream (Stream): Stream to make the default.
       )pbdoc");
   m.def(
       "new_stream",

--- a/python/src/stream.cpp
+++ b/python/src/stream.cpp
@@ -85,6 +85,7 @@ void init_stream(nb::module_& m) {
       "new_stream",
       &new_stream,
       "device"_a,
+      "threads"_a = 1,
       R"pbdoc(Make a new stream on the given device.)pbdoc");
 
   nb::class_<PyStreamContext>(m, "StreamContext", R"pbdoc(

--- a/python/tests/test_eval.py
+++ b/python/tests/test_eval.py
@@ -137,6 +137,18 @@ class TestEval(mlx_tests.MLXTestCase):
             mx.async_eval(x)
             mx.eval(a + b)
 
+    def test_multithreaded_stream(self):
+        arrays = [mx.random.uniform(shape=(4, 4)) for _ in range(8)]
+        mx.eval(arrays)
+        s = mx.new_stream(mx.cpu, threads=2)
+        with mx.stream(s):
+            outputs = [mx.exp(-mx.abs(x)) for x in arrays]
+            out_multi = sum(outputs)
+
+        outputs = [mx.exp(-mx.abs(x)) for x in arrays]
+        out = sum(outputs)
+        self.assertTrue(mx.allclose(out, out_multi))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
A possible implementation of multithreaded streams for the CPU.

I'm not entirely sure if 1. we should add it and 2. If this is a good way. There are some niche cases where it's useful to have a multi-threaded stream (like quantizing on a CPU-only machine).

On an M3 Max quantizing 8B Llama 3 to 4-bit with the CPU:

threads | time (seconds)
---- | ----
1 | 46.94
2 | 30.27
4 | 20.52
8 | 16.39

Interestingly using the CPU-only build is much faster 🤔 

threads | time (seconds)
---- | ----
1 | 36.27
2 | 20.09
4 | 12.41
8 | 8.89

With #1578 and 8 threads the CPU quantization time is 4.6 seconds.. which is pretty good for CPU only. Almost as fast as the GPU which is 3.03 seconds on the M3 max.