### PR TITLE
Chore: Add default language in pre-commit and bump hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,17 @@
+default_language_version:
+  python: python3.10
+
 repos:
 -   repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v18.1.8
+    rev: v19.1.4
     hooks:
     -   id: clang-format
 # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
 -   repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.8.0
+    rev: 24.10.0
     hooks:
     -   id: black
+    
 -   repo: https://github.com/pycqa/isort
     rev: 5.13.2
     hooks:

--- a/tests/array_tests.cpp
+++ b/tests/array_tests.cpp
@@ -129,37 +129,59 @@ TEST_CASE("test array types") {
   }
 
   // uint8
-  { basic_dtype_test(uint8_t, uint8); }
+  {
+    basic_dtype_test(uint8_t, uint8);
+  }
 
   // uint16
-  { basic_dtype_test(uint16_t, uint16); }
+  {
+    basic_dtype_test(uint16_t, uint16);
+  }
 
   // uint32
-  { basic_dtype_test(uint32_t, uint32); }
+  {
+    basic_dtype_test(uint32_t, uint32);
+  }
 
   // uint64
-  { basic_dtype_test(uint64_t, uint64); }
+  {
+    basic_dtype_test(uint64_t, uint64);
+  }
 
   // int8
-  { basic_dtype_test(int8_t, int8); }
+  {
+    basic_dtype_test(int8_t, int8);
+  }
 
   // int16
-  { basic_dtype_test(int16_t, int16); }
+  {
+    basic_dtype_test(int16_t, int16);
+  }
 
   // int32
-  { basic_dtype_test(int32_t, int32); }
+  {
+    basic_dtype_test(int32_t, int32);
+  }
 
   // int64
-  { basic_dtype_test(int64_t, int64); }
+  {
+    basic_dtype_test(int64_t, int64);
+  }
 
   // float16
-  { basic_dtype_test(float16_t, float16); }
+  {
+    basic_dtype_test(float16_t, float16);
+  }
 
   // float32
-  { basic_dtype_test(float, float32); }
+  {
+    basic_dtype_test(float, float32);
+  }
 
   // bfloat16
-  { basic_dtype_test(bfloat16_t, bfloat16); }
+  {
+    basic_dtype_test(bfloat16_t, bfloat16);
+  }
 
 #undef basic_dtype_test
 

--- a/tests/ops_tests.cpp
+++ b/tests/ops_tests.cpp
@@ -3045,13 +3045,17 @@ TEST_CASE("test divmod") {
 
   // Check that we can still eval when one output goes out of scope
   std::vector<array> out_holder;
-  { out_holder.push_back(divmod(x, y)[0]); }
+  {
+    out_holder.push_back(divmod(x, y)[0]);
+  }
   eval(out_holder);
   CHECK_EQ(out_holder[0].item<float>(), 0.0);
 
   // Check that we can still eval when the other output goes out of scope
   out_holder.clear();
-  { out_holder.push_back(divmod(x, y)[1]); }
+  {
+    out_holder.push_back(divmod(x, y)[1]);
+  }
   eval(out_holder);
   CHECK_EQ(out_holder[0].item<float>(), 1.0);
 }


### PR DESCRIPTION
I had the following issue with black when `default_language_version` was not mentioned:

```
black....................................................................Failed
- hook id: black
- exit code: 1

Python 3.12.5 has a memory safety issue that can cause Black's AST safety checks to fail. Please upgrade to Python 3.12.6 or downgrade to Python 3.12.4
```

Added default language as 3.10 and bumped up the hooks to solve this issue