### PR TITLE
Fix export.cpp compilation with MSVC

### DIFF
--- a/mlx/export.cpp
+++ b/mlx/export.cpp
@@ -9,17 +9,13 @@
 #define TOSTRING(x) STRINGIFY(x)
 
 // clang-format off
-#define SERIALIZE_PRIMITIVE(primitive, keys...)          \
-  {                                                      \
-    #primitive, {                                        \
-      [](Writer& os, const Primitive& p) {               \
-        serialize_primitive<primitive>(os, p);           \
-      },                                                 \
-      [](Reader& is, Stream s) {                         \
-        return deserialize_primitive<primitive>(is, s);  \
-      },                                                 \
-      {keys}                                             \
-    }                                                    \
+#define SERIALIZE_PRIMITIVE(primitive, ...)  \
+  {                                          \
+    #primitive, {                            \
+      serialize_primitive<primitive>,        \
+      deserialize_primitive<primitive>,      \
+      {__VA_ARGS__}                          \
+    }                                        \
   }
 // clang-format on
 

--- a/tests/export_import_tests.cpp
+++ b/tests/export_import_tests.cpp
@@ -13,7 +13,7 @@ using namespace mlx::core;
 
 namespace {
 std::string get_temp_file(const std::string& name) {
-  return std::filesystem::temp_directory_path().append(name);
+  return std::filesystem::temp_directory_path().append(name).string();
 }
 } // namespace
 


### PR DESCRIPTION
Compilation failed with `export.cpp(293,1): error C1061: compiler limit: blocks nested too deeply`, luckily it can be fixed by making code simpler.