### PR TITLE
Export / import functions to / from a file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ option(BUILD_SHARED_LIBS "Build mlx as a shared library" OFF)
 if(NOT MLX_VERSION)
   set(MLX_VERSION 0.21.1)
 endif()
+add_compile_definitions("MLX_VERSION=${MLX_VERSION}")
 
 # --------------------- Processor tests -------------------------
 

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -61,6 +61,7 @@ are the CPU and GPU.
    python/array
    python/data_types
    python/devices_and_streams
+   python/export
    python/ops
    python/random
    python/transforms

--- a/docs/src/python/export.rst
+++ b/docs/src/python/export.rst
@@ -1,0 +1,14 @@
+.. _export:
+
+Export Functions
+================
+
+.. currentmodule:: mlx.core
+
+.. autosummary::
+  :toctree: _autosummary
+
+   export_function
+   import_function
+   exporter
+   export_to_dot

--- a/examples/export/CMakeLists.txt
+++ b/examples/export/CMakeLists.txt
@@ -19,10 +19,11 @@ execute_process(
   COMMAND grep location
   COMMAND awk "{print $4 \"/mlx\"}"
   OUTPUT_STRIP_TRAILING_WHITESPACE
-  OUTPUT_VARIABLE MLX_DIR)
-list(APPEND CMAKE_PREFIX_PATH "${MLX_DIR}")
-
+  OUTPUT_VARIABLE MLX_ROOT)
 find_package(MLX CONFIG REQUIRED)
 
 add_executable(eval_mlp eval_mlp.cpp)
 target_link_libraries(eval_mlp PRIVATE mlx)
+
+add_executable(train_mlp train_mlp.cpp)
+target_link_libraries(train_mlp PRIVATE mlx)

--- a/examples/export/CMakeLists.txt
+++ b/examples/export/CMakeLists.txt
@@ -1,13 +1,11 @@
 cmake_minimum_required(VERSION 3.27)
 
-project(_ext LANGUAGES CXX)
+project(import_mlx LANGUAGES CXX)
 
 # ----------------------------- Setup -----------------------------
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
-option(BUILD_SHARED_LIBS "Build as a shared library" ON)
 
 # ----------------------------- Dependencies -----------------------------
 find_package(

--- a/examples/export/CMakeLists.txt
+++ b/examples/export/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.27)
+
+project(_ext LANGUAGES CXX)
+
+# ----------------------------- Setup -----------------------------
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+option(BUILD_SHARED_LIBS "Build as a shared library" ON)
+
+# ----------------------------- Dependencies -----------------------------
+find_package(
+  Python 3.9
+  COMPONENTS Interpreter Development.Module
+  REQUIRED)
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -m pip show mlx
+  COMMAND grep location
+  COMMAND awk "{print $4 \"/mlx\"}"
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  OUTPUT_VARIABLE MLX_DIR)
+list(APPEND CMAKE_PREFIX_PATH "${MLX_DIR}")
+
+find_package(MLX CONFIG REQUIRED)
+
+add_executable(eval_mlp eval_mlp.cpp)
+target_link_libraries(eval_mlp PRIVATE mlx)

--- a/examples/export/README.md
+++ b/examples/export/README.md
@@ -1,0 +1,30 @@
+## Setup
+
+Install mlx:
+
+```bash
+pip install mlx>=0.22
+```
+
+Build the C++ examples:
+
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+```
+
+## Run
+
+Run the Python script to export the function.
+
+```bash
+python eval_mlp.py
+```
+
+Then run the C++ program to import and run the function.
+
+```
+./build/eval_mlp
+```
+
+The two programs should output the same result.

--- a/examples/export/README.md
+++ b/examples/export/README.md
@@ -1,6 +1,6 @@
 ## Setup
 
-Install mlx:
+Install MLX:
 
 ```bash
 pip install mlx>=0.22
@@ -15,16 +15,35 @@ cmake --build build
 
 ## Run
 
-Run the Python script to export the function.
+### Eval MLP
+
+Run the Python script to export the eval function:
 
 ```bash
 python eval_mlp.py
 ```
 
-Then run the C++ program to import and run the function.
+Then run the C++ program to import and run the function:
 
 ```
 ./build/eval_mlp
 ```
 
-The two programs should output the same result.
+The Python and C++ programs should output the same result.
+
+### Train MLP
+
+Run the Python script to export the model initialization and training
+functions:
+
+```bash
+python train_mlp.py
+```
+
+Then run the C++ program to import and run the functions:
+
+```
+./build/train_mlp
+```
+
+The Python and C++ programs should output the same results.

--- a/examples/export/eval_mlp.cpp
+++ b/examples/export/eval_mlp.cpp
@@ -1,0 +1,25 @@
+// Copyright © 2024 Apple Inc.
+
+#include <mlx/mlx.h>
+#include <iostream>
+
+using namespace mlx::core;
+
+int main() {
+  int batch_size = 8;
+  int input_dim = 32;
+
+  // Make the input
+  random::seed(42);
+  auto example_x = random::uniform({batch_size, input_dim});
+
+  // Import the function
+  auto imported_forward = import_function("eval_mlp.mlxfn");
+
+  // Call the imported function
+  auto out = imported_forward({example_x})[0];
+
+  std::cout << out << std::endl;
+
+  return 0;
+}

--- a/examples/export/eval_mlp.cpp
+++ b/examples/export/eval_mlp.cpp
@@ -14,10 +14,10 @@ int main() {
   auto example_x = random::uniform({batch_size, input_dim});
 
   // Import the function
-  auto imported_forward = import_function("eval_mlp.mlxfn");
+  auto forward = import_function("eval_mlp.mlxfn");
 
   // Call the imported function
-  auto out = imported_forward({example_x})[0];
+  auto out = forward({example_x})[0];
 
   std::cout << out << std::endl;
 

--- a/examples/export/eval_mlp.py
+++ b/examples/export/eval_mlp.py
@@ -1,0 +1,52 @@
+# Copyright © 2024 Apple Inc.
+
+import mlx.core as mx
+import mlx.nn as nn
+import mlx.utils
+
+
+class MLP(nn.Module):
+    """A simple MLP."""
+
+    def __init__(
+        self, num_layers: int, input_dim: int, hidden_dim: int, output_dim: int
+    ):
+        super().__init__()
+        layer_sizes = [input_dim] + [hidden_dim] * num_layers + [output_dim]
+        self.layers = [
+            nn.Linear(idim, odim)
+            for idim, odim in zip(layer_sizes[:-1], layer_sizes[1:])
+        ]
+
+    def __call__(self, x):
+        for l in self.layers[:-1]:
+            x = nn.relu(l(x))
+        return self.layers[-1](x)
+
+
+if __name__ == "__main__":
+
+    batch_size = 8
+    input_dim = 32
+    output_dim = 10
+
+    # Load the model
+    mx.random.seed(0)  # Seed for params
+    model = MLP(num_layers=5, input_dim=input_dim, hidden_dim=64, output_dim=output_dim)
+    mx.eval(model)
+
+    # Note, the model parameters are saved in the export function
+    def forward(x):
+        return model(x)
+
+    mx.random.seed(42)  # Seed for input
+    example_x = mx.random.uniform(shape=(batch_size, input_dim))
+
+    mx.export_function("eval_mlp.mlxfn", forward, example_x)
+
+    # Import in Python
+    imported_forward = mx.import_function("eval_mlp.mlxfn")
+    expected = forward(example_x)
+    (out,) = imported_forward(example_x)
+    assert mx.allclose(expected, out)
+    print(out)

--- a/examples/export/train_mlp.cpp
+++ b/examples/export/train_mlp.cpp
@@ -1,0 +1,36 @@
+// Copyright © 2024 Apple Inc.
+
+#include <mlx/mlx.h>
+#include <iostream>
+
+using namespace mlx::core;
+
+int main() {
+  int batch_size = 8;
+  int input_dim = 32;
+  int output_dim = 10;
+
+  auto state = import_function("init_mlp.mlxfn")({});
+  std::cout << state[0] << std::endl;
+
+  // Make the input
+  random::seed(42);
+  auto example_X = random::normal({batch_size, input_dim});
+  auto example_y = random::randint(0, output_dim, {batch_size});
+
+  // Import the function
+  auto step = import_function("train_mlp.mlxfn");
+
+  // Call the imported function
+  for (int it = 0; it < 100; ++it) {
+    state.insert(state.end(), {example_X, example_y});
+    state = step(state);
+    eval(state);
+    auto loss = state.back();
+    state.pop_back();
+    if (it % 10 == 0) {
+      std::cout << "Loss " << loss.item<float>() << std::endl;
+    }
+  }
+  return 0;
+}

--- a/examples/export/train_mlp.cpp
+++ b/examples/export/train_mlp.cpp
@@ -11,7 +11,6 @@ int main() {
   int output_dim = 10;
 
   auto state = import_function("init_mlp.mlxfn")({});
-  std::cout << state[0] << std::endl;
 
   // Make the input
   random::seed(42);

--- a/examples/export/train_mlp.py
+++ b/examples/export/train_mlp.py
@@ -31,10 +31,9 @@ if __name__ == "__main__":
     input_dim = 32
     output_dim = 10
 
-    # Seed for the parameter initialization
-    mx.random.seed(0)
-
     def init():
+        # Seed for the parameter initialization
+        mx.random.seed(0)
         model = MLP(
             num_layers=3, input_dim=input_dim, hidden_dim=64, output_dim=output_dim
         )

--- a/examples/export/train_mlp.py
+++ b/examples/export/train_mlp.py
@@ -1,0 +1,75 @@
+# Copyright © 2024 Apple Inc.
+
+import mlx.core as mx
+import mlx.nn as nn
+import mlx.optimizers as optim
+import mlx.utils
+
+
+class MLP(nn.Module):
+    """A simple MLP."""
+
+    def __init__(
+        self, num_layers: int, input_dim: int, hidden_dim: int, output_dim: int
+    ):
+        super().__init__()
+        layer_sizes = [input_dim] + [hidden_dim] * num_layers + [output_dim]
+        self.layers = [
+            nn.Linear(idim, odim)
+            for idim, odim in zip(layer_sizes[:-1], layer_sizes[1:])
+        ]
+
+    def __call__(self, x):
+        for l in self.layers[:-1]:
+            x = nn.relu(l(x))
+        return self.layers[-1](x)
+
+
+if __name__ == "__main__":
+
+    batch_size = 8
+    input_dim = 32
+    output_dim = 10
+
+    # Seed for the parameter initialization
+    mx.random.seed(0)
+
+    def init():
+        model = MLP(
+            num_layers=3, input_dim=input_dim, hidden_dim=64, output_dim=output_dim
+        )
+        optimizer = optim.SGD(learning_rate=1e-1)
+        optimizer.init(model.parameters())
+        state = [model.parameters(), optimizer.state]
+        tree_structure, state = zip(*mlx.utils.tree_flatten(state))
+        return model, optimizer, tree_structure, state
+
+    model, optimizer, tree_structure, state = init()
+    mx.eval(state)
+    print(state[0])
+    mx.export_function("init_mlp.mlxfn", lambda: init()[-1])
+
+    def loss_fn(params, X, y):
+        model.update(params)
+        return nn.losses.cross_entropy(model(X), y, reduction="mean")
+
+    def step(*inputs):
+        *state, X, y = inputs
+        params, opt_state = mlx.utils.tree_unflatten(list(zip(tree_structure, state)))
+        optimizer.state = opt_state
+        loss, grads = mx.value_and_grad(loss_fn)(params, X, y)
+        params = optimizer.apply_gradients(grads, params)
+        _, state = zip(*mlx.utils.tree_flatten([params, optimizer.state]))
+        return *state, loss
+
+    # Make some random data
+    mx.random.seed(42)
+    example_X = mx.random.normal(shape=(batch_size, input_dim))
+    example_y = mx.random.randint(low=0, high=output_dim, shape=(batch_size,))
+    mx.export_function("train_mlp.mlxfn", step, *state, example_X, example_y)
+
+    imported_step = mx.import_function("train_mlp.mlxfn")
+    for it in range(100):
+        *state, loss = imported_step(*state, example_X, example_y)
+        if it % 10 == 0:
+            print(f"Loss {loss.item():.6}")

--- a/examples/export/train_mlp.py
+++ b/examples/export/train_mlp.py
@@ -43,9 +43,9 @@ if __name__ == "__main__":
         tree_structure, state = zip(*mlx.utils.tree_flatten(state))
         return model, optimizer, tree_structure, state
 
+    # Export the model parameter initialization
     model, optimizer, tree_structure, state = init()
     mx.eval(state)
-    print(state[0])
     mx.export_function("init_mlp.mlxfn", lambda: init()[-1])
 
     def loss_fn(params, X, y):
@@ -67,7 +67,9 @@ if __name__ == "__main__":
     example_y = mx.random.randint(low=0, high=output_dim, shape=(batch_size,))
     mx.export_function("train_mlp.mlxfn", step, *state, example_X, example_y)
 
+    # Export one step of SGD
     imported_step = mx.import_function("train_mlp.mlxfn")
+
     for it in range(100):
         *state, loss = imported_step(*state, example_X, example_y)
         if it % 10 == 0:

--- a/mlx/CMakeLists.txt
+++ b/mlx/CMakeLists.txt
@@ -5,6 +5,7 @@ target_sources(
           ${CMAKE_CURRENT_SOURCE_DIR}/compile.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/device.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/dtype.cpp
+          ${CMAKE_CURRENT_SOURCE_DIR}/export.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/einsum.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/fast.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/fft.cpp

--- a/mlx/compile.cpp
+++ b/mlx/compile.cpp
@@ -730,9 +730,12 @@ std::vector<array> compile_replace(
   }
 
   for (auto& a : tape) {
-    // Arrays in the tape without primitives are constants
-    // and can be used directly
-    if (!a.has_primitive()) {
+    // Arrays in the tape without primitives are either:
+    // - inputs, which are already in the map
+    // - constants, which can be used directly
+    // - primitives with no inputs which will become constants after the first
+    // eval
+    if (!a.has_primitive() || has_no_inputs(a.primitive())) {
       trace_to_real.insert({a.id(), a});
     } else {
       // Find real inputs

--- a/mlx/compile.cpp
+++ b/mlx/compile.cpp
@@ -1,5 +1,6 @@
 // Copyright © 2023-2024 Apple Inc.
 #include <cstdlib>
+#include <fstream>
 #include <map>
 #include <unordered_map>
 #include <unordered_set>
@@ -11,6 +12,7 @@
 #include "mlx/primitives.h"
 #include "mlx/transforms.h"
 #include "mlx/transforms_impl.h"
+#include "mlx/utils.h"
 
 namespace mlx::core {
 
@@ -909,6 +911,178 @@ void enable_compile() {
 
 void set_compile_mode(CompileMode mode) {
   detail::compile_mode() = mode;
+}
+
+std::vector<std::string> split(const std::string& str, char delim) {
+  std::vector<std::string> splits;
+  for (int j = 0; j < str.size();) {
+    int k = str.find(delim, j);
+    splits.push_back(str.substr(j, k - j));
+    if (k == std::string::npos) {
+      break;
+    }
+    j = k + 1;
+  }
+  return splits;
+}
+
+void export_function(
+    std::string path,
+    const std::function<std::vector<array>(const std::vector<array>&)>& fun,
+    const std::vector<array>& inputs,
+    bool shapeless /* = false */) {
+  // Trace to build the graph
+  auto [trace_inputs, trace_outputs] = detail::compile_trace(fun, inputs);
+
+  // DFS the graph and get the tape
+  auto [tape, parents_map] =
+      detail::compile_dfs(trace_inputs, trace_outputs, inputs);
+
+  detail::compile_simplify(tape, parents_map, trace_outputs, /* passes */ 3);
+
+  if (shapeless) {
+    detail::compile_validate_shapeless(tape);
+  }
+
+  // Serialize the tape, inputs, and outputs to the file
+  std::ofstream os(path);
+  if (!os.is_open()) {
+    throw std::runtime_error("[export_function] Failed to open " + path);
+  }
+  NodeNamer namer;
+  auto print_arrs =
+      [&namer, &os](const std::vector<array>& arrs, bool with_shape = true) {
+        for (auto& arr : arrs) {
+          os << namer.get_name(arr);
+          if (with_shape) {
+            os << ";" << arr.shape() << ";"
+               << static_cast<int>(arr.dtype().val()) << ","
+               << static_cast<int>(arr.dtype().size());
+          }
+          if (&arr != &arrs.back()) {
+            os << ":";
+          }
+        }
+      };
+
+  // Header
+  os << shapeless << "\n";
+
+  // Inputs and outputs
+  print_arrs(trace_inputs);
+  os << "\n";
+  print_arrs(trace_outputs, false);
+  os << "\n";
+
+  // Tape
+  for (auto& arr : tape) {
+    if (arr.has_primitive()) {
+      print_arrs(arr.inputs(), false);
+      os << "|";
+      arr.primitive().print(os);
+      os << "|";
+      print_arrs(arr.outputs());
+      os << "\n";
+    } else {
+      // TODO need shape info? Could be constant non input?
+      os << namer.get_name(arr) << "\n";
+    }
+  }
+}
+
+std::function<std::vector<array>(const std::vector<array>&)> import_function(
+    std::string path) {
+  // Read the tape from the file
+  std::ifstream is(path);
+  if (!is.is_open()) {
+    throw std::runtime_error("[import_function] Failed to open " + path);
+  }
+
+  std::string line;
+
+  // Parse header
+  getline(is, line);
+  bool shapeless = std::stoi(line);
+
+  std::unordered_map<std::string, array> name_map;
+
+  auto parse_shape = [](const std::string& str) {
+    // Trim ( and )
+    auto strs = split(str.substr(1, str.size() - 2), ',');
+    std::vector<int> shape;
+    shape.reserve(strs.size());
+    for (auto& s : strs) {
+      shape.push_back(std::stoi(s));
+    }
+    return shape;
+  };
+
+  auto parse_dtype = [](const std::string& str) {
+    auto strs = split(str, ',');
+    return Dtype(
+        static_cast<Dtype::Val>(std::stoi(strs[0])), std::stoi(strs[1]));
+  };
+
+  auto parse_arrays = [&](const std::string& str) {
+    std::vector<array> arrays;
+    for (auto& array_str : split(str, ':')) {
+      auto part_strs = split(array_str, ';');
+      auto& name = part_strs[0];
+      if (auto it = name_map.find(name); it != name_map.end()) {
+        arrays.push_back(it->second);
+      } else {
+        arrays.emplace_back(
+            std::move(parse_shape(part_strs[1])),
+            parse_dtype(part_strs[2]),
+            nullptr,
+            std::vector<array>{});
+        name_map.insert({name, arrays.back()});
+      }
+    }
+    return arrays;
+  };
+
+  getline(is, line);
+  std::vector<array> trace_inputs = parse_arrays(line);
+
+  // Parse outputs after building the tape
+  std::string output_line;
+  getline(is, output_line);
+
+  std::vector<array> tape;
+  while (getline(is, line)) {
+    auto fields = split(line, '|');
+    if (fields.size() > 1) {
+      auto inputs = parse_arrays(fields[0]);
+      // auto prim = parse_primitive(fields[1]);
+      auto output_strs = split(fields[2], ':');
+
+      // Special case for multi-output primitives
+      if (output_strs.size() > 1) {
+      } else {
+        auto part_strs = split(output_strs[0], ';');
+        name_map.emplace(
+            part_strs[0],
+            std::move(array(
+                std::move(parse_shape(part_strs[1])),
+                parse_dtype(part_strs[2]),
+                nullptr, // TODO replace with primitive
+                std::move(inputs))));
+      }
+    } else {
+      tape.push_back(name_map.find(fields[0])->second);
+    }
+  }
+  auto trace_outputs = parse_arrays(output_line);
+
+  return [tape = std::move(tape),
+          trace_inputs = std::move(trace_inputs),
+          trace_outputs = std::move(trace_outputs),
+          shapeless](const std::vector<array>& inputs) {
+    // TODO validate shapes and types
+    return detail::compile_replace(
+        tape, trace_inputs, trace_outputs, inputs, shapeless);
+  };
 }
 
 } // namespace mlx::core

--- a/mlx/compile.cpp
+++ b/mlx/compile.cpp
@@ -729,13 +729,15 @@ std::vector<array> compile_replace(
     trace_to_real.insert({trace_inputs[i].id(), inputs[i]});
   }
 
+  auto is_load = [](const Primitive& p) { return typeid(p) == typeid(Load); };
+
   for (auto& a : tape) {
     // Arrays in the tape without primitives are either:
     // - inputs, which are already in the map
     // - constants, which can be used directly
-    // - primitives with no inputs which will become constants after the first
-    // eval
-    if (!a.has_primitive() || has_no_inputs(a.primitive())) {
+    // - a load primitive which has no inputs and will become a constant
+    //   after the first eval
+    if (!a.has_primitive() || is_load(a.primitive())) {
       trace_to_real.insert({a.id(), a});
     } else {
       // Find real inputs

--- a/mlx/compile.h
+++ b/mlx/compile.h
@@ -42,19 +42,4 @@ void enable_compile();
 /** Set the compiler mode to the given value. */
 void set_compile_mode(CompileMode mode);
 
-/**
- * Export a function to a file.
- */
-void export_function(
-    std::string path,
-    const std::function<std::vector<array>(const std::vector<array>&)>& fun,
-    const std::vector<array>& inputs,
-    bool shapeless = false);
-
-/**
- * Import a function from a file.
- */
-std::function<std::vector<array>(const std::vector<array>&)> import_function(
-    std::string path);
-
 } // namespace mlx::core

--- a/mlx/compile.h
+++ b/mlx/compile.h
@@ -41,5 +41,4 @@ void enable_compile();
 
 /** Set the compiler mode to the given value. */
 void set_compile_mode(CompileMode mode);
-
 } // namespace mlx::core

--- a/mlx/compile.h
+++ b/mlx/compile.h
@@ -41,4 +41,20 @@ void enable_compile();
 
 /** Set the compiler mode to the given value. */
 void set_compile_mode(CompileMode mode);
+
+/**
+ * Export a function to a file.
+ */
+void export_function(
+    std::string path,
+    const std::function<std::vector<array>(const std::vector<array>&)>& fun,
+    const std::vector<array>& inputs,
+    bool shapeless = false);
+
+/**
+ * Import a function from a file.
+ */
+std::function<std::vector<array>(const std::vector<array>&)> import_function(
+    std::string path);
+
 } // namespace mlx::core

--- a/mlx/compile_impl.h
+++ b/mlx/compile_impl.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "mlx/device.h"
+#include "mlx/array.h"
 
 namespace mlx::core::detail {
 
@@ -22,4 +22,35 @@ void compile_erase(std::uintptr_t fun_id);
 void compile_clear_cache();
 
 bool compile_available_for_device(const Device& device);
+
+std::pair<std::vector<array>, std::vector<array>> compile_trace(
+    const std::function<std::vector<array>(const std::vector<array>&)>& fun,
+    const std::vector<array>& inputs);
+
+using ParentsMap =
+    std::unordered_map<std::uintptr_t, std::vector<std::pair<array, int>>>;
+
+// Traverses the graph to build a tape and a map of array ids to their parents
+std::pair<std::vector<array>, ParentsMap> compile_dfs(
+    const std::vector<array>& inputs,
+    const std::vector<array>& outputs,
+    const std::vector<array>& original_inputs);
+
+// Simplify the tape. Note, this function modifies in-place both the tape and
+// the parents map to remove orphaned arrays
+void compile_simplify(
+    std::vector<array>& tape,
+    ParentsMap& parents_map,
+    const std::vector<array>& outputs,
+    int passes);
+
+std::vector<array> compile_replace(
+    const std::vector<array>& tape,
+    const std::vector<array>& trace_inputs,
+    const std::vector<array>& trace_outputs,
+    const std::vector<array>& inputs,
+    bool shapeless);
+
+void compile_validate_shapeless(const std::vector<array>& tape);
+
 } // namespace mlx::core::detail

--- a/mlx/export.cpp
+++ b/mlx/export.cpp
@@ -180,7 +180,19 @@ PrimitiveFactory get_primitive_factory() {
           auto [alpha, beta] = deserialize<std::pair<float, float>>(is);
           return std::make_shared<AddMM>(s, alpha, beta);
         }}},
-      // Arange
+      {"Arange",
+       {[](Writer& os, const Primitive& p) {
+          auto [start, stop, step] = static_cast<const Arange&>(p).state();
+          serialize(os, start);
+          serialize(os, stop);
+          serialize(os, step);
+        },
+        [](Reader& is, Stream s) {
+          auto start = deserialize<double>(is);
+          auto stop = deserialize<double>(is);
+          auto step = deserialize<double>(is);
+          return std::make_shared<Arange>(s, start, stop, step);
+        }}},
       SERIALIZE_PRIMITIVE(ArcCos),
       SERIALIZE_PRIMITIVE(ArcCosh),
       SERIALIZE_PRIMITIVE(ArcSin),
@@ -208,7 +220,13 @@ PrimitiveFactory get_primitive_factory() {
           return std::make_shared<ArgReduce>(
               s, static_cast<ArgReduce::ReduceType>(reduce_type), axis);
         }}},
-      // ArgSort
+      {"ArgSort",
+       {[](Writer& os, const Primitive& p) {
+          serialize(os, static_cast<const ArgSort&>(p).state());
+        },
+        [](Reader& is, Stream s) {
+          return std::make_shared<ArgSort>(s, deserialize<int>(is));
+        }}},
       // AsStrided
       // BitwiseBinary
       // BlockMaskedMM
@@ -291,7 +309,14 @@ PrimitiveFactory get_primitive_factory() {
       SERIALIZE_PRIMITIVE(Tan),
       SERIALIZE_PRIMITIVE(Tanh),
       // View
-      // Transpose
+      {"Transpose",
+       {[](Writer& os, const Primitive& p) {
+          serialize(os, static_cast<const Transpose&>(p).state());
+        },
+        [](Reader& is, Stream s) {
+          auto axes = deserialize<std::vector<int>>(is);
+          return std::make_shared<Transpose>(s, std::move(axes));
+        }}},
       SERIALIZE_PRIMITIVE(QRF),
       SERIALIZE_PRIMITIVE(SVD)
       // Inverse

--- a/mlx/export.cpp
+++ b/mlx/export.cpp
@@ -54,6 +54,19 @@ constexpr bool is_pair = std::is_same_v<
         typename std::tuple_element<0, T>::type,
         typename std::tuple_element<1, T>::type>>;
 
+template <typename>
+constexpr bool dependent_false = false;
+
+template <typename T>
+struct NotSerializable {
+  static_assert(dependent_false<T>, "Type is not serializable.");
+};
+
+template <typename T>
+struct NotDeserializable {
+  static_assert(dependent_false<T>, "Type is not deserializable.");
+};
+
 template <typename T>
 void serialize(Writer& os, T v) {
   if constexpr (std::is_arithmetic_v<T>) {
@@ -68,7 +81,7 @@ void serialize(Writer& os, T v) {
     serialize(os, v.first);
     serialize(os, v.second);
   } else {
-    static_assert(false, "Type is not serializable.");
+    NotSerializable<T>();
   }
 }
 
@@ -92,7 +105,7 @@ T deserialize(Reader& is) {
         deserialize<typename std::tuple_element<0, T>::type>(is),
         deserialize<typename std::tuple_element<1, T>::type>(is));
   } else {
-    static_assert(false, "Type is not deserializable.");
+    NotDeserializable<T>();
   }
 }
 

--- a/mlx/export.cpp
+++ b/mlx/export.cpp
@@ -1,7 +1,9 @@
 // Copyright © 2024 Apple Inc.
 
-#include "mlx/export.h"
+#include <fstream>
+
 #include "mlx/compile_impl.h"
+#include "mlx/export.h"
 #include "mlx/primitives.h"
 #include "mlx/utils.h"
 

--- a/mlx/export.cpp
+++ b/mlx/export.cpp
@@ -121,10 +121,10 @@ T deserialize(Reader& is) {
     auto x2 = deserialize<typename std::tuple_element<1, T>::type>(is);
     return std::make_pair(x1, x2);
   } else if constexpr (is_3_tuple<T>) {
-    auto x1 = deserialize<typename std::tuple_element<0, T>::type>(is),
-         auto x2 = deserialize<typename std::tuple_element<1, T>::type>(is),
-         auto x3 = deserialize<typename std::tuple_element<2, T>::type>(is),
-         return std::make_tuple(x1, x2, x3);
+    auto x1 = deserialize<typename std::tuple_element<0, T>::type>(is);
+    auto x2 = deserialize<typename std::tuple_element<1, T>::type>(is);
+    auto x3 = deserialize<typename std::tuple_element<2, T>::type>(is);
+    return std::make_tuple(x1, x2, x3);
   } else {
     NotDeserializable<T>();
   }

--- a/mlx/export.cpp
+++ b/mlx/export.cpp
@@ -163,7 +163,6 @@ Stream deserialize(Reader& is) {
   auto stream_index = deserialize<int>(is);
   auto device_type = deserialize<Device::DeviceType>(is);
   auto device_index = deserialize<int>(is);
-  // TODO handle streams correctly
   return Stream(stream_index, Device(device_type, device_index));
 }
 
@@ -365,6 +364,11 @@ struct PrimitiveFactory {
 
   std::shared_ptr<Primitive> load(Reader& is) {
     auto stream = deserialize<Stream>(is);
+    if (get_stream(stream.index) != stream) {
+      std::ostringstream msg;
+      msg << "[import_function] Invalid stream encountered " << stream << ".";
+      throw std::invalid_argument(msg.str());
+    }
     auto name = deserialize<std::string>(is);
     if (auto it = factory.find(name); it != factory.end()) {
       return it->second.deserialize(is, stream);

--- a/mlx/export.cpp
+++ b/mlx/export.cpp
@@ -522,14 +522,14 @@ FunctionTable::Function* FunctionTable::find(
 }
 
 FunctionExporter::FunctionExporter(
-    const std::string& path,
+    const std::string& file,
     std::function<std::vector<array>(const Args&, const Kwargs&)> fun,
     bool shapeless)
-    : os(path),
+    : os(file),
       fun(std::move(fun)),
       ftable(std::make_shared<FunctionTable>(shapeless)) {
   if (!os.is_open()) {
-    throw std::runtime_error("[export_function] Failed to open " + path);
+    throw std::runtime_error("[export_function] Failed to open " + file);
   }
   write_header(os, count, shapeless);
 }
@@ -665,55 +665,55 @@ void FunctionExporter::operator()(const Args& args, const Kwargs& kwargs) {
 }
 
 FunctionExporter exporter(
-    const std::string& path,
+    const std::string& file,
     const std::function<std::vector<array>(const Args&)>& fun,
     bool shapeless /* = false */) {
   return FunctionExporter{
-      path,
+      file,
       [fun](const Args& args, const Kwargs&) { return fun(args); },
       shapeless};
 }
 
 FunctionExporter exporter(
-    const std::string& path,
+    const std::string& file,
     const std::function<std::vector<array>(const Kwargs&)>& fun,
     bool shapeless /* = false */) {
   return exporter(
-      path,
+      file,
       [fun](const Args&, const Kwargs kwargs) { return fun(kwargs); },
       shapeless);
 }
 
 FunctionExporter exporter(
-    const std::string& path,
+    const std::string& file,
     const std::function<std::vector<array>(const Args&, const Kwargs&)>& fun,
     bool shapeless /* = false */) {
-  return FunctionExporter{path, fun, shapeless};
+  return FunctionExporter{file, fun, shapeless};
 }
 
 void export_function(
-    const std::string& path,
+    const std::string& file,
     const std::function<std::vector<array>(const Args&)>& fun,
     const Args& args,
     bool shapeless /* = false */) {
-  exporter(path, fun, shapeless)(args);
+  exporter(file, fun, shapeless)(args);
 }
 
 void export_function(
-    const std::string& path,
+    const std::string& file,
     const std::function<std::vector<array>(const Kwargs&)>& fun,
     const Kwargs& kwargs,
     bool shapeless /* = false */) {
-  exporter(path, fun, shapeless)(kwargs);
+  exporter(file, fun, shapeless)(kwargs);
 }
 
 void export_function(
-    const std::string& path,
+    const std::string& file,
     const std::function<std::vector<array>(const Args&, const Kwargs&)>& fun,
     const Args& args,
     const Kwargs& kwargs,
     bool shapeless /* = false */) {
-  exporter(path, fun, shapeless)(args, kwargs);
+  exporter(file, fun, shapeless)(args, kwargs);
 }
 
 std::vector<array> ImportedFunction::operator()(const Kwargs& kwargs) const {
@@ -753,16 +753,16 @@ std::vector<array> ImportedFunction::operator()(
       fun->tape, fun->inputs, fun->outputs, inputs, ftable->shapeless);
 }
 
-ImportedFunction import_function(const std::string& path) {
-  return ImportedFunction{path};
+ImportedFunction import_function(const std::string& file) {
+  return ImportedFunction{file};
 }
 
-ImportedFunction::ImportedFunction(const std::string& path)
+ImportedFunction::ImportedFunction(const std::string& file)
     : ftable(std::make_shared<FunctionTable>()) {
-  auto is_ptr = std::make_shared<Reader>(path);
+  auto is_ptr = std::make_shared<Reader>(file);
   auto& is = *is_ptr;
   if (!is.is_open()) {
-    throw std::runtime_error("[import_function] Failed to open " + path);
+    throw std::runtime_error("[import_function] Failed to open " + file);
   }
 
   // Parse header

--- a/mlx/export.cpp
+++ b/mlx/export.cpp
@@ -187,7 +187,7 @@ void serialize_iterable(std::ofstream& os, const T& v);
 template <typename T>
 T deserialize_iterable(std::ifstream& is);
 
-#define SERIALIZABLE_ITERABLE(type)                  \
+#define SERIALIZE_ITERABLE(type)                     \
   void serialize(std::ofstream& os, const type& v) { \
     serialize_iterable(os, v);                       \
   }                                                  \
@@ -196,12 +196,12 @@ T deserialize_iterable(std::ifstream& is);
     return deserialize_iterable<type>(is);           \
   }
 
-SERIALIZABLE_ITERABLE(std::string)
-SERIALIZABLE_ITERABLE(std::vector<int>)
-SERIALIZABLE_ITERABLE(std::vector<uint64_t>)
-SERIALIZABLE_ITERABLE(std::vector<Dtype>)
-SERIALIZABLE_ITERABLE(std::vector<array>)
-SERIALIZABLE_ITERABLE(std::vector<std::vector<int>>)
+SERIALIZE_ITERABLE(std::string)
+SERIALIZE_ITERABLE(std::vector<int>)
+SERIALIZE_ITERABLE(std::vector<uint64_t>)
+SERIALIZE_ITERABLE(std::vector<Dtype>)
+SERIALIZE_ITERABLE(std::vector<array>)
+SERIALIZE_ITERABLE(std::vector<std::vector<int>>)
 
 template <typename T>
 void serialize_iterable(std::ofstream& os, const T& v) {

--- a/mlx/export.cpp
+++ b/mlx/export.cpp
@@ -117,14 +117,14 @@ T deserialize(Reader& is) {
     }
     return v;
   } else if constexpr (is_pair<T>) {
-    return std::make_pair(
-        deserialize<typename std::tuple_element<0, T>::type>(is),
-        deserialize<typename std::tuple_element<1, T>::type>(is));
+    auto x1 = deserialize<typename std::tuple_element<0, T>::type>(is);
+    auto x2 = deserialize<typename std::tuple_element<1, T>::type>(is);
+    return std::make_pair(x1, x2);
   } else if constexpr (is_3_tuple<T>) {
-    return std::make_tuple(
-        deserialize<typename std::tuple_element<0, T>::type>(is),
-        deserialize<typename std::tuple_element<1, T>::type>(is),
-        deserialize<typename std::tuple_element<2, T>::type>(is));
+    auto x1 = deserialize<typename std::tuple_element<0, T>::type>(is),
+         auto x2 = deserialize<typename std::tuple_element<1, T>::type>(is),
+         auto x3 = deserialize<typename std::tuple_element<2, T>::type>(is),
+         return std::make_tuple(x1, x2, x3);
   } else {
     NotDeserializable<T>();
   }

--- a/mlx/export.cpp
+++ b/mlx/export.cpp
@@ -1,0 +1,424 @@
+// Copyright © 2024 Apple Inc.
+
+#include "mlx/export.h"
+#include "mlx/compile_impl.h"
+#include "mlx/primitives.h"
+#include "mlx/utils.h"
+
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+
+#define SIMPLE_BUILDER(primitive) \
+  {#primitive,                    \
+   [](Stream s, std::ifstream&) { return std::make_shared<primitive>(s); }}
+
+namespace mlx::core {
+
+using PrimitiveFactory = std::unordered_map<
+    std::string,
+    std::function<std::shared_ptr<Primitive>(Stream s, std::ifstream&)>>;
+
+PrimitiveFactory get_primitive_factory() {
+  return {
+      SIMPLE_BUILDER(Abs),
+      SIMPLE_BUILDER(Add),
+      // AddMM
+      // Arange
+      SIMPLE_BUILDER(ArcCos),
+      SIMPLE_BUILDER(ArcCosh),
+      SIMPLE_BUILDER(ArcSin),
+      SIMPLE_BUILDER(ArcSinh),
+      SIMPLE_BUILDER(ArcTan),
+      SIMPLE_BUILDER(ArcTan2),
+      SIMPLE_BUILDER(ArcTanh),
+      // ArgPartition
+      // ArgReduce
+      // ArgSort
+      // AsStrided
+      // BitwiseBinary
+      // BlockMaskedMM
+      // Broadcast
+      SIMPLE_BUILDER(Ceil),
+      SIMPLE_BUILDER(Conjugate),
+      // Contiguous
+      // Convolution
+      SIMPLE_BUILDER(Copy),
+      SIMPLE_BUILDER(Cos),
+      SIMPLE_BUILDER(Cosh),
+      // CustomTransforms
+      SIMPLE_BUILDER(Depends),
+      SIMPLE_BUILDER(Divide),
+      SIMPLE_BUILDER(DivMod),
+      SIMPLE_BUILDER(Equal),
+      SIMPLE_BUILDER(Erf),
+      SIMPLE_BUILDER(ErfInv),
+      SIMPLE_BUILDER(Exp),
+      SIMPLE_BUILDER(Expm1),
+      // FFT
+      SIMPLE_BUILDER(Floor),
+      SIMPLE_BUILDER(Full),
+      // Gather
+      // GatherMM
+      SIMPLE_BUILDER(Greater),
+      SIMPLE_BUILDER(GreaterEqual),
+      SIMPLE_BUILDER(GreaterEqual),
+      // Hadamard
+      SIMPLE_BUILDER(Imag),
+      SIMPLE_BUILDER(Less),
+      SIMPLE_BUILDER(LessEqual),
+      // Load
+      // Log
+      SIMPLE_BUILDER(Log1p),
+      SIMPLE_BUILDER(LogicalNot),
+      SIMPLE_BUILDER(LogicalAnd),
+      SIMPLE_BUILDER(LogicalOr),
+      SIMPLE_BUILDER(LogAddExp),
+      SIMPLE_BUILDER(Matmul),
+      SIMPLE_BUILDER(Maximum),
+      SIMPLE_BUILDER(Minimum),
+      SIMPLE_BUILDER(Negative),
+      SIMPLE_BUILDER(NotEqual),
+      // NumberOfElements
+      // Pad
+      // Partition
+      SIMPLE_BUILDER(Power),
+      // QuantizedMatmul
+      // GatherQMM
+      // RandomBits
+      SIMPLE_BUILDER(Real),
+      SIMPLE_BUILDER(Remainder),
+      // Reshape
+      // Reduce
+      SIMPLE_BUILDER(Round),
+      // Scan
+      // Scatter
+      SIMPLE_BUILDER(Select),
+      SIMPLE_BUILDER(Sigmoid),
+      SIMPLE_BUILDER(Sign),
+      SIMPLE_BUILDER(Sin),
+      SIMPLE_BUILDER(Sinh),
+      // Slice
+      // SliceUpdate
+      // Softmax
+      // Sort
+      // Split
+      SIMPLE_BUILDER(Square),
+      // Sqrt
+      SIMPLE_BUILDER(StopGradient),
+      SIMPLE_BUILDER(Subtract),
+      SIMPLE_BUILDER(Tan),
+      SIMPLE_BUILDER(Tanh),
+      // View
+      // Transpose
+      SIMPLE_BUILDER(QRF),
+      SIMPLE_BUILDER(SVD)
+      // Inverse
+      // Cholesky
+      // Eigh
+  };
+}
+
+template <typename T>
+void write_bytes(std::ofstream& os, const T val) {
+  // TODO canonicalize endianness here
+  os.write(reinterpret_cast<const char*>(&val), sizeof(T));
+}
+
+template <typename T>
+void read_bytes(std::ifstream& is, T& val) {
+  // TODO potentially swap endianness here
+  is.read(reinterpret_cast<char*>(&val), sizeof(T));
+}
+
+template <typename T>
+T deserialize(std::ifstream& os);
+
+#define SERIALIZE_BUILTIN(type)               \
+  void serialize(std::ofstream& os, type v) { \
+    write_bytes(os, v);                       \
+  }                                           \
+  template <>                                 \
+  type deserialize(std::ifstream& is) {       \
+    type v;                                   \
+    read_bytes(is, v);                        \
+    return v;                                 \
+  }
+
+SERIALIZE_BUILTIN(bool)
+SERIALIZE_BUILTIN(char)
+SERIALIZE_BUILTIN(int)
+SERIALIZE_BUILTIN(uint64_t)
+
+void serialize(std::ofstream& os, const Stream& s) {
+  write_bytes(os, s.index);
+  write_bytes(os, static_cast<int>(s.device.type));
+  write_bytes(os, s.device.index);
+}
+template <>
+Stream deserialize(std::ifstream& is) {
+  int stream_index;
+  int device_type;
+  int device_index;
+  read_bytes(is, stream_index);
+  read_bytes(is, device_type);
+  read_bytes(is, device_index);
+  // TODO handle streams correctly
+  return Stream(
+      stream_index,
+      Device(static_cast<Device::DeviceType>(device_type), device_index));
+}
+
+void serialize(std::ofstream& os, const Dtype& t) {
+  write_bytes(os, static_cast<int>(t.val()));
+  write_bytes(os, t.size());
+}
+
+template <>
+Dtype deserialize(std::ifstream& is) {
+  int val;
+  uint8_t size;
+  read_bytes(is, val);
+  read_bytes(is, size);
+  return Dtype(static_cast<Dtype::Val>(val), size);
+};
+
+template <typename T>
+void serialize_iterable(std::ofstream& os, const T& v);
+template <typename T>
+T deserialize_iterable(std::ifstream& is);
+
+#define SERIALIZABLE_ITERABLE(type)                  \
+  void serialize(std::ofstream& os, const type& v) { \
+    serialize_iterable(os, v);                       \
+  }                                                  \
+  template <>                                        \
+  type deserialize(std::ifstream& is) {              \
+    return deserialize_iterable<type>(is);           \
+  }
+
+SERIALIZABLE_ITERABLE(std::string)
+SERIALIZABLE_ITERABLE(std::vector<int>)
+SERIALIZABLE_ITERABLE(std::vector<uint64_t>)
+SERIALIZABLE_ITERABLE(std::vector<Dtype>)
+SERIALIZABLE_ITERABLE(std::vector<array>)
+SERIALIZABLE_ITERABLE(std::vector<std::vector<int>>)
+
+template <typename T>
+void serialize_iterable(std::ofstream& os, const T& v) {
+  serialize(os, static_cast<uint64_t>(v.size()));
+  for (const auto& t : v) {
+    serialize(os, t);
+  }
+};
+
+template <typename T>
+T deserialize_iterable(std::ifstream& is) {
+  T v;
+  auto size = deserialize<uint64_t>(is);
+  v.reserve(size);
+  for (int i = 0; i < size; ++i) {
+    v.push_back(deserialize<typename T::value_type>(is));
+  }
+  return v;
+};
+
+void serialize(std::ofstream& os, const array& arr) {
+  serialize(os, arr.shape());
+  serialize(os, arr.dtype());
+}
+template <>
+array deserialize(std::ifstream& is) {
+  auto shape = deserialize<std::vector<int>>(is);
+  auto type = deserialize<Dtype>(is);
+  return array(std::move(shape), type, nullptr, std::vector<array>{});
+}
+
+void serialize(std::ofstream& os, const std::shared_ptr<Primitive>& p) {
+  serialize(os, p->stream());
+  std::ostringstream pname;
+  p->print(pname);
+  serialize(os, pname.str());
+}
+std::shared_ptr<Primitive> deserialize(
+    std::ifstream& is,
+    const PrimitiveFactory& factory) {
+  auto stream = deserialize<Stream>(is);
+  // TODO run some checks on the stream to make sure it exists
+  auto name = deserialize<std::string>(is);
+  return factory.find(name)->second(stream, is);
+}
+
+void export_function(
+    std::string path,
+    const std::function<std::vector<array>(const std::vector<array>&)>& fun,
+    const std::vector<array>& inputs,
+    bool shapeless /* = false */) {
+  // Trace to build the graph
+  auto [trace_inputs, trace_outputs] = detail::compile_trace(fun, inputs);
+
+  // DFS the graph and get the tape
+  auto [tape, parents_map] =
+      detail::compile_dfs(trace_inputs, trace_outputs, inputs);
+
+  detail::compile_simplify(tape, parents_map, trace_outputs, /* passes */ 3);
+
+  if (shapeless) {
+    detail::compile_validate_shapeless(tape);
+  }
+
+  // Serialize the tape, inputs, and outputs to the file
+  std::ofstream os(path, std::ios::binary);
+  if (!os.is_open()) {
+    throw std::runtime_error("[export_function] Failed to open " + path);
+  }
+
+  // Header
+  serialize(os, std::string(TOSTRING(MLX_VERSION)));
+  serialize(os, shapeless);
+
+  auto arrays_to_ids = [](const std::vector<array>& arrs) {
+    std::vector<uint64_t> ids;
+    for (auto& arr : arrs) {
+      ids.push_back(arr.id());
+    }
+    return ids;
+  };
+
+  // Inputs and outputs
+  serialize(os, arrays_to_ids(trace_inputs));
+  serialize(os, trace_inputs);
+  serialize(os, arrays_to_ids(trace_outputs));
+
+  // Tape
+  serialize(os, static_cast<uint64_t>(tape.size()));
+  for (auto& arr : tape) {
+    if (arr.has_primitive()) {
+      serialize(os, true);
+      serialize(os, arrays_to_ids(arr.inputs()));
+      serialize(os, arr.primitive_ptr());
+      serialize(os, static_cast<uint64_t>(arr.siblings().size()));
+      serialize(os, static_cast<uint64_t>(arr.id()));
+      if (arr.siblings().empty()) {
+        serialize(os, arr.shape());
+        serialize(os, arr.dtype());
+      } else {
+        auto outputs = arr.outputs();
+        serialize(os, arrays_to_ids(outputs));
+
+        std::vector<std::vector<int>> shapes;
+        std::vector<Dtype> dtypes;
+        for (auto& o : outputs) {
+          shapes.push_back(o.shape());
+          dtypes.push_back(o.dtype());
+        }
+        serialize(os, shapes);
+        serialize(os, dtypes);
+      }
+    } else {
+      serialize(os, false);
+      serialize(os, static_cast<uint64_t>(arr.id()));
+    }
+  }
+}
+
+std::function<std::vector<array>(const std::vector<array>&)> import_function(
+    std::string path) {
+  std::ifstream is(path, std::ios::binary);
+  if (!is.is_open()) {
+    throw std::runtime_error("[import_function] Failed to open " + path);
+  }
+
+  // Parse header
+  auto mlx_version = deserialize<std::string>(is);
+  bool shapeless = deserialize<bool>(is);
+
+  std::unordered_map<uint64_t, array> array_map;
+  auto trace_input_ids = deserialize<std::vector<uint64_t>>(is);
+  auto trace_inputs = deserialize<std::vector<array>>(is);
+  for (int i = 0; i < trace_inputs.size(); ++i) {
+    array_map.emplace(trace_input_ids[i], trace_inputs[i]);
+  }
+  auto trace_output_ids = deserialize<std::vector<uint64_t>>(is);
+
+  std::vector<array> tape;
+  auto tape_size = deserialize<uint64_t>(is);
+  tape.reserve(tape_size);
+
+  auto primitive_factory = get_primitive_factory();
+  for (size_t i = 0; i < tape_size; ++i) {
+    if (deserialize<bool>(is)) {
+      auto input_ids = deserialize<std::vector<uint64_t>>(is);
+      std::vector<array> inputs;
+      inputs.reserve(input_ids.size());
+      for (auto id : input_ids) {
+        inputs.push_back(array_map.at(id));
+      }
+      std::shared_ptr<Primitive> prim = deserialize(is, primitive_factory);
+      auto num_siblings = deserialize<uint64_t>(is);
+      auto id = deserialize<uint64_t>(is);
+      if (num_siblings == 0) {
+        auto shape = deserialize<std::vector<int>>(is);
+        auto type = deserialize<Dtype>(is);
+        tape.emplace_back(
+            std::move(shape), type, std::move(prim), std::move(inputs));
+        array_map.emplace(id, tape.back());
+      } else {
+        auto ids = deserialize<std::vector<uint64_t>>(is);
+        auto shapes = deserialize<std::vector<std::vector<int>>>(is);
+        auto types = deserialize<std::vector<Dtype>>(is);
+        auto arrays = array::make_arrays(
+            std::move(shapes),
+            std::move(types),
+            std::move(prim),
+            std::move(inputs));
+        for (int i = 0; i < arrays.size(); ++i) {
+          auto sid = ids[i];
+          if (sid == id) {
+            tape.push_back(arrays[i]);
+          }
+          array_map.emplace(sid, arrays[i]);
+        }
+      }
+    } else {
+      tape.push_back(array_map.at(deserialize<uint64_t>(is)));
+    }
+  }
+
+  std::vector<array> trace_outputs;
+  trace_outputs.reserve(trace_output_ids.size());
+  for (auto id : trace_output_ids) {
+    trace_outputs.push_back(array_map.at(id));
+  }
+
+  return [tape = std::move(tape),
+          trace_inputs = std::move(trace_inputs),
+          trace_outputs = std::move(trace_outputs),
+          shapeless](const std::vector<array>& inputs) {
+    if (inputs.size() != trace_inputs.size()) {
+      std::ostringstream msg;
+      msg << "[import_function::call] Incorrect number of arguments. Expected "
+          << trace_inputs.size() << " but received " << inputs.size() << ".";
+      throw std::invalid_argument(msg.str());
+    }
+    for (int i = 0; i < inputs.size(); ++i) {
+      if (inputs[i].dtype() != trace_inputs[i].dtype()) {
+        std::ostringstream msg;
+        msg << "[import_function::call] Incorrect type " << inputs[i].dtype()
+            << " for input " << i << ". Expected type "
+            << trace_inputs[i].dtype() << ".";
+        throw std::invalid_argument(msg.str());
+      }
+      if (!shapeless && inputs[i].shape() != trace_inputs[i].shape()) {
+        std::ostringstream msg;
+        msg << "[import_function::call] Incorrect shape " << inputs[i].shape()
+            << " for input " << i << ". Expected shape "
+            << trace_inputs[i].shape() << ".";
+        throw std::invalid_argument(msg.str());
+      }
+    }
+    return detail::compile_replace(
+        tape, trace_inputs, trace_outputs, inputs, shapeless);
+  };
+}
+
+} // namespace mlx::core

--- a/mlx/export.h
+++ b/mlx/export.h
@@ -2,23 +2,61 @@
 
 #pragma once
 
+#include <map>
+#include <set>
 #include "mlx/array.h"
 
 namespace mlx::core {
+
+using Args = std::vector<array>;
+using Kwargs = std::map<std::string, array>;
+
+struct FunctionExporter;
+
+FunctionExporter exporter(
+    const std::string& path,
+    const std::function<std::vector<array>(const Args&)>& fun,
+    bool shapeless = false);
+
+FunctionExporter exporter(
+    const std::string& path,
+    const std::function<std::vector<array>(const Kwargs&)>& fun,
+    bool shapeless = false);
+
+FunctionExporter exporter(
+    const std::string& path,
+    const std::function<std::vector<array>(const Args&, const Kwargs&)>& fun,
+    bool shapeless = false);
 
 /**
  * Export a function to a file.
  */
 void export_function(
-    std::string path,
-    const std::function<std::vector<array>(const std::vector<array>&)>& fun,
-    const std::vector<array>& inputs,
+    const std::string& path,
+    const std::function<std::vector<array>(const Args&)>& fun,
+    const Args& args,
     bool shapeless = false);
+
+void export_function(
+    const std::string& path,
+    const std::function<std::vector<array>(const Kwargs&)>& fun,
+    const Kwargs& kwargs,
+    bool shapeless = false);
+
+void export_function(
+    const std::string& path,
+    const std::function<std::vector<array>(const Args&, const Kwargs&)>& fun,
+    const Args& args,
+    const Kwargs& kwargs,
+    bool shapeless = false);
+
+struct ImportedFunction;
 
 /**
  * Import a function from a file.
  */
-std::function<std::vector<array>(const std::vector<array>&)> import_function(
-    std::string path);
+ImportedFunction import_function(const std::string& path);
 
 } // namespace mlx::core
+
+#include "mlx/export_impl.h"

--- a/mlx/export.h
+++ b/mlx/export.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include <fstream>
 #include "mlx/array.h"
 
 namespace mlx::core {

--- a/mlx/export.h
+++ b/mlx/export.h
@@ -1,0 +1,25 @@
+// Copyright © 2024 Apple Inc.
+
+#pragma once
+
+#include <fstream>
+#include "mlx/array.h"
+
+namespace mlx::core {
+
+/**
+ * Export a function to a file.
+ */
+void export_function(
+    std::string path,
+    const std::function<std::vector<array>(const std::vector<array>&)>& fun,
+    const std::vector<array>& inputs,
+    bool shapeless = false);
+
+/**
+ * Import a function from a file.
+ */
+std::function<std::vector<array>(const std::vector<array>&)> import_function(
+    std::string path);
+
+} // namespace mlx::core

--- a/mlx/export.h
+++ b/mlx/export.h
@@ -18,12 +18,12 @@ struct FunctionExporter;
  * the same file.
  */
 FunctionExporter exporter(
-    const std::string& path,
+    const std::string& file,
     const std::function<std::vector<array>(const Args&)>& fun,
     bool shapeless = false);
 
 FunctionExporter exporter(
-    const std::string& path,
+    const std::string& file,
     const std::function<std::vector<array>(const Kwargs&)>& fun,
     bool shapeless = false);
 
@@ -36,19 +36,19 @@ FunctionExporter exporter(
  * Export a function to a file.
  */
 void export_function(
-    const std::string& path,
+    const std::string& file,
     const std::function<std::vector<array>(const Args&)>& fun,
     const Args& args,
     bool shapeless = false);
 
 void export_function(
-    const std::string& path,
+    const std::string& file,
     const std::function<std::vector<array>(const Kwargs&)>& fun,
     const Kwargs& kwargs,
     bool shapeless = false);
 
 void export_function(
-    const std::string& path,
+    const std::string& file,
     const std::function<std::vector<array>(const Args&, const Kwargs&)>& fun,
     const Args& args,
     const Kwargs& kwargs,
@@ -59,7 +59,7 @@ struct ImportedFunction;
 /**
  * Import a function from a file.
  */
-ImportedFunction import_function(const std::string& path);
+ImportedFunction import_function(const std::string& file);
 
 } // namespace mlx::core
 

--- a/mlx/export.h
+++ b/mlx/export.h
@@ -13,6 +13,10 @@ using Kwargs = std::map<std::string, array>;
 
 struct FunctionExporter;
 
+/**
+ * Make an exporter to save multiple traces of a given function to
+ * the same file.
+ */
 FunctionExporter exporter(
     const std::string& path,
     const std::function<std::vector<array>(const Args&)>& fun,

--- a/mlx/export_impl.h
+++ b/mlx/export_impl.h
@@ -16,6 +16,12 @@ struct FunctionExporter {
   void operator()(const Kwargs& kwargs);
   void operator()(const Args& args, const Kwargs& kwargs);
 
+  void close();
+
+  FunctionExporter(const FunctionExporter&) = delete;
+  FunctionExporter& operator=(const FunctionExporter&) = delete;
+  FunctionExporter(FunctionExporter&& other) = default;
+
  private:
   struct FunctionInfo {
     std::vector<Shape> shapes;
@@ -49,7 +55,8 @@ struct FunctionExporter {
   void export_function(const Args& args, const Kwargs& kwargs);
   std::set<std::uintptr_t> constants;
   int count{0};
-  // std::vector<ExportedFunctionInfo> functions;
+  bool closed{false};
+  // TODO std::vector<ExportedFunctionInfo> functions;
 };
 
 struct ImportedFunction {

--- a/mlx/export_impl.h
+++ b/mlx/export_impl.h
@@ -1,0 +1,82 @@
+// Copyright © 2024 Apple Inc.
+
+#include "mlx/io/load.h"
+
+#pragma once
+
+namespace mlx::core {
+
+namespace {}
+
+struct FunctionExporter {
+  void operator()(const std::initializer_list<array>& args) {
+    this->operator()(Args(args));
+  }
+  void operator()(const Args& args);
+  void operator()(const Kwargs& kwargs);
+  void operator()(const Args& args, const Kwargs& kwargs);
+
+ private:
+  struct FunctionInfo {
+    std::vector<Shape> shapes;
+    std::vector<Dtype> types;
+    std::vector<std::string> kwarg_keys;
+  };
+
+  friend FunctionExporter exporter(
+      const std::string&,
+      const std::function<std::vector<array>(const Args&)>&,
+      bool shapeless);
+
+  friend FunctionExporter exporter(
+      const std::string&,
+      const std::function<std::vector<array>(const Kwargs&)>&,
+      bool shapeless);
+
+  friend FunctionExporter exporter(
+      const std::string&,
+      const std::function<std::vector<array>(const Args&, const Kwargs&)>&,
+      bool shapeless);
+
+  FunctionExporter(
+      const std::string& path,
+      std::function<std::vector<array>(const Args&, const Kwargs&)> fun,
+      bool shapeless);
+
+  io::FileWriter os;
+  std::function<std::vector<array>(const Args&, const Kwargs& kwargs)> fun;
+  bool shapeless;
+  void export_function(const Args& args, const Kwargs& kwargs);
+  std::set<std::uintptr_t> constants;
+  int count{0};
+  // std::vector<ExportedFunctionInfo> functions;
+};
+
+struct ImportedFunction {
+  std::vector<array> operator()(
+      const std::initializer_list<array>& args) const {
+    return this->operator()(Args(args));
+  }
+  std::vector<array> operator()(const Args& args) const;
+  std::vector<array> operator()(const Kwargs& kwargs) const;
+  std::vector<array> operator()(const Args& args, const Kwargs& kwargs) const;
+
+ private:
+  ImportedFunction(const std::string& path);
+  struct Function {
+    std::vector<std::string> kwarg_keys;
+    std::vector<array> trace_inputs;
+    std::vector<array> trace_outputs;
+    std::vector<array> tape;
+  };
+
+  bool shapeless;
+  friend ImportedFunction import_function(const std::string&);
+  ImportedFunction();
+
+  // Index functions by number of inputs as a heuristic for reasonably
+  // fast lookup
+  std::unordered_map<int, std::vector<Function>> functions;
+};
+
+} // namespace mlx::core

--- a/mlx/export_impl.h
+++ b/mlx/export_impl.h
@@ -39,7 +39,7 @@ struct FunctionExporter {
       bool shapeless);
 
   FunctionExporter(
-      const std::string& path,
+      const std::string& file,
       std::function<std::vector<array>(const Args&, const Kwargs&)> fun,
       bool shapeless);
   io::FileWriter os;
@@ -61,7 +61,7 @@ struct ImportedFunction {
   std::vector<array> operator()(const Args& args, const Kwargs& kwargs) const;
 
  private:
-  ImportedFunction(const std::string& path);
+  ImportedFunction(const std::string& file);
   friend ImportedFunction import_function(const std::string&);
   ImportedFunction();
 

--- a/mlx/fast.cpp
+++ b/mlx/fast.cpp
@@ -697,8 +697,7 @@ array scaled_dot_product_attention(
     return array(
         std::move(out_shape),
         final_type,
-        std::make_shared<ScaledDotProductAttention>(
-            stream, fallback, scale, false),
+        std::make_shared<ScaledDotProductAttention>(stream, fallback, scale),
         {q, k, v});
   }
 
@@ -712,7 +711,7 @@ array scaled_dot_product_attention(
 bool ScaledDotProductAttention::is_equivalent(const Primitive& other) const {
   const ScaledDotProductAttention& a_other =
       static_cast<const ScaledDotProductAttention&>(other);
-  return needs_mask_ == a_other.needs_mask_ && scale_ == a_other.scale_;
+  return scale_ == a_other.scale_;
 }
 
 array pack_and_quantize(

--- a/mlx/fast_primitives.h
+++ b/mlx/fast_primitives.h
@@ -60,6 +60,10 @@ class RMSNorm : public Custom {
   bool is_equivalent(const Primitive& other) const override;
   DEFINE_INPUT_OUTPUT_SHAPE()
 
+  auto state() const {
+    return std::make_pair(nullptr, eps_);
+  }
+
  private:
   std::function<std::vector<array>(std::vector<array>)> fallback_;
   float eps_;
@@ -82,6 +86,9 @@ class RMSNormVJP : public Custom {
 
   DEFINE_PRINT(RMSNormVJP)
   bool is_equivalent(const Primitive& other) const override;
+  auto state() const {
+    return std::make_pair(nullptr, eps_);
+  }
 
  private:
   std::function<std::vector<array>(std::vector<array>)> fallback_;
@@ -112,6 +119,9 @@ class LayerNorm : public Custom {
   DEFINE_PRINT(LayerNorm)
   bool is_equivalent(const Primitive& other) const override;
   DEFINE_INPUT_OUTPUT_SHAPE()
+  auto state() const {
+    return std::make_pair(nullptr, eps_);
+  }
 
  private:
   std::function<std::vector<array>(std::vector<array>)> fallback_;
@@ -135,6 +145,9 @@ class LayerNormVJP : public Custom {
 
   DEFINE_PRINT(LayerNormVJP)
   bool is_equivalent(const Primitive& other) const override;
+  auto state() const {
+    return std::make_pair(nullptr, eps_);
+  }
 
  private:
   std::function<std::vector<array>(std::vector<array>)> fallback_;
@@ -174,6 +187,10 @@ class RoPE : public Custom {
   DEFINE_PRINT(RoPE)
   bool is_equivalent(const Primitive& other) const override;
   DEFINE_INPUT_OUTPUT_SHAPE()
+  auto state() const {
+    return std::make_tuple(
+        nullptr, dims_, traditional_, base_, scale_, forward_);
+  }
 
  private:
   std::function<std::vector<array>(std::vector<array>)> fallback_;
@@ -189,9 +206,8 @@ class ScaledDotProductAttention : public Custom {
   explicit ScaledDotProductAttention(
       Stream stream,
       std::function<std::vector<array>(std::vector<array>)> fallback,
-      const float scale,
-      const bool needs_mask)
-      : Custom(stream, fallback), scale_(scale), needs_mask_(needs_mask) {}
+      const float scale)
+      : Custom(stream, fallback), scale_(scale) {}
 
   void eval_cpu(const std::vector<array>& inputs, std::vector<array>& outputs)
       override {
@@ -208,11 +224,13 @@ class ScaledDotProductAttention : public Custom {
 
   DEFINE_PRINT(ScaledDotProductAttention);
   DEFINE_INPUT_OUTPUT_SHAPE()
+  auto state() const {
+    return std::make_pair(nullptr, scale_);
+  }
 
  private:
   std::function<std::vector<array>(std::vector<array>)> fallback_;
   float scale_;
-  bool needs_mask_;
 };
 
 class AffineQuantize : public Custom {
@@ -238,6 +256,9 @@ class AffineQuantize : public Custom {
 
   bool is_equivalent(const Primitive& other) const override;
   std::vector<Shape> output_shapes(const std::vector<array>& inputs) override;
+  auto state() const {
+    return std::make_tuple(nullptr, group_size_, bits_, dequantize_);
+  }
 
  private:
   std::function<std::vector<array>(std::vector<array>)> fallback_;

--- a/mlx/io/load.h
+++ b/mlx/io/load.h
@@ -78,8 +78,15 @@ class ParallelFileReader : public Reader {
     return lseek(fd_, 0, SEEK_CUR);
   }
 
-  void seek(int64_t, std::ios_base::seekdir = std::ios_base::beg) override {
-    throw std::runtime_error("[ParallelFileReader::seek] Not allowed");
+  // Warning: do not use this function from multiple threads as
+  // it advances the file descriptor
+  void seek(int64_t off, std::ios_base::seekdir way = std::ios_base::beg)
+      override {
+    if (way == std::ios_base::beg) {
+      lseek(fd_, off, 0);
+    } else {
+      lseek(fd_, off, SEEK_CUR);
+    }
   }
 
   // Warning: do not use this function from multiple threads as

--- a/mlx/io/load.h
+++ b/mlx/io/load.h
@@ -115,8 +115,16 @@ class FileWriter : public Writer {
             0644)),
         label_(std::move(file_path)) {}
 
+  FileWriter(const FileWriter&) = delete;
+  FileWriter& operator=(const FileWriter&) = delete;
+  FileWriter(FileWriter&& other) {
+    std::swap(fd_, other.fd_);
+  }
+
   ~FileWriter() override {
-    close(fd_);
+    if (fd_ != 0) {
+      close(fd_);
+    }
   }
 
   bool is_open() const override {
@@ -158,7 +166,7 @@ class FileWriter : public Writer {
   }
 
  private:
-  int fd_;
+  int fd_{0};
   std::string label_;
 };
 

--- a/mlx/mlx.h
+++ b/mlx/mlx.h
@@ -9,6 +9,7 @@
 #include "mlx/distributed/distributed.h"
 #include "mlx/distributed/ops.h"
 #include "mlx/einsum.h"
+#include "mlx/export.h"
 #include "mlx/fast.h"
 #include "mlx/fft.h"
 #include "mlx/io.h"

--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -4486,7 +4486,7 @@ std::pair<std::vector<array>, std::vector<int>> View::vmap(
 }
 
 void View::print(std::ostream& os) {
-  os << "View" << dtype_;
+  os << "View " << dtype_;
 }
 
 bool View::is_equivalent(const Primitive& other) const {

--- a/mlx/primitives.h
+++ b/mlx/primitives.h
@@ -442,6 +442,9 @@ class AsType : public UnaryPrimitive {
   DEFINE_PRINT(AsType)
   DEFINE_INPUT_OUTPUT_SHAPE()
   bool is_equivalent(const Primitive& other) const override;
+  Dtype state() const {
+    return dtype_;
+  };
 
  private:
   Dtype dtype_;
@@ -1121,6 +1124,9 @@ class Gather : public UnaryPrimitive {
   DEFINE_PRINT(Gather)
   bool is_equivalent(const Primitive& other) const override;
   std::vector<Shape> output_shapes(const std::vector<array>& inputs) override;
+  std::pair<std::vector<int>, std::vector<int>> state() const {
+    return {axes_, slice_sizes_};
+  }
 
  private:
   void eval(const std::vector<array>& inputs, array& out);
@@ -1277,6 +1283,10 @@ class Log : public UnaryPrimitive {
   DEFINE_GRADS()
   DEFINE_DEFAULT_IS_EQUIVALENT()
   DEFINE_INPUT_OUTPUT_SHAPE()
+
+  Base state() const {
+    return base_;
+  };
 
   void print(std::ostream& os) override {
     switch (base_) {
@@ -1506,6 +1516,9 @@ class NumberOfElements : public UnaryPrimitive {
   std::vector<Shape> output_shapes(const std::vector<array>& inputs) override {
     return {{}};
   }
+  std::tuple<std::vector<int>, bool, Dtype> state() const {
+    return {axes_, inverted_, dtype_};
+  }
 
  private:
   std::vector<int> axes_;
@@ -1645,6 +1658,9 @@ class RandomBits : public UnaryPrimitive {
   DEFINE_VMAP()
   DEFINE_PRINT(RandomBits)
   bool is_equivalent(const Primitive& other) const override;
+  std::pair<std::vector<int>, int> state() const {
+    return {shape_, width_};
+  };
 
  private:
   Shape shape_;
@@ -1679,6 +1695,9 @@ class Reshape : public UnaryPrimitive {
   DEFINE_GRADS()
   DEFINE_PRINT(Reshape)
   bool is_equivalent(const Primitive& other) const override;
+  std::vector<int> state() const {
+    return shape_;
+  };
 
  private:
   Shape shape_;
@@ -1730,6 +1749,9 @@ class Reduce : public UnaryPrimitive {
     }
   }
   bool is_equivalent(const Primitive& other) const override;
+  std::pair<ReduceType, std::vector<int>> state() const {
+    return {reduce_type_, axes_};
+  };
 
  private:
   ReduceType reduce_type_;
@@ -1841,6 +1863,9 @@ class Scatter : public UnaryPrimitive {
     }
   }
   bool is_equivalent(const Primitive& other) const override;
+  std::pair<ReduceType, std::vector<int>> state() const {
+    return {reduce_type_, axes_};
+  };
 
  private:
   void eval(const std::vector<array>& inputs, array& out);
@@ -2027,6 +2052,9 @@ class Split : public Primitive {
   DEFINE_GRADS()
   DEFINE_PRINT(Split)
   bool is_equivalent(const Primitive& other) const override;
+  std::pair<std::vector<int>, int> state() const {
+    return {indices_, axis_};
+  };
 
  private:
   void eval(const std::vector<array>& inputs, std::vector<array>& outputs);

--- a/mlx/primitives.h
+++ b/mlx/primitives.h
@@ -203,6 +203,9 @@ class AddMM : public UnaryPrimitive {
   DEFINE_PRINT(AddMM)
 
   bool is_equivalent(const Primitive& other) const override;
+  std::pair<float, float> state() const {
+    return {alpha_, beta_};
+  };
 
  private:
   const float alpha_;
@@ -390,6 +393,9 @@ class ArgReduce : public UnaryPrimitive {
   DEFINE_PRINT(ArgReduce)
   bool is_equivalent(const Primitive& other) const override;
   std::vector<Shape> output_shapes(const std::vector<array>& inputs) override;
+  std::pair<ReduceType, int> state() const {
+    return {reduce_type_, axis_};
+  };
 
  private:
   ReduceType reduce_type_;
@@ -535,6 +541,9 @@ class Broadcast : public UnaryPrimitive {
   DEFINE_GRADS()
   DEFINE_PRINT(Broadcast)
   bool is_equivalent(const Primitive& other) const override;
+  std::vector<int> state() const {
+    return shape_;
+  };
 
   std::vector<Shape> output_shapes(const std::vector<array>& inputs) override;
 

--- a/mlx/primitives.h
+++ b/mlx/primitives.h
@@ -2171,21 +2171,6 @@ class Unflatten : public UnaryPrimitive {
   void eval(const std::vector<array>& inputs, array& out);
 };
 
-class Uniform : public UnaryPrimitive {
- public:
-  explicit Uniform(Stream stream) : UnaryPrimitive(stream) {}
-
-  void eval_cpu(const std::vector<array>& inputs, array& out) override;
-  void eval_gpu(const std::vector<array>& inputs, array& out) override;
-
-  DEFINE_VMAP()
-  DEFINE_PRINT(Uniform)
-  DEFINE_DEFAULT_IS_EQUIVALENT()
-
- private:
-  void eval(const std::vector<array>& inputs, array& out);
-};
-
 class View : public UnaryPrimitive {
  public:
   explicit View(Stream stream, Dtype dtype)

--- a/mlx/primitives.h
+++ b/mlx/primitives.h
@@ -466,6 +466,9 @@ class AsStrided : public UnaryPrimitive {
   DEFINE_GRADS()
   DEFINE_PRINT(AsStrided)
   bool is_equivalent(const Primitive& other) const override;
+  auto state() const {
+    return std::make_tuple(shape_, strides_, offset_);
+  }
 
  private:
   Shape shape_;
@@ -490,6 +493,9 @@ class BitwiseBinary : public UnaryPrimitive {
   bool is_equivalent(const Primitive& other) const override;
   void print(std::ostream& os) override;
   DEFINE_INPUT_OUTPUT_SHAPE()
+  auto state() const {
+    return op_;
+  }
 
  private:
   Op op_;
@@ -511,6 +517,9 @@ class BlockMaskedMM : public UnaryPrimitive {
 
   DEFINE_PRINT(BlockMaskedMM)
   bool is_equivalent(const Primitive& other) const override;
+  auto state() const {
+    return block_size_;
+  }
 
  private:
   int block_size_;
@@ -634,6 +643,9 @@ class Concatenate : public UnaryPrimitive {
   DEFINE_PRINT(Concatenate)
   bool is_equivalent(const Primitive& other) const override;
   std::vector<Shape> output_shapes(const std::vector<array>& inputs) override;
+  auto state() const {
+    return axis_;
+  }
 
  private:
   int axis_;
@@ -705,6 +717,15 @@ class Convolution : public UnaryPrimitive {
 
   DEFINE_PRINT(Convolution)
   bool is_equivalent(const Primitive& other) const override;
+  auto state() const {
+    return std::make_tuple(
+        padding_,
+        kernel_strides_,
+        kernel_dilation_,
+        input_dilation_,
+        groups_,
+        flip_);
+  }
 
  private:
   std::vector<int> padding_;
@@ -1025,6 +1046,9 @@ class ExpandDims : public UnaryPrimitive {
   bool is_equivalent(const Primitive& other) const override;
 
   static Shape output_shape(const array& input, const std::vector<int>& axes);
+  auto state() const {
+    return axes_;
+  }
 
  private:
   void eval(const std::vector<array>& inputs, array& out);
@@ -1048,6 +1072,9 @@ class FFT : public UnaryPrimitive {
   DEFINE_PRINT(FFT)
 
   bool is_equivalent(const Primitive& other) const override;
+  auto state() const {
+    return std::make_tuple(axes_, inverse_, real_);
+  }
 
  private:
   std::vector<size_t> axes_;
@@ -1072,6 +1099,9 @@ class Flatten : public UnaryPrimitive {
   bool is_equivalent(const Primitive& other) const override;
 
   static Shape output_shape(const array& input, int start_axis, int end_axis);
+  auto state() const {
+    return std::make_pair(start_axis_, end_axis_);
+  }
 
  private:
   int start_axis_;
@@ -1185,6 +1215,9 @@ class Hadamard : public UnaryPrimitive {
   DEFINE_INPUT_OUTPUT_SHAPE()
 
   bool is_equivalent(const Primitive& other) const override;
+  auto state() const {
+    return scale_;
+  }
 
  private:
   float scale_;
@@ -1550,6 +1583,9 @@ class Pad : public UnaryPrimitive {
   DEFINE_GRADS()
   DEFINE_PRINT(Pad)
   bool is_equivalent(const Primitive& other) const override;
+  auto state() const {
+    return std::make_tuple(axes_, low_pad_size_, high_pad_size_);
+  }
 
  private:
   std::vector<int> axes_;
@@ -1572,6 +1608,9 @@ class Partition : public UnaryPrimitive {
   DEFINE_PRINT(Partition)
   DEFINE_INPUT_OUTPUT_SHAPE()
   bool is_equivalent(const Primitive& other) const override;
+  auto state() const {
+    return std::make_pair(kth_, axis_);
+  };
 
  private:
   int kth_;
@@ -1617,6 +1656,9 @@ class QuantizedMatmul : public UnaryPrimitive {
   DEFINE_PRINT(QuantizedMatmul)
   bool is_equivalent(const Primitive& other) const override;
   std::vector<Shape> output_shapes(const std::vector<array>& inputs) override;
+  auto state() const {
+    return std::make_tuple(group_size_, bits_, transpose_);
+  }
 
  private:
   int group_size_;
@@ -1641,6 +1683,9 @@ class GatherQMM : public UnaryPrimitive {
   DEFINE_GRADS()
   DEFINE_PRINT(GatherQMM)
   bool is_equivalent(const Primitive& other) const override;
+  auto state() const {
+    return std::make_tuple(group_size_, bits_, transpose_);
+  }
 
  private:
   int group_size_;
@@ -1820,6 +1865,9 @@ class Scan : public UnaryPrimitive {
     }
   }
   bool is_equivalent(const Primitive& other) const override;
+  auto state() const {
+    return std::make_tuple(reduce_type_, axis_, reverse_, inclusive_);
+  }
 
  private:
   ReduceType reduce_type_;
@@ -1963,6 +2011,9 @@ class Slice : public UnaryPrimitive {
   DEFINE_GRADS()
   DEFINE_PRINT(Slice)
   bool is_equivalent(const Primitive& other) const override;
+  auto state() const {
+    return std::make_tuple(start_indices_, end_indices_, strides_);
+  }
 
  private:
   Shape start_indices_;
@@ -1992,6 +2043,9 @@ class SliceUpdate : public UnaryPrimitive {
   DEFINE_PRINT(SliceUpdate)
   bool is_equivalent(const Primitive& other) const override;
   DEFINE_INPUT_OUTPUT_SHAPE()
+  auto state() const {
+    return std::make_tuple(start_indices_, end_indices_, strides_);
+  }
 
  private:
   Shape start_indices_;
@@ -2015,6 +2069,9 @@ class Softmax : public UnaryPrimitive {
   DEFINE_INPUT_OUTPUT_SHAPE()
 
   bool is_equivalent(const Primitive& other) const override;
+  auto state() const {
+    return precise_;
+  };
 
  private:
   void eval(const std::vector<array>& inputs, array& out);
@@ -2034,6 +2091,9 @@ class Sort : public UnaryPrimitive {
   DEFINE_PRINT(Sort)
   DEFINE_INPUT_OUTPUT_SHAPE()
   bool is_equivalent(const Primitive& other) const override;
+  auto state() const {
+    return axis_;
+  }
 
  private:
   int axis_;
@@ -2095,6 +2155,9 @@ class Sqrt : public UnaryPrimitive {
   DEFINE_GRADS()
   DEFINE_INPUT_OUTPUT_SHAPE()
   bool is_equivalent(const Primitive& other) const override;
+  auto state() const {
+    return recip_;
+  }
 
   void print(std::ostream& os) override {
     if (recip_) {
@@ -2216,6 +2279,9 @@ class Unflatten : public UnaryPrimitive {
   bool is_equivalent(const Primitive& other) const override;
 
   static Shape output_shape(const array& input, int axis, const Shape& shape);
+  auto state() const {
+    return std::make_pair(axis_, shape_);
+  }
 
  private:
   int axis_;
@@ -2234,6 +2300,9 @@ class View : public UnaryPrimitive {
   DEFINE_VMAP()
   void print(std::ostream& os) override;
   bool is_equivalent(const Primitive& other) const override;
+  auto state() const {
+    return dtype_;
+  }
 
  private:
   Dtype dtype_;
@@ -2306,6 +2375,9 @@ class Inverse : public UnaryPrimitive {
 
   DEFINE_VMAP()
   DEFINE_PRINT(Inverse)
+  auto state() const {
+    return std::make_pair(tri_, upper_);
+  }
 
  private:
   void eval(const std::vector<array>& inputs, array& output);
@@ -2320,6 +2392,9 @@ class Cholesky : public UnaryPrimitive {
 
   void eval_cpu(const std::vector<array>& inputs, array& out) override;
   void eval_gpu(const std::vector<array>& inputs, array& out) override;
+  auto state() const {
+    return upper_;
+  }
 
   DEFINE_VMAP()
   DEFINE_PRINT(Cholesky)
@@ -2347,6 +2422,9 @@ class Eigh : public Primitive {
   std::vector<Shape> output_shapes(const std::vector<array>& inputs) override;
 
   bool is_equivalent(const Primitive& other) const override;
+  auto state() const {
+    return std::make_pair(uplo_, compute_eigenvectors_);
+  }
 
  private:
   void eval(const std::vector<array>& inputs, std::vector<array>& outputs);

--- a/mlx/primitives.h
+++ b/mlx/primitives.h
@@ -361,6 +361,9 @@ class ArgPartition : public UnaryPrimitive {
   DEFINE_PRINT(ArgPartition)
   DEFINE_INPUT_OUTPUT_SHAPE()
   bool is_equivalent(const Primitive& other) const override;
+  std::pair<int, int> state() const {
+    return {kth_, axis_};
+  };
 
  private:
   int kth_;

--- a/mlx/primitives.h
+++ b/mlx/primitives.h
@@ -2158,6 +2158,9 @@ class Squeeze : public UnaryPrimitive {
   bool is_equivalent(const Primitive& other) const override;
 
   static Shape output_shape(const array& input, const std::vector<int>& axes);
+  auto state() const {
+    return axes_;
+  };
 
  private:
   void eval(const std::vector<array>& inputs, array& out);

--- a/mlx/primitives.h
+++ b/mlx/primitives.h
@@ -933,6 +933,9 @@ class Equal : public UnaryPrimitive {
       os << "Equal";
     }
   }
+  auto state() const {
+    return equal_nan_;
+  };
 
  private:
   void eval(const std::vector<array>& inputs, array& out);

--- a/mlx/primitives.h
+++ b/mlx/primitives.h
@@ -223,6 +223,9 @@ class Arange : public UnaryPrimitive {
   DEFINE_PRINT(Arange)
   bool is_equivalent(const Primitive& other) const override;
   std::vector<Shape> output_shapes(const std::vector<array>& inputs) override;
+  std::tuple<double, double, double> state() const {
+    return {start_, stop_, step_};
+  };
 
  private:
   double start_;
@@ -416,6 +419,9 @@ class ArgSort : public UnaryPrimitive {
   DEFINE_PRINT(ArgSort)
   DEFINE_INPUT_OUTPUT_SHAPE()
   bool is_equivalent(const Primitive& other) const override;
+  int state() const {
+    return axis_;
+  };
 
  private:
   int axis_;
@@ -2212,6 +2218,9 @@ class Transpose : public UnaryPrimitive {
   DEFINE_PRINT(Transpose)
   bool is_equivalent(const Primitive& other) const override;
   std::vector<Shape> output_shapes(const std::vector<array>& inputs) override;
+  std::vector<int> state() const {
+    return axes_;
+  };
 
  private:
   std::vector<int> axes_;

--- a/mlx/scheduler.cpp
+++ b/mlx/scheduler.cpp
@@ -21,6 +21,10 @@ void set_default_stream(Stream s) {
   return scheduler::scheduler().set_default_stream(s);
 }
 
+Stream get_stream(int index) {
+  return scheduler::scheduler().get_stream(index);
+}
+
 Stream new_stream(Device d) {
   if (!metal::is_available() && d == Device::gpu) {
     throw std::invalid_argument(

--- a/mlx/scheduler.h
+++ b/mlx/scheduler.h
@@ -96,6 +96,9 @@ class Scheduler {
   Stream get_default_stream(const Device& d) const {
     return default_streams_.at(d.type);
   }
+  Stream get_stream(int index) const {
+    return streams_.at(index)->stream;
+  }
 
   void set_default_stream(const Stream& s) {
     default_streams_.at(s.device.type) = s;

--- a/mlx/stream.h
+++ b/mlx/stream.h
@@ -21,6 +21,9 @@ void set_default_stream(Stream s);
 /** Make a new stream on the given device. */
 Stream new_stream(Device d);
 
+/** Get the stream with the given index. */
+Stream get_stream(int index);
+
 inline bool operator==(const Stream& lhs, const Stream& rhs) {
   return lhs.index == rhs.index;
 }

--- a/mlx/transforms.h
+++ b/mlx/transforms.h
@@ -10,6 +10,11 @@ namespace mlx::core {
 
 void async_eval(std::vector<array> outputs);
 
+template <typename... Arrays, typename = enable_for_arrays_t<Arrays...>>
+void async_eval(Arrays&&... outputs) {
+  async_eval(std::vector<array>{std::forward<Arrays>(outputs)...});
+}
+
 void eval(std::vector<array> outputs);
 
 template <typename... Arrays, typename = enable_for_arrays_t<Arrays...>>

--- a/python/src/CMakeLists.txt
+++ b/python/src/CMakeLists.txt
@@ -11,6 +11,7 @@ nanobind_add_module(
   ${CMAKE_CURRENT_SOURCE_DIR}/convert.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/device.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/distributed.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/export.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/fast.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/fft.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/indexing.cpp

--- a/python/src/convert.cpp
+++ b/python/src/convert.cpp
@@ -331,7 +331,7 @@ PyScalarT validate_shape(
         t = pycomplex;
       } else {
         std::ostringstream msg;
-        msg << "Invalid type  " << nb::type_name(l.type()).c_str()
+        msg << "Invalid type " << nb::type_name(l.type()).c_str()
             << " received in array initialization.";
         throw std::invalid_argument(msg.str());
       }

--- a/python/src/export.cpp
+++ b/python/src/export.cpp
@@ -1,0 +1,143 @@
+// Copyright © 2024 Apple Inc.
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
+
+#include <fstream>
+
+#include "mlx/array.h"
+#include "mlx/export.h"
+#include "mlx/graph_utils.h"
+#include "python/src/trees.h"
+
+namespace nb = nanobind;
+using namespace nb::literals;
+using namespace mlx::core;
+
+template <typename T>
+bool check_arrs(const T& iterable) {
+  for (auto it = iterable.begin(); it != iterable.end(); ++it) {
+    if (!nb::isinstance<array>(*it)) {
+      return false;
+    }
+  }
+  return true;
+};
+
+bool valid_inputs(const nb::args& inputs) {
+  if (inputs.size() > 0 && nb::isinstance<array>(inputs[0])) {
+    return check_arrs(inputs);
+  } else if (inputs.size() > 1) {
+    return false;
+  } else if (inputs.size() == 1) {
+    if (nb::isinstance<nb::list>(inputs[0])) {
+      return check_arrs(nb::cast<nb::list>(inputs[0]));
+    } else if (nb::isinstance<nb::tuple>(inputs[0])) {
+      return check_arrs(nb::cast<nb::tuple>(inputs[0]));
+    } else {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool valid_outputs(const nb::object& outputs) {
+  if (nb::isinstance<array>(outputs)) {
+    return true;
+  } else if (nb::isinstance<nb::list>(outputs)) {
+    return check_arrs(nb::cast<nb::list>(outputs));
+  } else if (nb::isinstance<nb::tuple>(outputs)) {
+    return check_arrs(nb::cast<nb::tuple>(outputs));
+  }
+  return false;
+}
+
+void init_export(nb::module_& m) {
+  m.def(
+      "export_function",
+      [](const std::string& path,
+         const nb::callable& fun,
+         const nb::args& arrays,
+         bool shapeless) {
+        if (!valid_inputs(arrays)) {
+          throw std::invalid_argument(
+              "[export_function] Inputs can be either a variable number "
+              "of arrays or a single tuple or list of arrays.");
+        }
+
+        std::vector<array> inputs = tree_flatten(arrays, true);
+        auto wrapped_fun =
+            [&fun,
+             &arrays](const std::vector<array>& inputs) -> std::vector<array> {
+          auto outputs = fun(*tree_unflatten(arrays, inputs));
+          if (!valid_outputs(outputs)) {
+            throw std::invalid_argument(
+                "[export_function] Outputs can be either a variable number "
+                "of arrays or a single tuple or list of arrays.");
+          }
+          return tree_flatten(outputs, true);
+        };
+        export_function(path, wrapped_fun, inputs, shapeless);
+      },
+      "path"_a,
+      "fun"_a,
+      "arrays"_a,
+      nb::kw_only(),
+      "shapeless"_a = false,
+      nb::sig(
+          "def export_function(path: str, fun: Callable, **arrays: array, *, shapeless: bool = False)"),
+      R"pbdoc(
+        Export a function to a file.
+
+        Args:
+            path (str): File path where the function is saved.
+            fun (Callable): A function which takes as input zero or more
+              :class:`array` and returns one or more :class:`array`.
+            *arrays (array): Array inputs to the function.
+            shapeless (bool, optional): Whether or not the function allows changing the
+              shapes of inputs.
+      )pbdoc");
+  m.def(
+      "import_function",
+      [](const std::string& path) {
+        return nb::cpp_function(
+            [fn = import_function(path)](const nb::args& arrays) {
+              if (!valid_inputs(arrays)) {
+                throw std::invalid_argument(
+                    "[import_function::call] Inputs can be either a variable "
+                    "number of arrays or a single tuple / list of arrays.");
+              }
+              return nb::tuple(nb::cast(fn(tree_flatten(arrays, true))));
+            });
+      },
+      "path"_a,
+      nb::sig("def import_function(path: str) -> Callable"),
+      R"pbdoc(
+        Import a function from a file.
+
+        Args:
+            path (str): File path where the function is saved.
+
+        Returns:
+            Callable: The imported function.
+      )pbdoc");
+  m.def(
+      "export_to_dot",
+      [](nb::object file, const nb::args& args) {
+        std::vector<array> arrays = tree_flatten(args);
+        if (nb::isinstance<nb::str>(file)) {
+          std::ofstream out(nb::cast<std::string>(file));
+          export_to_dot(out, arrays);
+        } else if (nb::hasattr(file, "write")) {
+          std::ostringstream out;
+          export_to_dot(out, arrays);
+          auto write = file.attr("write");
+          write(out.str());
+        } else {
+          throw std::invalid_argument(
+              "export_to_dot accepts file-like objects or strings to be used as filenames");
+        }
+      },
+      "file"_a,
+      "args"_a);
+}

--- a/python/src/export.cpp
+++ b/python/src/export.cpp
@@ -90,12 +90,12 @@ void init_export(nb::module_& m) {
         Export a function to a file.
 
         Args:
-            path (str): File path where the function is saved.
+            path (str): Path to export the function to.
             fun (Callable): A function which takes as input zero or more
               :class:`array` and returns one or more :class:`array`.
             *arrays (array): Array inputs to the function.
-            shapeless (bool, optional): Whether or not the function allows changing the
-              shapes of inputs.
+            shapeless (bool, optional): Whether or not the function allows
+              changing the shapes of inputs.
       )pbdoc");
   m.def(
       "import_function",
@@ -105,7 +105,7 @@ void init_export(nb::module_& m) {
               if (!valid_inputs(arrays)) {
                 throw std::invalid_argument(
                     "[import_function::call] Inputs can be either a variable "
-                    "number of arrays or a single tuple / list of arrays.");
+                    "number of arrays or a single tuple or list of arrays.");
               }
               return nb::tuple(nb::cast(fn(tree_flatten(arrays, true))));
             });
@@ -116,7 +116,7 @@ void init_export(nb::module_& m) {
         Import a function from a file.
 
         Args:
-            path (str): File path where the function is saved.
+            path (str): Path to import the function from.
 
         Returns:
             Callable: The imported function.
@@ -135,7 +135,8 @@ void init_export(nb::module_& m) {
           write(out.str());
         } else {
           throw std::invalid_argument(
-              "export_to_dot accepts file-like objects or strings to be used as filenames");
+              "[export_to_dot] Accepts file-like objects or strings "
+              "to be used as filenames.");
         }
       },
       "file"_a,

--- a/python/src/export.cpp
+++ b/python/src/export.cpp
@@ -181,7 +181,6 @@ void init_export(nb::module_& m) {
       "fun"_a,
       nb::kw_only(),
       "shapeless"_a = false);
-
   m.def(
       "export_to_dot",
       [](nb::object file, const nb::args& args) {

--- a/python/src/export.cpp
+++ b/python/src/export.cpp
@@ -1,5 +1,7 @@
 // Copyright © 2024 Apple Inc.
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/map.h>
+#include <nanobind/stl/optional.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
@@ -14,42 +16,68 @@ namespace mx = mlx::core;
 namespace nb = nanobind;
 using namespace nb::literals;
 
-template <typename T>
-bool check_arrs(const T& iterable) {
-  for (auto it = iterable.begin(); it != iterable.end(); ++it) {
-    if (!nb::isinstance<mx::array>(*it)) {
-      return false;
+std::pair<std::vector<mx::array>, std::map<std::string, mx::array>>
+validate_and_extract_inputs(
+    const nb::args& args,
+    const nb::kwargs& kwargs,
+    const std::string& prefix) {
+  auto maybe_throw = [&prefix](bool valid) {
+    if (!valid) {
+      throw std::invalid_argument(
+          prefix +
+          " Inputs can either be a variable "
+          "number of positional and keyword arrays or a single tuple "
+          "and/or dictionary of arrays.");
     }
-  }
-  return true;
-};
-
-bool valid_inputs(const nb::args& inputs) {
-  if (inputs.size() > 0 && nb::isinstance<mx::array>(inputs[0])) {
-    return check_arrs(inputs);
-  } else if (inputs.size() > 1) {
-    return false;
-  } else if (inputs.size() == 1) {
-    if (nb::isinstance<nb::list>(inputs[0])) {
-      return check_arrs(nb::cast<nb::list>(inputs[0]));
-    } else if (nb::isinstance<nb::tuple>(inputs[0])) {
-      return check_arrs(nb::cast<nb::tuple>(inputs[0]));
-    } else {
-      return false;
+  };
+  std::vector<mx::array> args_;
+  std::map<std::string, mx::array> kwargs_;
+  if (args.size() == 0) {
+    // No args so kwargs must be keyword arrays
+    maybe_throw(nb::try_cast(kwargs, kwargs_));
+  } else if (args.size() > 0 && nb::isinstance<mx::array>(args[0])) {
+    // Args are positional arrays and kwargs are keyword arrays
+    maybe_throw(nb::try_cast(args, args_));
+    maybe_throw(nb::try_cast(kwargs, kwargs_));
+  } else if (args.size() == 1) {
+    // - args[0] can be a tuple or list or arrays or a dict
+    //   with string keys and array values
+    // - kwargs should be empty
+    maybe_throw(kwargs.size() == 0);
+    if (!nb::try_cast(args[0], args_)) {
+      maybe_throw(nb::try_cast(args[0], kwargs_));
     }
+  } else if (args.size() == 2) {
+    // - args[0] can be a tuple or list of arrays
+    // - args[1] can be a dict of string keys with array values.
+    // - kwargs should be empty
+    maybe_throw(kwargs.size() == 0);
+    maybe_throw(nb::try_cast(args[0], args_));
+    maybe_throw(nb::try_cast(args[1], kwargs_));
+  } else {
+    maybe_throw(false);
   }
-  return true;
+  return {args_, kwargs_};
 }
 
-bool valid_outputs(const nb::object& outputs) {
-  if (nb::isinstance<mx::array>(outputs)) {
-    return true;
-  } else if (nb::isinstance<nb::list>(outputs)) {
-    return check_arrs(nb::cast<nb::list>(outputs));
-  } else if (nb::isinstance<nb::tuple>(outputs)) {
-    return check_arrs(nb::cast<nb::tuple>(outputs));
-  }
-  return false;
+auto wrap_export_function(const nb::callable& fun) {
+  return [fun](
+             const std::vector<mx::array>& args_,
+             const std::map<std::string, mx::array>& kwargs_) {
+    auto kwargs = nb::dict();
+    kwargs.update(nb::cast(kwargs_));
+    auto args = nb::tuple(nb::cast(args_));
+    auto outputs = fun(*args, **kwargs);
+    std::vector<mx::array> outputs_;
+    if (nb::isinstance<mx::array>(outputs)) {
+      outputs_.push_back(nb::cast<mx::array>(outputs));
+    } else if (!nb::try_cast(outputs, outputs_)) {
+      throw std::invalid_argument(
+          "[export_function] Outputs can be either a single array "
+          "a tuple or list of arrays.");
+    }
+    return outputs_;
+  };
 }
 
 void init_export(nb::module_& m) {
@@ -57,69 +85,103 @@ void init_export(nb::module_& m) {
       "export_function",
       [](const std::string& path,
          const nb::callable& fun,
-         const nb::args& arrays,
-         bool shapeless) {
-        if (!valid_inputs(arrays)) {
-          throw std::invalid_argument(
-              "[export_function] Inputs can be either a variable number "
-              "of arrays or a single tuple or list of arrays.");
-        }
-
-        std::vector<mx::array> inputs = tree_flatten(arrays, true);
-        auto wrapped_fun = [&fun, &arrays](const std::vector<mx::array>& inputs)
-            -> std::vector<mx::array> {
-          auto outputs = fun(*tree_unflatten(arrays, inputs));
-          if (!valid_outputs(outputs)) {
-            throw std::invalid_argument(
-                "[export_function] Outputs can be either a variable number "
-                "of arrays or a single tuple or list of arrays.");
-          }
-          return tree_flatten(outputs, true);
-        };
-        mx::export_function(path, wrapped_fun, inputs, shapeless);
+         const nb::args& args,
+         bool shapeless,
+         const nb::kwargs& kwargs) {
+        auto [args_, kwargs_] =
+            validate_and_extract_inputs(args, kwargs, "[export_function]");
+        mx::export_function(
+            path, wrap_export_function(fun), args_, kwargs_, shapeless);
       },
       "path"_a,
       "fun"_a,
-      "arrays"_a,
+      "args"_a,
       nb::kw_only(),
       "shapeless"_a = false,
+      "kwargs"_a,
       nb::sig(
-          "def export_function(path: str, fun: Callable, **arrays: array, *, shapeless: bool = False)"),
+          "def export_function(path: str, fun: Callable, *args, *, shapeless: bool = False, **kwargs)"),
       R"pbdoc(
         Export a function to a file.
+
+        To export ``fun`` Example input arrays must be provided. The arrays
+        can be either variable ``*args`` and ``**kwargs`` or a tuple of arrays and/or
+        dictionary of string keys with array values.
 
         Args:
             path (str): Path to export the function to.
             fun (Callable): A function which takes as input zero or more
               :class:`array` and returns one or more :class:`array`.
-            *arrays (array): Array inputs to the function.
+            *args (array): Example array inputs to the function.
             shapeless (bool, optional): Whether or not the function allows
               changing the shapes of inputs.
+            **kwargs (array): Additional example keyword array inputs to the function.
       )pbdoc");
   m.def(
       "import_function",
       [](const std::string& path) {
         return nb::cpp_function(
-            [fn = mx::import_function(path)](const nb::args& arrays) {
-              if (!valid_inputs(arrays)) {
-                throw std::invalid_argument(
-                    "[import_function::call] Inputs can be either a variable "
-                    "number of arrays or a single tuple or list of arrays.");
-              }
-              return nb::tuple(nb::cast(fn(tree_flatten(arrays, true))));
+            [fn = mx::import_function(path)](
+                const nb::args& args, const nb::kwargs& kwargs) {
+              auto [args_, kwargs_] = validate_and_extract_inputs(
+                  args, kwargs, "[import_function::call]");
+              return nb::tuple(nb::cast(fn(args_, kwargs_)));
             });
       },
       "path"_a,
-      nb::sig("def import_function(path: str) -> Callable"),
       R"pbdoc(
         Import a function from a file.
+
+        The imported function can be called either with variable ``*args`` and
+        ``**kwargs`` or with a tuple of arrays and/or dictionary of string
+        keys with array values.
 
         Args:
             path (str): Path to import the function from.
 
         Returns:
             Callable: The imported function.
+
+        Example:
+          >>> fn = mx.import("function.mlxfn")
+          >>> out = fn(a, b, x=x, y=y)[0]
+          >>>
+          >>> out = fn((a, b), {"x": x, "y": y}[0]
       )pbdoc");
+
+  nb::class_<mx::FunctionExporter>(m, "FunctionExporter")
+      .def("close", &mx::FunctionExporter::close)
+      .def(
+          "__enter__", [](mx::FunctionExporter& exporter) { return &exporter; })
+      .def(
+          "__exit__",
+          [](mx::FunctionExporter& exporter,
+             const std::optional<nb::object>&,
+             const std::optional<nb::object>&,
+             const std::optional<nb::object>&) { exporter.close(); },
+          "exc_type"_a = nb::none(),
+          "exc_value"_a = nb::none(),
+          "traceback"_a = nb::none())
+      .def(
+          "__call__",
+          [](mx::FunctionExporter& exporter,
+             const nb::args& args,
+             const nb::kwargs& kwargs) {
+            auto [args_, kwargs_] =
+                validate_and_extract_inputs(args, kwargs, "[export_function]");
+            exporter(args_, kwargs_);
+          });
+
+  m.def(
+      "exporter",
+      [](const std::string& path, const nb::callable& fun, bool shapeless) {
+        return mx::exporter(path, wrap_export_function(fun), shapeless);
+      },
+      "path"_a,
+      "fun"_a,
+      nb::kw_only(),
+      "shapeless"_a = false);
+
   m.def(
       "export_to_dot",
       [](nb::object file, const nb::args& args) {

--- a/python/src/mlx.cpp
+++ b/python/src/mlx.cpp
@@ -19,6 +19,7 @@ void init_linalg(nb::module_&);
 void init_constants(nb::module_&);
 void init_fast(nb::module_&);
 void init_distributed(nb::module_&);
+void init_export(nb::module_&);
 
 NB_MODULE(core, m) {
   m.doc() = "mlx: A framework for machine learning on Apple silicon.";
@@ -39,6 +40,7 @@ NB_MODULE(core, m) {
   init_constants(m);
   init_fast(m);
   init_distributed(m);
+  init_export(m);
 
   m.attr("__version__") = TOSTRING(_VERSION_);
 }

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -2898,7 +2898,7 @@ void init_ops(nb::module_& m) {
         Generate multidimensional coordinate grids from 1-D coordinate arrays
 
         Args:
-            arrays (array): Input arrays.
+            *arrays (array): Input arrays.
             sparse (bool, optional): If ``True``, a sparse grid is returned in which each output
               array has a single non-zero element. If ``False``, a dense grid is returned.
               Defaults to ``False``.
@@ -3840,8 +3840,8 @@ void init_ops(nb::module_& m) {
 
         Args:
             file (file, str): Path to file to which the arrays are saved.
-            args (arrays): Arrays to be saved.
-            kwargs (arrays): Arrays to be saved. Each array will be saved
+            *args (arrays): Arrays to be saved.
+            **kwargs (arrays): Arrays to be saved. Each array will be saved
               with the associated keyword as the output file name.
       )pbdoc");
   m.def(

--- a/python/src/transforms.cpp
+++ b/python/src/transforms.cpp
@@ -943,34 +943,34 @@ void init_transforms(nb::module_& m) {
       Note, all custom transformations are optional. Undefined transformations
       fall back to the default behaviour.
 
-      Example usage:
+      Example:
 
-      .. code-block:: python
+        .. code-block:: python
 
-          import mlx.core as mx
+            import mlx.core as mx
 
-          @mx.custom_function
-          def f(x, y):
-              return mx.sin(x) * y
+            @mx.custom_function
+            def f(x, y):
+                return mx.sin(x) * y
 
-          @f.vjp
-          def f_vjp(primals, cotangent, output):
+            @f.vjp
+            def f_vjp(primals, cotangent, output):
+                x, y = primals
+                return cotan * mx.cos(x) * y, cotan * mx.sin(x)
+
+            @f.jvp
+            def f_jvp(primals, tangents):
               x, y = primals
-              return cotan * mx.cos(x) * y, cotan * mx.sin(x)
+              dx, dy = tangents
+              return dx * mx.cos(x) * y + dy * mx.sin(x)
 
-          @f.jvp
-          def f_jvp(primals, tangents):
-            x, y = primals
-            dx, dy = tangents
-            return dx * mx.cos(x) * y + dy * mx.sin(x)
-
-          @f.vmap
-          def f_vmap(inputs, axes):
-            x, y = inputs
-            ax, ay = axes
-            if ay != ax and ax is not None:
-                y = y.swapaxes(ay, ax)
-            return mx.sin(x) * y, (ax or ay)
+            @f.vmap
+            def f_vmap(inputs, axes):
+              x, y = inputs
+              ax, ay = axes
+              if ay != ax and ax is not None:
+                  y = y.swapaxes(ay, ax)
+              return mx.sin(x) * y, (ax or ay)
       )pbdoc")
       .def(
           nb::init<nb::callable>(),

--- a/python/src/transforms.cpp
+++ b/python/src/transforms.cpp
@@ -8,14 +8,12 @@
 #include <nanobind/stl/vector.h>
 
 #include <algorithm>
-#include <fstream>
 #include <numeric>
 #include <sstream>
 
 #include "mlx/array.h"
 #include "mlx/compile.h"
 #include "mlx/compile_impl.h"
-#include "mlx/graph_utils.h"
 #include "mlx/transforms.h"
 #include "mlx/transforms_impl.h"
 #include "mlx/utils.h"
@@ -1313,25 +1311,6 @@ void init_transforms(nb::module_& m) {
         Returns:
             Callable: The vectorized function.
       )pbdoc");
-  m.def(
-      "export_to_dot",
-      [](nb::object file, const nb::args& args) {
-        std::vector<mx::array> arrays = tree_flatten(args);
-        if (nb::isinstance<nb::str>(file)) {
-          std::ofstream out(nb::cast<std::string>(file));
-          export_to_dot(out, arrays);
-        } else if (nb::hasattr(file, "write")) {
-          std::ostringstream out;
-          export_to_dot(out, arrays);
-          auto write = file.attr("write");
-          write(out.str());
-        } else {
-          throw std::invalid_argument(
-              "export_to_dot accepts file-like objects or strings to be used as filenames");
-        }
-      },
-      "file"_a,
-      "args"_a);
   m.def(
       "compile",
       [](const nb::callable& fun,

--- a/python/tests/test_export_import.py
+++ b/python/tests/test_export_import.py
@@ -1,0 +1,136 @@
+# Copyright © 2024 Apple Inc.
+
+import os
+import tempfile
+import unittest
+
+import mlx.core as mx
+import mlx_tests
+
+
+class TestExportImport(mlx_tests.MLXTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.test_dir_fid = tempfile.TemporaryDirectory()
+        cls.test_dir = cls.test_dir_fid.name
+        if not os.path.isdir(cls.test_dir):
+            os.mkdir(cls.test_dir)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.test_dir_fid.cleanup()
+
+    def test_basic_import_export(self):
+        path = os.path.join(self.test_dir, "fn.mlxfn")
+
+        # Function with no inputs
+        def fun():
+            return mx.zeros((3, 3))
+
+        mx.export_function(path, fun)
+        imported = mx.import_function(path)
+
+        expected = fun()
+        (out,) = imported()
+        self.assertTrue(mx.array_equal(out, expected))
+
+        # Simple function with inputs
+        def fun(x):
+            return mx.abs(mx.sin(x))
+
+        inputs = mx.array([1.0, 2.0, 3.0, 4.0, 5.0])
+
+        mx.export_function(path, fun, inputs)
+        imported = mx.import_function(path)
+
+        expected = fun(inputs)
+        (out,) = imported(inputs)
+        self.assertTrue(mx.allclose(out, expected))
+
+        # Inputs in a list or tuple
+        def fun(x):
+            return mx.abs(mx.sin(x[0]))
+
+        mx.export_function(path, fun, [inputs])
+        imported = mx.import_function(path)
+
+        expected = fun([inputs])
+        (out,) = imported([inputs])
+        self.assertTrue(mx.allclose(out, expected))
+
+        mx.export_function(path, fun, (inputs,))
+        imported = mx.import_function(path)
+        (out,) = imported((inputs,))
+        self.assertTrue(mx.allclose(out, expected))
+
+        # Outputs in a list
+        def fun(x):
+            return [mx.abs(mx.sin(x))]
+
+        mx.export_function(path, fun, inputs)
+        imported = mx.import_function(path)
+        (out,) = imported(inputs)
+        self.assertTrue(mx.allclose(out, expected))
+
+        # Outputs in a tuple
+        def fun(x):
+            return (mx.abs(mx.sin(x)),)
+
+        mx.export_function(path, fun, inputs)
+        imported = mx.import_function(path)
+        (out,) = imported(inputs)
+        self.assertTrue(mx.allclose(out, expected))
+
+        # Check throws on invalid inputs / outputs
+        def fun(x):
+            return mx.abs(x)
+
+        with self.assertRaises(ValueError):
+            mx.export_function(path, fun, "hi")
+
+        with self.assertRaises(ValueError):
+            mx.export_function(path, fun, mx.array(1.0), "hi")
+
+        def fun(x):
+            return mx.abs(x["hi"])
+
+        with self.assertRaises(ValueError):
+            mx.export_function(path, fun, {"hi": mx.array(1.0)})
+
+        def fun(x):
+            return mx.abs(x[0][0])
+
+        with self.assertRaises(ValueError):
+            mx.export_function(path, fun, [[mx.array(1.0)]])
+
+        def fun():
+            return (mx.zeros((3, 3)), 1)
+
+        with self.assertRaises(ValueError):
+            mx.export_function(path, fun)
+
+        def fun():
+            return (mx.zeros((3, 3)), [mx.zeros((3, 3))])
+
+        with self.assertRaises(ValueError):
+            mx.export_function(path, fun)
+
+        def fun(x, y):
+            return x + y
+
+        mx.export_function(path, fun, mx.array(1.0), mx.array(1.0))
+        imported = mx.import_function(path)
+
+        with self.assertRaises(ValueError):
+            imported(mx.array(1.0), 1.0)
+
+        with self.assertRaises(ValueError):
+            imported(mx.array(1.0), mx.array(1.0), mx.array(1.0))
+
+        with self.assertRaises(ValueError):
+            imported(mx.array(1.0), [mx.array(1.0)])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_export_import.py
+++ b/python/tests/test_export_import.py
@@ -131,6 +131,24 @@ class TestExportImport(mlx_tests.MLXTestCase):
         with self.assertRaises(ValueError):
             imported(mx.array(1.0), [mx.array(1.0)])
 
+    def test_export_random_sample(self):
+        path = os.path.join(self.test_dir, "fn.mlxfn")
+
+        mx.random.seed(5)
+
+        def fun():
+            return mx.random.uniform(shape=(3,))
+
+        mx.export_function(path, fun)
+        imported = mx.import_function(path)
+
+        (out,) = imported()
+
+        mx.random.seed(5)
+        expected = fun()
+
+        self.assertTrue(mx.array_equal(out, expected))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/test_export_import.py
+++ b/python/tests/test_export_import.py
@@ -50,14 +50,17 @@ class TestExportImport(mlx_tests.MLXTestCase):
 
         # Inputs in a list or tuple
         def fun(x):
-            return mx.abs(mx.sin(x[0]))
+            x = mx.abs(mx.sin(x))
+            return x
 
         mx.export_function(path, fun, [inputs])
-        return
         imported = mx.import_function(path)
 
-        expected = fun([inputs])
+        expected = fun(inputs)
         (out,) = imported([inputs])
+        self.assertTrue(mx.allclose(out, expected))
+
+        (out,) = imported(inputs)
         self.assertTrue(mx.allclose(out, expected))
 
         mx.export_function(path, fun, (inputs,))
@@ -92,12 +95,6 @@ class TestExportImport(mlx_tests.MLXTestCase):
 
         with self.assertRaises(ValueError):
             mx.export_function(path, fun, mx.array(1.0), "hi")
-
-        def fun(x):
-            return mx.abs(x["hi"])
-
-        with self.assertRaises(ValueError):
-            mx.export_function(path, fun, {"hi": mx.array(1.0)})
 
         def fun(x):
             return mx.abs(x[0][0])

--- a/python/tests/test_load.py
+++ b/python/tests/test_load.py
@@ -28,15 +28,14 @@ class TestLoad(mlx_tests.MLXTestCase):
     def setUpClass(cls):
         cls.test_dir_fid = tempfile.TemporaryDirectory()
         cls.test_dir = cls.test_dir_fid.name
+        if not os.path.isdir(cls.test_dir):
+            os.mkdir(cls.test_dir)
 
     @classmethod
     def tearDownClass(cls):
         cls.test_dir_fid.cleanup()
 
     def test_save_and_load(self):
-        if not os.path.isdir(self.test_dir):
-            os.mkdir(self.test_dir)
-
         for dt in self.dtypes:
             with self.subTest(dtype=dt):
                 for i, shape in enumerate([(1,), (23,), (1024, 1024), (4, 6, 3, 1, 2)]):
@@ -64,9 +63,6 @@ class TestLoad(mlx_tests.MLXTestCase):
                         self.assertTrue(np.array_equal(load_arr_mlx_npy, save_arr_npy))
 
     def test_save_and_load_safetensors(self):
-        if not os.path.isdir(self.test_dir):
-            os.mkdir(self.test_dir)
-
         test_file = os.path.join(self.test_dir, "test.safetensors")
         with self.assertRaises(Exception):
             mx.save_safetensors(test_file, {"a": mx.ones((4, 4))}, {"testing": 0})
@@ -330,9 +326,6 @@ class TestLoad(mlx_tests.MLXTestCase):
                         self.assertTrue(np.array_equal(save_arrs_npy[k], v))
 
     def test_non_contiguous(self):
-        if not os.path.isdir(self.test_dir):
-            os.mkdir(self.test_dir)
-
         a = mx.broadcast_to(mx.array([1, 2]), [4, 2])
 
         save_file = os.path.join(self.test_dir, "a.npy")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(
           creations_tests.cpp
           device_tests.cpp
           einsum_tests.cpp
+          export_import_tests.cpp
           eval_tests.cpp
           fft_tests.cpp
           load_tests.cpp

--- a/tests/export_import_tests.cpp
+++ b/tests/export_import_tests.cpp
@@ -149,3 +149,17 @@ TEST_CASE("test export function with variable inputs") {
   out = imported_fun({array(1), array(2), array(3)})[0];
   CHECK(array_equal(out, array({7, 7, 7, 7})).item<bool>());
 }
+
+TEST_CASE("test export function on different stream") {
+  std::string file_path = get_temp_file("model.mlxfn");
+
+  // Caller is responsible for setting up streams before
+  // importing functoins
+  auto fun = [](const std::vector<array>& args) -> std::vector<array> {
+    return {abs(args[0], Stream(1000, Device::cpu))};
+  };
+
+  export_function(file_path, fun, {array({0, 1, 2})});
+
+  CHECK_THROWS(import_function(file_path));
+}

--- a/tests/export_import_tests.cpp
+++ b/tests/export_import_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Apple Inc.
+// Copyright © 2024 Apple Inc.
 
 #include <filesystem>
 #include <stdexcept>
@@ -18,7 +18,7 @@ std::string get_temp_file(const std::string& name) {
 } // namespace
 
 TEST_CASE("test export basic functions") {
-  std::string file_path = "model.mlxfn"; // get_temp_file("model.mlxfn");
+  std::string file_path = get_temp_file("model.mlxfn");
 
   auto fun = [](std::vector<array> x) -> std::vector<array> {
     return {negative(exp(x[0]))};
@@ -40,5 +40,40 @@ TEST_CASE("test export basic functions") {
 
   auto expected = fun({array({1.0, -1.0})});
   auto out = imported_fun({array({1.0, -1.0})});
+  CHECK(allclose(expected[0], out[0]).item<bool>());
+}
+
+TEST_CASE("test export multi output primitives") {
+  std::string file_path = get_temp_file("model.mlxfn");
+
+  auto fun = [](std::vector<array> x) -> std::vector<array> {
+    return {divmod(x[0], x[1])};
+  };
+
+  auto inputs = std::vector<array>{array({5.0, -10.0}), array({3.0, -2.0})};
+  export_function(file_path, fun, inputs);
+
+  auto imported_fun = import_function(file_path);
+
+  auto expected = fun(inputs);
+  auto out = imported_fun(inputs);
+  CHECK(allclose(expected[0], out[0]).item<bool>());
+  CHECK(allclose(expected[1], out[1]).item<bool>());
+}
+
+TEST_CASE("test export primitives with state") {
+  std::string file_path = get_temp_file("model.mlxfn");
+
+  auto fun = [](std::vector<array> x) -> std::vector<array> {
+    return {argpartition(x[0], 2, 0)};
+  };
+
+  auto x = array({1, 3, 2, 4, 5, 7, 6, 8}, {4, 2});
+  export_function(file_path, fun, {x});
+
+  auto imported_fun = import_function(file_path);
+
+  auto expected = fun({x});
+  auto out = imported_fun({x});
   CHECK(allclose(expected[0], out[0]).item<bool>());
 }

--- a/tests/export_import_tests.cpp
+++ b/tests/export_import_tests.cpp
@@ -43,6 +43,22 @@ TEST_CASE("test export basic functions") {
   CHECK(allclose(expected[0], out[0]).item<bool>());
 }
 
+TEST_CASE("test export function with no inputs") {
+  auto fun = [](std::vector<array> x) -> std::vector<array> {
+    return {zeros({2, 2})};
+  };
+
+  std::string file_path = get_temp_file("model.mlxfn");
+
+  export_function(file_path, fun, {});
+
+  auto imported_fun = import_function(file_path);
+
+  auto expected = fun({});
+  auto out = imported_fun({});
+  CHECK(allclose(expected[0], out[0]).item<bool>());
+}
+
 TEST_CASE("test export multi output primitives") {
   std::string file_path = get_temp_file("model.mlxfn");
 

--- a/tests/export_import_tests.cpp
+++ b/tests/export_import_tests.cpp
@@ -6,7 +6,7 @@
 
 #include "doctest/doctest.h"
 
-#include "mlx/compile.h"
+#include "mlx/export.h"
 #include "mlx/mlx.h"
 
 using namespace mlx::core;
@@ -21,10 +21,24 @@ TEST_CASE("test export basic functions") {
   std::string file_path = "model.mlxfn"; // get_temp_file("model.mlxfn");
 
   auto fun = [](std::vector<array> x) -> std::vector<array> {
-    return {abs(negative(exp(x[0])))};
+    return {negative(exp(x[0]))};
   };
 
   export_function(file_path, fun, {array({1.0, 2.0})});
 
   auto imported_fun = import_function(file_path);
+
+  // Check num inputs mismatch throws
+  CHECK_THROWS_AS(
+      imported_fun({array({1.0}), array({2.0})}), std::invalid_argument);
+
+  // Check shape mismatch throws
+  CHECK_THROWS_AS(imported_fun({array({1.0})}), std::invalid_argument);
+
+  // Check type mismatch throws
+  CHECK_THROWS_AS(imported_fun({array({1.0}, float16)}), std::invalid_argument);
+
+  auto expected = fun({array({1.0, -1.0})});
+  auto out = imported_fun({array({1.0, -1.0})});
+  CHECK(allclose(expected[0], out[0]).item<bool>());
 }

--- a/tests/export_import_tests.cpp
+++ b/tests/export_import_tests.cpp
@@ -1,0 +1,30 @@
+// Copyright © 2023 Apple Inc.
+
+#include <filesystem>
+#include <stdexcept>
+#include <vector>
+
+#include "doctest/doctest.h"
+
+#include "mlx/compile.h"
+#include "mlx/mlx.h"
+
+using namespace mlx::core;
+
+namespace {
+std::string get_temp_file(const std::string& name) {
+  return std::filesystem::temp_directory_path().append(name);
+}
+} // namespace
+
+TEST_CASE("test export basic functions") {
+  std::string file_path = "model.mlxfn"; // get_temp_file("model.mlxfn");
+
+  auto fun = [](std::vector<array> x) -> std::vector<array> {
+    return {abs(negative(exp(x[0])))};
+  };
+
+  export_function(file_path, fun, {array({1.0, 2.0})});
+
+  auto imported_fun = import_function(file_path);
+}


### PR DESCRIPTION
Adds `export_function` and `import_function` so that we can save and load functions from a file. Makes it possible to use functions written in one language from another language (e.g. Python -> C++).

Basically works like so:

In Python:

```python
# Note, the model parameters are saved in the export function
# An alternative is to make them inputs to forward
def forward(x):
    return model(x)

example_x = mx.zeros(shape=(batch_size, input_dim))

# Export to file using example input
mx.export_function("model.mlxfn", forward, example_x)
```

Then in C++, for example:

```c++
  auto example_x = random::uniform({batch_size, input_dim});

  // Import the function
  auto forward = import_function("model.mlxfn");

  // Call the imported function
  auto out = forward({example_x})[0];
```

Some notes on the implementation:

- Reuses a lot of the compile infrastructure which simplifies things dramatically
- The serialization of everything is mostly decoupled from the rest of the code and kept in the `export.cpp`
- Serializing primitives that have member variables requires some way of accessing them. The API is not opinionated about this (so the primitive interface didn't change at all).. but the convention I'm using is to have a `state` which returns the data to save
- Likely can use templates / preprocessor to reduce more boiler-plate from some of serialization code in `export.cpp`. But didn't want to obfuscate / over engineer it much yet until getting some input.
