### PR TITLE
Added missing unordered_map include that fixes build on FreeBSD

### DIFF
--- a/mlx/compile_impl.h
+++ b/mlx/compile_impl.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <unordered_map>
+
 #include "mlx/array.h"
 
 namespace mlx::core::detail {


### PR DESCRIPTION
## Proposed changes

Added missing unordered_map include that fixes build on FreeBSD.

Fixes build:
* For FreeBSD in cross-compile Linux env.: https://github.com/JuliaPackaging/Yggdrasil/pull/10019

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
