### PR TITLE
0ul is not size_t on MSVC

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -824,7 +824,7 @@ array slice_update(
 
   // Broadcast update with unspecified axes
   auto up_shape = update.shape();
-  auto dim_diff = std::max(src.ndim() - update.ndim(), 0ul);
+  auto dim_diff = std::max(src.ndim() - update.ndim(), size_t(0));
   up_shape.insert(
       up_shape.begin(), src.shape().begin(), src.shape().begin() + dim_diff);
   for (int d = dim_diff; d < src.ndim(); ++d) {


### PR DESCRIPTION
Fix compilation error with MSVC due to args passed `std::max` have different types.