### PR TITLE
Shapeless slice update and broadcast when possible

### DIFF
--- a/mlx/backend/metal/slicing.cpp
+++ b/mlx/backend/metal/slicing.cpp
@@ -14,7 +14,7 @@ void slice_gpu(
     const Shape& start_indices,
     const Shape& strides,
     const Stream& s) {
-  // Calculate out strides, initial offset and if copy needs to be made
+  // Calculate out strides and initial offset
   auto [data_offset, inp_strides] = prepare_slice(in, start_indices, strides);
 
   size_t data_end = 1;

--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -740,6 +740,13 @@ bool Broadcast::is_equivalent(const Primitive& other) const {
   return shape_ == b_other.shape_;
 }
 
+std::vector<Shape> Broadcast::output_shapes(const std::vector<array>& inputs) {
+  if (broadcast_shapes(inputs[0].shape(), shape_) != shape_) {
+    throw std::invalid_argument("[Broadcast] Unable to infer broadcast shape");
+  }
+  return {shape_};
+}
+
 std::vector<array> Ceil::vjp(
     const std::vector<array>& primals,
     const std::vector<array>& cotangents,
@@ -3585,63 +3592,9 @@ std::vector<array> Slice::vjp(
     const std::vector<array>&) {
   // Check inputs
   assert(primals.size() == 1);
-
-  std::vector<array> inds;
-  std::vector<int> ind_axes;
-  std::vector<array> single_inds;
-  std::vector<int> single_ind_axes;
-  for (int i = 0; i < start_indices_.size(); ++i) {
-    auto start = start_indices_[i];
-    auto end = end_indices_[i];
-    auto stride = strides_[i];
-    if (start == 0 && stride == 1) {
-      continue;
-    }
-    if (stride == 1) {
-      single_inds.push_back(array(start));
-      single_ind_axes.push_back(i);
-    } else {
-      inds.push_back(arange(start, end, stride, stream()));
-      ind_axes.push_back(i);
-    }
-  }
-
-  // Transpose and reshape cotangents
-  auto cotan = cotangents[0];
-  if (!ind_axes.empty()) {
-    Shape cotan_shape;
-    for (auto ax : ind_axes) {
-      cotan_shape.push_back(cotan.shape(ax));
-    }
-    std::vector<int> cotan_axes(ind_axes);
-    for (int j = 0, i = 0; i < cotan.ndim(); ++i) {
-      if (j < ind_axes.size() && ind_axes[j] == i) {
-        cotan_shape.push_back(1);
-        j++;
-      } else {
-        cotan_shape.push_back(cotan.shape(i));
-        cotan_axes.push_back(i);
-      }
-    }
-    cotan =
-        reshape(transpose(cotan, cotan_axes, stream()), cotan_shape, stream());
-  }
-
-  // Make indices broadcastable
-  Shape inds_shape(inds.size(), 1);
-  for (int i = 0; i < inds.size(); ++i) {
-    inds_shape[i] = inds[i].size();
-    inds[i] = reshape(inds[i], inds_shape, stream());
-    inds_shape[i] = 1;
-  }
-
-  // Concatenate all the indices and axes
-  inds.insert(inds.end(), single_inds.begin(), single_inds.end());
-  ind_axes.insert(
-      ind_axes.end(), single_ind_axes.begin(), single_ind_axes.end());
-
-  return {scatter_add(
-      zeros_like(primals[0], stream()), inds, cotan, ind_axes, stream())};
+  auto out = zeros_like(primals[0], stream());
+  return {slice_update(
+      out, cotangents[0], start_indices_, end_indices_, strides_, stream())};
 }
 
 std::vector<array> Slice::jvp(

--- a/mlx/primitives.h
+++ b/mlx/primitives.h
@@ -533,6 +533,8 @@ class Broadcast : public UnaryPrimitive {
   DEFINE_PRINT(Broadcast)
   bool is_equivalent(const Primitive& other) const override;
 
+  std::vector<Shape> output_shapes(const std::vector<array>& inputs) override;
+
  private:
   Shape shape_;
 
@@ -1943,6 +1945,7 @@ class SliceUpdate : public UnaryPrimitive {
   DEFINE_GRADS()
   DEFINE_PRINT(SliceUpdate)
   bool is_equivalent(const Primitive& other) const override;
+  DEFINE_INPUT_OUTPUT_SHAPE()
 
  private:
   Shape start_indices_;

--- a/python/tests/test_compile.py
+++ b/python/tests/test_compile.py
@@ -817,6 +817,19 @@ class TestCompile(mlx_tests.MLXTestCase):
         fun = mx.compile(lambda a, b: a @ b, shapeless=True)
         self.assertTrue(mx.allclose(fun(a, b), a @ b))
 
+    def test_shapeless_compile_slice_update(self):
+        def fun(x):
+            x[2] = mx.array([3.0])
+            return x
+
+        cfun = mx.compile(fun, shapeless=True)
+
+        a = mx.array([0.0, 1.0, 2.0, 3.0])
+        self.assertTrue(mx.allclose(cfun(a), fun(a)))
+
+        a = mx.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        self.assertTrue(mx.allclose(cfun(a), fun(a)))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- Allow slice update to be shapeless since we know it's output shape
- Allow broadcast to be shapeless when possible and throw an error if it's not possible: (condition is `broadcast_shapes(in.shape(), shape) == shape`)
- Remove redundant shapeless condition + checks. The shapeless validation was a redundant run-time check. The compiled function will already throw if a primitive does not have a shape inference implemented (e.g. `output_shapes`) so there was really no need for that extra check.
- `a[0] = x` uses slice update instead of scatter
- Simplify + speedup `slice::vjp` by using `slice_update` instead of scatter