### PR TITLE
Fix performance bug in qvm

### DIFF
--- a/mlx/backend/metal/kernels/quantized.h
+++ b/mlx/backend/metal/kernels/quantized.h
@@ -854,15 +854,17 @@ METAL_FUNC void qvm_impl(
   constexpr int power_of_2_bits = (bits & (bits - 1)) == 0;
   constexpr int num_simdgroups = 2;
   constexpr int pack_factor = bits == 3 ? 8 : bits == 6 ? 4 : 32 / bits;
-  constexpr int bytes_per_pack = power_of_2_bits ? 4 : 3;
+  constexpr int bytes_per_pack = power_of_2_bits ? 1 : 3;
   constexpr int tn = 32 / pack_factor;
   constexpr int block_size = SIMD_SIZE;
 
-  const device uint8_t* ws = (const device uint8_t*)w;
+  using W_T =
+      typename ConditionalType<power_of_2_bits, uint32_t, uint8_t>::type;
+  const device W_T* ws = (const device W_T*)w;
 
   typedef float U;
   typedef struct {
-    uint8_t wi[tn * bytes_per_pack];
+    W_T wi[tn * bytes_per_pack];
   } vec_w;
 
   thread vec_w w_local;

--- a/mlx/backend/metal/kernels/utils.h
+++ b/mlx/backend/metal/kernels/utils.h
@@ -421,3 +421,14 @@ inline complex64_t simd_shuffle(complex64_t data, uint16_t lane) {
   return complex64_t(
       simd_shuffle(data.real, lane), simd_shuffle(data.imag, lane));
 }
+
+// std::conditional is not included with Metal
+template <bool condition, typename T, typename U>
+struct ConditionalType {
+  using type = U;
+};
+
+template <typename T, typename U>
+struct ConditionalType<true, T, U> {
+  using type = T;
+};


### PR DESCRIPTION
I assumed this [refactor](https://github.com/ml-explore/mlx/pull/1616) wouldn't matter for the `qvm` since it doesn't make a difference for the `qmv` but turns out it really slows things down at long context:

Before:
```
Prompt: 9 tokens, 4.092 tokens-per-sec
Generation: 100 tokens, 15.318 tokens-per-sec
Peak memory: 5.410 GB
```
After:
```
Prompt: 9 tokens, 29.152 tokens-per-sec
Generation: 100 tokens, 29.119 tokens-per-sec
Peak memory: 5.410 GB
```
