### PR TITLE
Do not join threads on process exit

### DIFF
--- a/mlx/scheduler.cpp
+++ b/mlx/scheduler.cpp
@@ -56,8 +56,12 @@ namespace scheduler {
 
 /** A singleton scheduler to manage devices, streams, and task execution. */
 Scheduler& scheduler() {
-  static Scheduler scheduler;
-  return scheduler;
+  // By creating the |scheduler| on heap, the destructor of Scheduler will not
+  // be called on exit and stream threads will not be joined. This is because
+  // the threads may already be destroyed by OS (especially on Windows) during
+  // process exit.
+  static Scheduler* scheduler = new Scheduler;
+  return *scheduler;
 }
 
 } // namespace scheduler


### PR DESCRIPTION
On Windows the process hangs on exit after running some ops, after some debugging I found that it stuck at the `synchronize` call in `~StreamThread`, which was because the thread was already terminated by OS on process exit.

C++ does not seem to specify when threads are terminated during process exit, but at least on Windows the destructors of static objects are called after the stream threads get terminated, resulting in posting tasks in `~StreamThread` not working and thus the hang.

A simple fix is to just let the OS collect the threads, i.e. what this PR does. If you prefer a clean exit, we can have the language bindings destroy the `Schedule` in their exit handlers, which are called before the actual process exit.