### PR TITLE
Fix Distributed Communication documentation (correct usage of `mx.distributed.init().size()` in `all_reduce_grads`)

### DIFF
--- a/docs/src/usage/distributed.rst
+++ b/docs/src/usage/distributed.rst
@@ -131,7 +131,8 @@ have to :func:`mlx.utils.tree_map` the gradients with following function.
 .. code:: python
 
     def all_avg(x):
-        return mx.distributed.all_sum(x) / mx.distributed.init().size()
+        N = mx.distributed.init().size()
+        return mx.distributed.all_sum(x) / N
 
 Putting everything together our training loop step looks as follows with
 everything else remaining the same.
@@ -141,12 +142,13 @@ everything else remaining the same.
     from mlx.utils import tree_map
 
     def all_reduce_grads(grads):
-        N = mx.distributed.init()
+        N = mx.distributed.init().size()
         if N == 1:
             return grads
         return tree_map(
-                lambda x: mx.distributed.all_sum(x) / N,
-                grads)
+            lambda x: mx.distributed.all_sum(x) / N,
+            grads
+        )
 
     def step(model, x, y):
         loss, grads = loss_grad_fn(model, x, y)

--- a/docs/src/usage/distributed.rst
+++ b/docs/src/usage/distributed.rst
@@ -131,8 +131,7 @@ have to :func:`mlx.utils.tree_map` the gradients with following function.
 .. code:: python
 
     def all_avg(x):
-        N = mx.distributed.init().size()
-        return mx.distributed.all_sum(x) / N
+        return mx.distributed.all_sum(x) / mx.distributed.init().size()
 
 Putting everything together our training loop step looks as follows with
 everything else remaining the same.


### PR DESCRIPTION
## Proposed changes

This fix updates the Distributed Communication documentation to reflect the correct usage of `mx.distributed.init().size()` in the `all_reduce_grads` function. The previous implementation incorrectly assumed `mx.distributed.init()` directly provided the number of processes.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
