### PR TITLE
add cubic to type hinting for upsample

### DIFF
--- a/python/mlx/nn/layers/upsample.py
+++ b/python/mlx/nn/layers/upsample.py
@@ -219,7 +219,7 @@ class Upsample(Module):
     def __init__(
         self,
         scale_factor: Union[float, Tuple],
-        mode: Literal["nearest", "linear"] = "nearest",
+        mode: Literal["nearest", "linear", "cubic"] = "nearest",
         align_corners: bool = False,
     ):
         super().__init__()


### PR DESCRIPTION
## Proposed changes

`"cubic"` missing in type-hinting of `mode` parameter in `Upsample`

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
