### PR TITLE
Cpu fast quantize

### DIFF
--- a/mlx/backend/no_cpu/primitives.cpp
+++ b/mlx/backend/no_cpu/primitives.cpp
@@ -1,6 +1,7 @@
 // Copyright © 2024 Apple Inc.
 
 #include "mlx/primitives.h"
+#include "mlx/fast_primitives.h"
 
 #define NO_CPU_MULTI(func)                                             \
   void func::eval_cpu(                                                 \
@@ -111,5 +112,9 @@ NO_CPU(Tanh)
 NO_CPU(Transpose)
 NO_CPU(Inverse)
 NO_CPU(View)
+
+namespace fast {
+NO_CPU_MULTI(AffineQuantize)
+} // namespace fast
 
 } // namespace mlx::core

--- a/mlx/fast_primitives.h
+++ b/mlx/fast_primitives.h
@@ -228,9 +228,7 @@ class AffineQuantize : public Custom {
         dequantize_(dequantize) {}
 
   void eval_cpu(const std::vector<array>& inputs, std::vector<array>& outputs)
-      override {
-    throw std::runtime_error("NYI");
-  }
+      override;
 
   void eval_gpu(const std::vector<array>& inputs, std::vector<array>& outputs)
       override;


### PR DESCRIPTION
Maybe worth merging this. We have the fast op already so it's a small addition. And the benchmarks look pretty decent.

Quantizing Llama 3.1 8B on CPU on M3 Max:

Pre: 33.34 seconds
Post: 16.542 seconds
