### PR TITLE
mpi send use input as output

### DIFF
--- a/mlx/backend/metal/distributed.cpp
+++ b/mlx/backend/metal/distributed.cpp
@@ -3,6 +3,7 @@
 #include <cassert>
 
 #include "mlx/allocator.h"
+#include "mlx/backend/common/utils.h"
 #include "mlx/backend/metal/device.h"
 #include "mlx/distributed/ops.h"
 #include "mlx/distributed/primitives.h"
@@ -111,6 +112,7 @@ void Send::eval_gpu(
         static_cast<MTL::Event*>(in.event().raw_event().get()),
         in.event().value());
   }
+  move_or_copy(in, out);
 }
 
 void Recv::eval_gpu(
@@ -133,6 +135,7 @@ void Recv::eval_gpu(
   // Encode a wait event as there is no input for the recv to encode a signal.
   auto& s = stream();
   auto& d = metal::device(s.device);
+  d.end_encoding(s.index);
   auto command_buffer = d.get_command_buffer(s.index);
   command_buffer->encodeWait(
       static_cast<MTL::Event*>(out.event().raw_event().get()),

--- a/mlx/distributed/ops.cpp
+++ b/mlx/distributed/ops.cpp
@@ -78,7 +78,10 @@ array send(
   }
 
   return array(
-      {0}, int32, std::make_shared<Send>(to_stream(s), group, dst), {x});
+      x.shape(),
+      x.dtype(),
+      std::make_shared<Send>(to_stream(s), group, dst),
+      {x});
 }
 
 array recv(

--- a/mlx/distributed/primitives.cpp
+++ b/mlx/distributed/primitives.cpp
@@ -3,6 +3,7 @@
 #include <cassert>
 
 #include "mlx/allocator.h"
+#include "mlx/backend/common/utils.h"
 #include "mlx/distributed/ops.h"
 #include "mlx/distributed/primitives.h"
 #include "mlx/ops.h"
@@ -105,6 +106,7 @@ void Send::eval_cpu(
   assert(outputs.size() == 1);
 
   distributed::detail::send(group(), inputs[0], dst_);
+  move_or_copy(inputs[0], outputs[0]);
 }
 
 std::pair<std::vector<array>, std::vector<int>> Send::vmap(

--- a/python/src/distributed.cpp
+++ b/python/src/distributed.cpp
@@ -148,7 +148,7 @@ void init_distributed(nb::module_& parent_module) {
             in which case the default stream of the default device is used.
 
         Returns:
-          array: An empty array which when evaluated the send is performed.
+          array: An array identical to ``x`` which when evaluated the send is performed.
       )pbdoc");
 
   m.def(

--- a/python/tests/mpi_test_distributed.py
+++ b/python/tests/mpi_test_distributed.py
@@ -111,6 +111,14 @@ class TestDistributed(mlx_tests.MLXTestCase):
 
         self.assertTrue(mx.all(x == (1024 if pairs.rank() == 0 else 512)))
 
+        # Check recv and computation in same eval:
+        y = mx.ones((5, 5)) + mx.array(2.0)
+        if send:
+            x = mx.distributed.send(2 * x, neighbor, group=pairs)
+        else:
+            x = mx.distributed.recv_like(x, neighbor, group=pairs)
+        mx.eval(y, x)
+
     def test_average_gradients(self):
         original_all_sum = mx.distributed.all_sum
         n_calls = 0


### PR DESCRIPTION
1. Change send to return input as output to make it easier to eval the right graph
2. Fix bug in recv forgetting to end encoding

As for 1, I found it much simpler to implement pipeline parallelism if the `send` has that behavior. Otherwise one has to keep track of the output of send as an additional output to be evaluated which is quite cumbersome (it has to be wired through all the way to the `eval` call which can be far away from the call to `send`).

For example with this API you can just replace the `model.__call__` with the following simple change and everything else stays the same:

```python
       if cache is None:
            cache = [None] * len(self.layers)

        if rank < world_size - 1:
            h = mx.distributed.recv_like(h, (rank + 1))

        for layer, c in zip(self.layers, cache):
            h = layer(h, mask, c)

        # Send to the next process
        if rank != 0:
            h = mx.distributed.send(h, (rank - 1) % world_size)
```

I also think we don't loose anyhting here as no additional computation is being done and one can always treat the output of `send` as a seperate variable than the input to get the old behavior, basically:

```python
y = mx.distributed.send(x, dst)
```
