### PR TITLE
Transfer exceptions thrown in stream threads to main thread

### DIFF
--- a/mlx/array.cpp
+++ b/mlx/array.cpp
@@ -113,6 +113,8 @@ void array::eval() {
   // Ensure the array is ready to be read
   if (status() == Status::unscheduled) {
     mlx::core::eval({*this});
+  } else if (status() == Status::failure) {
+    throw *exception();
   } else {
     wait();
   }

--- a/mlx/array.h
+++ b/mlx/array.h
@@ -358,6 +358,9 @@ class array {
     // status of `x` in `auto x = a + b; eval(x);`
     scheduled,
 
+    // Exception was thrown when evaluating the array.
+    failure,
+
     // The array's `eval_*` function has been run, but the computation is not
     // necessarily complete. The array will have memory allocated and if it is
     // not a tracer then it will be detached from the graph.
@@ -400,6 +403,14 @@ class array {
   }
   // Check if the array is a tracer array
   bool is_tracer() const;
+
+  // Set and get the exception thrown when evaluating the array.
+  void set_exception(const std::runtime_error& e) {
+    array_desc_->exception = std::make_unique<std::runtime_error>(e);
+  }
+  std::runtime_error* exception() const {
+    return array_desc_->exception.get();
+  }
 
   void set_data(allocator::Buffer buffer, Deleter d = allocator::free);
 
@@ -474,6 +485,9 @@ class array {
     std::vector<array> siblings;
     // The arrays position in the output list
     uint32_t position{0};
+
+    // The exception thrown when evaluating the array.
+    std::unique_ptr<std::runtime_error> exception;
 
     explicit ArrayDesc(Shape shape, Dtype dtype);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,10 @@ target_sources(
           linalg_tests.cpp
           ${METAL_TEST_SOURCES})
 
+if(NOT MLX_BUILD_ACCELERATE)
+  target_sources(tests PRIVATE exception_tests.cpp)
+endif()
+
 target_link_libraries(tests PRIVATE mlx doctest)
 doctest_discover_tests(tests)
 add_test(NAME tests COMMAND tests)

--- a/tests/exception_tests.cpp
+++ b/tests/exception_tests.cpp
@@ -1,0 +1,31 @@
+// Copyright © 2025 Apple Inc.
+
+#include <numeric>
+
+#include "doctest/doctest.h"
+
+#include "mlx/mlx.h"
+
+using namespace mlx::core;
+
+TEST_CASE("test exception from eval_cpu") {
+  array a = ones({2, 4}, bfloat16);
+  array b = ones({4, 2}, bfloat16);
+  array out = matmul(a, b, Device::cpu);
+  CHECK_THROWS_WITH_AS(
+      eval(out),
+      "[Matmul::eval_cpu] Currently only supports float32.",
+      std::runtime_error);
+}
+
+TEST_CASE("test exception from array.eval") {
+  array a = ones({2, 4}, bfloat16);
+  array b = ones({4, 2}, bfloat16);
+  array out = matmul(a, b, Device::cpu);
+  async_eval(out);
+  synchronize();
+  CHECK_THROWS_WITH_AS(
+      out.eval(),
+      "[Matmul::eval_cpu] Currently only supports float32.",
+      std::runtime_error);
+}


### PR DESCRIPTION
This PR catches exceptions when evaluating arrays in stream threads, and re-throw them in the main thread.

With this change errors happened in array evaluation can be caught in language bindings as exceptions, rather than hard crashes. Which is especially valuable for Windows, where the uncaught C++ exceptions are not printed in console and even a compilation failure requires attaching a debugger to find out the error message.

A few uncertain things with this PR:

* Only `std::runtime_error` is caught, catching other types of exceptions requires recording the type information of exception which I think does not worth the efforts.
* The tests are using `matmul` to throw errors, is there a reliable way to throw errors on all platforms?
* A new `failure` status is added to array, I'm not certain if there are side effects.