### PR TITLE
Fix KeyError raised in Module.update.

### DIFF
--- a/python/mlx/nn/layers/base.py
+++ b/python/mlx/nn/layers/base.py
@@ -308,6 +308,7 @@ class Module(dict):
         Returns:
             The module instance after updating the parameters.
         """
+        from mlx.nn.layers.containers import Sequential
 
         def apply(dst, parameters):
             if isinstance(parameters, dict):
@@ -322,6 +323,8 @@ class Module(dict):
                         elif isinstance(current_value, (dict, list)):
                             apply(current_value, new_value)
             elif isinstance(parameters, list):
+                if isinstance(dst, Sequential):
+                    dst = dst["layers"]
                 for i in range(len(parameters)):
                     current_value = dst[i]
                     new_value = parameters[i]


### PR DESCRIPTION
e.g., load safetensors from black-forest-labs/FLUX.1-Depth-dev-lora.

```log
Traceback (most recent call last):
  File "/Volumes/Develop/MLX/mlx-examples/flux/txt2image.py", line 141, in <module>
    load_adapter(flux, args.adapter, fuse=args.fuse_adapter)
  File "/Volumes/Develop/MLX/mlx-examples/flux/txt2image.py", line 106, in load_adapter
    flux.flow.load_weights(list(weights.items()), strict=False)
  File "/opt/anaconda3/envs/MLX/lib/python3.12/site-packages/mlx/nn/layers/base.py", line 195, in load_weights
    self.update(tree_unflatten(weights))
  File "/opt/anaconda3/envs/MLX/lib/python3.12/site-packages/mlx/nn/layers/base.py", line 335, in update
    apply(self, parameters)
  File "/opt/anaconda3/envs/MLX/lib/python3.12/site-packages/mlx/nn/layers/base.py", line 323, in apply
    apply(current_value, new_value)
  File "/opt/anaconda3/envs/MLX/lib/python3.12/site-packages/mlx/nn/layers/base.py", line 331, in apply
    current_value.update(new_value)
  File "/opt/anaconda3/envs/MLX/lib/python3.12/site-packages/mlx/nn/layers/base.py", line 335, in update
    apply(self, parameters)
  File "/opt/anaconda3/envs/MLX/lib/python3.12/site-packages/mlx/nn/layers/base.py", line 321, in apply
    current_value.update(new_value)
  File "/opt/anaconda3/envs/MLX/lib/python3.12/site-packages/mlx/nn/layers/base.py", line 335, in update
    apply(self, parameters)
  File "/opt/anaconda3/envs/MLX/lib/python3.12/site-packages/mlx/nn/layers/base.py", line 326, in apply
    current_value = dst[i]
                    ~~~^^^
KeyError: 0
```