### PR TITLE
Download OpenBLAS binaries when building with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,11 +118,26 @@ if(MLX_BUILD_CPU)
   if(ACCELERATE_LIBRARY)
     message(STATUS "Accelerate found ${ACCELERATE_LIBRARY}")
     set(MLX_BUILD_ACCELERATE ON)
-    target_link_libraries(mlx PUBLIC ${ACCELERATE_LIBRARY})
-    add_compile_definitions(ACCELERATE_NEW_LAPACK)
   else()
     message(STATUS "Accelerate or arm neon not found, using default backend.")
     set(MLX_BUILD_ACCELERATE OFF)
+  endif()
+
+  if(MLX_BUILD_ACCELERATE)
+    target_link_libraries(mlx PUBLIC ${ACCELERATE_LIBRARY})
+    add_compile_definitions(ACCELERATE_NEW_LAPACK)
+  elseif(MSVC)
+    # Download prebuilt binaries when building with Visual Studio, as there is
+    # no package manager available.
+    FetchContent_Declare(
+      openblas
+      URL https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.28/OpenBLAS-0.3.28-x64.zip)
+    FetchContent_MakeAvailable(openblas)
+    target_link_libraries(
+      mlx PRIVATE "${openblas_SOURCE_DIR}/lib/libopenblas.a")
+    target_include_directories(
+      mlx PRIVATE "${openblas_SOURCE_DIR}/include")
+  else()
     if(${CMAKE_HOST_APPLE})
       # The blas shipped in macOS SDK is not supported, search homebrew for
       # openblas instead.
@@ -154,16 +169,22 @@ if(MLX_BUILD_CPU)
     message(STATUS "Blas include " ${BLAS_INCLUDE_DIRS})
     target_include_directories(mlx PRIVATE ${BLAS_INCLUDE_DIRS})
     target_link_libraries(mlx PUBLIC ${BLAS_LIBRARIES})
-
-    if(WIN32)
-      find_package(dlfcn-win32 REQUIRED)
-      message(STATUS "dlfcn-win32 lib " ${dlfcn-win32_LIBRARIES})
-      message(STATUS "dlfcn-win32 include " ${dlfcn-win32_INCLUDE_DIRS})
-      target_link_libraries(mlx PUBLIC ${dlfcn-win32_LIBRARIES})
-    endif()
   endif()
 else()
   set(MLX_BUILD_ACCELERATE OFF)
+endif()
+
+if(WIN32)
+  if(MSVC)
+    # GGUF does not build with MSVC.
+    set(MLX_BUILD_GGUF OFF)
+  else()
+    # Building with MinGW.
+    find_package(dlfcn-win32 REQUIRED)
+    message(STATUS "dlfcn-win32 lib " ${dlfcn-win32_LIBRARIES})
+    message(STATUS "dlfcn-win32 include " ${dlfcn-win32_INCLUDE_DIRS})
+    target_link_libraries(mlx PUBLIC ${dlfcn-win32_LIBRARIES})
+  endif()
 endif()
 
 find_package(MPI)


### PR DESCRIPTION
## Proposed changes

Refs https://github.com/ml-explore/mlx/issues/1513.

There is currently no distribution of OpenBLAS on Windows that can be found by `find_package`, this change makes CMake download and link with the official release on GitHub.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
