### PR TITLE
Do not pass integers to isnan

### DIFF
--- a/mlx/backend/common/ops.h
+++ b/mlx/backend/common/ops.h
@@ -500,7 +500,12 @@ struct Equal {
 struct NaNEqual {
   template <typename T>
   bool operator()(T x, T y) {
-    return x == y || (std::isnan(x) && std::isnan(y));
+    if constexpr (std::is_integral_v<T>) {
+      // isnan always returns false for integers, and MSVC refuses to compile.
+      return x == y;
+    } else {
+      return x == y || (std::isnan(x) && std::isnan(y));
+    }
   }
 };
 


### PR DESCRIPTION
Refs https://github.com/ml-explore/mlx/issues/1513.

Passing integers to isnan is a compilation error in MSVC, see also https://stackoverflow.com/questions/61646166/how-to-resolve-fpclassify-ambiguous-call-to-overloaded-function.