### PR TITLE
Work around MSVC error C2580

### DIFF
--- a/mlx/array.h
+++ b/mlx/array.h
@@ -67,7 +67,9 @@ class array {
   array& operator=(array&& other) && = delete;
 
   /** Default copy and move constructors otherwise. */
+#if !defined(_MSC_VER)
   array& operator=(array&& other) & = default;
+#endif
   array(const array& other) = default;
   array(array&& other) = default;
 


### PR DESCRIPTION
Refs https://github.com/ml-explore/mlx/issues/1513.

It seems to be a bug of MSVC that it can not distinguish between:

```c++
  array& operator=(array&& other) && = delete;
  array& operator=(array&& other) & = default;
```

and gives error:

```
C:\cygwin\home\zcbenz\codes\mlx\mlx/array.h(70,10): error C2580: 'mlx::core::array
 &mlx::core::array::operator =(mlx::core::array &&) &': multiple versions of a def
aulted special member functions are not allowed [C:\cygwin\home\zcbenz\codes\mlx\b
uild\mlx.vcxproj]
```
