### PR TITLE
Allocate raw JSON metadata buffer on the heap, and limit its size

### DIFF
--- a/mlx/io/safetensors.cpp
+++ b/mlx/io/safetensors.cpp
@@ -110,7 +110,8 @@ SafetensorsLoad load_safetensors(
   }
 
   uint64_t jsonHeaderLength = 0;
-  constexpr uint64_t kMaxJsonHeaderLength = 1ULL << 30;
+  // This is the same limit as in the original Rust Safetensors code.
+  constexpr uint64_t kMaxJsonHeaderLength = 100000000;
   in_stream->read(reinterpret_cast<char*>(&jsonHeaderLength), 8);
   if (jsonHeaderLength <= 0 || jsonHeaderLength >= kMaxJsonHeaderLength) {
     throw std::runtime_error(


### PR DESCRIPTION
## Proposed changes

We've run into an issue where on iOS, where the stack size is smaller, stack allocation of a buffer for a large Safetensors header blows up the stack. Also, there seems to be no upper limit for how large this buffer can be. This PR fixes both of the issues by:

- Allocating the buffer on the heap
- Imposing the upper bound of 1GiB on its size.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
