### PR TITLE
Compile changes if stream changes

### DIFF
--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -184,10 +184,6 @@ void init_array(nb::module_& m) {
       R"pbdoc(
       A helper object to apply updates at specific indices.
       )pbdoc")
-      .def(
-          nb::init<const array&>(),
-          "x"_a,
-          nb::sig("def __init__(self, x: array)"))
       .def("__getitem__", &ArrayAt::set_indices, "indices"_a.none())
       .def("add", &ArrayAt::add, "value"_a)
       .def("subtract", &ArrayAt::subtract, "value"_a)
@@ -202,10 +198,6 @@ void init_array(nb::module_& m) {
       R"pbdoc(
       A helper object to iterate over the 1st dimension of an array.
       )pbdoc")
-      .def(
-          nb::init<const array&>(),
-          "x"_a,
-          nb::sig("def __init__(self, x: array)"))
       .def("__next__", &ArrayPythonIterator::next)
       .def("__iter__", [](const ArrayPythonIterator& it) { return it; });
 

--- a/python/src/stream.cpp
+++ b/python/src/stream.cpp
@@ -48,7 +48,6 @@ void init_stream(nb::module_& m) {
       R"pbdoc(
       A stream for running operations on a given device.
       )pbdoc")
-      .def(nb::init<int, Device>(), "index"_a, "device"_a)
       .def_ro("device", &Stream::device)
       .def(
           "__repr__",

--- a/tests/compile_tests.cpp
+++ b/tests/compile_tests.cpp
@@ -719,3 +719,14 @@ TEST_CASE("test compile strides") {
     CHECK_EQ(out.strides().size(), 3);
   }
 }
+
+TEST_CASE("test compile change streams") {
+  auto cfun = compile(simple_fun);
+  auto out = cfun({array(1.0f), array(2.0f)})[0];
+  CHECK_EQ(out.primitive().stream(), default_stream(default_device()));
+
+  auto s = new_stream(default_device());
+  StreamContext sctx(s);
+  out = cfun({array(1.0f), array(2.0f)})[0];
+  CHECK_EQ(out.primitive().stream(), s);
+}


### PR DESCRIPTION
If the default stream or device change then we recompile the function.  

I looked into the alternative of updating the stream dynamically but it was quite a bit more complicated, especially considering the fact that we often use different primitives for different devices.

Another option is to update the compiled primitive only if the default device changes and dynamically update the stream. This is still complex since we need to track if the stream was set as a default or set explicitly. Presumably if you set it explicitly then you don't want it to change under your feet.

Closes #1624 