### PR TITLE
More primitives for compiling with shapeless

### DIFF
--- a/mlx/compile.cpp
+++ b/mlx/compile.cpp
@@ -1,5 +1,4 @@
 // Copyright © 2023-2024 Apple Inc.
-
 #include <cstdlib>
 #include <map>
 #include <unordered_map>
@@ -8,6 +7,7 @@
 #include "mlx/allocator.h"
 #include "mlx/compile.h"
 #include "mlx/compile_impl.h"
+#include "mlx/fast_primitives.h"
 #include "mlx/primitives.h"
 #include "mlx/transforms.h"
 #include "mlx/transforms_impl.h"
@@ -73,11 +73,19 @@ bool is_fusable(const Primitive& p) {
 }
 
 bool allows_shapeless(const Primitive& p) {
-  return typeid(p) == typeid(Compiled) || is_unary(p) || is_binary(p) ||
-      is_noop(p) || is_reduction(p) || typeid(p) == typeid(Softmax) ||
-      typeid(p) == typeid(Sort) || typeid(p) == typeid(ArgSort) ||
-      typeid(p) == typeid(ArgPartition) || typeid(p) == typeid(Partition) ||
-      typeid(p) == typeid(Select) || typeid(p) == typeid(NumberOfElements);
+  return typeid(p) == typeid(Arange) || typeid(p) == typeid(Compiled) ||
+      is_unary(p) || is_binary(p) || is_noop(p) || is_reduction(p) ||
+      typeid(p) == typeid(Softmax) || typeid(p) == typeid(Sort) ||
+      typeid(p) == typeid(ArgSort) || typeid(p) == typeid(ArgPartition) ||
+      typeid(p) == typeid(Partition) || typeid(p) == typeid(Select) ||
+      typeid(p) == typeid(NumberOfElements) || typeid(p) == typeid(Reshape) ||
+      typeid(p) == typeid(Gather) || typeid(p) == typeid(Transpose) ||
+      typeid(p) == typeid(Concatenate) || typeid(p) == typeid(Matmul) ||
+      typeid(p) == typeid(QuantizedMatmul) ||
+      typeid(p) == typeid(fast::AffineQuantize) ||
+      typeid(p) == typeid(fast::LayerNorm) ||
+      typeid(p) == typeid(fast::RMSNorm) || typeid(p) == typeid(fast::RoPE) ||
+      typeid(p) == typeid(fast::ScaledDotProductAttention);
 }
 
 Compiled::Compiled(

--- a/mlx/compile.cpp
+++ b/mlx/compile.cpp
@@ -78,10 +78,9 @@ bool allows_shapeless(const Primitive& p) {
       typeid(p) == typeid(Softmax) || typeid(p) == typeid(Sort) ||
       typeid(p) == typeid(ArgSort) || typeid(p) == typeid(ArgPartition) ||
       typeid(p) == typeid(Partition) || typeid(p) == typeid(Select) ||
-      typeid(p) == typeid(NumberOfElements) || typeid(p) == typeid(Reshape) ||
-      typeid(p) == typeid(Gather) || typeid(p) == typeid(Transpose) ||
-      typeid(p) == typeid(Concatenate) || typeid(p) == typeid(Matmul) ||
-      typeid(p) == typeid(QuantizedMatmul) ||
+      typeid(p) == typeid(NumberOfElements) || typeid(p) == typeid(Gather) ||
+      typeid(p) == typeid(Transpose) || typeid(p) == typeid(Concatenate) ||
+      typeid(p) == typeid(Matmul) || typeid(p) == typeid(QuantizedMatmul) ||
       typeid(p) == typeid(fast::AffineQuantize) ||
       typeid(p) == typeid(fast::LayerNorm) ||
       typeid(p) == typeid(fast::RMSNorm) || typeid(p) == typeid(fast::RoPE) ||

--- a/mlx/compile.cpp
+++ b/mlx/compile.cpp
@@ -101,23 +101,23 @@ Compiled::Compiled(
       constant_ids_(std::move(constant_ids)) {}
 
 std::vector<array> Compiled::vjp(
-    const std::vector<array>& primals,
-    const std::vector<array>& cotangents,
-    const std::vector<int>& argnums,
-    const std::vector<array>& outputs) {
+    const std::vector<array>&,
+    const std::vector<array>&,
+    const std::vector<int>&,
+    const std::vector<array>&) {
   throw std::runtime_error("[Compiled] Cannot vjp primitive.");
 }
 
 std::vector<array> Compiled::jvp(
-    const std::vector<array>& primals,
-    const std::vector<array>& tangents,
-    const std::vector<int>& argnums) {
+    const std::vector<array>&,
+    const std::vector<array>&,
+    const std::vector<int>&) {
   throw std::runtime_error("[Compiled] Cannot jvp primitive.");
 }
 
 std::pair<std::vector<array>, std::vector<int>> Compiled::vmap(
-    const std::vector<array>& inputs,
-    const std::vector<int>& axes) {
+    const std::vector<array>&,
+    const std::vector<int>&) {
   throw std::runtime_error("[Compiled] Cannot vmap primitive.");
 }
 
@@ -142,13 +142,12 @@ void Compiled::print(std::ostream& os) {
   }
 }
 
-std::vector<std::vector<int>> Compiled::output_shapes(
-    const std::vector<array>& inputs) {
+std::vector<Shape> Compiled::output_shapes(const std::vector<array>& inputs) {
   size_t nd = 0;
   for (auto& in : inputs) {
     nd = std::max(nd, in.ndim());
   }
-  std::vector<int> out_shape(nd, 0);
+  Shape out_shape(nd, 0);
   for (auto& in : inputs) {
     auto dd = nd - in.ndim();
     for (auto i = dd; i < nd; ++i) {
@@ -156,7 +155,7 @@ std::vector<std::vector<int>> Compiled::output_shapes(
     }
   }
   // All outputs have the same shape
-  return std::vector<std::vector<int>>(outputs_.size(), out_shape);
+  return std::vector<Shape>(outputs_.size(), out_shape);
 }
 
 namespace detail {
@@ -561,14 +560,12 @@ void compile_fuse(
     //  - Collect inputs to the new compiled primitive
     //  - Add fusable primitives to a tape in the correct order
 
-    std::function<void(
-        const array&, int, const Stream&, const std::vector<int>&)>
-        recurse;
+    std::function<void(const array&, int, const Stream&, const Shape&)> recurse;
     std::unordered_set<uintptr_t> cache;
     recurse = [&](const array& a,
                   int depth,
                   const Stream& s,
-                  const std::vector<int>& shape) {
+                  const Shape& shape) {
       if (cache.find(a.id()) != cache.end()) {
         return;
       }
@@ -675,7 +672,7 @@ void compile_fuse(
     }
     old_outputs.push_back(arr);
 
-    std::vector<std::vector<int>> shapes;
+    std::vector<Shape> shapes;
     std::vector<Dtype> types;
     for (auto& o : old_outputs) {
       if (o.shape() != old_outputs.back().shape()) {
@@ -779,7 +776,7 @@ std::vector<array> compile_replace(
         for (auto& o : trace_out) {
           types.push_back(o.dtype());
         }
-        std::vector<std::vector<int>> shapes;
+        std::vector<Shape> shapes;
         if (shapeless) {
           shapes = a.primitive().output_shapes(real_inputs);
         } else {

--- a/mlx/fast.cpp
+++ b/mlx/fast.cpp
@@ -915,6 +915,31 @@ array affine_dequantize(
   return fallback({w, scales, biases})[0];
 }
 
+bool AffineQuantize::is_equivalent(const Primitive& other) const {
+  const AffineQuantize& p_other = static_cast<const AffineQuantize&>(other);
+  return (
+      p_other.group_size_ == group_size_ && p_other.bits_ == bits_ &&
+      p_other.dequantize_ == dequantize_);
+}
+
+std::vector<Shape> AffineQuantize::output_shapes(
+    const std::vector<array>& inputs) {
+  auto& w = inputs[0];
+  if (dequantize_) {
+    auto out_size = w.shape(-1) * 32 / bits_;
+    auto out_shape = w.shape();
+    out_shape.back() = out_size;
+    return {std::move(out_shape)};
+  } else {
+    auto wq_shape = w.shape();
+    wq_shape.back() = w.shape(-1) * bits_ / 32;
+    auto sshape = w.shape();
+    sshape.back() = w.shape(-1) / group_size_;
+    bshape = sshape;
+    return {std::move(wq_shape), std::move(sshape), std::move(bshape)};
+  }
+}
+
 std::string write_signature(
     std::string func_name,
     const std::string& header,

--- a/mlx/fast.cpp
+++ b/mlx/fast.cpp
@@ -935,7 +935,7 @@ std::vector<Shape> AffineQuantize::output_shapes(
     wq_shape.back() = w.shape(-1) * bits_ / 32;
     auto sshape = w.shape();
     sshape.back() = w.shape(-1) / group_size_;
-    bshape = sshape;
+    auto bshape = sshape;
     return {std::move(wq_shape), std::move(sshape), std::move(bshape)};
   }
 }

--- a/mlx/fast_primitives.h
+++ b/mlx/fast_primitives.h
@@ -58,6 +58,7 @@ class RMSNorm : public Custom {
 
   DEFINE_PRINT(RMSNorm)
   bool is_equivalent(const Primitive& other) const override;
+  DEFINE_INPUT_OUTPUT_SHAPE()
 
  private:
   std::function<std::vector<array>(std::vector<array>)> fallback_;
@@ -110,6 +111,7 @@ class LayerNorm : public Custom {
 
   DEFINE_PRINT(LayerNorm)
   bool is_equivalent(const Primitive& other) const override;
+  DEFINE_INPUT_OUTPUT_SHAPE()
 
  private:
   std::function<std::vector<array>(std::vector<array>)> fallback_;
@@ -173,6 +175,7 @@ class RoPE : public Custom {
 
   DEFINE_PRINT(RoPE)
   bool is_equivalent(const Primitive& other) const override;
+  DEFINE_INPUT_OUTPUT_SHAPE()
 
  private:
   std::function<std::vector<array>(std::vector<array>)> fallback_;
@@ -207,6 +210,7 @@ class ScaledDotProductAttention : public Custom {
   bool is_equivalent(const Primitive& other) const override;
 
   DEFINE_PRINT(ScaledDotProductAttention);
+  DEFINE_INPUT_OUTPUT_SHAPE()
 
  private:
   std::function<std::vector<array>(std::vector<array>)> fallback_;
@@ -234,6 +238,9 @@ class AffineQuantize : public Custom {
       override;
 
   DEFINE_PRINT(AffineQuantize);
+
+  bool is_equivalent(const Primitive& other) const override;
+  std::vector<Shape> output_shapes(const std::vector<array>& inputs) override;
 
  private:
   std::function<std::vector<array>(std::vector<array>)> fallback_;

--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -267,6 +267,11 @@ bool Arange::is_equivalent(const Primitive& other) const {
       step_ == a_other.step_);
 }
 
+std::vector<Shape> Arange::output_shapes(const std::vector<array>&) {
+  auto real_size = std::ceil((stop_ - start_) / step_);
+  return {{std::max(static_cast<int>(real_size), 0)}};
+}
+
 std::vector<array> ArcCos::vjp(
     const std::vector<array>& primals,
     const std::vector<array>& cotangents,
@@ -534,11 +539,10 @@ std::pair<std::vector<array>, std::vector<int>> ArgSort::vmap(
   return {{argsort(inputs[0], axis_ + axis_left, stream())}, axes};
 }
 
-std::vector<std::vector<int>> ArgReduce::output_shapes(
-    const std::vector<array>& inputs) {
+std::vector<Shape> ArgReduce::output_shapes(const std::vector<array>& inputs) {
   auto out_shape = inputs[0].shape();
   out_shape[axis_] = 1;
-  return {out_shape};
+  return {std::move(out_shape)};
 }
 
 bool ArgSort::is_equivalent(const Primitive& other) const {
@@ -787,6 +791,23 @@ std::pair<std::vector<array>, std::vector<int>> Eigh::vmap(
   return {outputs, std::vector<int>(outputs.size(), ax)};
 }
 
+std::vector<Shape> Eigh::output_shapes(const std::vector<array>& inputs) {
+  auto shape = inputs[0].shape();
+  shape.pop_back(); // Remove last dimension for eigenvalues
+  if (compute_eigenvectors_) {
+    return {
+        std::move(shape), inputs[0].shape()}; // Eigenvalues and eigenvectors
+  } else {
+    return {std::move(shape)}; // Only eigenvalues
+  }
+}
+
+bool Eigh::is_equivalent(const Primitive& other) const {
+  auto& e_other = static_cast<const Eigh&>(other);
+  return uplo_ == e_other.uplo_ &&
+      compute_eigenvectors_ == e_other.compute_eigenvectors_;
+}
+
 std::vector<array> Concatenate::vjp(
     const std::vector<array>& primals,
     const std::vector<array>& cotangents,
@@ -879,6 +900,15 @@ std::pair<std::vector<array>, std::vector<int>> Concatenate::vmap(
 bool Concatenate::is_equivalent(const Primitive& other) const {
   const Concatenate& c_other = static_cast<const Concatenate&>(other);
   return axis_ == c_other.axis_;
+}
+
+std::vector<Shape> Concatenate::output_shapes(
+    const std::vector<array>& inputs) {
+  auto shape = inputs[0].shape();
+  for (int i = 1; i < inputs.size(); ++i) {
+    shape[axis_] += inputs[i].shape(axis_);
+  }
+  return {std::move(shape)};
 }
 
 std::pair<std::vector<array>, std::vector<int>> Conjugate::vmap(
@@ -1811,6 +1841,15 @@ bool Gather::is_equivalent(const Primitive& other) const {
   return axes_ == g_other.axes_ && slice_sizes_ == g_other.slice_sizes_;
 }
 
+std::vector<Shape> Gather::output_shapes(const std::vector<array>& inputs) {
+  Shape out_shape;
+  if (inputs.size() > 1) {
+    out_shape = inputs[0].shape();
+  }
+  out_shape.insert(out_shape.end(), slice_sizes_.begin(), slice_sizes_.end());
+  return {std::move(out_shape)};
+}
+
 std::pair<std::vector<array>, std::vector<int>> Greater::vmap(
     const std::vector<array>& inputs,
     const std::vector<int>& axes) {
@@ -2182,6 +2221,12 @@ std::pair<std::vector<array>, std::vector<int>> Matmul::vmap(
   auto a = maybe_move_ax(inputs[0], axes[0]);
   auto b = maybe_move_ax(inputs[1], axes[1]);
   return {{matmul(a, b, stream())}, {0}};
+}
+
+std::vector<Shape> Matmul::output_shapes(const std::vector<array>& inputs) {
+  auto out_shape = inputs[0].shape();
+  out_shape.back() = inputs[1].shape(-1);
+  return {std::move(out_shape)};
 }
 
 std::vector<array> Maximum::vjp(
@@ -2608,6 +2653,15 @@ bool QuantizedMatmul::is_equivalent(const Primitive& other) const {
       transpose_ == qm_other.transpose_;
 }
 
+std::vector<Shape> QuantizedMatmul::output_shapes(
+    const std::vector<array>& inputs) {
+  auto& w = inputs[1];
+  int w_outer_dims = (transpose_) ? w.shape(-2) : w.shape(-1) * 32 / bits_;
+  auto out_shape = inputs[0].shape();
+  out_shape.back() = w_outer_dims;
+  return {std::move(out_shape)};
+}
+
 std::pair<std::vector<array>, std::vector<int>> GatherQMM::vmap(
     const std::vector<array>& inputs,
     const std::vector<int>& axes) {
@@ -2802,6 +2856,9 @@ std::vector<array> Reshape::jvp(
 
 bool Reshape::is_equivalent(const Primitive& other) const {
   const Reshape& r_other = static_cast<const Reshape&>(other);
+  if (!expression_.empty()) {
+    return expression_ == r_other.expression_;
+  }
   return shape_ == r_other.shape_;
 }
 
@@ -2937,13 +2994,12 @@ bool Reduce::is_equivalent(const Primitive& other) const {
   return reduce_type_ == r_other.reduce_type_ && axes_ == r_other.axes_;
 }
 
-std::vector<std::vector<int>> Reduce::output_shapes(
-    const std::vector<array>& inputs) {
-  std::vector<int> out_shape = inputs[0].shape();
+std::vector<Shape> Reduce::output_shapes(const std::vector<array>& inputs) {
+  auto out_shape = inputs[0].shape();
   for (auto i : axes_) {
     out_shape[i] = 1;
   }
-  return {out_shape};
+  return {std::move(out_shape)};
 }
 
 std::vector<array> Round::vjp(
@@ -4207,6 +4263,15 @@ std::pair<std::vector<array>, std::vector<int>> Transpose::vmap(
 bool Transpose::is_equivalent(const Primitive& other) const {
   const Transpose& t_other = static_cast<const Transpose&>(other);
   return axes_ == t_other.axes_;
+}
+
+std::vector<Shape> Transpose::output_shapes(const std::vector<array>& inputs) {
+  auto& in = inputs[0];
+  Shape shape(in.ndim(), 0);
+  for (int i = 0; i < axes_.size(); ++i) {
+    shape[i] = in.shape()[axes_[i]];
+  }
+  return {std::move(shape)};
 }
 
 std::pair<std::vector<array>, std::vector<int>> NumberOfElements::vmap(

--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -2856,9 +2856,6 @@ std::vector<array> Reshape::jvp(
 
 bool Reshape::is_equivalent(const Primitive& other) const {
   const Reshape& r_other = static_cast<const Reshape&>(other);
-  if (!expression_.empty()) {
-    return expression_ == r_other.expression_;
-  }
   return shape_ == r_other.shape_;
 }
 

--- a/mlx/primitives.h
+++ b/mlx/primitives.h
@@ -1616,7 +1616,6 @@ class Reshape : public UnaryPrimitive {
   DEFINE_GRADS()
   DEFINE_PRINT(Reshape)
   bool is_equivalent(const Primitive& other) const override;
-  std::vector<Shape> output_shapes(const std::vector<array>& inputs) override;
 
  private:
   Shape shape_;


### PR DESCRIPTION
Added several more primitives to allow compiling with `shapeless=True` (and hopefully exporting with `shapeless=True`).

- `Arange`
- `Gather`
- `Transpose`
- `Concatenate`
- `Matmul`
- `QuantizedMatmul`
- `fast::AffineQuantize`
- `fast::LayerNorm`
- `fast::RMSNorm`
- `fast::RoPE`
- `fast::ScaledDotProductAttention`