### PR TITLE
allow compiling lambdas in C++

### DIFF
--- a/mlx/compile.cpp
+++ b/mlx/compile.cpp
@@ -829,6 +829,11 @@ std::function<std::vector<array>(const std::vector<array>&)> compile(
   if (skip_compile()) {
     return fun;
   }
+  if (!fun) {
+    throw std::invalid_argument(
+        "[compile] Cannot compile a function without a target.");
+  }
+
   return [fun = std::move(fun),
           fun_id,
           shapeless,
@@ -899,7 +904,6 @@ std::function<std::vector<array>(const std::vector<array>&)> compile(
   if (detail::skip_compile()) {
     return fun;
   }
-
   auto fun_id = detail::get_function_address(fun);
   if (fun_id) {
     // If the function has an addressable target then no need to manage it's

--- a/mlx/compile.cpp
+++ b/mlx/compile.cpp
@@ -208,8 +208,7 @@ std::uintptr_t get_function_address(const std::function<T(U...)>& fun) {
   using FunType = T (*)(U...);
   const FunType* fun_ptr = fun.template target<FunType>();
   if (fun_ptr == nullptr) {
-    throw std::invalid_argument(
-        "[compile] Cannot compile a non-addressable function.");
+    return 0;
   }
   return reinterpret_cast<std::uintptr_t>(*fun_ptr);
 }
@@ -817,17 +816,23 @@ void compile_validate_shapeless(const std::vector<array>& tape) {
   }
 }
 
+bool skip_compile() {
+  return compile_mode() == CompileMode::disabled ||
+      !(compile_available_for_device(default_device()));
+}
+
 std::function<std::vector<array>(const std::vector<array>&)> compile(
-    const std::function<std::vector<array>(const std::vector<array>&)>& fun,
+    std::function<std::vector<array>(const std::vector<array>&)> fun,
     std::uintptr_t fun_id,
     bool shapeless /* = false */,
     std::vector<uint64_t> constants /* = {} */) {
-  if (compile_mode() == CompileMode::disabled ||
-      !(compile_available_for_device(default_device()))) {
+  if (skip_compile()) {
     return fun;
   }
-  return [fun, fun_id, shapeless, constants = std::move(constants)](
-             const std::vector<array>& inputs) {
+  return [fun = std::move(fun),
+          fun_id,
+          shapeless,
+          constants = std::move(constants)](const std::vector<array>& inputs) {
     // If the inputs are tracers, trace the original graph
     if (std::any_of(inputs.begin(), inputs.end(), [](auto& in) {
           return in.is_tracer();
@@ -889,13 +894,42 @@ void compile_clear_cache() {
 } // namespace detail
 
 std::function<std::vector<array>(const std::vector<array>&)> compile(
-    const std::function<std::vector<array>(const std::vector<array>&)>& fun,
+    std::function<std::vector<array>(const std::vector<array>&)> fun,
     bool shapeless /* false */) {
-  if (detail::compile_mode() == CompileMode::disabled) {
+  if (detail::skip_compile()) {
     return fun;
   }
+
   auto fun_id = detail::get_function_address(fun);
-  return detail::compile(fun, fun_id, shapeless);
+  if (fun_id) {
+    // If the function has an addressable target then no need to manage it's
+    // lifetime
+    return detail::compile(std::move(fun), fun_id, shapeless);
+  } else {
+    auto pfun = std::shared_ptr<
+        std::function<std::vector<array>(const std::vector<array>&)>>(
+        new std::function<std::vector<array>(const std::vector<array>&)>{fun},
+        [](auto p) {
+          detail::compile_erase(reinterpret_cast<std::uintptr_t>(p));
+          delete p;
+        });
+    fun_id = reinterpret_cast<std::uintptr_t>(pfun.get());
+    return detail::compile(
+        [pfun = std::move(pfun)](const auto& inputs) {
+          return (*pfun)(inputs);
+        },
+        fun_id,
+        shapeless);
+  }
+}
+
+std::function<std::vector<array>(const std::vector<array>&)> compile(
+    std::vector<array>(fun)(const std::vector<array>&),
+    bool shapeless /* = false */) {
+  if (detail::skip_compile()) {
+    return fun;
+  }
+  return detail::compile(fun, reinterpret_cast<std::uintptr_t>(fun), shapeless);
 }
 
 void disable_compile() {

--- a/mlx/compile.h
+++ b/mlx/compile.h
@@ -17,6 +17,17 @@ std::function<std::vector<array>(const std::vector<array>&)> compile(
     std::vector<array>(fun)(const std::vector<array>&),
     bool shapeless = false);
 
+// Convert capture-less lambdas to function pointers.
+template <
+    typename F,
+    typename = std::enable_if_t<
+        std::is_convertible_v<F, decltype(+std::declval<F>())>>>
+std::function<std::vector<array>(const std::vector<array>&)> compile(
+    F&& f,
+    bool shapeless = false) {
+  return compile(+f, shapeless);
+}
+
 /** Globally disable compilation.
  * Setting the environment variable ``MLX_DISABLE_COMPILE`` can also
  * be used to disable compilation.

--- a/mlx/compile.h
+++ b/mlx/compile.h
@@ -10,7 +10,11 @@ enum class CompileMode { disabled, no_simplify, no_fuse, enabled };
 
 /** Compile takes a function and returns a compiled function. */
 std::function<std::vector<array>(const std::vector<array>&)> compile(
-    const std::function<std::vector<array>(const std::vector<array>&)>& fun,
+    std::function<std::vector<array>(const std::vector<array>&)> fun,
+    bool shapeless = false);
+
+std::function<std::vector<array>(const std::vector<array>&)> compile(
+    std::vector<array>(fun)(const std::vector<array>&),
     bool shapeless = false);
 
 /** Globally disable compilation.

--- a/mlx/compile_impl.h
+++ b/mlx/compile_impl.h
@@ -9,7 +9,7 @@ namespace mlx::core::detail {
 // This is not part of the general C++ API as calling with a bad id is a bad
 // idea.
 std::function<std::vector<array>(const std::vector<array>&)> compile(
-    const std::function<std::vector<array>(const std::vector<array>&)>& fun,
+    std::function<std::vector<array>(const std::vector<array>&)> fun,
     std::uintptr_t fun_id,
     bool shapeless = false,
     std::vector<uint64_t> constants = {});

--- a/tests/compile_tests.cpp
+++ b/tests/compile_tests.cpp
@@ -739,6 +739,29 @@ TEST_CASE("test compile lambda") {
   auto out = compile(+fun)({array(-1)});
   CHECK_EQ(out[0].item<int>(), 1);
 
+  decltype(compile(nullptr)) c_local_fun;
+  {
+    auto local_fun = [](const std::vector<array>& inputs) {
+      return std::vector<array>{abs(inputs[0])};
+    };
+    c_local_fun = compile(+local_fun);
+  }
+
+  // This is ok even though local_fun is out of scope
+  out = c_local_fun({array(-1)});
+  CHECK_EQ(out[0].item<int>(), 1);
+
+  {
+    int x = 2;
+    auto local_fun = [x](const std::vector<array>& inputs) {
+      return std::vector<array>{inputs[0] + x};
+    };
+    c_local_fun = compile(local_fun);
+  }
+  // Also ok even though local_fun is out of scope.
+  out = c_local_fun({array(0)});
+  CHECK_EQ(out[0].item<int>(), 2);
+
   int x = 2;
   auto fun_with_capture = [&x](const std::vector<array>& inputs) {
     return std::vector<array>{inputs[0] + x};

--- a/tests/compile_tests.cpp
+++ b/tests/compile_tests.cpp
@@ -736,7 +736,7 @@ TEST_CASE("test compile lambda") {
     return std::vector<array>{abs(inputs[0])};
   };
 
-  auto out = compile(+fun)({array(-1)});
+  auto out = compile(fun)({array(-1)});
   CHECK_EQ(out[0].item<int>(), 1);
 
   decltype(compile(nullptr)) c_local_fun;
@@ -744,7 +744,7 @@ TEST_CASE("test compile lambda") {
     auto local_fun = [](const std::vector<array>& inputs) {
       return std::vector<array>{abs(inputs[0])};
     };
-    c_local_fun = compile(+local_fun);
+    c_local_fun = compile(local_fun);
   }
 
   // This is ok even though local_fun is out of scope


### PR DESCRIPTION
Allows compiling lambda functions in C++.


There is an edge case difference between Python and C++ to note. We have slightly less ability to cache captured lambdas in C++ than in  Python because they aren't reference counted pointers in C++. In Python:

```python
f = lambda ...
cf = mx.compile(f) 
# calling cf doesn't recompile (unless you change input shape/typ)

# Assuming cf is still in scope
df = mx.compile(f) # also doesn't recompile
```

The second one works because `f` is basically a shared pointer to an underlying object and we use the pointer value as the function id and hold a reference to it inside the compiled `cf`. If `cf` goes out of scope then we will in fact recompile `df`.

In C++

```c++
auto f = [=](...) { ... };  # captures something
auto cf = compile(f);
# calling cf doesn't recompile (unless you change input shape/typ)
auto df = compile(f); # recompiles
```

`f` is implicitly cast to a `std::function` and so we don't have the address of the original lambda. But even if we did it's a bad idea to use if because `f` is a temporary object so the address can belong to a new lambda when `f` is destroyed and we can't detect when the underlying `f` is destroyed.

I don't really think this is an issue because compiling once and calling many times is the sensible usage. However, if it becomes an issue we can provide a `compile(shared_ptr<std::function>)` overload and then safely not recompile if you did:

```c++
compile(std::make_share(f));
```