### PR TITLE
Use Py_ssize_t in python bindings

### DIFF
--- a/python/src/buffer.h
+++ b/python/src/buffer.h
@@ -56,13 +56,13 @@ std::string buffer_format(const array& a) {
 
 struct buffer_info {
   std::string format;
-  std::vector<ssize_t> shape;
-  std::vector<ssize_t> strides;
+  std::vector<Py_ssize_t> shape;
+  std::vector<Py_ssize_t> strides;
 
   buffer_info(
       std::string format,
-      std::vector<ssize_t> shape_in,
-      std::vector<ssize_t> strides_in)
+      std::vector<Py_ssize_t> shape_in,
+      std::vector<Py_ssize_t> strides_in)
       : format(std::move(format)),
         shape(std::move(shape_in)),
         strides(std::move(strides_in)) {}
@@ -91,8 +91,8 @@ extern "C" inline int getbuffer(PyObject* obj, Py_buffer* view, int flags) {
     a.eval();
   }
 
-  std::vector<ssize_t> shape(a.shape().begin(), a.shape().end());
-  std::vector<ssize_t> strides(a.strides().begin(), a.strides().end());
+  std::vector<Py_ssize_t> shape(a.shape().begin(), a.shape().end());
+  std::vector<Py_ssize_t> strides(a.strides().begin(), a.strides().end());
   for (auto& s : strides) {
     s *= a.itemsize();
   }

--- a/python/src/indexing.cpp
+++ b/python/src/indexing.cpp
@@ -603,7 +603,7 @@ std::tuple<std::vector<array>, array, std::vector<int>> mlx_scatter_args_nd(
   }
 
   // Analyse the types of the indices
-  unsigned long max_dim = 0;
+  size_t max_dim = 0;
   bool arrays_first = false;
   int num_none = 0;
   int num_slices = 0;


### PR DESCRIPTION
Refs https://github.com/ml-explore/mlx/issues/1513.

Same with https://github.com/ml-explore/mlx/pull/1673 that the use of `ssize_t` has to be replaced. In this PR I use `Py_ssize_t ` instead since they are going to be assigned to `Py_buffer` and other types do not compile.

This PR also includes a tiny fix that too small to be a separate PR.