### PR TITLE
Optionally specify names for arrays when exporting

### DIFF
--- a/mlx/graph_utils.cpp
+++ b/mlx/graph_utils.cpp
@@ -117,7 +117,8 @@ void export_to_dot(
       [&](const array& x) {
         if (!x.has_primitive()) {
           input_set.insert(x.id());
-          os << "{ rank=source; " << namer.get_name(x) << "; }" << std::endl;
+          os << "{ rank=source; \"" << namer.get_name(x) << "\"; }"
+             << std::endl;
           return;
         }
 
@@ -131,7 +132,8 @@ void export_to_dot(
           os << "; }" << std::endl;
           // Arrows to primitive's inputs
           for (auto& a : x.inputs()) {
-            os << namer.get_name(a) << " -> " << x.primitive_id() << std::endl;
+            os << '"' << namer.get_name(a) << "\" -> " << x.primitive_id()
+               << std::endl;
           }
         }
 
@@ -141,10 +143,11 @@ void export_to_dot(
           if (output_set.find(a.id()) != output_set.end()) {
             os << "rank=sink; ";
           }
-          os << namer.get_name(a);
-          os << "; }" << std::endl;
+          os << '"' << namer.get_name(a);
+          os << "\"; }" << std::endl;
           if (x.has_primitive()) {
-            os << x.primitive_id() << " -> " << namer.get_name(a) << std::endl;
+            os << x.primitive_id() << " -> \"" << namer.get_name(a) << '"'
+               << std::endl;
           }
         }
       },

--- a/mlx/graph_utils.cpp
+++ b/mlx/graph_utils.cpp
@@ -30,6 +30,10 @@ const std::string& NodeNamer::get_name(const array& x) {
   return it->second;
 }
 
+void NodeNamer::set_name(const array& x, std::string n) {
+  names[x.id()] = std::move(n);
+}
+
 void depth_first_traversal(
     std::function<void(array)> callback,
     const std::vector<array>& outputs) {
@@ -55,7 +59,10 @@ void depth_first_traversal(
   }
 }
 
-void print_graph(std::ostream& os, const std::vector<array>& outputs) {
+void print_graph(
+    std::ostream& os,
+    NodeNamer namer,
+    const std::vector<array>& outputs) {
   std::vector<array> tape;
   std::vector<array> inputs;
 
@@ -69,7 +76,6 @@ void print_graph(std::ostream& os, const std::vector<array>& outputs) {
       },
       outputs);
 
-  NodeNamer namer;
   auto print_arrs = [&namer, &os](std::vector<array> arrs) {
     for (auto& arr : arrs) {
       os << namer.get_name(arr);
@@ -96,7 +102,10 @@ void print_graph(std::ostream& os, const std::vector<array>& outputs) {
   }
 }
 
-void export_to_dot(std::ostream& os, const std::vector<array>& outputs) {
+void export_to_dot(
+    std::ostream& os,
+    NodeNamer namer,
+    const std::vector<array>& outputs) {
   os << "digraph {" << std::endl;
 
   std::unordered_set<std::uintptr_t> output_set;
@@ -104,7 +113,6 @@ void export_to_dot(std::ostream& os, const std::vector<array>& outputs) {
     output_set.insert(o.id());
   }
   std::unordered_set<std::uintptr_t> input_set;
-  NodeNamer namer;
   depth_first_traversal(
       [&](const array& x) {
         if (!x.has_primitive()) {

--- a/mlx/graph_utils.h
+++ b/mlx/graph_utils.h
@@ -12,20 +12,50 @@ struct NodeNamer {
   std::unordered_map<std::uintptr_t, std::string> names;
 
   const std::string& get_name(const array& x);
+  void set_name(const array& x, std::string n);
 };
 
-void print_graph(std::ostream& os, const std::vector<array>& outputs);
+void print_graph(
+    std::ostream& os,
+    NodeNamer namer,
+    const std::vector<array>& outputs);
 
-template <typename... Arrays, typename = enable_for_arrays_t<Arrays...>>
-void print_graph(std::ostream& os, Arrays&&... outputs) {
-  print_graph(os, std::vector<array>{std::forward<Arrays>(outputs)...});
+inline void print_graph(std::ostream& os, const std::vector<array>& outputs) {
+  print_graph(os, NodeNamer{}, outputs);
 }
 
-void export_to_dot(std::ostream& os, const std::vector<array>& outputs);
+template <typename... Arrays, typename = enable_for_arrays_t<Arrays...>>
+inline void print_graph(std::ostream& os, Arrays&&... outputs) {
+  print_graph(
+      os, NodeNamer{}, std::vector<array>{std::forward<Arrays>(outputs)...});
+}
 
 template <typename... Arrays, typename = enable_for_arrays_t<Arrays...>>
-void export_to_dot(std::ostream& os, Arrays&&... outputs) {
-  export_to_dot(os, std::vector<array>{std::forward<Arrays>(outputs)...});
+inline void
+print_graph(std::ostream& os, NodeNamer namer, Arrays&&... outputs) {
+  print_graph(os, namer, std::vector<array>{std::forward<Arrays>(outputs)...});
+}
+
+void export_to_dot(
+    std::ostream& os,
+    NodeNamer namer,
+    const std::vector<array>& outputs);
+
+inline void export_to_dot(std::ostream& os, const std::vector<array>& outputs) {
+  export_to_dot(os, NodeNamer{}, outputs);
+}
+
+template <typename... Arrays, typename = enable_for_arrays_t<Arrays...>>
+inline void export_to_dot(std::ostream& os, Arrays&&... outputs) {
+  export_to_dot(
+      os, NodeNamer{}, std::vector<array>{std::forward<Arrays>(outputs)...});
+}
+
+template <typename... Arrays, typename = enable_for_arrays_t<Arrays...>>
+inline void
+export_to_dot(std::ostream& os, NodeNamer namer, Arrays&&... outputs) {
+  export_to_dot(
+      os, namer, std::vector<array>{std::forward<Arrays>(outputs)...});
 }
 
 } // namespace mlx::core

--- a/mlx/graph_utils.h
+++ b/mlx/graph_utils.h
@@ -33,7 +33,10 @@ inline void print_graph(std::ostream& os, Arrays&&... outputs) {
 template <typename... Arrays, typename = enable_for_arrays_t<Arrays...>>
 inline void
 print_graph(std::ostream& os, NodeNamer namer, Arrays&&... outputs) {
-  print_graph(os, namer, std::vector<array>{std::forward<Arrays>(outputs)...});
+  print_graph(
+      os,
+      std::move(namer),
+      std::vector<array>{std::forward<Arrays>(outputs)...});
 }
 
 void export_to_dot(
@@ -55,7 +58,9 @@ template <typename... Arrays, typename = enable_for_arrays_t<Arrays...>>
 inline void
 export_to_dot(std::ostream& os, NodeNamer namer, Arrays&&... outputs) {
   export_to_dot(
-      os, namer, std::vector<array>{std::forward<Arrays>(outputs)...});
+      os,
+      std::move(namer),
+      std::vector<array>{std::forward<Arrays>(outputs)...});
 }
 
 } // namespace mlx::core

--- a/python/src/export.cpp
+++ b/python/src/export.cpp
@@ -242,7 +242,8 @@ void init_export(nb::module_& m) {
   m.def(
       "export_to_dot",
       [](nb::object file, const nb::args& args, const nb::kwargs& kwargs) {
-        std::vector<mx::array> arrays = tree_flatten(args);
+        std::vector<mx::array> arrays =
+            tree_flatten(nb::make_tuple(args, kwargs));
         mx::NodeNamer namer;
         for (const auto& n : kwargs) {
           namer.set_name(


### PR DESCRIPTION
This allows passing arrays as kwargs to `export_to_dot` in order to assign names to nodes in the graph. Example usage:

```python
model = ...
x = ...
loss, grads = nn.value_and_grad(...)(x)
weight_names = dict([
  (k.replace(".", "/"), v)
  for k, v in tree_flatten(model.parameters())
])
grad_names = dict([
  ("grad/" + k.replace(".", "/"), v)
  for k, v in tree_flatten(grads)
])
mx.export_to_dot("fwd_bwd.dot", loss, grads, loss=loss, **weight_names, **grad_names)
```