### PR TITLE
Use int64_t instead of ssize_t

### DIFF
--- a/mlx/utils.h
+++ b/mlx/utils.h
@@ -70,7 +70,7 @@ bool is_same_shape(const std::vector<array>& arrays);
 template <typename T>
 int check_shape_dim(const T dim) {
   constexpr bool is_signed = std::numeric_limits<T>::is_signed;
-  using U = std::conditional_t<is_signed, ssize_t, size_t>;
+  using U = std::conditional_t<is_signed, int64_t, size_t>;
   constexpr U min = static_cast<U>(std::numeric_limits<int>::min());
   constexpr U max = static_cast<U>(std::numeric_limits<int>::max());
 

--- a/tests/utils_tests.cpp
+++ b/tests/utils_tests.cpp
@@ -67,15 +67,15 @@ TEST_CASE("test check shape dimension") {
   CHECK_EQ(check_shape_dim(-4), -4);
   CHECK_EQ(check_shape_dim(0), 0);
   CHECK_EQ(check_shape_dim(12), 12);
-  CHECK_EQ(check_shape_dim(static_cast<ssize_t>(dim_min)), dim_min);
-  CHECK_EQ(check_shape_dim(static_cast<ssize_t>(dim_max)), dim_max);
+  CHECK_EQ(check_shape_dim(static_cast<int64_t>(dim_min)), dim_min);
+  CHECK_EQ(check_shape_dim(static_cast<int64_t>(dim_max)), dim_max);
   CHECK_EQ(check_shape_dim(static_cast<size_t>(0)), 0);
   CHECK_EQ(check_shape_dim(static_cast<size_t>(dim_max)), dim_max);
   CHECK_THROWS_AS(
-      check_shape_dim(static_cast<ssize_t>(dim_min) - 1),
+      check_shape_dim(static_cast<int64_t>(dim_min) - 1),
       std::invalid_argument);
   CHECK_THROWS_AS(
-      check_shape_dim(static_cast<ssize_t>(dim_max) + 1),
+      check_shape_dim(static_cast<int64_t>(dim_max) + 1),
       std::invalid_argument);
   CHECK_THROWS_AS(
       check_shape_dim(static_cast<size_t>(dim_max) + 1), std::invalid_argument);


### PR DESCRIPTION
Refs https://github.com/ml-explore/mlx/issues/1513.

`ssize_t` is a POSIX type and not available in MSVC, I think `int64_t` should do the same.