### PR TITLE
Fix a flaky test and the pre-commit hooks.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,3 @@
-default_language_version:
-  python: python3.10
-
 repos:
 -   repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v19.1.4

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -1,5 +1,6 @@
 # Copyright © 2023-2024 Apple Inc.
 
+import gc
 import operator
 import pickle
 import resource
@@ -1942,6 +1943,7 @@ class TestArray(mlx_tests.MLXTestCase):
             return b
 
         t()
+        gc.collect()
         expected = get_mem()
         for _ in range(100):
             t()


### PR DESCRIPTION
Fix a flaky test and the pre-commit hooks.

Having the default language specified breaks things if you don't have the version available so it doesn't seem like a good idea to specify it.