### PR TITLE
Include command stdout in error message

### DIFF
--- a/mlx/backend/common/compiled_cpu.cpp
+++ b/mlx/backend/common/compiled_cpu.cpp
@@ -7,6 +7,8 @@
 #include <mutex>
 #include <shared_mutex>
 
+#include <fmt/format.h>
+
 #include "mlx/backend/common/compiled.h"
 #include "mlx/backend/common/compiled_preamble.h"
 #include "mlx/backend/common/jit_compiler.h"
@@ -105,14 +107,14 @@ void* compile(
     source_file << source_code;
     source_file.close();
 
-    std::string command = JitCompiler::build_command(
-        output_dir, source_file_name, shared_lib_name);
-    auto return_code = system(command.c_str());
-    if (return_code) {
-      std::ostringstream msg;
-      msg << "[Compile::eval_cpu] Failed to compile function " << kernel_name
-          << " with error code " << return_code << "." << std::endl;
-      throw std::runtime_error(msg.str());
+    try {
+      JitCompiler::exec(JitCompiler::build_command(
+          output_dir, source_file_name, shared_lib_name));
+    } catch (const std::exception& error) {
+      throw std::runtime_error(fmt::format(
+          "[Compile::eval_cpu] Failed to compile function {0}: {1}",
+          kernel_name,
+          error.what()));
     }
   }
 

--- a/mlx/backend/common/jit_compiler.cpp
+++ b/mlx/backend/common/jit_compiler.cpp
@@ -133,7 +133,11 @@ std::string JitCompiler::exec(const std::string& cmd) {
   if (status == -1) {
     throw std::runtime_error("pclose() failed.");
   }
+#ifdef _MSC_VER
+  int code = status;
+#else
   int code = WEXITSTATUS(status);
+#endif
   if (code != 0) {
     throw std::runtime_error(fmt::format(
         "Failed to execute command with return code {0}: \"{1}\", "

--- a/mlx/backend/common/jit_compiler.h
+++ b/mlx/backend/common/jit_compiler.h
@@ -12,6 +12,9 @@ class JitCompiler {
       const std::filesystem::path& dir,
       const std::string& source_file_name,
       const std::string& shared_lib_name);
+
+  // Run a command and get its output.
+  static std::string exec(const std::string& cmd);
 };
 
 } // namespace mlx::core


### PR DESCRIPTION
When compilation fails, users can see the reason in error message:

`Terminating due to uncaught exception: [Compile::eval_cpu] Failed to compile function Cf4BroadcastBDf4AddAC_VS_f4f4_11160318154034397263_contiguous: Failed to execute command with return code 127: "g++ -std=c++17 -O3 -Wall -fPIC -shared '/var/folders/4v/b5_8jfds0x71cym60rd_km1m0000gn/T/Cf4BroadcastBDf4AddAC_VS_f4f4_11160318154034397263_contiguous.cpp' -o '/var/folders/4v/b5_8jfds0x71cym60rd_km1m0000gn/T/libCf4BroadcastBDf4AddAC_VS_f4f4_11160318154034397263_contiguous.so' 2>&1", the output is: sh: g++: No such file or directory`