### PR TITLE
Metal-cpp version bump

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ elseif(MLX_BUILD_METAL)
   message(STATUS "Building with macOS SDK version ${MACOS_SDK_VERSION}")
 
   set(METAL_CPP_URL
-      https://developer.apple.com/metal/cpp/files/metal-cpp_macOS15_iOS18-beta.zip
+      https://developer.apple.com/metal/cpp/files/metal-cpp_macOS15_iOS18.zip
   )
 
   if(NOT CMAKE_OSX_DEPLOYMENT_TARGET STREQUAL "")


### PR DESCRIPTION
Apple has released the stable version of Metal-cpp for macOS 15 and iOS 18. CMakeLists.txt is updated to build with it instead of the beta one.
