### PR TITLE
Shapeless compile in docs and partially shapeless reshape

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -363,41 +363,12 @@ array reshape(const array& a, Shape shape, StreamOrDevice s /* = {} */) {
   if (a.shape() == shape) {
     return a;
   }
-
-  size_t size = 1;
-  int infer_idx = -1;
-  for (int i = 0; i < shape.size(); ++i) {
-    if (shape[i] == -1) {
-      if (infer_idx >= 0) {
-        throw std::invalid_argument(
-            "[reshape] Reshape can only infer one dimension.");
-      }
-      infer_idx = i;
-    } else {
-      size *= shape[i];
-    }
-  }
-
-  // Infer the shape
-  if (size > 0) {
-    if (infer_idx >= 0) {
-      shape[infer_idx] = a.size() / size;
-      size *= shape[infer_idx];
-    }
-  } else if (infer_idx >= 0) {
-    throw std::invalid_argument(
-        "[reshape] Cannot infer the shape of an empty array");
-  }
-
-  // Check that the reshaping is valid
-  if (a.size() != size) {
-    std::ostringstream msg;
-    msg << "[reshape] Cannot reshape array of size " << a.size()
-        << " into shape " << shape << ".";
-    throw std::invalid_argument(msg.str());
-  }
-  auto p = std::make_shared<Reshape>(to_stream(s), shape);
-  return array(std::move(shape), a.dtype(), std::move(p), {a});
+  auto out_shape = Reshape::output_shape(a, shape);
+  return array(
+      std::move(out_shape),
+      a.dtype(),
+      std::make_shared<Reshape>(to_stream(s), std::move(shape)),
+      {a});
 }
 
 array unflatten(

--- a/mlx/primitives.h
+++ b/mlx/primitives.h
@@ -1746,6 +1746,8 @@ class Reshape : public UnaryPrimitive {
   std::vector<int> state() const {
     return shape_;
   };
+  static Shape output_shape(const array& input, Shape shape);
+  std::vector<Shape> output_shapes(const std::vector<array>& inputs) override;
 
  private:
   Shape shape_;

--- a/python/tests/test_compile.py
+++ b/python/tests/test_compile.py
@@ -830,6 +830,25 @@ class TestCompile(mlx_tests.MLXTestCase):
         a = mx.array([0.0, 1.0, 2.0, 3.0, 4.0])
         self.assertTrue(mx.allclose(cfun(a), fun(a)))
 
+    def test_shapeless_compile_with_reshape(self):
+        def fun(x):
+            return x.reshape(x.shape[0] * x.shape[1], -1)
+
+        compiled_fun = mx.compile(fun, shapeless=True)
+
+        x = mx.zeros(shape=(2, 3, 4))
+        out = compiled_fun(x)
+        self.assertEqual(out.shape, (6, 4))
+
+        x = mx.zeros(shape=(2, 3, 8))
+        out = compiled_fun(x)
+        self.assertEqual(out.shape, (6, 8))
+
+        x = mx.zeros(shape=(5, 5, 5))
+
+        with self.assertRaises(ValueError):
+            compiled_fun(x)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/compile_tests.cpp
+++ b/tests/compile_tests.cpp
@@ -685,7 +685,8 @@ auto compile_shapeless_ok(const std::vector<array>& inputs) {
 TEST_CASE("test shapeless compile") {
   {
     auto cfun = compile(compile_shapeless_not_ok, /* shapeless */ true);
-    CHECK_THROWS(cfun({array({1, 2, 3, 4})}));
+    cfun({array({1, 2, 3, 4})});
+    CHECK_THROWS(cfun({array({1, 2, 3, 4, 5})}));
   }
 
   {


### PR DESCRIPTION
- Add a section on shapeless compilation in the compile usage guide
- Allow reshape to be shapeless when the inferred shape is valid