### PR TITLE
Shape and Strides 1 / N

### DIFF
--- a/mlx/ops.h
+++ b/mlx/ops.h
@@ -49,8 +49,8 @@ array astype(array a, Dtype dtype, StreamOrDevice s = {});
 /** Create a view of an array with the given shape and strides. */
 array as_strided(
     array a,
-    std::vector<int> shape,
-    std::vector<size_t> strides,
+    Shape shape,
+    Strides strides,
     size_t offset,
     StreamOrDevice s = {});
 
@@ -58,31 +58,27 @@ array as_strided(
 array copy(array a, StreamOrDevice s = {});
 
 /** Fill an array of the given shape with the given value(s). */
-array full(
-    std::vector<int> shape,
-    array vals,
-    Dtype dtype,
-    StreamOrDevice s = {});
-array full(std::vector<int> shape, array vals, StreamOrDevice s = {});
+array full(Shape shape, array vals, Dtype dtype, StreamOrDevice s = {});
+array full(Shape shape, array vals, StreamOrDevice s = {});
 template <typename T>
-array full(std::vector<int> shape, T val, Dtype dtype, StreamOrDevice s = {}) {
+array full(Shape shape, T val, Dtype dtype, StreamOrDevice s = {}) {
   return full(std::move(shape), array(val, dtype), to_stream(s));
 }
 template <typename T>
-array full(std::vector<int> shape, T val, StreamOrDevice s = {}) {
+array full(Shape shape, T val, StreamOrDevice s = {}) {
   return full(std::move(shape), array(val), to_stream(s));
 }
 
 /** Fill an array of the given shape with zeros. */
-array zeros(const std::vector<int>& shape, Dtype dtype, StreamOrDevice s = {});
-inline array zeros(const std::vector<int>& shape, StreamOrDevice s = {}) {
+array zeros(const Shape& shape, Dtype dtype, StreamOrDevice s = {});
+inline array zeros(const Shape& shape, StreamOrDevice s = {}) {
   return zeros(shape, float32, s);
 }
 array zeros_like(const array& a, StreamOrDevice s = {});
 
 /** Fill an array of the given shape with ones. */
-array ones(const std::vector<int>& shape, Dtype dtype, StreamOrDevice s = {});
-inline array ones(const std::vector<int>& shape, StreamOrDevice s = {}) {
+array ones(const Shape& shape, Dtype dtype, StreamOrDevice s = {});
+inline array ones(const Shape& shape, StreamOrDevice s = {}) {
   return ones(shape, float32, s);
 }
 array ones_like(const array& a, StreamOrDevice s = {});
@@ -119,7 +115,7 @@ array tril(array x, int k = 0, StreamOrDevice s = {});
 array triu(array x, int k = 0, StreamOrDevice s = {});
 
 /** Reshape an array to the given shape. */
-array reshape(const array& a, std::vector<int> shape, StreamOrDevice s = {});
+array reshape(const array& a, Shape shape, StreamOrDevice s = {});
 
 /** Flatten the dimensions in the range `[start_axis, end_axis]` . */
 array flatten(
@@ -161,33 +157,29 @@ array expand_dims(const array& a, int axis, StreamOrDevice s = {});
 /** Slice an array. */
 array slice(
     const array& a,
-    std::vector<int> start,
-    std::vector<int> stop,
-    std::vector<int> strides,
+    Shape start,
+    Shape stop,
+    Shape strides,
     StreamOrDevice s = {});
 
 /** Slice an array with a stride of 1 in each dimension. */
-array slice(
-    const array& a,
-    std::vector<int> start,
-    std::vector<int> stop,
-    StreamOrDevice s = {});
+array slice(const array& a, Shape start, Shape stop, StreamOrDevice s = {});
 
 /** Update a slice from the source array */
 array slice_update(
     const array& src,
     const array& update,
-    std::vector<int> start,
-    std::vector<int> stop,
-    std::vector<int> strides,
+    Shape start,
+    Shape stop,
+    Shape strides,
     StreamOrDevice s = {});
 
 /** Update a slice from the source array with stride 1 in each dimension */
 array slice_update(
     const array& src,
     const array& update,
-    std::vector<int> start,
-    std::vector<int> stop,
+    Shape start,
+    Shape stop,
     StreamOrDevice s = {});
 
 /** Split an array into sub-arrays along a given axis. */
@@ -288,10 +280,7 @@ array pad(
 array transpose(const array& a, StreamOrDevice s = {});
 
 /** Broadcast an array to a given shape. */
-array broadcast_to(
-    const array& a,
-    const std::vector<int>& shape,
-    StreamOrDevice s = {});
+array broadcast_to(const array& a, const Shape& shape, StreamOrDevice s = {});
 
 /** Broadcast a vector of arrays against one another. */
 std::vector<array> broadcast_arrays(
@@ -917,13 +906,13 @@ array gather(
     const array& a,
     const std::vector<array>& indices,
     const std::vector<int>& axes,
-    const std::vector<int>& slice_sizes,
+    const Shape& slice_sizes,
     StreamOrDevice s = {});
 inline array gather(
     const array& a,
     const array& indices,
     int axis,
-    const std::vector<int>& slice_sizes,
+    const Shape& slice_sizes,
     StreamOrDevice s = {}) {
   return gather(a, {indices}, std::vector<int>{axis}, slice_sizes, s);
 }
@@ -1459,24 +1448,13 @@ array view(const array& a, const Dtype& dtype, StreamOrDevice s = {});
 
 /** Roll elements along an axis and introduce them on the other side */
 array roll(const array& a, int shift, StreamOrDevice s = {});
-array roll(
-    const array& a,
-    const std::vector<int>& shift,
-    StreamOrDevice s = {});
+array roll(const array& a, const Shape& shift, StreamOrDevice s = {});
 array roll(const array& a, int shift, int axis, StreamOrDevice s = {});
+array roll(const array& a, int shift, const Shape& axes, StreamOrDevice s = {});
+array roll(const array& a, const Shape& shift, int axis, StreamOrDevice s = {});
 array roll(
     const array& a,
-    int shift,
-    const std::vector<int>& axes,
-    StreamOrDevice s = {});
-array roll(
-    const array& a,
-    const std::vector<int>& shift,
-    int axis,
-    StreamOrDevice s = {});
-array roll(
-    const array& a,
-    const std::vector<int>& shift,
+    const Shape& shift,
     const std::vector<int>& axes,
     StreamOrDevice s = {});
 

--- a/mlx/utils.cpp
+++ b/mlx/utils.cpp
@@ -66,9 +66,7 @@ Dtype result_type(const std::vector<array>& arrays) {
   return t;
 }
 
-std::vector<int> broadcast_shapes(
-    const std::vector<int>& s1,
-    const std::vector<int>& s2) {
+Shape broadcast_shapes(const Shape& s1, const Shape& s2) {
   // Use the same broadcasting rules as numpy
   // https://numpy.org/doc/1.20/user/theory.broadcasting.html
   // "The size of the trailing axes for both arrays in an operation must
@@ -79,7 +77,7 @@ std::vector<int> broadcast_shapes(
   int diff = std::abs(ndim1 - ndim2);
   const auto& big = ndim1 > ndim2 ? s1 : s2;
   const auto& small = ndim1 > ndim2 ? s2 : s1;
-  std::vector<int> out_shape(ndim);
+  Shape out_shape(ndim);
   for (int i = ndim - 1; i >= diff; --i) {
     int a = big[i];
     int b = small[i - diff];
@@ -158,10 +156,8 @@ std::ostream& operator<<(std::ostream& os, uint8_t x) {
 
 namespace {
 
-inline size_t elem_to_loc(
-    int elem,
-    const std::vector<int>& shape,
-    const std::vector<size_t>& strides) {
+inline size_t
+elem_to_loc(int elem, const Shape& shape, const Strides& strides) {
   size_t loc = 0;
   for (int i = shape.size() - 1; i >= 0; --i) {
     auto q_and_r = ldiv(elem, shape[i]);
@@ -199,7 +195,6 @@ void print_subarray(std::ostream& os, const array& a, size_t index, int dim) {
 
 template <typename T>
 void print_array(std::ostream& os, const array& a) {
-  std::vector<int> indices(a.ndim(), 0);
   os << std::boolalpha;
   os << "array(";
   if (a.ndim() == 0) {
@@ -310,7 +305,7 @@ std::ostream& operator<<(std::ostream& os, array a) {
   return os;
 }
 
-std::ostream& operator<<(std::ostream& os, const std::vector<int>& v) {
+std::ostream& operator<<(std::ostream& os, const Shape& v) {
   os << "(";
   for (int i = 0; i < v.size(); ++i) {
     os << v[i] << ((i == v.size() - 1) ? "" : ",");
@@ -319,7 +314,7 @@ std::ostream& operator<<(std::ostream& os, const std::vector<int>& v) {
   return os;
 }
 
-std::ostream& operator<<(std::ostream& os, const std::vector<size_t>& v) {
+std::ostream& operator<<(std::ostream& os, const Strides& v) {
   os << "(";
   for (int i = 0; i < v.size(); ++i) {
     os << v[i] << ((i == v.size() - 1) ? "" : ",");

--- a/mlx/utils.h
+++ b/mlx/utils.h
@@ -62,9 +62,7 @@ inline Dtype result_type(const array& a, const array& b, const array& c) {
 }
 Dtype result_type(const std::vector<array>& arrays);
 
-std::vector<int> broadcast_shapes(
-    const std::vector<int>& s1,
-    const std::vector<int>& s2);
+Shape broadcast_shapes(const Shape& s1, const Shape& s2);
 
 bool is_same_shape(const std::vector<array>& arrays);
 
@@ -96,8 +94,8 @@ std::ostream& operator<<(std::ostream& os, const Stream& s);
 std::ostream& operator<<(std::ostream& os, const Dtype& d);
 std::ostream& operator<<(std::ostream& os, const Dtype::Kind& k);
 std::ostream& operator<<(std::ostream& os, array a);
-std::ostream& operator<<(std::ostream& os, const std::vector<int>& v);
-std::ostream& operator<<(std::ostream& os, const std::vector<size_t>& v);
+std::ostream& operator<<(std::ostream& os, const Shape& v);
+std::ostream& operator<<(std::ostream& os, const Strides& v);
 std::ostream& operator<<(std::ostream& os, const std::vector<int64_t>& v);
 inline std::ostream& operator<<(std::ostream& os, const complex64_t& v) {
   return os << v.real() << (v.imag() >= 0 ? "+" : "") << v.imag() << "j";


### PR DESCRIPTION
Adds a typedef for shape and strides to facilitate switching them if needed.

- `Strides` is currently an alias for `std::vector<size_t>` with the intention of switching it to `std::vector<int64_t>`
- `Shape` is currently an alias for `std::vector<int>` with possibility of eventually switching uint or maybe a larger precisoin
- Might be interesting to try a small vector optimization for these types which is another reason to prefer the typedef over just switching the value type.

If you all are cool with the naming / approach then I can start making the change to use the typedefs and try and switch to a `int64_t` stride.

CC @davidkoski 