### PR TITLE
Added missing unordered_map includes

### DIFF
--- a/mlx/array.cpp
+++ b/mlx/array.cpp
@@ -1,5 +1,6 @@
 // Copyright © 2023-2024 Apple Inc.
 #include <functional>
+#include <unordered_map>
 
 #include "mlx/array.h"
 #include "mlx/ops.h"

--- a/mlx/backend/metal/metal.h
+++ b/mlx/backend/metal/metal.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <unordered_map>
 #include <variant>
 
 #include "mlx/array.h"

--- a/mlx/graph_utils.h
+++ b/mlx/graph_utils.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <unordered_map>
+
 #include "mlx/array.h"
 
 namespace mlx::core {

--- a/mlx/io.h
+++ b/mlx/io.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <unordered_map>
 #include <variant>
 
 #include "mlx/array.h"


### PR DESCRIPTION
## Proposed changes

Added missing unordered_map includes.

Fixes build:
* For macOS in cross-compile Linux env.: [Fixed build of MLX C when using CMake option MLX_C_USE_SYSTEM_MLX](https://buildkite.com/julialang/yggdrasil/builds/15056#01936c9b-b61a-4849-b800-ca039c3202a7/673-860): https://github.com/JuliaPackaging/Yggdrasil/pull/9809
* For FreeBSD in cross-compile Linux env.: https://github.com/JuliaPackaging/Yggdrasil/pull/9898

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
