### PR TITLE
Use a fork of gguf-tools to make it work on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,8 +115,6 @@ endif()
 
 if(WIN32)
   if(MSVC)
-    # GGUF does not build with MSVC.
-    set(MLX_BUILD_GGUF OFF)
     # There is no prebuilt OpenBLAS distribution for MSVC.
     set(MLX_BUILD_BLAS_FROM_SOURCE ON)
   endif()

--- a/mlx/io/CMakeLists.txt
+++ b/mlx/io/CMakeLists.txt
@@ -17,14 +17,10 @@ if(MLX_BUILD_GGUF)
   message(STATUS "Downloading gguflib")
   FetchContent_Declare(
     gguflib
-    GIT_REPOSITORY https://github.com/antirez/gguf-tools/
-    GIT_TAG af7d88d808a7608a33723fba067036202910acb3)
+    GIT_REPOSITORY https://github.com/frost-beta/gguf-tools.git
+    GIT_TAG a8001a0a6603a4f6a833678e5854f0e18332518d)
   FetchContent_MakeAvailable(gguflib)
-  target_include_directories(mlx
-                             PRIVATE $<BUILD_INTERFACE:${gguflib_SOURCE_DIR}>)
-  add_library(gguflib STATIC ${gguflib_SOURCE_DIR}/fp16.c
-                             ${gguflib_SOURCE_DIR}/gguflib.c)
-  target_link_libraries(mlx PRIVATE $<BUILD_INTERFACE:gguflib>)
+  target_link_libraries(mlx PRIVATE gguflib)
   target_sources(mlx PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/gguf.cpp
                              ${CMAKE_CURRENT_SOURCE_DIR}/gguf_quants.cpp)
 else()

--- a/mlx/io/gguf.cpp
+++ b/mlx/io/gguf.cpp
@@ -242,9 +242,9 @@ GGUFLoad load_gguf(const std::string& file, StreamOrDevice s) {
   }
 
   std::unique_ptr<gguf_ctx, decltype(&gguf_close)> ctx(
-      gguf_open(file.data()), gguf_close);
+      gguf_open(file.data(), O_RDONLY | O_BINARY), gguf_close);
   if (!ctx) {
-    throw std::runtime_error("[load_gguf] gguf_init failed");
+    throw std::runtime_error("[load_gguf] gguf_open failed");
   }
   auto metadata = load_metadata(ctx.get());
   auto arrays = load_arrays(ctx.get());
@@ -434,7 +434,7 @@ void save_gguf(
     const char* tensorname = key.c_str();
     const uint64_t namelen = key.length();
     const uint32_t num_dim = arr.ndim();
-    uint64_t dim[num_dim];
+    std::vector<uint64_t> dim(num_dim);
     for (int i = 0; i < num_dim; i++) {
       dim[i] = arr.shape()[num_dim - 1 - i];
     }
@@ -443,7 +443,7 @@ void save_gguf(
             tensorname,
             namelen,
             num_dim,
-            dim,
+            dim.data(),
             gguf_type.value(),
             tensor_offset)) {
       throw std::runtime_error("[save_gguf] gguf_append_tensor_info failed");


### PR DESCRIPTION
Refs https://github.com/ml-explore/mlx/issues/1513.

https://github.com/antirez/gguf-tools is not being maintained, valid pull requests are left there months without getting a reply. Making gguf-tools work on Windows is not hard but with current state I can't get my work merged to upstream, so I think using a forked repo should be reasonable for now, and I can always try to merge things back once the upstream is alive.

My changes to gguf-tools are in https://github.com/frost-beta/gguf-tools/commits/main/, with a bonus side effect to fix https://github.com/antirez/gguf-tools/issues/18, a MLX issue I was surprised to find out.