### PR TITLE
Print exceptions in eval_cpu/eval_gpu and abort

### DIFF
--- a/mlx/backend/metal/metal.cpp
+++ b/mlx/backend/metal/metal.cpp
@@ -47,7 +47,11 @@ std::function<void()> make_task(array arr, bool signal) {
       }
 
       debug_set_primitive_buffer_label(command_buffer, arr.primitive());
-      arr.primitive().eval_gpu(arr.inputs(), outputs);
+      try {
+        arr.primitive().eval_gpu(arr.inputs(), outputs);
+      } catch (const std::exception& error) {
+        abort_with_exception(error);
+      }
     }
     std::vector<std::shared_ptr<array::Data>> buffers;
     for (auto& in : arr.inputs()) {

--- a/mlx/transforms.cpp
+++ b/mlx/transforms.cpp
@@ -220,7 +220,11 @@ array eval_impl(std::vector<array> outputs, bool async) {
         }
         scheduler::notify_new_task(stream);
         auto outputs = arr.outputs();
-        arr.primitive().eval_cpu(arr.inputs(), outputs);
+        try {
+          arr.primitive().eval_cpu(arr.inputs(), outputs);
+        } catch (const std::exception& error) {
+          abort_with_exception(error);
+        }
         if (!arr.is_tracer()) {
           arr.detach();
         }

--- a/mlx/utils.cpp
+++ b/mlx/utils.cpp
@@ -1,6 +1,7 @@
 // Copyright © 2023 Apple Inc.
 
 #include <cstdlib>
+#include <iostream>
 #include <sstream>
 #include <vector>
 
@@ -60,6 +61,13 @@ inline void PrintFormatter::print(std::ostream& os, complex64_t val) {
 PrintFormatter& get_global_formatter() {
   static PrintFormatter formatter;
   return formatter;
+}
+
+void abort_with_exception(const std::exception& error) {
+  std::ostringstream msg;
+  msg << "Terminating due to uncaught exception: " << error.what();
+  std::cerr << msg.str() << std::endl;
+  std::abort();
 }
 
 Dtype result_type(const std::vector<array>& arrays) {

--- a/mlx/utils.h
+++ b/mlx/utils.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <exception>
 #include <variant>
 
 #include "mlx/array.h"
@@ -52,6 +53,9 @@ struct PrintFormatter {
 };
 
 PrintFormatter& get_global_formatter();
+
+/** Print the exception and then abort. */
+void abort_with_exception(const std::exception& error);
 
 /** Holds information about floating-point types. */
 struct finfo {


### PR DESCRIPTION
Catch exceptions when calling `eval_cpu`/`eval_gpu`, print them, and then abort.

Some platforms like Windows do not print uncaught exceptions in console, and this change gives them a chance to print out the error before termination.