### PR TITLE
Work around function std name collision in MSVC

### DIFF
--- a/mlx/mlx.h
+++ b/mlx/mlx.h
@@ -13,7 +13,7 @@
 #include "mlx/fft.h"
 #include "mlx/io.h"
 #include "mlx/linalg.h"
-#include "mlx/ops.h"
+#include "mlx/ops_public.h"
 #include "mlx/random.h"
 #include "mlx/stream.h"
 #include "mlx/transforms.h"

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -1704,17 +1704,17 @@ array var(
   return var(a, std::vector<int>{axis}, keepdims, ddof, to_stream(s));
 }
 
-array std(
+array std_dev(
     const array& a,
     bool keepdims,
     int ddof /* = 0*/,
     StreamOrDevice s /* = {}*/) {
   std::vector<int> axes(a.ndim());
   std::iota(axes.begin(), axes.end(), 0);
-  return std(a, axes, keepdims, ddof, to_stream(s));
+  return std_dev(a, axes, keepdims, ddof, to_stream(s));
 }
 
-array std(
+array std_dev(
     const array& a,
     const std::vector<int>& axes,
     bool keepdims /* = false */,
@@ -1723,13 +1723,13 @@ array std(
   return sqrt(var(a, axes, keepdims, ddof, s), s);
 }
 
-array std(
+array std_dev(
     const array& a,
     int axis,
     bool keepdims /* = false */,
     int ddof /* = 0*/,
     StreamOrDevice s /* = {} */) {
-  return std(a, std::vector<int>{axis}, keepdims, ddof, to_stream(s));
+  return std_dev(a, std::vector<int>{axis}, keepdims, ddof, to_stream(s));
 }
 
 array prod(const array& a, bool keepdims, StreamOrDevice s /* = {}*/) {

--- a/mlx/ops.h
+++ b/mlx/ops.h
@@ -543,14 +543,18 @@ array var(
     StreamOrDevice s = {});
 
 /** Computes the standard deviation of the elements of an array. */
-array std(const array& a, bool keepdims, int ddof = 0, StreamOrDevice s = {});
-inline array std(const array& a, StreamOrDevice s = {}) {
-  return std(a, false, 0, to_stream(s));
+array std_dev(
+    const array& a,
+    bool keepdims,
+    int ddof = 0,
+    StreamOrDevice s = {});
+inline array std_dev(const array& a, StreamOrDevice s = {}) {
+  return std_dev(a, false, 0, to_stream(s));
 }
 
 /** Computes the standard deviatoin of the elements of an array along the given
  * axes */
-array std(
+array std_dev(
     const array& a,
     const std::vector<int>& axes,
     bool keepdims = false,
@@ -559,7 +563,7 @@ array std(
 
 /** Computes the standard deviation of the elements of an array along the given
  * axis */
-array std(
+array std_dev(
     const array& a,
     int axis,
     bool keepdims = false,

--- a/mlx/ops_public.h
+++ b/mlx/ops_public.h
@@ -6,8 +6,13 @@
 
 namespace mlx::core {
 
+// The "std" function has a name collision with "namespace std" in MSVC after
+// "using namespace mlx::core", to work around it in our python bindings code
+// we use "std_dev" as name instead and only expose the "std" function in
+// public header.
 template <typename... Args>
 inline array std(Args&&... args) {
   return std_dev(std::forward<Args>(args)...);
 }
+
 } // namespace mlx::core

--- a/mlx/ops_public.h
+++ b/mlx/ops_public.h
@@ -1,0 +1,13 @@
+// Copyright © 2023-2024 Apple Inc.
+
+#pragma once
+
+#include "mlx/ops.h"
+
+namespace mlx::core {
+
+template <typename... Args>
+inline array std(Args&&... args) {
+  return std_dev(std::forward<Args>(args)...);
+}
+} // namespace mlx::core

--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -1132,7 +1132,7 @@ void init_array(nb::module_& m) {
              bool keepdims,
              int ddof,
              StreamOrDevice s) {
-            return mlx::core::std(
+            return std_dev(
                 a, get_reduce_axes(axis, a.ndim()), keepdims, ddof, s);
           },
           "axis"_a = nb::none(),

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -2384,7 +2384,7 @@ void init_ops(nb::module_& m) {
          bool keepdims,
          int ddof,
          StreamOrDevice s) {
-        return mlx::core::std(
+        return std_dev(
             a, get_reduce_axes(axis, a.ndim()), keepdims, ddof, s);
       },
       nb::arg(),


### PR DESCRIPTION
Refs https://github.com/ml-explore/mlx/issues/1513.

There is a bug in MSVC that, if the `std` function is exposed to current scope with `using namespace mlx::core`, all following `std::xxx` invocations that try to access the `namespace std` will fail with very unhelpful errors:

```
C:\cygwin\home\zcbenz\codes\mlx\python\src\array.cpp(28,18): error C2874: using-de
claration causes a multiple declaration of 'std' [C:\cygwin\home\zcbenz\codes\mlx\
build\temp.win-amd64-cpython-311\Release\mlx.core\python\src\core.vcxproj]
      C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.42.
  34433\include\numeric(22,1):
      see declaration of 'std'
C:\Users\zcbenz\AppData\Roaming\Python\Python311\site-packages\nanobind\include\na
nobind\nb_cast.h(160,27): error C2872: 'std': ambiguous symbol [C:\cygwin\home\zcb
enz\codes\mlx\build\temp.win-amd64-cpython-311\Release\mlx.core\python\src\core.vc
xproj]
  (compiling source file '../../../../../../python/src/convert.cpp')
      C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.42.
  34433\include\numeric(22,1):
      could be 'std'
      C:\Users\zcbenz\AppData\Roaming\Python\Python311\site-packages\nanobind\incl
  ude\nanobind\nb_cast.h(160,27):
      or       'std'
```

(MSVC thinks `std::` is ambiguous.)

There are 2 solutions, one taken by this PR is to rename the `std` function to `std_dev` and use it internally, while adding a `std` alias only available in public `mlx.h` header. It makes minimum changes to existing code with the cost of adding a new header.

The other solution would be replacing the `using namespace mlx::core` with `namespace mx = mlx::core` and use `mx::xxx()` instead of `xxx()` in the python bindings code. I prefer this one but it would result in a relatively large PR.