### PR TITLE
Simplify removes no-ops from the tape

### DIFF
--- a/mlx/backend/common/compiled.h
+++ b/mlx/backend/common/compiled.h
@@ -11,9 +11,7 @@
 namespace mlx::core {
 
 inline bool is_static_cast(const Primitive& p) {
-  return (
-      typeid(p) == typeid(Broadcast) || typeid(p) == typeid(Copy) ||
-      typeid(p) == typeid(StopGradient) || typeid(p) == typeid(AsType));
+  return (typeid(p) == typeid(Broadcast) || typeid(p) == typeid(AsType));
 }
 
 std::string build_lib_name(

--- a/mlx/compile.cpp
+++ b/mlx/compile.cpp
@@ -68,8 +68,7 @@ bool is_reduction(const Primitive& p) {
 }
 
 bool is_fusable(const Primitive& p) {
-  return is_unary(p) || is_binary(p) || is_ternary(p) || is_broadcast(p) ||
-      is_noop(p);
+  return is_unary(p) || is_binary(p) || is_ternary(p) || is_broadcast(p);
 }
 
 Compiled::Compiled(

--- a/mlx/compile_impl.h
+++ b/mlx/compile_impl.h
@@ -38,12 +38,11 @@ std::pair<std::vector<array>, ParentsMap> compile_dfs(
     const std::vector<array>& outputs,
     const std::vector<array>& original_inputs);
 
-// Simplify the tape. Note, this function modifies in-place both the tape and
-// the parents map to remove orphaned arrays
+// Simplify the tape.
 void compile_simplify(
     std::vector<array>& tape,
     ParentsMap& parents_map,
-    const std::vector<array>& outputs,
+    std::vector<array>& outputs,
     int passes);
 
 std::vector<array> compile_replace(

--- a/tests/compile_tests.cpp
+++ b/tests/compile_tests.cpp
@@ -157,6 +157,17 @@ TEST_CASE("test simplify") {
   set_compile_mode(CompileMode::enabled);
 }
 
+TEST_CASE("test simplify noops") {
+  set_compile_mode(CompileMode::no_fuse);
+  auto a = array({1.0f, 2.0f});
+  auto fun = [](const std::vector<array>& inputs) -> std::vector<array> {
+    return {copy(stop_gradient(exp(stop_gradient(inputs[0]))))};
+  };
+  auto b = compile(fun)({a})[0];
+  CHECK(b.inputs()[0].id() == a.id());
+  set_compile_mode(CompileMode::enabled);
+}
+
 auto add_diff(const std::vector<array>& inputs) {
   auto a = inputs[0];
   return std::vector<array>{cos(a) + sin(a)};


### PR DESCRIPTION
It's a minor optimization but:

- reduces the tape size when no-ops are not fused
- exposes more possibility for merging arrays in simplify
- increases fusability given the depth limit