### PR TITLE
feat(nn): add CausalConv1d

### DIFF
--- a/docs/src/python/nn/layers.rst
+++ b/docs/src/python/nn/layers.rst
@@ -16,6 +16,7 @@ Layers
    BatchNorm
    CELU
    Conv1d
+   CausalConv1d
    Conv2d
    Conv3d
    ConvTranspose1d

--- a/python/mlx/nn/layers/__init__.py
+++ b/python/mlx/nn/layers/__init__.py
@@ -54,7 +54,7 @@ from mlx.nn.layers.activations import (
 )
 from mlx.nn.layers.base import Module
 from mlx.nn.layers.containers import Sequential
-from mlx.nn.layers.convolution import Conv1d, Conv2d, Conv3d
+from mlx.nn.layers.convolution import CausalConv1d, Conv1d, Conv2d, Conv3d
 from mlx.nn.layers.convolution_transpose import (
     ConvTranspose1d,
     ConvTranspose2d,

--- a/python/mlx/nn/layers/convolution.py
+++ b/python/mlx/nn/layers/convolution.py
@@ -82,6 +82,60 @@ class Conv1d(Module):
         return y
 
 
+class CausalConv1d(Conv1d):
+    """Applies a 1-dimensional causal convolution over the multi-channel input sequence,
+    ensuring that each output at time t only depends on inputs up to time t.
+
+    This is commonly used in time series tasks such as Wavenet and Temporal Convolution Network.
+
+    The channels are expected to be last i.e. the input shape should be ``NLC`` where:
+
+    * ``N`` is the batch dimension
+    * ``L`` is the sequence length
+    * ``C`` is the number of input channels
+
+    Args:
+        in_channels (int): The number of input channels
+        out_channels (int): The number of output channels
+        kernel_size (int): The size of the convolution filters
+        stride (int, optional): The stride when applying the filter.
+            Default: ``1``.
+        dilation (int, optional): The dilation of the convolution.
+        groups (int, optional): The number of groups for the convolution.
+            Default: ``1``.
+        bias (bool, optional): If ``True`` add a learnable bias to the output.
+            Default: ``True``
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        stride: int = 1,
+        dilation: int = 1,
+        groups: int = 1,
+        bias: bool = True,
+    ):
+        super().__init__(
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride,
+            ((kernel_size - 1) * dilation),
+            dilation,
+            groups,
+            bias,
+        )
+        self.kernel_size = kernel_size
+
+    def __call__(self, x):
+        y = super().__call__(x)
+        if self.kernel_size > 0:
+            y = y[:, 0 : (y.shape[1] - self.padding), :]
+        return y
+
+
 class Conv2d(Module):
     """Applies a 2-dimensional convolution over the multi-channel input image.
 


### PR DESCRIPTION
## Proposed changes
This pull request introduces `CausalConv1d`, a 1-dimensional causal convolution layer designed for time series tasks such as [WaveNet](https://arxiv.org/abs/1609.03499) and [Temporal Convolutional Network](https://arxiv.org/abs/1803.01271).

The `CausalConv1d` layer ensures that each output at time \( t \) is computed using inputs up to and including time \( t \), without depending on future inputs. This is crucial for maintaining causality in time series predictions.


![](https://production-media.paperswithcode.com/methods/Screen_Shot_2020-05-24_at_12.09.54_AM_HZBIcHD.png)


## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
