### PR TITLE
Use && instead of and

### DIFF
--- a/mlx/fast.cpp
+++ b/mlx/fast.cpp
@@ -533,7 +533,7 @@ array scaled_dot_product_attention(
       throw std::invalid_argument(msg.str());
     }
   }
-  if (mask and (*mask).ndim() > 4) {
+  if (mask && (*mask).ndim() > 4) {
     std::ostringstream msg;
     msg << "[scaled_dot_product_attention] the mask with shape "
         << (*mask).shape() << " expected to have at most rank 4";

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -808,7 +808,7 @@ std::vector<array> meshgrid(
     outputs.push_back(reshape(arrays[i], std::move(shape), s));
   }
 
-  if (indexing == "xy" and ndim > 1) {
+  if (indexing == "xy" && ndim > 1) {
     Shape shape(ndim, 1);
 
     shape[1] = arrays[0].size();


### PR DESCRIPTION
Refs https://github.com/ml-explore/mlx/issues/1513.

It is in C++ spec but unfortunately MSVC takes it as error.