### PR TITLE
Fix OOB access in qmv

### DIFF
--- a/mlx/backend/metal/kernels/quantized.h
+++ b/mlx/backend/metal/kernels/quantized.h
@@ -628,10 +628,12 @@ METAL_FUNC void qmv_impl(
       const device T* sl = scales + row * in_vec_size_g;
       const device T* bl = biases + row * in_vec_size_g;
 
-      U s = sl[0];
-      U b = bl[0];
-      result[row] += qdot_safe<U, values_per_thread, bits>(
-          wl, x_thread, s, b, sum, remaining);
+      if (remaining > 0) {
+        U s = sl[0];
+        U b = bl[0];
+        result[row] += qdot_safe<U, values_per_thread, bits>(
+            wl, x_thread, s, b, sum, remaining);
+      }
     }
 
     for (int row = 0; row < results_per_simdgroup; row++) {


### PR DESCRIPTION
This was breaking quantized generation with `SmolLM2-135M-Instruct` specifically with group size 32.

No clear difference in performance before and after (tested with group size 64 which still worked on `main`).

Before:
```
Prompt: 38 tokens, 629.657 tokens-per-sec
Generation: 574 tokens, 261.939 tokens-per-sec
Peak memory: 0.164 GB
```
After:
```
Prompt: 38 tokens, 630.536 tokens-per-sec
Generation: 574 tokens, 262.050 tokens-per-sec
Peak memory: 0.164 GB
```
