### PR TITLE
[WIP] Dynamic reshape

### DIFF
--- a/mlx/compile.cpp
+++ b/mlx/compile.cpp
@@ -80,7 +80,8 @@ bool allows_shapeless(const Primitive& p) {
       typeid(p) == typeid(Partition) || typeid(p) == typeid(Select) ||
       typeid(p) == typeid(NumberOfElements) || typeid(p) == typeid(Gather) ||
       typeid(p) == typeid(Transpose) || typeid(p) == typeid(Concatenate) ||
-      typeid(p) == typeid(Matmul) || typeid(p) == typeid(QuantizedMatmul) ||
+      typeid(p) == typeid(Reshape) || typeid(p) == typeid(Matmul) ||
+      typeid(p) == typeid(QuantizedMatmul) ||
       typeid(p) == typeid(fast::AffineQuantize) ||
       typeid(p) == typeid(fast::LayerNorm) ||
       typeid(p) == typeid(fast::RMSNorm) || typeid(p) == typeid(fast::RoPE) ||

--- a/mlx/ops.h
+++ b/mlx/ops.h
@@ -117,6 +117,12 @@ array triu(array x, int k = 0, StreamOrDevice s = {});
 /** Reshape an array to the given shape. */
 array reshape(const array& a, Shape shape, StreamOrDevice s = {});
 
+/** Dynamically reshape an array based on the given expressions. */
+array dynamic_reshape(
+    const array& a,
+    std::vector<std::variant<int, std::string>> expressions,
+    StreamOrDevice s = {});
+
 /** Flatten the dimensions in the range `[start_axis, end_axis]` . */
 array flatten(
     const array& a,

--- a/mlx/primitives.h
+++ b/mlx/primitives.h
@@ -1611,8 +1611,11 @@ class Reshape : public UnaryPrimitive {
 
   explicit Reshape(
       Stream stream,
-      std::vector<std::variant<int, std::string>> expression)
-      : UnaryPrimitive(stream), expression_(std::move(expression)) {}
+      std::vector<std::variant<int, std::string>> expressions,
+      std::unordered_map<char, int> char_to_dim)
+      : UnaryPrimitive(stream),
+        expressions_(std::move(expressions)),
+        char_to_dim_(std::move(char_to_dim)) {}
 
   void eval_cpu(const std::vector<array>& inputs, array& out) override;
   void eval_gpu(const std::vector<array>& inputs, array& out) override;
@@ -1623,9 +1626,15 @@ class Reshape : public UnaryPrimitive {
   bool is_equivalent(const Primitive& other) const override;
   std::vector<Shape> output_shapes(const std::vector<array>& inputs) override;
 
+  static Shape shape_from_expressions(
+      const std::vector<std::variant<int, std::string>>& expressions,
+      const std::unordered_map<char, int>& char_to_dim,
+      const array& in);
+
  private:
   Shape shape_;
-  std::vector<std::variant<int, std::string>> expression_;
+  std::vector<std::variant<int, std::string>> expressions_;
+  std::unordered_map<char, int> char_to_dim_;
 
   void eval(const std::vector<array>& inputs, array& out);
 

--- a/mlx/primitives.h
+++ b/mlx/primitives.h
@@ -1609,6 +1609,11 @@ class Reshape : public UnaryPrimitive {
   explicit Reshape(Stream stream, const Shape& shape)
       : UnaryPrimitive(stream), shape_(shape) {}
 
+  explicit Reshape(
+      Stream stream,
+      std::vector<std::variant<int, std::string>> expression)
+      : UnaryPrimitive(stream), expression_(std::move(expression)) {}
+
   void eval_cpu(const std::vector<array>& inputs, array& out) override;
   void eval_gpu(const std::vector<array>& inputs, array& out) override;
 
@@ -1616,9 +1621,11 @@ class Reshape : public UnaryPrimitive {
   DEFINE_GRADS()
   DEFINE_PRINT(Reshape)
   bool is_equivalent(const Primitive& other) const override;
+  std::vector<Shape> output_shapes(const std::vector<array>& inputs) override;
 
  private:
   Shape shape_;
+  std::vector<std::variant<int, std::string>> expression_;
 
   void eval(const std::vector<array>& inputs, array& out);
 

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -4880,4 +4880,27 @@ void init_ops(nb::module_& m) {
         Returns:
             array: The imaginary part of ``a``.
       )pbdoc");
+  m.def(
+      "dynamic_reshape",
+      &dynamic_reshape,
+      nb::arg(),
+      "expression"_a,
+      nb::kw_only(),
+      "stream"_a = nb::none(),
+      nb::sig(
+          "def dynamic_reshape(a: array, /, expression: Sequence[Union[int, str]], *, stream: "
+          "Union[None, Stream, Device] = None) -> array"),
+      R"pbdoc(
+        Dynamically reshape an array based on the given expression.
+
+        Args:
+            a (array): Input array.
+            expression (tuple(int or str)): The expression which determines the
+              output shape.
+            stream (Stream, optional): Stream or device. Defaults to ``None``
+              in which case the default stream of the default device is used.
+
+        Returns:
+            array: The reshaped array.
+      )pbdoc");
 }

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -4884,19 +4884,19 @@ void init_ops(nb::module_& m) {
       "dynamic_reshape",
       &dynamic_reshape,
       nb::arg(),
-      "expression"_a,
+      "expressions"_a,
       nb::kw_only(),
       "stream"_a = nb::none(),
       nb::sig(
-          "def dynamic_reshape(a: array, /, expression: Sequence[Union[int, str]], *, stream: "
+          "def dynamic_reshape(a: array, /, expressions: Sequence[Union[int, str]], *, stream: "
           "Union[None, Stream, Device] = None) -> array"),
       R"pbdoc(
         Dynamically reshape an array based on the given expression.
 
         Args:
             a (array): Input array.
-            expression (tuple(int or str)): The expression which determines the
-              output shape.
+            expressions (tuple(int or str)): The expressions which determine
+              the output shape.
             stream (Stream, optional): Stream or device. Defaults to ``None``
               in which case the default stream of the default device is used.
 

--- a/python/tests/test_compile.py
+++ b/python/tests/test_compile.py
@@ -809,6 +809,29 @@ class TestCompile(mlx_tests.MLXTestCase):
         out = fun(*inputs)
         self.assertTrue(mx.allclose(out, mx.full((2, 2), 20)))
 
+    def test_compile_shapeless_with_reshape(self):
+        def fun(a):
+            return mx.reshape(a, (4, 7, 4, 2))
+
+        cfun = mx.compile(fun, shapeless=True)
+
+        a = mx.zeros((4, 7, 8))
+
+        with self.assertRaises(ValueError):
+            b = cfun(a)
+
+        def fun(a):
+            return mx.dynamic_reshape(a, ("B", "L", 4, 2))
+
+        cfun = mx.compile(fun, shapeless=True)
+
+        b = cfun(a)
+        self.assertEqual(b.shape, (4, 7, 4, 2))
+
+        a = mx.zeros((4, 9, 8))
+        b = cfun(a)
+        self.assertEqual(b.shape, (4, 9, 4, 2))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -2718,6 +2718,16 @@ class TestOps(mlx_tests.MLXTestCase):
         a = mx.dynamic_reshape(a, ())
         self.assertEqual(a.shape, ())
 
+        a = mx.zeros((4, 4, 4))
+        b = mx.dynamic_reshape(a, ("a", "b", "c"))
+        self.assertEqual(b.shape, (4, 4, 4))
+
+        b = mx.dynamic_reshape(a, ("a*b", "c"))
+        self.assertEqual(b.shape, (4 * 4, 4))
+
+        b = mx.dynamic_reshape(a, ("a*b*c", 1, 1))
+        self.assertEqual(b.shape, (4 * 4 * 4, 1, 1))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -2713,6 +2713,11 @@ class TestOps(mlx_tests.MLXTestCase):
         self.assertEqual(mx.imag(z).dtype, mx.float32)
         self.assertTrue(mx.array_equal(mx.imag(z), y))
 
+    def test_dynamic_reshape(self):
+        a = mx.array(1)[None, None]
+        a = mx.dynamic_reshape(a, ())
+        self.assertEqual(a.shape, ())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/ops_tests.cpp
+++ b/tests/ops_tests.cpp
@@ -3769,3 +3769,23 @@ TEST_CASE("test contiguous") {
   CHECK(x.flags().col_contiguous);
   CHECK_EQ(x.strides(), decltype(x.strides()){1, 2});
 }
+
+TEST_CASE("test dynamic reshape") {
+  auto x = array({1}, {1, 1, 1});
+  CHECK_EQ(dynamic_reshape(x, {}).shape(), Shape{});
+
+  // Bad character
+  CHECK_THROWS(dynamic_reshape(x, {"&", 1, 1}));
+
+  // No dim in string
+  CHECK_THROWS(dynamic_reshape(x, {"1", 1, 1}));
+
+  // Too many dims
+  CHECK_THROWS(dynamic_reshape(x, {"abcd", 1, 1}));
+
+  // Too many dims
+  CHECK_THROWS(dynamic_reshape(x, {"a", "b", "c", "d"}));
+
+  // Too many inferred dims
+  CHECK_THROWS(dynamic_reshape(x, {"a", -1, -1}));
+}


### PR DESCRIPTION
WIP/RFC on adding this so we can compile / export functions which use a reshape but have inputs which change shapes.

The idea being able to export something auto-regressive like an LLM which has a varying reshape in the attention layer (`L` changes based on the length of the prompt):

```python
queries = queries.reshape(B, L, self.n_heads, -1)
```

Here's an example of how it looks:

```python
def fun(a):
    return mx.dynamic_reshape(a, ("B", "L", 4, -1))

cfun = mx.compile(fun, shapeless=True)

b = cfun(a)
self.assertEqual(b.shape, (4, 7, 4, 2))

a = mx.zeros((4, 9, 8))
b = cfun(a)
self.assertEqual(b.shape, (4, 9, 4, 2))
```

The input to `dynamic_reshape` is `expressions` which is basically a sequence of expressions which can be `int` or `str`. Right now they are pretty basic but still cover every case I can think of. If it's an `int` it's static unless it's `-1` in which case it has the usual inference semantics. If it's a string expression then the dims get mapped in the order we encounter them. The expressions can also be things like:

- `a*b`  or `a*4`
- `a/2` and `2*b`
- `a*b*c`

Some more examples:

```python
a = mx.zeros((4, 4, 4))

# shape (4, 1, 4, 1, 4) but the 4's are dynamic (e.g. an expand dim without hardcoding shapes)
b = mx.dynamic_reshape(a, ("a", 1, "b", 1, "c"))

# shape (16, 4) but the 16 is dynamic
b = mx.dynamic_reshape(a, ("a*b", 4))

# shape 64  (e.g a dynamic flatten)
b = mx.dynamic_reshape(a, ("a*b*c"))

# shape (2, 8, 4) -> the 2 and 8 are dynamic, `a` has to be a multiple of 2
b = mx.dynamic_reshape(a, ("a/2", "2*b", 4))
```
