### PR TITLE
Convert filesystem path to std::string explicitly

### DIFF
--- a/tests/load_tests.cpp
+++ b/tests/load_tests.cpp
@@ -11,7 +11,7 @@
 using namespace mlx::core;
 
 std::string get_temp_file(const std::string& name) {
-  return std::filesystem::temp_directory_path().append(name);
+  return std::filesystem::temp_directory_path().append(name).string();
 }
 
 TEST_CASE("test save_safetensors") {


### PR DESCRIPTION
Refs https://github.com/ml-explore/mlx/issues/1513.

The `std::filesystem::path` can not be silently converted to `std::string` on Windows because the native path uses a different char type.