### PR TITLE
Reduce specializations

### DIFF
--- a/mlx/backend/common/reduce.cpp
+++ b/mlx/backend/common/reduce.cpp
@@ -148,7 +148,7 @@ void reduce_dispatch_sum_prod(
   } else {
     auto op = [](auto y, auto x) { (*y) *= x; };
     if constexpr (std::is_integral_v<InT> && sizeof(InT) <= 4) {
-      reduction_op<InT, int32_t>(in, out, axes, 0, op);
+      reduction_op<InT, int32_t>(in, out, axes, 1, op);
     } else {
       reduction_op<InT, InT>(in, out, axes, 1, op);
     }

--- a/mlx/backend/common/reduce.cpp
+++ b/mlx/backend/common/reduce.cpp
@@ -140,15 +140,18 @@ void reduce_dispatch_sum_prod(
     const std::vector<int>& axes) {
   if (rtype == Reduce::Sum) {
     auto op = [](auto y, auto x) { (*y) = (*y) + x; };
-    if (out.dtype() == int32) {
-      // special case since the input type can be bool
+    if constexpr (std::is_integral_v<InT> && sizeof(InT) <= 4) {
       reduction_op<InT, int32_t>(in, out, axes, 0, op);
     } else {
       reduction_op<InT, InT>(in, out, axes, 0, op);
     }
   } else {
     auto op = [](auto y, auto x) { (*y) *= x; };
-    reduction_op<InT, InT>(in, out, axes, 1, op);
+    if constexpr (std::is_integral_v<InT> && sizeof(InT) <= 4) {
+      reduction_op<InT, int32_t>(in, out, axes, 0, op);
+    } else {
+      reduction_op<InT, InT>(in, out, axes, 1, op);
+    }
   }
 }
 

--- a/mlx/backend/metal/jit_kernels.cpp
+++ b/mlx/backend/metal/jit_kernels.cpp
@@ -1,5 +1,4 @@
 // Copyright © 2024 Apple Inc.
-
 #include "mlx/backend/common/compiled.h"
 #include "mlx/backend/metal/jit/arange.h"
 #include "mlx/backend/metal/jit/gemv_masked.h"

--- a/mlx/backend/metal/jit_kernels.cpp
+++ b/mlx/backend/metal/jit_kernels.cpp
@@ -360,28 +360,29 @@ MTL::ComputePipelineState* get_reduce_kernel(
     const std::string& op_name,
     const array& in,
     const array& out,
+    //    const std::string idx_t /* = "" */,
     int ndim /* = -1 */,
     int bm /* = -1 */,
     int bn /* = -1 */) {
   auto lib = d.get_library(kernel_name, [&]() {
     std::string op_type = op_name;
     op_type[0] = std::toupper(op_name[0]);
-    std::ostringstream kernel_source;
     auto in_type = get_type_string(in.dtype());
     auto out_type = get_type_string(out.dtype());
     std::string op = op_type + "<" + out_type + ">";
-    kernel_source << metal::utils() << metal::reduce_utils() << metal::reduce();
+    std::string kernel_source = metal::utils();
+    concatenate(kernel_source, metal::reduce_utils(), metal::reduce());
     if (bm >= 0) {
-      kernel_source << get_template_definition(
+      kernel_source += get_template_definition(
           kernel_name, func_name, in_type, out_type, op, ndim, bm, bn);
     } else if (ndim >= 0) {
-      kernel_source << get_template_definition(
+      kernel_source += get_template_definition(
           kernel_name, func_name, in_type, out_type, op, ndim);
     } else {
-      kernel_source << get_template_definition(
+      kernel_source += get_template_definition(
           kernel_name, func_name, in_type, out_type, op);
     }
-    return kernel_source.str();
+    return kernel_source;
   });
   auto st = d.get_kernel(kernel_name, lib);
   return st;

--- a/mlx/backend/metal/kernels.h
+++ b/mlx/backend/metal/kernels.h
@@ -81,15 +81,16 @@ MTL::ComputePipelineState* get_reduce_init_kernel(
     const std::string& kernel_name,
     const std::string& func_name,
     const std::string& op_name,
-    const array& out);
+    const Dtype& out_type);
 
 MTL::ComputePipelineState* get_reduce_kernel(
     metal::Device& d,
     const std::string& kernel_name,
     const std::string& func_name,
     const std::string& op_name,
-    const array& in,
-    const array& out,
+    const Dtype& in_type,
+    const Dtype& out_type,
+    const std::string& idx_t,
     int ndim = -1,
     int bm = -1,
     int bn = -1);

--- a/mlx/backend/metal/kernels/reduce.metal
+++ b/mlx/backend/metal/kernels/reduce.metal
@@ -17,8 +17,6 @@ instantiate_init_reduce(and, bool_, bool, And)
 instantiate_init_reduce(or, bool_, bool, Or)
 
 #define instantiate_init_sum_prod(name, op)                 \
-  instantiate_init_reduce(name, int8, int8_t, op)           \
-  instantiate_init_reduce(name, int16, int16_t, op)         \
   instantiate_init_reduce(name, int32, int32_t, op)         \
   instantiate_init_reduce(name, int64, int64_t, op)         \
   instantiate_init_reduce(name, float16, float16_t, op)     \
@@ -127,8 +125,7 @@ instantiate_init_min_max(max, Max)
   instantiate_col_reduce_general(name##tname, itype, otype, op<otype>)
 
 #define instantiate_and_or(name, op)                           \
-  instantiate_reduce_functions(name, bool_, bool, bool, op)    \
-  instantiate_reduce_functions(name, int8, int8_t, bool, op)   \
+  instantiate_reduce_functions(name, bool, int8_t, bool, op)   \
   instantiate_reduce_functions(name, int16, int16_t, bool, op) \
   instantiate_reduce_functions(name, int32, int32_t, bool, op) \
   instantiate_reduce_functions(name, int64, int64_t, bool, op)
@@ -136,11 +133,9 @@ instantiate_init_min_max(max, Max)
 instantiate_and_or(and, And)
 instantiate_and_or(or, Or)
 
-instantiate_reduce_functions(sum, bool_, bool, int32_t, Sum)
-
 #define instantiate_sum_prod(name, op)                                       \
-  instantiate_reduce_functions(name, int8, int8_t, int8_t, op)               \
-  instantiate_reduce_functions(name, int16, int16_t, int16_t, op)            \
+  instantiate_reduce_functions(name, int8, int8_t, int32_t, op)              \
+  instantiate_reduce_functions(name, int16, int16_t, int32_t, op)            \
   instantiate_reduce_functions(name, int32, int32_t, int32_t, op)            \
   instantiate_reduce_functions(name, int64, int64_t, int64_t, op)            \
   instantiate_reduce_functions(name, float16, float16_t, float16_t, op)      \

--- a/mlx/backend/metal/kernels/reduce.metal
+++ b/mlx/backend/metal/kernels/reduce.metal
@@ -113,35 +113,45 @@ instantiate_reduce_from_types(instantiate_all_reduce, or, bool, Or<bool>)
 // special case bool with larger output type
 instantiate_all_reduce(sumbool_, bool, uint32_t, Sum<uint32_t>)
 
-#define instantiate_col_reduce_small(name, itype, otype, op, dim)      \
+#define instantiate_col_reduce_small(name, itype, otype, op, dim) \
   instantiate_kernel("col_reduce_small_" #dim "_reduce_" #name,        \
                      col_reduce_small,                                 \
-                     itype, otype, op, dim)                            \
+                     itype, otype, op, uint, dim)                      \
   instantiate_kernel("col_reduce_longcolumn_" #dim "_reduce_" #name,   \
                      col_reduce_longcolumn,                            \
-                     itype, otype, op, dim)
+                     itype, otype, op, uint, dim)
+//  instantiate_kernel("col_reduce_small_large_" #dim "_reduce_" #name,        \
+//                     col_reduce_small,                                 \
+//                     itype, otype, op, size_t, dim)                            \
+//  instantiate_kernel("col_reduce_longcolumn_large_" #dim "_reduce_" #name,   \
+//                     col_reduce_longcolumn,                            \
+//                     itype, otype, op, size_t, dim)
 
 #define instantiate_col_reduce_looped_tile(name, itype, otype, op, dim, bm, bn)  \
   instantiate_kernel("col_reduce_looped_" #dim "_" #bm "_" #bn "_reduce_" #name, \
                      col_reduce_looped,                                          \
-                     itype, otype, op, dim, bm, bn)
+                     itype, otype, op, uint, dim, bm, bn)
+//  instantiate_kernel("col_reduce_looped_large_" #dim "_" #bm "_" #bn "_reduce_" #name, \
+//                     col_reduce_looped,                                          \
+//                     itype, otype, op, size_t, dim, bm, bn)
 
 #define instantiate_col_reduce_2pass_tile(name, itype, otype, op, dim, bm, bn)  \
   instantiate_kernel("col_reduce_2pass_" #dim "_" #bm "_" #bn "_reduce_" #name, \
                      col_reduce_2pass,                                          \
-                     itype, otype, op, dim, bm, bn)
+                     itype, otype, op, uint, dim, bm, bn)
+//  instantiate_kernel("col_reduce_2pass_large_" #dim "_" #bm "_" #bn "_reduce_" #name, \
+//                     col_reduce_2pass,                                          \
+//                     itype, otype, op, size_t, dim, bm, bn)
 
 #define instantiate_col_reduce_looped(name, itype, otype, op, dim)        \
   instantiate_col_reduce_looped_tile(name, itype, otype, op, dim, 32, 32) \
   instantiate_col_reduce_2pass_tile(name, itype, otype, op, dim, 32, 32)
 
 #define instantiate_col_reduce_general(name, itype, otype, op) \
-  instantiate_col_reduce_small(name, itype, otype, op, 0)      \
   instantiate_col_reduce_small(name, itype, otype, op, 1)      \
   instantiate_col_reduce_small(name, itype, otype, op, 2)      \
   instantiate_col_reduce_small(name, itype, otype, op, 3)      \
   instantiate_col_reduce_small(name, itype, otype, op, 4)      \
-  instantiate_col_reduce_looped(name, itype, otype, op, 0)     \
   instantiate_col_reduce_looped(name, itype, otype, op, 1)     \
   instantiate_col_reduce_looped(name, itype, otype, op, 2)     \
   instantiate_col_reduce_looped(name, itype, otype, op, 3)     \
@@ -160,20 +170,24 @@ instantiate_reduce_from_types(instantiate_col_reduce_general, or, bool, Or<bool>
 #define instantiate_row_reduce_small(name, itype, otype, op, dim) \
   instantiate_kernel("row_reduce_small_" #dim "_reduce_" #name,   \
                      row_reduce_small,                            \
-                     itype, otype, op, dim)
+                     itype, otype, op, uint, dim)
+//  instantiate_kernel("row_reduce_small_large_" #dim "_reduce_" #name,   \
+//                     row_reduce_small,                            \
+//                     itype, otype, op, size_t, dim)
 
 #define instantiate_row_reduce_looped(name, itype, otype, op, dim) \
   instantiate_kernel("row_reduce_looped_" #dim "_reduce_" #name,   \
-                     row_reduce_looped, \
-                     itype, otype, op, dim)
+                     row_reduce_looped,                            \
+                     itype, otype, op, uint, dim)
+//  instantiate_kernel("row_reduce_looped_large_" #dim "_reduce_" #name,   \
+//                     row_reduce_looped,                            \
+//                     itype, otype, op, size_t, dim)
 
 #define instantiate_row_reduce_general(name, itype, otype, op) \
-  instantiate_row_reduce_small(name, itype, otype, op, 0)      \
   instantiate_row_reduce_small(name, itype, otype, op, 1)      \
   instantiate_row_reduce_small(name, itype, otype, op, 2)      \
   instantiate_row_reduce_small(name, itype, otype, op, 3)      \
   instantiate_row_reduce_small(name, itype, otype, op, 4)      \
-  instantiate_row_reduce_looped(name, itype, otype, op, 0)     \
   instantiate_row_reduce_looped(name, itype, otype, op, 1)     \
   instantiate_row_reduce_looped(name, itype, otype, op, 2)     \
   instantiate_row_reduce_looped(name, itype, otype, op, 3)     \

--- a/mlx/backend/metal/kernels/reduce.metal
+++ b/mlx/backend/metal/kernels/reduce.metal
@@ -10,108 +10,65 @@
 #include "mlx/backend/metal/kernels/reduction/ops.h"
 #include "mlx/backend/metal/kernels/reduce.h"
 
-#define instantiate_reduce_helper_floats(inst_f, name, op) \
-  inst_f(name, float16, half, op)                          \
-  inst_f(name, float32, float, op)                         \
-  inst_f(name, bfloat16, bfloat16_t, op)
+// sum / prod get bool, signed integers, floats
+// sum output type is special case for bool and int
 
-#define instantiate_reduce_helper_uints(inst_f, name, op)  \
-  inst_f(name, uint8, uint8_t, op)                         \
-  inst_f(name, uint16, uint16_t, op)                       \
-  inst_f(name, uint32, uint32_t, op)
+// prod gets bool, signed integers, floats
+// and / or get bool, signed integers
+// min / max get everything
 
-#define instantiate_reduce_helper_ints(inst_f, name, op) \
-  inst_f(name, int8, int8_t, op)                         \
-  inst_f(name, int16, int16_t, op)                       \
-  inst_f(name, int32, int32_t, op)
+#define instantiate_init_reduce(name, tname, type, op) \
+  instantiate_kernel("init_reduce_" #name #tname, init_reduce, type, op<type>)
 
-#define instantiate_reduce_helper_64b(inst_f, name, op) \
-  inst_f(name, int64, int64_t, op)                      \
-  inst_f(name, uint64, uint64_t, op)                    \
-  inst_f(name, complex64, complex64_t, op)
-
-#define instantiate_reduce_helper_types(inst_f, name, op) \
-  instantiate_reduce_helper_floats(inst_f, name, op)      \
-  instantiate_reduce_helper_uints(inst_f, name, op)       \
-  instantiate_reduce_helper_ints(inst_f, name, op)
-
-#define instantiate_reduce_ops(inst_f, type_f) \
-  type_f(inst_f, sum, Sum)                     \
-  type_f(inst_f, prod, Prod)                   \
-  type_f(inst_f, min, Min)                     \
-  type_f(inst_f, max, Max)
-
-// Special case for bool reductions
-#define instantiate_reduce_from_types_helper( \
-    inst_f, name, tname, itype, otype, op)    \
-    inst_f(name##tname, itype, otype, op)
-
-#define instantiate_reduce_from_types(inst_f, name, otype, op)  \
-  instantiate_reduce_from_types_helper(                         \
-    inst_f, name, bool_, bool, otype, op)                       \
-  instantiate_reduce_from_types_helper(                         \
-    inst_f, name, uint8, uint8_t, otype, op)                    \
-  instantiate_reduce_from_types_helper(                         \
-    inst_f, name, uint16, uint16_t, otype, op)                  \
-  instantiate_reduce_from_types_helper(                         \
-    inst_f, name, uint32, uint32_t, otype, op)                  \
-  instantiate_reduce_from_types_helper(                         \
-    inst_f, name, uint64, uint64_t, otype, op)                  \
-  instantiate_reduce_from_types_helper(                         \
-    inst_f, name, int8, int8_t, otype, op)                      \
-  instantiate_reduce_from_types_helper(                         \
-    inst_f, name, int16, int16_t, otype, op)                    \
-  instantiate_reduce_from_types_helper(                         \
-    inst_f, name, int32, int32_t, otype, op)                    \
-  instantiate_reduce_from_types_helper(                         \
-    inst_f, name, int64, int64_t, otype, op)                    \
-  instantiate_reduce_from_types_helper(                         \
-    inst_f, name, float16, half, otype, op)                     \
-  instantiate_reduce_from_types_helper(                         \
-    inst_f,                                                     \
-    name,                                                       \
-    float32,                                                    \
-    float,                                                      \
-    otype,                                                      \
-    op)                                                         \
-  instantiate_reduce_from_types_helper(                         \
-    inst_f,                                                     \
-    name,                                                       \
-    bfloat16,                                                   \
-    bfloat16_t,                                                 \
-    otype,                                                      \
-    op)
-
-#define instantiate_init_reduce(name, otype, op) \
-  instantiate_kernel("init_reduce_" #name,       \
-                     init_reduce,                \
-                     otype, op)
-
-#define instantiate_init_reduce_helper(name, tname, type, op) \
-  instantiate_init_reduce(name##tname, type, op<type>)
-
-instantiate_reduce_ops(instantiate_init_reduce_helper, instantiate_reduce_helper_types)
-instantiate_reduce_ops(instantiate_init_reduce_helper, instantiate_reduce_helper_64b)
-
-instantiate_init_reduce(andbool_, bool, And<bool>)
-instantiate_init_reduce(orbool_, bool, Or<bool>)
+instantiate_init_reduce(and, bool_, bool, And)
+instantiate_init_reduce(or, bool_, bool, Or)
+instantiate_init_reduce(sum, int8, int8_t, Sum)
+instantiate_init_reduce(sum, int16, int16_t, Sum)
+instantiate_init_reduce(sum, int32, int32_t, Sum)
+instantiate_init_reduce(sum, int64, int64_t, Sum)
+instantiate_init_reduce(sum, float16, float16_t, Sum)
+instantiate_init_reduce(sum, bfloat16, bfloat16_t, Sum)
+instantiate_init_reduce(sum, float32, float, Sum)
+instantiate_init_reduce(sum, complex64, complex64_t, Sum)
+instantiate_init_reduce(prod, int8, int8_t, Prod)
+instantiate_init_reduce(prod, int16, int16_t, Prod)
+instantiate_init_reduce(prod, int32, int32_t, Prod)
+instantiate_init_reduce(prod, int64, int64_t, Prod)
+instantiate_init_reduce(prod, float16, float16_t, Prod)
+instantiate_init_reduce(prod, bfloat16, bfloat16_t, Prod)
+instantiate_init_reduce(prod, float32, float, Prod)
+instantiate_init_reduce(prod, complex64, complex64_t, Prod)
+instantiate_init_reduce(min, bool_, bool, Min)
+instantiate_init_reduce(min, int8, int8_t, Min)
+instantiate_init_reduce(min, int16, int16_t, Min)
+instantiate_init_reduce(min, int32, int32_t, Min)
+instantiate_init_reduce(min, int64, int64_t, Min)
+instantiate_init_reduce(min, uint8, uint8_t, Min)
+instantiate_init_reduce(min, uint16, uint16_t, Min)
+instantiate_init_reduce(min, uint32, uint32_t, Min)
+instantiate_init_reduce(min, uint64, uint64_t, Min)
+instantiate_init_reduce(min, float16, float16_t, Min)
+instantiate_init_reduce(min, bfloat16, bfloat16_t, Min)
+instantiate_init_reduce(min, float32, float, Min)
+instantiate_init_reduce(min, complex64, complex64_t, Min)
+instantiate_init_reduce(max, bool_, bool, Max)
+instantiate_init_reduce(max, int8, int8_t, Max)
+instantiate_init_reduce(max, int16, int16_t, Max)
+instantiate_init_reduce(max, int32, int32_t, Max)
+instantiate_init_reduce(max, int64, int64_t, Max)
+instantiate_init_reduce(max, uint8, uint8_t, Max)
+instantiate_init_reduce(max, uint16, uint16_t, Max)
+instantiate_init_reduce(max, uint32, uint32_t, Max)
+instantiate_init_reduce(max, uint64, uint64_t, Max)
+instantiate_init_reduce(max, float16, float16_t, Max)
+instantiate_init_reduce(max, bfloat16, bfloat16_t, Max)
+instantiate_init_reduce(max, float32, float, Max)
+instantiate_init_reduce(max, complex64, complex64_t, Max)
 
 #define instantiate_all_reduce(name, itype, otype, op) \
   instantiate_kernel("all_reduce_" #name,              \
                      all_reduce,                       \
                      itype, otype, op)
-
-#define instantiate_same_all_reduce_helper(name, tname, type, op) \
-  instantiate_all_reduce(name##tname, type, type, op<type>)
-
-instantiate_reduce_ops(instantiate_same_all_reduce_helper, instantiate_reduce_helper_types)
-instantiate_reduce_ops(instantiate_same_all_reduce_helper, instantiate_reduce_helper_64b)
-
-instantiate_reduce_from_types(instantiate_all_reduce, and, bool, And<bool>)
-instantiate_reduce_from_types(instantiate_all_reduce, or, bool, Or<bool>)
-
-// special case bool with larger output type
-instantiate_all_reduce(sumbool_, bool, uint32_t, Sum<uint32_t>)
 
 #define instantiate_col_reduce_small(name, itype, otype, op, dim) \
   instantiate_kernel("col_reduce_small_" #dim "_reduce_" #name,        \
@@ -119,29 +76,29 @@ instantiate_all_reduce(sumbool_, bool, uint32_t, Sum<uint32_t>)
                      itype, otype, op, uint, dim)                      \
   instantiate_kernel("col_reduce_longcolumn_" #dim "_reduce_" #name,   \
                      col_reduce_longcolumn,                            \
-                     itype, otype, op, uint, dim)
-//  instantiate_kernel("col_reduce_small_large_" #dim "_reduce_" #name,        \
-//                     col_reduce_small,                                 \
-//                     itype, otype, op, size_t, dim)                            \
-//  instantiate_kernel("col_reduce_longcolumn_large_" #dim "_reduce_" #name,   \
-//                     col_reduce_longcolumn,                            \
-//                     itype, otype, op, size_t, dim)
+                     itype, otype, op, uint, dim)     \
+  instantiate_kernel("col_reduce_small_large_" #dim "_reduce_" #name,        \
+                     col_reduce_small,                                 \
+                     itype, otype, op, size_t, dim)                            \
+  instantiate_kernel("col_reduce_longcolumn_large_" #dim "_reduce_" #name,   \
+                     col_reduce_longcolumn,                            \
+                     itype, otype, op, size_t, dim)
 
 #define instantiate_col_reduce_looped_tile(name, itype, otype, op, dim, bm, bn)  \
   instantiate_kernel("col_reduce_looped_" #dim "_" #bm "_" #bn "_reduce_" #name, \
                      col_reduce_looped,                                          \
-                     itype, otype, op, uint, dim, bm, bn)
-//  instantiate_kernel("col_reduce_looped_large_" #dim "_" #bm "_" #bn "_reduce_" #name, \
-//                     col_reduce_looped,                                          \
-//                     itype, otype, op, size_t, dim, bm, bn)
+                     itype, otype, op, uint, dim, bm, bn) \
+  instantiate_kernel("col_reduce_looped_large_" #dim "_" #bm "_" #bn "_reduce_" #name, \
+                     col_reduce_looped,                                          \
+                     itype, otype, op, size_t, dim, bm, bn)
 
 #define instantiate_col_reduce_2pass_tile(name, itype, otype, op, dim, bm, bn)  \
   instantiate_kernel("col_reduce_2pass_" #dim "_" #bm "_" #bn "_reduce_" #name, \
                      col_reduce_2pass,                                          \
-                     itype, otype, op, uint, dim, bm, bn)
-//  instantiate_kernel("col_reduce_2pass_large_" #dim "_" #bm "_" #bn "_reduce_" #name, \
-//                     col_reduce_2pass,                                          \
-//                     itype, otype, op, size_t, dim, bm, bn)
+                     itype, otype, op, uint, dim, bm, bn) \
+  instantiate_kernel("col_reduce_2pass_large_" #dim "_" #bm "_" #bn "_reduce_" #name, \
+                     col_reduce_2pass,                                          \
+                     itype, otype, op, size_t, dim, bm, bn)
 
 #define instantiate_col_reduce_looped(name, itype, otype, op, dim)        \
   instantiate_col_reduce_looped_tile(name, itype, otype, op, dim, 32, 32) \
@@ -151,59 +108,96 @@ instantiate_all_reduce(sumbool_, bool, uint32_t, Sum<uint32_t>)
   instantiate_col_reduce_small(name, itype, otype, op, 1)      \
   instantiate_col_reduce_small(name, itype, otype, op, 2)      \
   instantiate_col_reduce_small(name, itype, otype, op, 3)      \
-  instantiate_col_reduce_small(name, itype, otype, op, 4)      \
   instantiate_col_reduce_looped(name, itype, otype, op, 1)     \
   instantiate_col_reduce_looped(name, itype, otype, op, 2)     \
-  instantiate_col_reduce_looped(name, itype, otype, op, 3)     \
-  instantiate_col_reduce_looped(name, itype, otype, op, 4)
-
-#define instantiate_same_col_reduce_helper(name, tname, type, op)  \
-  instantiate_col_reduce_general(name##tname, type, type, op<type>)
-
-instantiate_reduce_ops(instantiate_same_col_reduce_helper, instantiate_reduce_helper_types)
-instantiate_reduce_ops(instantiate_same_col_reduce_helper, instantiate_reduce_helper_64b)
-
-instantiate_col_reduce_general(sumbool_, bool, uint32_t, Sum<uint32_t>)
-instantiate_reduce_from_types(instantiate_col_reduce_general, and, bool, And<bool>)
-instantiate_reduce_from_types(instantiate_col_reduce_general, or, bool, Or<bool>)
+  instantiate_col_reduce_looped(name, itype, otype, op, 3)
 
 #define instantiate_row_reduce_small(name, itype, otype, op, dim) \
   instantiate_kernel("row_reduce_small_" #dim "_reduce_" #name,   \
                      row_reduce_small,                            \
-                     itype, otype, op, uint, dim)
-//  instantiate_kernel("row_reduce_small_large_" #dim "_reduce_" #name,   \
-//                     row_reduce_small,                            \
-//                     itype, otype, op, size_t, dim)
+                     itype, otype, op, uint, dim)         \
+  instantiate_kernel("row_reduce_small_large_" #dim "_reduce_" #name,   \
+                     row_reduce_small,                            \
+                     itype, otype, op, size_t, dim)
 
 #define instantiate_row_reduce_looped(name, itype, otype, op, dim) \
   instantiate_kernel("row_reduce_looped_" #dim "_reduce_" #name,   \
                      row_reduce_looped,                            \
-                     itype, otype, op, uint, dim)
-//  instantiate_kernel("row_reduce_looped_large_" #dim "_reduce_" #name,   \
-//                     row_reduce_looped,                            \
-//                     itype, otype, op, size_t, dim)
+                     itype, otype, op, uint, dim)                  \
+  instantiate_kernel("row_reduce_looped_large_" #dim "_reduce_" #name,   \
+                     row_reduce_looped,                            \
+                     itype, otype, op, size_t, dim)
 
 #define instantiate_row_reduce_general(name, itype, otype, op) \
   instantiate_row_reduce_small(name, itype, otype, op, 1)      \
   instantiate_row_reduce_small(name, itype, otype, op, 2)      \
   instantiate_row_reduce_small(name, itype, otype, op, 3)      \
-  instantiate_row_reduce_small(name, itype, otype, op, 4)      \
   instantiate_row_reduce_looped(name, itype, otype, op, 1)     \
   instantiate_row_reduce_looped(name, itype, otype, op, 2)     \
   instantiate_row_reduce_looped(name, itype, otype, op, 3)     \
-  instantiate_row_reduce_looped(name, itype, otype, op, 4)     \
   instantiate_kernel("row_reduce_simple_" #name,               \
                      row_reduce_simple,                        \
                      itype, otype, op)
 
-#define instantiate_same_row_reduce_helper(name, tname, type, op)  \
-  instantiate_row_reduce_general(name##tname, type, type, op<type>)
+#define instantiate_reduce_functions(name, tname, itype, otype, op)    \
+  instantiate_all_reduce(name##tname, itype, otype, op<otype>)         \
+  instantiate_row_reduce_general(name##tname, itype, otype, op<otype>) \
+  instantiate_col_reduce_general(name##tname, itype, otype, op<otype>)
 
-instantiate_reduce_ops(instantiate_same_row_reduce_helper, instantiate_reduce_helper_types)
-instantiate_reduce_ops(instantiate_same_row_reduce_helper, instantiate_reduce_helper_64b)
+instantiate_reduce_functions(and, bool_, bool, bool, And)
+instantiate_reduce_functions(and, int8, int8_t, bool, And)
+instantiate_reduce_functions(and, int16, int16_t, bool, And)
+instantiate_reduce_functions(and, int32, int32_t, bool, And)
+instantiate_reduce_functions(and, int64, int64_t, bool, And)
+instantiate_reduce_functions(or, bool_, bool, bool, Or)
+instantiate_reduce_functions(or, int8, int8_t, bool, Or)
+instantiate_reduce_functions(or, int16, int16_t, bool, Or)
+instantiate_reduce_functions(or, int32, int32_t, bool, Or)
+instantiate_reduce_functions(or, int64, int64_t, bool, Or)
 
-instantiate_reduce_from_types(instantiate_row_reduce_general, and, bool, And<bool>)
-instantiate_reduce_from_types(instantiate_row_reduce_general, or, bool, Or<bool>)
+instantiate_reduce_functions(sum, bool_, bool, int32_t, Sum)
+instantiate_reduce_functions(sum, int8, int8_t, int8_t, Sum)
+instantiate_reduce_functions(sum, int16, int16_t, int16_t, Sum)
+instantiate_reduce_functions(sum, int32, int32_t, int32_t, Sum)
+instantiate_reduce_functions(sum, int64, int64_t, int64_t, Sum)
+instantiate_reduce_functions(sum, float16, float16_t, float16_t, Sum)
+instantiate_reduce_functions(sum, bfloat16, bfloat16_t, bfloat16_t, Sum)
+instantiate_reduce_functions(sum, float32, float, float, Sum)
+instantiate_reduce_functions(sum, complex64, complex64_t, complex64_t, Sum)
 
-instantiate_row_reduce_general(sumbool_, bool, uint32_t, Sum<uint32_t>)
+instantiate_reduce_functions(prod, int8, int8_t, int8_t, Prod)
+instantiate_reduce_functions(prod, int16, int16_t, int16_t, Prod)
+instantiate_reduce_functions(prod, int32, int32_t, int32_t, Prod)
+instantiate_reduce_functions(prod, int64, int64_t, int64_t, Prod)
+instantiate_reduce_functions(prod, float16, float16_t, float16_t, Prod)
+instantiate_reduce_functions(prod, bfloat16, bfloat16_t, bfloat16_t, Prod)
+instantiate_reduce_functions(prod, float32, float, float, Prod)
+instantiate_reduce_functions(prod, complex64, complex64_t, complex64_t, Prod)
+
+instantiate_reduce_functions(min, int8, int8_t, int8_t, Min)
+instantiate_reduce_functions(min, int16, int16_t, int16_t, Min)
+instantiate_reduce_functions(min, int32, int32_t, int32_t, Min)
+instantiate_reduce_functions(min, int64, int64_t, int64_t, Min)
+instantiate_reduce_functions(min, uint8, uint8_t, uint8_t, Min)
+instantiate_reduce_functions(min, uint16, uint16_t, uint16_t, Min)
+instantiate_reduce_functions(min, uint32, uint32_t, uint32_t, Min)
+instantiate_reduce_functions(min, uint64, uint64_t, uint64_t, Min)
+instantiate_reduce_functions(min, float16, float16_t, float16_t, Min)
+instantiate_reduce_functions(min, bfloat16, bfloat16_t, bfloat16_t, Min)
+instantiate_reduce_functions(min, float32, float, float, Min)
+instantiate_reduce_functions(min, complex64, complex64_t, complex64_t, Min)
+
+instantiate_reduce_functions(max, int8, int8_t, int8_t, Max)
+instantiate_reduce_functions(max, int16, int16_t, int16_t, Max)
+instantiate_reduce_functions(max, int32, int32_t, int32_t, Max)
+instantiate_reduce_functions(max, int64, int64_t, int64_t, Max)
+instantiate_reduce_functions(max, uint8, uint8_t, uint8_t, Max)
+instantiate_reduce_functions(max, uint16, uint16_t, uint16_t, Max)
+instantiate_reduce_functions(max, uint32, uint32_t, uint32_t, Max)
+instantiate_reduce_functions(max, uint64, uint64_t, uint64_t, Max)
+instantiate_reduce_functions(max, float16, float16_t, float16_t, Max)
+instantiate_reduce_functions(max, bfloat16, bfloat16_t, bfloat16_t, Max)
+instantiate_reduce_functions(max, float32, float, float, Max)
+instantiate_reduce_functions(max, complex64, complex64_t, complex64_t, Max)
+
     // clang-format on

--- a/mlx/backend/metal/kernels/reduce.metal
+++ b/mlx/backend/metal/kernels/reduce.metal
@@ -88,11 +88,9 @@ instantiate_init_min_max(max, Max)
 
 #define instantiate_col_reduce_general(name, itype, otype, op) \
   instantiate_col_reduce_small(name, itype, otype, op, 1)      \
-  instantiate_col_reduce_small(name, itype, otype, op, 2)      \
-  instantiate_col_reduce_small(name, itype, otype, op, 3)      \
+  instantiate_col_reduce_small(name, itype, otype, op, 5)      \
   instantiate_col_reduce_looped(name, itype, otype, op, 1)     \
-  instantiate_col_reduce_looped(name, itype, otype, op, 2)     \
-  instantiate_col_reduce_looped(name, itype, otype, op, 3)
+  instantiate_col_reduce_looped(name, itype, otype, op, 5)
 
 #define instantiate_row_reduce_small(name, itype, otype, op, dim)     \
   instantiate_kernel("row_reduce_small_" #dim "_reduce_" #name,       \
@@ -112,11 +110,9 @@ instantiate_init_min_max(max, Max)
 
 #define instantiate_row_reduce_general(name, itype, otype, op) \
   instantiate_row_reduce_small(name, itype, otype, op, 1)      \
-  instantiate_row_reduce_small(name, itype, otype, op, 2)      \
-  instantiate_row_reduce_small(name, itype, otype, op, 3)      \
+  instantiate_row_reduce_small(name, itype, otype, op, 5)      \
   instantiate_row_reduce_looped(name, itype, otype, op, 1)     \
-  instantiate_row_reduce_looped(name, itype, otype, op, 2)     \
-  instantiate_row_reduce_looped(name, itype, otype, op, 3)     \
+  instantiate_row_reduce_looped(name, itype, otype, op, 5)     \
   instantiate_kernel("row_reduce_simple_" #name,               \
                      row_reduce_simple,                        \
                      itype, otype, op)

--- a/mlx/backend/metal/kernels/reduce.metal
+++ b/mlx/backend/metal/kernels/reduce.metal
@@ -10,94 +10,76 @@
 #include "mlx/backend/metal/kernels/reduction/ops.h"
 #include "mlx/backend/metal/kernels/reduce.h"
 
-// sum / prod get bool, signed integers, floats
-// sum output type is special case for bool and int
-
-// prod gets bool, signed integers, floats
-// and / or get bool, signed integers
-// min / max get everything
-
 #define instantiate_init_reduce(name, tname, type, op) \
   instantiate_kernel("init_reduce_" #name #tname, init_reduce, type, op<type>)
 
 instantiate_init_reduce(and, bool_, bool, And)
 instantiate_init_reduce(or, bool_, bool, Or)
-instantiate_init_reduce(sum, int8, int8_t, Sum)
-instantiate_init_reduce(sum, int16, int16_t, Sum)
-instantiate_init_reduce(sum, int32, int32_t, Sum)
-instantiate_init_reduce(sum, int64, int64_t, Sum)
-instantiate_init_reduce(sum, float16, float16_t, Sum)
-instantiate_init_reduce(sum, bfloat16, bfloat16_t, Sum)
-instantiate_init_reduce(sum, float32, float, Sum)
-instantiate_init_reduce(sum, complex64, complex64_t, Sum)
-instantiate_init_reduce(prod, int8, int8_t, Prod)
-instantiate_init_reduce(prod, int16, int16_t, Prod)
-instantiate_init_reduce(prod, int32, int32_t, Prod)
-instantiate_init_reduce(prod, int64, int64_t, Prod)
-instantiate_init_reduce(prod, float16, float16_t, Prod)
-instantiate_init_reduce(prod, bfloat16, bfloat16_t, Prod)
-instantiate_init_reduce(prod, float32, float, Prod)
-instantiate_init_reduce(prod, complex64, complex64_t, Prod)
-instantiate_init_reduce(min, bool_, bool, Min)
-instantiate_init_reduce(min, int8, int8_t, Min)
-instantiate_init_reduce(min, int16, int16_t, Min)
-instantiate_init_reduce(min, int32, int32_t, Min)
-instantiate_init_reduce(min, int64, int64_t, Min)
-instantiate_init_reduce(min, uint8, uint8_t, Min)
-instantiate_init_reduce(min, uint16, uint16_t, Min)
-instantiate_init_reduce(min, uint32, uint32_t, Min)
-instantiate_init_reduce(min, uint64, uint64_t, Min)
-instantiate_init_reduce(min, float16, float16_t, Min)
-instantiate_init_reduce(min, bfloat16, bfloat16_t, Min)
-instantiate_init_reduce(min, float32, float, Min)
-instantiate_init_reduce(min, complex64, complex64_t, Min)
-instantiate_init_reduce(max, bool_, bool, Max)
-instantiate_init_reduce(max, int8, int8_t, Max)
-instantiate_init_reduce(max, int16, int16_t, Max)
-instantiate_init_reduce(max, int32, int32_t, Max)
-instantiate_init_reduce(max, int64, int64_t, Max)
-instantiate_init_reduce(max, uint8, uint8_t, Max)
-instantiate_init_reduce(max, uint16, uint16_t, Max)
-instantiate_init_reduce(max, uint32, uint32_t, Max)
-instantiate_init_reduce(max, uint64, uint64_t, Max)
-instantiate_init_reduce(max, float16, float16_t, Max)
-instantiate_init_reduce(max, bfloat16, bfloat16_t, Max)
-instantiate_init_reduce(max, float32, float, Max)
-instantiate_init_reduce(max, complex64, complex64_t, Max)
+
+#define instantiate_init_sum_prod(name, op)                 \
+  instantiate_init_reduce(name, int8, int8_t, op)           \
+  instantiate_init_reduce(name, int16, int16_t, op)         \
+  instantiate_init_reduce(name, int32, int32_t, op)         \
+  instantiate_init_reduce(name, int64, int64_t, op)         \
+  instantiate_init_reduce(name, float16, float16_t, op)     \
+  instantiate_init_reduce(name, bfloat16, bfloat16_t, op)   \
+  instantiate_init_reduce(name, float32, float, op)         \
+  instantiate_init_reduce(name, complex64, complex64_t, op)
+
+instantiate_init_sum_prod(sum, Sum)
+instantiate_init_sum_prod(prod, Prod)
+
+#define instantiate_init_min_max(name, op)                   \
+  instantiate_init_reduce(name, bool_, bool, op)             \
+  instantiate_init_reduce(name, int8, int8_t, op)            \
+  instantiate_init_reduce(name, int16, int16_t, op)          \
+  instantiate_init_reduce(name, int32, int32_t, op)          \
+  instantiate_init_reduce(name, int64, int64_t, op)          \
+  instantiate_init_reduce(name, uint8, uint8_t, op)          \
+  instantiate_init_reduce(name, uint16, uint16_t, op)        \
+  instantiate_init_reduce(name, uint32, uint32_t, op)        \
+  instantiate_init_reduce(name, uint64, uint64_t, op)        \
+  instantiate_init_reduce(name, float16, float16_t, op)      \
+  instantiate_init_reduce(name, bfloat16, bfloat16_t, op)    \
+  instantiate_init_reduce(name, float32, float, op)          \
+  instantiate_init_reduce(name, complex64, complex64_t, op)
+
+instantiate_init_min_max(min, Min)
+instantiate_init_min_max(max, Max)
 
 #define instantiate_all_reduce(name, itype, otype, op) \
   instantiate_kernel("all_reduce_" #name,              \
                      all_reduce,                       \
                      itype, otype, op)
 
-#define instantiate_col_reduce_small(name, itype, otype, op, dim) \
-  instantiate_kernel("col_reduce_small_" #dim "_reduce_" #name,        \
-                     col_reduce_small,                                 \
-                     itype, otype, op, uint, dim)                      \
-  instantiate_kernel("col_reduce_longcolumn_" #dim "_reduce_" #name,   \
-                     col_reduce_longcolumn,                            \
-                     itype, otype, op, uint, dim)     \
-  instantiate_kernel("col_reduce_small_large_" #dim "_reduce_" #name,        \
-                     col_reduce_small,                                 \
-                     itype, otype, op, size_t, dim)                            \
-  instantiate_kernel("col_reduce_longcolumn_large_" #dim "_reduce_" #name,   \
-                     col_reduce_longcolumn,                            \
+#define instantiate_col_reduce_small(name, itype, otype, op, dim)          \
+  instantiate_kernel("col_reduce_small_" #dim "_reduce_" #name,            \
+                     col_reduce_small,                                     \
+                     itype, otype, op, uint, dim)                          \
+  instantiate_kernel("col_reduce_longcolumn_" #dim "_reduce_" #name,       \
+                     col_reduce_longcolumn,                                \
+                     itype, otype, op, uint, dim)                          \
+  instantiate_kernel("col_reduce_small_large_" #dim "_reduce_" #name,      \
+                     col_reduce_small,                                     \
+                     itype, otype, op, size_t, dim)                        \
+  instantiate_kernel("col_reduce_longcolumn_large_" #dim "_reduce_" #name, \
+                     col_reduce_longcolumn,                                \
                      itype, otype, op, size_t, dim)
 
-#define instantiate_col_reduce_looped_tile(name, itype, otype, op, dim, bm, bn)  \
-  instantiate_kernel("col_reduce_looped_" #dim "_" #bm "_" #bn "_reduce_" #name, \
-                     col_reduce_looped,                                          \
-                     itype, otype, op, uint, dim, bm, bn) \
+#define instantiate_col_reduce_looped_tile(name, itype, otype, op, dim, bm, bn)        \
+  instantiate_kernel("col_reduce_looped_" #dim "_" #bm "_" #bn "_reduce_" #name,       \
+                     col_reduce_looped,                                                \
+                     itype, otype, op, uint, dim, bm, bn)                              \
   instantiate_kernel("col_reduce_looped_large_" #dim "_" #bm "_" #bn "_reduce_" #name, \
-                     col_reduce_looped,                                          \
+                     col_reduce_looped,                                                \
                      itype, otype, op, size_t, dim, bm, bn)
 
-#define instantiate_col_reduce_2pass_tile(name, itype, otype, op, dim, bm, bn)  \
-  instantiate_kernel("col_reduce_2pass_" #dim "_" #bm "_" #bn "_reduce_" #name, \
-                     col_reduce_2pass,                                          \
-                     itype, otype, op, uint, dim, bm, bn) \
+#define instantiate_col_reduce_2pass_tile(name, itype, otype, op, dim, bm, bn)        \
+  instantiate_kernel("col_reduce_2pass_" #dim "_" #bm "_" #bn "_reduce_" #name,       \
+                     col_reduce_2pass,                                                \
+                     itype, otype, op, uint, dim, bm, bn)                             \
   instantiate_kernel("col_reduce_2pass_large_" #dim "_" #bm "_" #bn "_reduce_" #name, \
-                     col_reduce_2pass,                                          \
+                     col_reduce_2pass,                                                \
                      itype, otype, op, size_t, dim, bm, bn)
 
 #define instantiate_col_reduce_looped(name, itype, otype, op, dim)        \
@@ -112,20 +94,20 @@ instantiate_init_reduce(max, complex64, complex64_t, Max)
   instantiate_col_reduce_looped(name, itype, otype, op, 2)     \
   instantiate_col_reduce_looped(name, itype, otype, op, 3)
 
-#define instantiate_row_reduce_small(name, itype, otype, op, dim) \
-  instantiate_kernel("row_reduce_small_" #dim "_reduce_" #name,   \
-                     row_reduce_small,                            \
-                     itype, otype, op, uint, dim)         \
-  instantiate_kernel("row_reduce_small_large_" #dim "_reduce_" #name,   \
-                     row_reduce_small,                            \
+#define instantiate_row_reduce_small(name, itype, otype, op, dim)     \
+  instantiate_kernel("row_reduce_small_" #dim "_reduce_" #name,       \
+                     row_reduce_small,                                \
+                     itype, otype, op, uint, dim)                     \
+  instantiate_kernel("row_reduce_small_large_" #dim "_reduce_" #name, \
+                     row_reduce_small,                                \
                      itype, otype, op, size_t, dim)
 
-#define instantiate_row_reduce_looped(name, itype, otype, op, dim) \
-  instantiate_kernel("row_reduce_looped_" #dim "_reduce_" #name,   \
-                     row_reduce_looped,                            \
-                     itype, otype, op, uint, dim)                  \
+#define instantiate_row_reduce_looped(name, itype, otype, op, dim)       \
+  instantiate_kernel("row_reduce_looped_" #dim "_reduce_" #name,         \
+                     row_reduce_looped,                                  \
+                     itype, otype, op, uint, dim)                        \
   instantiate_kernel("row_reduce_looped_large_" #dim "_reduce_" #name,   \
-                     row_reduce_looped,                            \
+                     row_reduce_looped,                                  \
                      itype, otype, op, size_t, dim)
 
 #define instantiate_row_reduce_general(name, itype, otype, op) \
@@ -144,60 +126,45 @@ instantiate_init_reduce(max, complex64, complex64_t, Max)
   instantiate_row_reduce_general(name##tname, itype, otype, op<otype>) \
   instantiate_col_reduce_general(name##tname, itype, otype, op<otype>)
 
-instantiate_reduce_functions(and, bool_, bool, bool, And)
-instantiate_reduce_functions(and, int8, int8_t, bool, And)
-instantiate_reduce_functions(and, int16, int16_t, bool, And)
-instantiate_reduce_functions(and, int32, int32_t, bool, And)
-instantiate_reduce_functions(and, int64, int64_t, bool, And)
-instantiate_reduce_functions(or, bool_, bool, bool, Or)
-instantiate_reduce_functions(or, int8, int8_t, bool, Or)
-instantiate_reduce_functions(or, int16, int16_t, bool, Or)
-instantiate_reduce_functions(or, int32, int32_t, bool, Or)
-instantiate_reduce_functions(or, int64, int64_t, bool, Or)
+#define instantiate_and_or(name, op)                           \
+  instantiate_reduce_functions(name, bool_, bool, bool, op)    \
+  instantiate_reduce_functions(name, int8, int8_t, bool, op)   \
+  instantiate_reduce_functions(name, int16, int16_t, bool, op) \
+  instantiate_reduce_functions(name, int32, int32_t, bool, op) \
+  instantiate_reduce_functions(name, int64, int64_t, bool, op)
+
+instantiate_and_or(and, And)
+instantiate_and_or(or, Or)
 
 instantiate_reduce_functions(sum, bool_, bool, int32_t, Sum)
-instantiate_reduce_functions(sum, int8, int8_t, int8_t, Sum)
-instantiate_reduce_functions(sum, int16, int16_t, int16_t, Sum)
-instantiate_reduce_functions(sum, int32, int32_t, int32_t, Sum)
-instantiate_reduce_functions(sum, int64, int64_t, int64_t, Sum)
-instantiate_reduce_functions(sum, float16, float16_t, float16_t, Sum)
-instantiate_reduce_functions(sum, bfloat16, bfloat16_t, bfloat16_t, Sum)
-instantiate_reduce_functions(sum, float32, float, float, Sum)
-instantiate_reduce_functions(sum, complex64, complex64_t, complex64_t, Sum)
 
-instantiate_reduce_functions(prod, int8, int8_t, int8_t, Prod)
-instantiate_reduce_functions(prod, int16, int16_t, int16_t, Prod)
-instantiate_reduce_functions(prod, int32, int32_t, int32_t, Prod)
-instantiate_reduce_functions(prod, int64, int64_t, int64_t, Prod)
-instantiate_reduce_functions(prod, float16, float16_t, float16_t, Prod)
-instantiate_reduce_functions(prod, bfloat16, bfloat16_t, bfloat16_t, Prod)
-instantiate_reduce_functions(prod, float32, float, float, Prod)
-instantiate_reduce_functions(prod, complex64, complex64_t, complex64_t, Prod)
+#define instantiate_sum_prod(name, op)                                       \
+  instantiate_reduce_functions(name, int8, int8_t, int8_t, op)               \
+  instantiate_reduce_functions(name, int16, int16_t, int16_t, op)            \
+  instantiate_reduce_functions(name, int32, int32_t, int32_t, op)            \
+  instantiate_reduce_functions(name, int64, int64_t, int64_t, op)            \
+  instantiate_reduce_functions(name, float16, float16_t, float16_t, op)      \
+  instantiate_reduce_functions(name, bfloat16, bfloat16_t, bfloat16_t, op)   \
+  instantiate_reduce_functions(name, float32, float, float, op)              \
+  instantiate_reduce_functions(name, complex64, complex64_t, complex64_t, op)
 
-instantiate_reduce_functions(min, int8, int8_t, int8_t, Min)
-instantiate_reduce_functions(min, int16, int16_t, int16_t, Min)
-instantiate_reduce_functions(min, int32, int32_t, int32_t, Min)
-instantiate_reduce_functions(min, int64, int64_t, int64_t, Min)
-instantiate_reduce_functions(min, uint8, uint8_t, uint8_t, Min)
-instantiate_reduce_functions(min, uint16, uint16_t, uint16_t, Min)
-instantiate_reduce_functions(min, uint32, uint32_t, uint32_t, Min)
-instantiate_reduce_functions(min, uint64, uint64_t, uint64_t, Min)
-instantiate_reduce_functions(min, float16, float16_t, float16_t, Min)
-instantiate_reduce_functions(min, bfloat16, bfloat16_t, bfloat16_t, Min)
-instantiate_reduce_functions(min, float32, float, float, Min)
-instantiate_reduce_functions(min, complex64, complex64_t, complex64_t, Min)
+instantiate_sum_prod(sum, Sum)
+instantiate_sum_prod(prod, Prod)
 
-instantiate_reduce_functions(max, int8, int8_t, int8_t, Max)
-instantiate_reduce_functions(max, int16, int16_t, int16_t, Max)
-instantiate_reduce_functions(max, int32, int32_t, int32_t, Max)
-instantiate_reduce_functions(max, int64, int64_t, int64_t, Max)
-instantiate_reduce_functions(max, uint8, uint8_t, uint8_t, Max)
-instantiate_reduce_functions(max, uint16, uint16_t, uint16_t, Max)
-instantiate_reduce_functions(max, uint32, uint32_t, uint32_t, Max)
-instantiate_reduce_functions(max, uint64, uint64_t, uint64_t, Max)
-instantiate_reduce_functions(max, float16, float16_t, float16_t, Max)
-instantiate_reduce_functions(max, bfloat16, bfloat16_t, bfloat16_t, Max)
-instantiate_reduce_functions(max, float32, float, float, Max)
-instantiate_reduce_functions(max, complex64, complex64_t, complex64_t, Max)
+#define instantiate_min_max(name, op)                                        \
+  instantiate_reduce_functions(name, int8, int8_t, int8_t, op)               \
+  instantiate_reduce_functions(name, int16, int16_t, int16_t, op)            \
+  instantiate_reduce_functions(name, int32, int32_t, int32_t, op)            \
+  instantiate_reduce_functions(name, int64, int64_t, int64_t, op)            \
+  instantiate_reduce_functions(name, uint8, uint8_t, uint8_t, op)            \
+  instantiate_reduce_functions(name, uint16, uint16_t, uint16_t, op)         \
+  instantiate_reduce_functions(name, uint32, uint32_t, uint32_t, op)         \
+  instantiate_reduce_functions(name, uint64, uint64_t, uint64_t, op)         \
+  instantiate_reduce_functions(name, float16, float16_t, float16_t, op)      \
+  instantiate_reduce_functions(name, bfloat16, bfloat16_t, bfloat16_t, op)   \
+  instantiate_reduce_functions(name, float32, float, float, op)              \
+  instantiate_reduce_functions(name, complex64, complex64_t, complex64_t, op)
 
+instantiate_min_max(min, Min)
+instantiate_min_max(max, Max)
     // clang-format on

--- a/mlx/backend/metal/kernels/reduce.metal
+++ b/mlx/backend/metal/kernels/reduce.metal
@@ -125,7 +125,7 @@ instantiate_init_min_max(max, Max)
   instantiate_col_reduce_general(name##tname, itype, otype, op<otype>)
 
 #define instantiate_and_or(name, op)                           \
-  instantiate_reduce_functions(name, bool, int8_t, bool, op)   \
+  instantiate_reduce_functions(name, bool_, bool, bool, op)   \
   instantiate_reduce_functions(name, int16, int16_t, bool, op) \
   instantiate_reduce_functions(name, int32, int32_t, bool, op) \
   instantiate_reduce_functions(name, int64, int64_t, bool, op)

--- a/mlx/backend/metal/kernels/reduce.metal
+++ b/mlx/backend/metal/kernels/reduce.metal
@@ -88,8 +88,10 @@ instantiate_init_min_max(max, Max)
 
 #define instantiate_col_reduce_general(name, itype, otype, op) \
   instantiate_col_reduce_small(name, itype, otype, op, 1)      \
+  instantiate_col_reduce_small(name, itype, otype, op, 2)      \
   instantiate_col_reduce_small(name, itype, otype, op, 5)      \
   instantiate_col_reduce_looped(name, itype, otype, op, 1)     \
+  instantiate_col_reduce_looped(name, itype, otype, op, 2)     \
   instantiate_col_reduce_looped(name, itype, otype, op, 5)
 
 #define instantiate_row_reduce_small(name, itype, otype, op, dim)     \
@@ -110,8 +112,10 @@ instantiate_init_min_max(max, Max)
 
 #define instantiate_row_reduce_general(name, itype, otype, op) \
   instantiate_row_reduce_small(name, itype, otype, op, 1)      \
+  instantiate_row_reduce_small(name, itype, otype, op, 2)      \
   instantiate_row_reduce_small(name, itype, otype, op, 5)      \
   instantiate_row_reduce_looped(name, itype, otype, op, 1)     \
+  instantiate_row_reduce_looped(name, itype, otype, op, 2)     \
   instantiate_row_reduce_looped(name, itype, otype, op, 5)     \
   instantiate_kernel("row_reduce_simple_" #name,               \
                      row_reduce_simple,                        \

--- a/mlx/backend/metal/kernels/reduction/reduce_all.h
+++ b/mlx/backend/metal/kernels/reduction/reduce_all.h
@@ -1,6 +1,11 @@
 // Copyright © 2023-2024 Apple Inc.
 
-template <typename T, typename U, typename Op, int N_READS = REDUCE_N_READS>
+template <
+    typename T,
+    typename U,
+    typename Op,
+    typename IdxT = size_t,
+    int N_READS = REDUCE_N_READS>
 [[kernel]] void all_reduce(
     const device T* in [[buffer(0)]],
     device U* out [[buffer(1)]],
@@ -16,10 +21,10 @@ template <typename T, typename U, typename Op, int N_READS = REDUCE_N_READS>
   threadgroup U shared_vals[simd_size];
 
   U total = Op::init;
-  int64_t start_idx = gid.y * row_size;
-  int64_t actual_row =
+  IdxT start_idx = gid.y * IdxT(row_size);
+  IdxT actual_row =
       (start_idx + row_size <= in_size) ? row_size : in_size - start_idx;
-  int64_t blocks = actual_row / (lsize.x * N_READS);
+  IdxT blocks = actual_row / (lsize.x * N_READS);
   int extra = actual_row - blocks * (lsize.x * N_READS);
   extra -= lid.x * N_READS;
   start_idx += lid.x * N_READS;
@@ -30,7 +35,7 @@ template <typename T, typename U, typename Op, int N_READS = REDUCE_N_READS>
     extra = 0;
   }
 
-  for (int64_t b = 0; b < blocks; b++) {
+  for (IdxT b = 0; b < blocks; b++) {
     for (int i = 0; i < N_READS; i++) {
       total = op(static_cast<U>(in[i]), total);
     }

--- a/mlx/backend/metal/kernels/reduction/reduce_all.h
+++ b/mlx/backend/metal/kernels/reduction/reduce_all.h
@@ -4,7 +4,7 @@ template <
     typename T,
     typename U,
     typename Op,
-    typename IdxT = size_t,
+    typename IdxT = int64_t,
     int N_READS = REDUCE_N_READS>
 [[kernel]] void all_reduce(
     const device T* in [[buffer(0)]],

--- a/mlx/backend/metal/kernels/reduction/reduce_col.h
+++ b/mlx/backend/metal/kernels/reduction/reduce_col.h
@@ -19,7 +19,7 @@ template <typename T, typename U, typename Op, typename IdxT, int NDIMS>
     uint3 lsize [[threads_per_threadgroup]]) {
   constexpr int n_reads = 4;
   Op op;
-  LoopedElemToLoc<NDIMS, IdxT> loop(reduce_ndim);
+  LoopedElemToLoc<NDIMS, IdxT, (NDIMS > 2)> loop(reduce_ndim);
   const device T* row;
 
   U totals[n_reads];
@@ -112,7 +112,7 @@ template <typename T, typename U, typename Op, typename IdxT, int NDIMS>
     uint3 lid [[thread_position_in_threadgroup]],
     uint3 lsize [[threads_per_threadgroup]]) {
   Op op;
-  LoopedElemToLoc<NDIMS, IdxT> loop(reduce_ndim);
+  LoopedElemToLoc<NDIMS, IdxT, (NDIMS > 2)> loop(reduce_ndim);
   const device T* row;
 
   IdxT out_idx = gid.x + gsize.x * IdxT(gid.y);
@@ -184,7 +184,7 @@ template <
 
   threadgroup U shared_vals[BN * BM];
   U totals[n_reads];
-  LoopedElemToLoc<NDIMS, IdxT> loop(reduce_ndim);
+  LoopedElemToLoc<NDIMS, IdxT, (NDIMS > 2)> loop(reduce_ndim);
   const device T* row;
 
   for (int i = 0; i < n_reads; i++) {
@@ -327,7 +327,7 @@ template <
 
   threadgroup U shared_vals[BN * BM];
   U totals[n_reads];
-  LoopedElemToLoc<NDIMS> loop(reduce_ndim);
+  LoopedElemToLoc<NDIMS, IdxT, (NDIMS > 2)> loop(reduce_ndim);
   const device T* row;
 
   for (int i = 0; i < n_reads; i++) {

--- a/mlx/backend/metal/kernels/reduction/reduce_row.h
+++ b/mlx/backend/metal/kernels/reduction/reduce_row.h
@@ -215,7 +215,7 @@ template <
   Op op;
 
   U total_val = Op::init;
-  LoopedElemToLoc<NDIMS, IdxT> loop(reduce_ndim);
+  LoopedElemToLoc<NDIMS, IdxT, (NDIMS > 2)> loop(reduce_ndim);
 
   // Precompute some row reduction numbers
   const device T* row;
@@ -340,7 +340,7 @@ template <
   in += elem_to_loc<size_t, IdxT>(out_idx, shape, strides, ndim) +
       lid.x * N_READS;
 
-  LoopedElemToLoc<NDIMS, IdxT> loop(reduce_ndim);
+  LoopedElemToLoc<NDIMS, IdxT, (NDIMS > 2)> loop(reduce_ndim);
   const device T* row;
   int blocks = IdxT(row_size) / (lsize.x * N_READS);
   int extra = row_size - blocks * (lsize.x * N_READS);

--- a/mlx/backend/metal/kernels/utils.h
+++ b/mlx/backend/metal/kernels/utils.h
@@ -246,24 +246,27 @@ struct LoopedElemToLoc {
 
 template <typename OffsetT>
 struct LoopedElemToLoc<1, OffsetT> {
-  OffsetT offset{0};
   int dim;
+  OffsetT offset{0};
+  uint index{0};
 
   LoopedElemToLoc(int dim) : dim(dim) {}
 
   void next(const constant int* shape, const constant size_t* strides) {
+    index++;
     if (dim > 1) {
-      offset = elem_to_loc<size_t, OffsetT>(offset + 1, shape, strides, dim);
+      offset = elem_to_loc<size_t, OffsetT>(index, shape, strides, dim);
     } else {
       offset += strides[0];
     }
   }
 
   void next(int n, const constant int* shape, const constant size_t* strides) {
+    index += n;
     if (dim > 1) {
-      offset = elem_to_loc<size_t, OffsetT>(offset + n, shape, strides, dim);
+      offset = elem_to_loc<size_t, OffsetT>(index, shape, strides, dim);
     } else {
-      offset += n * strides[0];
+      offset += index * strides[0];
     }
   }
 

--- a/mlx/backend/metal/kernels/utils.h
+++ b/mlx/backend/metal/kernels/utils.h
@@ -216,6 +216,9 @@ struct LoopedElemToLoc {
   void next(const constant int* shape, const constant size_t* strides) {
     index++;
     offset += OffsetT(strides[dim - 1]);
+    if (dim == 1) {
+      return;
+    }
 
     if (index >= shape[dim - 1]) {
       index = 0;
@@ -227,6 +230,9 @@ struct LoopedElemToLoc {
   void next(int n, const constant int* shape, const constant size_t* strides) {
     index += n;
     offset += n * OffsetT(strides[dim - 1]);
+    if (dim == 1) {
+      return;
+    }
 
     if (index >= shape[dim - 1]) {
       int extra = index - shape[dim - 1];
@@ -257,7 +263,7 @@ struct LoopedElemToLoc<1, OffsetT> {
     if (dim > 1) {
       offset = elem_to_loc<size_t, OffsetT>(index, shape, strides, dim);
     } else {
-      offset = index * strides[0];
+      offset += OffsetT(strides[0]);
     }
   }
 
@@ -266,7 +272,7 @@ struct LoopedElemToLoc<1, OffsetT> {
     if (dim > 1) {
       offset = elem_to_loc<size_t, OffsetT>(index, shape, strides, dim);
     } else {
-      offset = index * strides[0];
+      offset = index * OffsetT(strides[0]);
     }
   }
 

--- a/mlx/backend/metal/kernels/utils.h
+++ b/mlx/backend/metal/kernels/utils.h
@@ -257,7 +257,7 @@ struct LoopedElemToLoc<1, OffsetT> {
     if (dim > 1) {
       offset = elem_to_loc<size_t, OffsetT>(index, shape, strides, dim);
     } else {
-      offset += strides[0];
+      offset = index * strides[0];
     }
   }
 
@@ -266,7 +266,7 @@ struct LoopedElemToLoc<1, OffsetT> {
     if (dim > 1) {
       offset = elem_to_loc<size_t, OffsetT>(index, shape, strides, dim);
     } else {
-      offset += index * strides[0];
+      offset = index * strides[0];
     }
   }
 

--- a/mlx/backend/metal/nojit_kernels.cpp
+++ b/mlx/backend/metal/nojit_kernels.cpp
@@ -99,7 +99,7 @@ MTL::ComputePipelineState* get_reduce_init_kernel(
     const std::string& kernel_name,
     const std::string&,
     const std::string&,
-    const array&) {
+    const Dtype&) {
   return d.get_kernel(kernel_name);
 }
 
@@ -108,8 +108,9 @@ MTL::ComputePipelineState* get_reduce_kernel(
     const std::string& kernel_name,
     const std::string&,
     const std::string&,
-    const array&,
-    const array&,
+    const Dtype&,
+    const Dtype&,
+    const std::string&,
     int,
     int,
     int) {

--- a/mlx/backend/metal/nojit_kernels.cpp
+++ b/mlx/backend/metal/nojit_kernels.cpp
@@ -1,3 +1,4 @@
+// Copyright © 2024 Apple Inc.
 
 #include "mlx/backend/metal/kernels.h"
 #include "mlx/backend/metal/utils.h"

--- a/mlx/backend/metal/reduce.cpp
+++ b/mlx/backend/metal/reduce.cpp
@@ -258,6 +258,9 @@ std::pair<Dtype, Dtype> remap_reduce_types(
           return {int64, int64};
       }
     }
+    if (in.dtype() == bool_) {
+      return {in.dtype(), int32};
+    }
     return {in.dtype(), in.dtype()};
   } else if (op_name == "and" || op_name == "or") {
     if (in.dtype().size() == 1) {
@@ -364,13 +367,7 @@ void all_reduce_dispatch(
     std::string kname_2nd_pass = func_name;
     concatenate(kname_2nd_pass, "_", op_name, type_to_name(intermediate));
     auto kernel_2nd_pass = get_reduce_kernel(
-        d,
-        kname_2nd_pass,
-        func_name,
-        op_name,
-        intermediate.dtype(),
-        out_type,
-        "int64_t");
+        d, kname_2nd_pass, func_name, op_name, out_type, out_type, "int64_t");
     compute_encoder.set_compute_pipeline_state(kernel_2nd_pass);
     size_t intermediate_size = n_rows;
     grid_dims = MTL::Size(threadgroup_2nd_pass, 1, 1);

--- a/mlx/backend/metal/reduce.cpp
+++ b/mlx/backend/metal/reduce.cpp
@@ -202,7 +202,13 @@ inline bool is_64b_dtype(Dtype dtype) {
 }
 
 inline int get_kernel_reduce_ndim(int reduce_ndim) {
-  return (reduce_ndim <= 1) ? 1 : 5;
+  if (reduce_ndim <= 1) {
+    return 1;
+  } else if (reduce_ndim == 2) {
+    return 2;
+  } else {
+    return 5;
+  }
 }
 
 inline int threadgroup_size_from_row_size(int row_size) {

--- a/mlx/backend/metal/reduce.cpp
+++ b/mlx/backend/metal/reduce.cpp
@@ -202,7 +202,7 @@ inline bool is_64b_dtype(Dtype dtype) {
 }
 
 inline int get_kernel_reduce_ndim(int reduce_ndim) {
-  return std::min(std::max(reduce_ndim, 1), 3);
+  return (reduce_ndim <= 1) ? 1 : 5;
 }
 
 inline int threadgroup_size_from_row_size(int row_size) {

--- a/mlx/backend/metal/reduce.cpp
+++ b/mlx/backend/metal/reduce.cpp
@@ -249,9 +249,9 @@ std::pair<Dtype, Dtype> remap_reduce_types(
     if (issubdtype(in.dtype(), integer)) {
       switch (in.dtype().size()) {
         case 1:
-          return {int8, int8};
+          return {int8, int32};
         case 2:
-          return {int16, int16};
+          return {int16, int32};
         case 4:
           return {int32, int32};
         case 8:
@@ -259,7 +259,7 @@ std::pair<Dtype, Dtype> remap_reduce_types(
       }
     }
     if (in.dtype() == bool_) {
-      return {in.dtype(), int32};
+      return {int8, int32};
     }
     return {in.dtype(), in.dtype()};
   } else if (op_name == "and" || op_name == "or") {
@@ -963,7 +963,7 @@ void Reduce::eval_gpu(const std::vector<array>& inputs, array& out) {
       op_name = "sum";
       break;
     case Reduce::Prod:
-      op_name = out.dtype() == bool_ ? "and" : "prod";
+      op_name = "prod";
       break;
     case Reduce::Min:
       op_name = out.dtype() == bool_ ? "and" : "min";

--- a/mlx/backend/metal/utils.cpp
+++ b/mlx/backend/metal/utils.cpp
@@ -6,9 +6,9 @@ using namespace mlx;
 
 namespace mlx::core {
 
-std::string type_to_name(const array& a) {
+std::string type_to_name(const Dtype& t) {
   std::string tname;
-  switch (a.dtype()) {
+  switch (t) {
     case bool_:
       tname = "bool_";
       break;
@@ -50,6 +50,10 @@ std::string type_to_name(const array& a) {
       break;
   }
   return tname;
+}
+
+std::string type_to_name(const array& a) {
+  return type_to_name(a.dtype());
 }
 
 MTL::Size get_block_dims(int dim0, int dim1, int dim2, int pow2 /* = 10 */) {

--- a/mlx/backend/metal/utils.h
+++ b/mlx/backend/metal/utils.h
@@ -8,6 +8,7 @@
 
 namespace mlx::core {
 
+std::string type_to_name(const Dtype& t);
 std::string type_to_name(const array& a);
 
 // Compute the thread block dimensions which fit the given

--- a/python/tests/test_reduce.py
+++ b/python/tests/test_reduce.py
@@ -131,6 +131,28 @@ class TestReduce(mlx_tests.MLXTestCase):
         mxsum = y.sum().item()
         self.assertEqual(npsum, mxsum)
 
+    def test_many_reduction_axes(self):
+
+        def check(x, axes):
+            expected = x
+            for ax in axes:
+                expected = mx.sum(expected, axis=ax, keepdims=True)
+            out = mx.sum(x, axis=axes, keepdims=True)
+            self.assertTrue(mx.array_equal(out, expected))
+
+        x = mx.random.randint(0, 10, shape=(4, 4, 4, 4, 4))
+        check(x, (0, 2, 4))
+
+        x = mx.random.randint(0, 10, shape=(4, 4, 4, 4, 4, 4, 4))
+        check(x, (0, 2, 4, 6))
+
+        x = mx.random.randint(0, 10, shape=(4, 4, 4, 4, 4, 4, 4, 4, 4))
+        check(x, (0, 2, 4, 6, 8))
+
+        x = mx.random.randint(0, 10, shape=(4, 4, 4, 4, 4, 4, 4, 4, 4, 128))
+        x = x.transpose(1, 0, 2, 3, 4, 5, 6, 7, 8, 9)
+        check(x, (1, 3, 5, 7, 9))
+
 
 if __name__ == "__main__":
     unittest.main(failfast=True)


### PR DESCRIPTION
- Adds uint specialization for indexing
- Changes looped indexer to be faster for more indices
- Reduces the binary size by:
  - `uint` and `int` use the same kernels for `sum` and `prod`
  - `and` and `or` use the same kernel for all dtypes with the same size
  - Removed unneeded (`DIM=0` specialization in the looper)
  - Using three dimension specializations `DIM=1,2,5`
- Changed sum and prod to reduce integer types into 32-bit precision. This follows Jax / NumPy and I think is more consistent given that we already do this for `bool`.

### Binary size

Old Metal library size = 77 Mb
New Metal library size = 76 Mb

Adding the same fusion of operations to the CPU dispatch saves about 0.7 MB from the CPU-only build:

Pre: 11.6 MB
Post: 10.9 MB

### Benchmarks M1 MAX

Size | Axes | Transposed | Pre | Post
--- | ---- | ---- | --- | ----
256x128x128x16 | 0,1,2 | N| 8.89 | 8.09
2x4x4x4194304 | 0,2 | N | 23.96 | 18.9
128x512x128 | 1 | N | 7.17 |  2.51
4x128x256x1024 | 0,2 | N | 13.29 | 13.25
512x512x64 | 2 | Y | 25.85 | 27.07
512x4x4x4x4x4x4x4x4| 0,2,4,6,8 | N | 7.13 | 6.41
32x4x4x4x4x4x4x4x4x4x4 |0,2,4,6,8,10 | N | 59.35 | 4.91
4x4x4x4x4x4x4x4x4x128 | 1,3,5,7,9 | Y | 3.43 | 3.27
4x32x4x32x128 | 0,2,4 | N | 0.202 | 0.178
4x8x4x8x4x128 | 1,3,5 | N |  0.110 | 0.104
4x8x4x8x4x32x32 |0,2,4,6 | N | 0.626 | 0.646
4x8x4x8x4x32x16x2 |0,2,4,6 | N | 46.22 | 10.77

### Benchmarks M3 MAX

Size | Axes | Transposed | Pre | Post
--- | ---- | ---- | --- | ----
256x128x128x16 | 0,1,2 | N| 6.72 | 6.71
2x4x4x4194304 | 0,2 | N | 15.75 | 15.82
128x512x128 | 1 | N | 3.32 | 1.22
4x128x256x1024 | 0,2 | N |13.22 | 13.16
512x512x64 | 2 | Y |1.49 | 1.57
512x4x4x4x4x4x4x4x4| 0,2,4,6,8 | N |8.352  | 5.98
32x4x4x4x4x4x4x4x4x4x4 |0,2,4,6,8,10 | N | 29.50 | 8.70
4x4x4x4x4x4x4x4x4x128 | 1,3,5,7,9 | Y | 2.84 | 3.06
4x32x4x32x128 | 0,2,4 | N |0.108 | 0.103
4x8x4x8x4x128 | 1,3,5 | N | 0.081  | 0.075
4x8x4x8x4x32x32 |0,2,4,6 | N |0.22 | 0.21
4x8x4x8x4x32x16x2 |0,2,4,6 | N | 27.40 | 5.03

Full benchmarks below:


```
#!/bin/bash
python benchmarks/python/comparative/bench_mlx.py sum_axis --size 256x128x128x16 --axis 0,1,2
python benchmarks/python/comparative/bench_mlx.py sum_axis --size 2x4x4x4194304 --axis 0,2
python benchmarks/python/comparative/bench_mlx.py sum_axis --size 128x512x128 --axis 1
python benchmarks/python/comparative/bench_mlx.py sum_axis --size 4x128x256x1024 --axis 0,2
python benchmarks/python/comparative/bench_mlx.py sum_axis --size 512x512x64 --transpose 1,0,2 --axis 2
python benchmarks/python/comparative/bench_mlx.py sum_axis --size 512x4x4x4x4x4x4x4x4 --axis 0,2,4,6,8
python benchmarks/python/comparative/bench_mlx.py sum_axis --size 32x4x4x4x4x4x4x4x4x4x4 --axis 0,2,4,6,8,10
python benchmarks/python/comparative/bench_mlx.py sum_axis --size 4x4x4x4x4x4x4x4x4x128 --transpose 1,0,2,3,4,5,6,7,8,9 --axis 1,3,5,7,9
python benchmarks/python/comparative/bench_mlx.py sum_axis --size 4x32x4x32x128 --axis 0,2,4
python benchmarks/python/comparative/bench_mlx.py sum_axis --size 4x8x4x8x4x128 --axis 1,3,5
python benchmarks/python/comparative/bench_mlx.py sum_axis --size 4x8x4x8x4x32x32 --axis 0,2,4,6
python benchmarks/python/comparative/bench_mlx.py sum_axis --size 4x8x4x8x4x32x16x2 --axis 0,2,4,6
```
