### PR TITLE
Fix batched qmv bug

### DIFF
--- a/mlx/backend/metal/kernels/quantized.h
+++ b/mlx/backend/metal/kernels/quantized.h
@@ -1216,7 +1216,7 @@ METAL_FUNC void adjust_matrix_offsets(
     const device T*& scales,
     const device T*& biases,
     device T*& y,
-    int out_vec_size,
+    int output_stride,
     const constant int& x_batch_ndims,
     const constant int* x_shape,
     const constant int64_t* x_strides,
@@ -1245,7 +1245,6 @@ METAL_FUNC void adjust_matrix_offsets(
     scales += idx.y;
     biases += idx.z;
   }
-  int output_stride = out_vec_size * x_shape[x_batch_ndims];
   y += tid.z * output_stride;
 }
 
@@ -1258,7 +1257,7 @@ METAL_FUNC void adjust_matrix_offsets(
     const device uint32_t* lhs_indices,
     const device uint32_t* rhs_indices,
     device T*& y,
-    int out_vec_size,
+    int output_stride,
     const constant int& batch_ndims,
     const constant int* batch_shape,
     const constant int64_t* lhs_strides,
@@ -1300,7 +1299,6 @@ METAL_FUNC void adjust_matrix_offsets(
     scales += idx.y;
     biases += idx.z;
   }
-  int output_stride = out_vec_size * x_shape[x_batch_ndims];
   y += tid.z * output_stride;
 }
 
@@ -1325,13 +1323,14 @@ template <typename T, int group_size, int bits, int D, bool batched>
     uint quad_gid [[quadgroup_index_in_threadgroup]],
     uint quad_lid [[thread_index_in_quadgroup]]) {
   if (batched) {
+    int M = x_shape[x_batch_ndims];
     adjust_matrix_offsets<T>(
         x,
         w,
         scales,
         biases,
         y,
-        out_vec_size,
+        out_vec_size * M,
         x_batch_ndims,
         x_shape,
         x_strides,
@@ -1376,13 +1375,14 @@ template <typename T, int group_size, int bits, bool batched>
     uint simd_gid [[simdgroup_index_in_threadgroup]],
     uint simd_lid [[thread_index_in_simdgroup]]) {
   if (batched) {
+    int M = x_shape[x_batch_ndims];
     adjust_matrix_offsets<T>(
         x,
         w,
         scales,
         biases,
         y,
-        out_vec_size,
+        out_vec_size * M,
         x_batch_ndims,
         x_shape,
         x_strides,
@@ -1427,13 +1427,14 @@ template <typename T, const int group_size, const int bits, bool batched>
     uint simd_gid [[simdgroup_index_in_threadgroup]],
     uint simd_lid [[thread_index_in_simdgroup]]) {
   if (batched) {
+    int M = x_shape[x_batch_ndims];
     adjust_matrix_offsets<T>(
         x,
         w,
         scales,
         biases,
         y,
-        out_vec_size,
+        out_vec_size * M,
         x_batch_ndims,
         x_shape,
         x_strides,
@@ -1478,13 +1479,14 @@ template <typename T, const int group_size, const int bits, bool batched>
     uint simd_gid [[simdgroup_index_in_threadgroup]],
     uint simd_lid [[thread_index_in_simdgroup]]) {
   if (batched) {
+    int M = x_shape[x_batch_ndims];
     adjust_matrix_offsets<T>(
         x,
         w,
         scales,
         biases,
         y,
-        out_vec_size,
+        out_vec_size * M,
         x_batch_ndims,
         x_shape,
         x_strides,
@@ -1529,13 +1531,14 @@ template <typename T, const int group_size, const int bits, int split_k = 32>
     uint3 tid [[threadgroup_position_in_grid]],
     uint simd_gid [[simdgroup_index_in_threadgroup]],
     uint simd_lid [[thread_index_in_simdgroup]]) {
+  int M = x_shape[x_batch_ndims];
   adjust_matrix_offsets<T>(
       x,
       w,
       scales,
       biases,
       y,
-      out_vec_size,
+      out_vec_size * M,
       x_batch_ndims,
       x_shape,
       x_strides,
@@ -1607,7 +1610,7 @@ template <
         scales,
         biases,
         y,
-        N,
+        M * N,
         x_batch_ndims,
         x_shape,
         x_strides,
@@ -1666,7 +1669,7 @@ template <
         scales,
         biases,
         y,
-        N,
+        M * N,
         x_batch_ndims,
         x_shape,
         x_strides,
@@ -1708,6 +1711,7 @@ template <typename T, int group_size, int bits>
     uint3 tid [[threadgroup_position_in_grid]],
     uint simd_gid [[simdgroup_index_in_threadgroup]],
     uint simd_lid [[thread_index_in_simdgroup]]) {
+  int M = x_shape[x_batch_ndims];
   adjust_matrix_offsets<T>(
       x,
       w,
@@ -1716,7 +1720,7 @@ template <typename T, int group_size, int bits>
       lhs_indices,
       rhs_indices,
       y,
-      out_vec_size,
+      out_vec_size * M,
       batch_ndims,
       batch_shape,
       lhs_strides,
@@ -1769,6 +1773,7 @@ template <typename T, int group_size, int bits>
     uint3 tid [[threadgroup_position_in_grid]],
     uint simd_gid [[simdgroup_index_in_threadgroup]],
     uint simd_lid [[thread_index_in_simdgroup]]) {
+  int M = x_shape[x_batch_ndims];
   adjust_matrix_offsets<T>(
       x,
       w,
@@ -1777,7 +1782,7 @@ template <typename T, int group_size, int bits>
       lhs_indices,
       rhs_indices,
       y,
-      out_vec_size,
+      out_vec_size * M,
       batch_ndims,
       batch_shape,
       lhs_strides,
@@ -1830,6 +1835,7 @@ template <typename T, int group_size, int bits>
     uint3 tid [[threadgroup_position_in_grid]],
     uint simd_gid [[simdgroup_index_in_threadgroup]],
     uint simd_lid [[thread_index_in_simdgroup]]) {
+  int M = x_shape[x_batch_ndims];
   adjust_matrix_offsets<T>(
       x,
       w,
@@ -1838,7 +1844,7 @@ template <typename T, int group_size, int bits>
       lhs_indices,
       rhs_indices,
       y,
-      out_vec_size,
+      out_vec_size * M,
       batch_ndims,
       batch_shape,
       lhs_strides,
@@ -1915,7 +1921,7 @@ template <
       lhs_indices,
       rhs_indices,
       y,
-      N,
+      M * N,
       batch_ndims,
       batch_shape,
       lhs_strides,
@@ -1983,7 +1989,7 @@ template <
       lhs_indices,
       rhs_indices,
       y,
-      N,
+      M * N,
       batch_ndims,
       batch_shape,
       lhs_strides,

--- a/mlx/backend/metal/kernels/quantized.h
+++ b/mlx/backend/metal/kernels/quantized.h
@@ -1216,7 +1216,7 @@ METAL_FUNC void adjust_matrix_offsets(
     const device T*& scales,
     const device T*& biases,
     device T*& y,
-    int output_stride,
+    int out_vec_size,
     const constant int& x_batch_ndims,
     const constant int* x_shape,
     const constant int64_t* x_strides,
@@ -1245,6 +1245,7 @@ METAL_FUNC void adjust_matrix_offsets(
     scales += idx.y;
     biases += idx.z;
   }
+  int output_stride = out_vec_size * x_shape[x_batch_ndims];
   y += tid.z * output_stride;
 }
 
@@ -1257,7 +1258,7 @@ METAL_FUNC void adjust_matrix_offsets(
     const device uint32_t* lhs_indices,
     const device uint32_t* rhs_indices,
     device T*& y,
-    int output_stride,
+    int out_vec_size,
     const constant int& batch_ndims,
     const constant int* batch_shape,
     const constant int64_t* lhs_strides,
@@ -1299,6 +1300,7 @@ METAL_FUNC void adjust_matrix_offsets(
     scales += idx.y;
     biases += idx.z;
   }
+  int output_stride = out_vec_size * x_shape[x_batch_ndims];
   y += tid.z * output_stride;
 }
 
@@ -1605,7 +1607,7 @@ template <
         scales,
         biases,
         y,
-        M * N,
+        N,
         x_batch_ndims,
         x_shape,
         x_strides,
@@ -1664,7 +1666,7 @@ template <
         scales,
         biases,
         y,
-        M * N,
+        N,
         x_batch_ndims,
         x_shape,
         x_strides,
@@ -1913,7 +1915,7 @@ template <
       lhs_indices,
       rhs_indices,
       y,
-      M * N,
+      N,
       batch_ndims,
       batch_shape,
       lhs_strides,
@@ -1981,7 +1983,7 @@ template <
       lhs_indices,
       rhs_indices,
       y,
-      M * N,
+      N,
       batch_ndims,
       batch_shape,
       lhs_strides,

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -212,11 +212,12 @@ class TestQuantized(mlx_tests.MLXTestCase):
                 w_hat = mx.dequantize(w_q, scales, biases)
 
                 # Test qmv
-                x = mx.random.normal(shape=(3, 1, 256))
-                y_q = mx.quantized_matmul(x, w_q, scales, biases, transpose=True)
-                y_hat = x @ mx.swapaxes(w_hat, -1, -2)
-                self.assertEqual(y_q.shape, y_hat.shape)
-                self.assertLess((y_q - y_hat).abs().max(), 1e-3)
+                for shape in [(3, 1, 256), (3, 4, 256)]:
+                    x = mx.random.normal(shape=shape)
+                    y_q = mx.quantized_matmul(x, w_q, scales, biases, transpose=True)
+                    y_hat = x @ mx.swapaxes(w_hat, -1, -2)
+                    self.assertEqual(y_q.shape, y_hat.shape)
+                    self.assertLess((y_q - y_hat).abs().max(), 1e-3)
 
                 # Test qmm_t
                 x = mx.random.normal(shape=(3, 10, 256))


### PR DESCRIPTION
Resolves https://github.com/ml-explore/mlx-examples/issues/1182

This fixes a (B, M, K) x (B, N, K) `qmv`/`qvm` when B > 1 and M > 1.

This only occurs for small B < 6 since otherwise we use `qmm_t`/`qmm_n` which explains why it took a little while to pop up.

Previously we weren't adjusting the output stride by M, so we wouldn't write the entire output.

