### PR TITLE
Explicit parentheses around some logical operators

### DIFF
--- a/mlx/array.cpp
+++ b/mlx/array.cpp
@@ -119,7 +119,7 @@ void array::eval() {
 }
 
 bool array::is_tracer() const {
-    return (array_desc_->is_tracer && in_tracing()) || retain_graph();
+  return (array_desc_->is_tracer && in_tracing()) || retain_graph();
 }
 
 void array::set_data(allocator::Buffer buffer, Deleter d) {

--- a/mlx/array.cpp
+++ b/mlx/array.cpp
@@ -119,7 +119,7 @@ void array::eval() {
 }
 
 bool array::is_tracer() const {
-  return array_desc_->is_tracer && in_tracing() || retain_graph();
+    return (array_desc_->is_tracer && in_tracing()) || retain_graph();
 }
 
 void array::set_data(allocator::Buffer buffer, Deleter d) {

--- a/mlx/backend/common/binary.h
+++ b/mlx/backend/common/binary.h
@@ -28,8 +28,8 @@ BinaryOpType get_binary_op_type(const array& a, const array& b) {
   } else if (b.data_size() == 1 && a.flags().contiguous) {
     bopt = BinaryOpType::VectorScalar;
   } else if (
-      a.flags().row_contiguous && b.flags().row_contiguous ||
-      a.flags().col_contiguous && b.flags().col_contiguous) {
+      (a.flags().row_contiguous && b.flags().row_contiguous) ||
+      (a.flags().col_contiguous && b.flags().col_contiguous)) {
     bopt = BinaryOpType::VectorVector;
   } else {
     bopt = BinaryOpType::General;

--- a/mlx/backend/common/primitives.cpp
+++ b/mlx/backend/common/primitives.cpp
@@ -605,7 +605,7 @@ void View::eval_cpu(const std::vector<array>& inputs, array& out) {
   // - type size is the same
   // - type size is smaller and the last axis is contiguous
   // - the entire array is row contiguous
-    if (ibytes == obytes || (obytes < ibytes && in.strides().back() == 1) ||
+  if (ibytes == obytes || (obytes < ibytes && in.strides().back() == 1) ||
       in.flags().row_contiguous) {
     auto strides = in.strides();
     for (int i = 0; i < static_cast<int>(strides.size()) - 1; ++i) {

--- a/mlx/backend/common/primitives.cpp
+++ b/mlx/backend/common/primitives.cpp
@@ -605,7 +605,7 @@ void View::eval_cpu(const std::vector<array>& inputs, array& out) {
   // - type size is the same
   // - type size is smaller and the last axis is contiguous
   // - the entire array is row contiguous
-  if (ibytes == obytes || obytes < ibytes && in.strides().back() == 1 ||
+    if (ibytes == obytes || (obytes < ibytes && in.strides().back() == 1) ||
       in.flags().row_contiguous) {
     auto strides = in.strides();
     for (int i = 0; i < static_cast<int>(strides.size()) - 1; ++i) {

--- a/mlx/backend/metal/primitives.cpp
+++ b/mlx/backend/metal/primitives.cpp
@@ -440,7 +440,7 @@ void View::eval_gpu(const std::vector<array>& inputs, array& out) {
   // - type size is the same
   // - type size is smaller and the last axis is contiguous
   // - the entire array is row contiguous
-    if (ibytes == obytes || (obytes < ibytes && in.strides().back() == 1) ||
+  if (ibytes == obytes || (obytes < ibytes && in.strides().back() == 1) ||
       in.flags().row_contiguous) {
     auto strides = in.strides();
     for (int i = 0; i < static_cast<int>(strides.size()) - 1; ++i) {

--- a/mlx/backend/metal/primitives.cpp
+++ b/mlx/backend/metal/primitives.cpp
@@ -440,7 +440,7 @@ void View::eval_gpu(const std::vector<array>& inputs, array& out) {
   // - type size is the same
   // - type size is smaller and the last axis is contiguous
   // - the entire array is row contiguous
-  if (ibytes == obytes || obytes < ibytes && in.strides().back() == 1 ||
+    if (ibytes == obytes || (obytes < ibytes && in.strides().back() == 1) ||
       in.flags().row_contiguous) {
     auto strides = in.strides();
     for (int i = 0; i < static_cast<int>(strides.size()) - 1; ++i) {

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -157,7 +157,7 @@ array arange(
   // Check if start and stop specify a valid range because if not, we have to
   // return an empty array
   if (std::isinf(step) &&
-      (step > 0 && start < stop || step < 0 && start > stop)) {
+      ((step > 0 && start < stop) || (step < 0 && start > stop))) {
     return array({start}, dtype);
   }
 


### PR DESCRIPTION
## Proposed changes

This minor change is here to satisfy my warning flags ([`-Wlogical-op-parentheses`](https://clang.llvm.org/docs/DiagnosticsReference.html#wlogical-op-parentheses)) which recommend making the priority between `&&` and `||` explicit with parentheses. The change is just cosmetic and does not alter the behavior, but it makes it a bit more explicit which operator gets evaluated in which order. 

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes

