### PR TITLE
io/load: Enabled pread implementation for mingw32

### DIFF
--- a/mlx/io/load.cpp
+++ b/mlx/io/load.cpp
@@ -6,9 +6,11 @@
 #include <sstream>
 
 // Used by pread implementation.
+#ifdef _WIN32
+#include <windows.h>
+#endif
 #ifdef _MSC_VER
 #define NOMINMAX
-#include <windows.h>
 #endif
 
 #include "mlx/io/load.h"
@@ -106,7 +108,7 @@ Dtype dtype_from_array_protocol(std::string_view t) {
       "[from_str] Invalid array protocol type-string: " + std::string(t));
 }
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 // There is no pread on Windows, emulate it with ReadFile.
 int64_t pread(int fd, void* buf, uint64_t size, uint64_t offset) {
   HANDLE file = reinterpret_cast<HANDLE>(_get_osfhandle(fd));


### PR DESCRIPTION
## Proposed changes

Enables `pread` implementation  #1666 for mingw32.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
