### PR TITLE
Use correct complex type for MSVC

### DIFF
--- a/mlx/backend/common/lapack.h
+++ b/mlx/backend/common/lapack.h
@@ -2,6 +2,15 @@
 
 #pragma once
 
+// Required for Visual Studio.
+// https://github.com/OpenMathLib/OpenBLAS/blob/develop/docs/install.md
+#ifdef _MSC_VER
+#include <complex>
+#define LAPACK_COMPLEX_CUSTOM
+#define lapack_complex_float std::complex<float>
+#define lapack_complex_double std::complex<double>
+#endif
+
 #ifdef ACCELERATE_NEW_LAPACK
 #include <Accelerate/Accelerate.h>
 #else


### PR DESCRIPTION
Refs https://github.com/ml-explore/mlx/issues/1513.

OpenBLAS's default define for complex type does not compile on MSVC, check the "Change in complex types for Visual Studio 2017 and up" in its document:
https://github.com/OpenMathLib/OpenBLAS/blob/develop/docs/install.md