### PR TITLE
Support bias correction in Adam and AdamW optimizers

### DIFF
--- a/python/tests/test_optimizers.py
+++ b/python/tests/test_optimizers.py
@@ -11,6 +11,15 @@ import mlx.optimizers as opt
 import mlx.utils
 import mlx_tests
 from mlx.utils import tree_flatten, tree_map, tree_unflatten
+import numpy as np
+
+try:
+    import torch
+    import torch.nn.functional as F
+
+    has_torch = True
+except ImportError as e:
+    has_torch = False
 
 
 def get_all_optimizers():
@@ -186,10 +195,8 @@ class TestOptimizers(mlx_tests.MLXTestCase):
                 )
             )
 
+    @unittest.skipIf(not has_torch, "requires Torch")
     def test_adamw_matches_pytorch(self):
-        import numpy as np
-        import torch
-
         mx.random.seed(0)
         np.random.seed(0)
 

--- a/python/tests/test_optimizers.py
+++ b/python/tests/test_optimizers.py
@@ -185,7 +185,7 @@ class TestOptimizers(mlx_tests.MLXTestCase):
                     optim.state,
                 )
             )
-    
+
     def test_adamw_matches_pytorch(self):
         import numpy as np
         import torch

--- a/python/tests/test_optimizers.py
+++ b/python/tests/test_optimizers.py
@@ -10,8 +10,8 @@ import mlx.nn as nn
 import mlx.optimizers as opt
 import mlx.utils
 import mlx_tests
-from mlx.utils import tree_flatten, tree_map, tree_unflatten
 import numpy as np
+from mlx.utils import tree_flatten, tree_map, tree_unflatten
 
 try:
     import torch


### PR DESCRIPTION
## Proposed changes

The original implementation of AdamW doesn't include bias correction (https://github.com/ml-explore/mlx/pull/72). I found this causes problems when using it to learn a trivial task such as memorization using a [GPT2-like architecture](https://github.com/karpathy/build-nanogpt) whereas the equivalent pytorch implementation doesn't exhibit this behavior; the changes in this PR resolve the issue.

I've manually confirmed that this matches Pytorch behavior up to some small floating point differences, and also replicated a simpler version of it in mlx tests which breaks for main but passes in my branch.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
