### PR TITLE
Disable MSVC warnings

### DIFF
--- a/mlx/CMakeLists.txt
+++ b/mlx/CMakeLists.txt
@@ -18,6 +18,11 @@ target_sources(
           ${CMAKE_CURRENT_SOURCE_DIR}/linalg.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/backend/metal/metal.h)
 
+if(MSVC)
+  # Disable some MSVC warnings to speed up compilation.
+  target_compile_options(mlx PUBLIC /wd4068 /wd4244 /wd4267 /wd4804)
+endif()
+
 if(MLX_BUILD_CPU)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/backend/common)
 else()


### PR DESCRIPTION
Refs https://github.com/ml-explore/mlx/issues/1513.

Disable MSVC warnings about unknown pragmas and conversions between different types.

While generally we should leave the warnings on but most files have a dozen of warnings and it slowed compilation a lot and hid important messages. Let's just turn them off for now.