### PR TITLE
Fix broadcast_arrays python sig

### DIFF
--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -2808,7 +2808,7 @@ void init_ops(nb::module_& m) {
       nb::kw_only(),
       "stream"_a = nb::none(),
       nb::sig(
-          "def broadcast_arrays(*arrays: array, *, stream: Union[None, Stream, Device] = None) -> Tuple[array, ...]"),
+          "def broadcast_arrays(*arrays: array, stream: Union[None, Stream, Device] = None) -> Tuple[array, ...]"),
       R"pbdoc(
         Broadcast arrays against one another.
 


### PR DESCRIPTION
## Proposed changes

The newly added [broadcast_arrays function](https://github.com/ml-explore/mlx/commit/1ccaf80575e33183237d7c3af5c2ead4437e037d#diff-8a607e80673e9f8e9c1e73a5aba9d6f89ac56ad34765e4022d5130f890776cacR2811) has a signature that is rejected by mypy because it has multiple stars (one varargs and one kwonly specifier): 

```
omlish/bootstrap/tests/test_marshal.py:1: note: In module imported here:
.venvs/default/lib/python3.12/site-packages/mlx/core/__init__.pyi:1030:39: error: * argument may appear only
once  [syntax]
    def broadcast_arrays(*arrays: array, *, stream: Union[None, Stream, Device] = None) -> Tuple[array, .....
                                          ^
Found 1 error in 1 file (errors prevented further checking)
make: *** [mypy] Error 2
```

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
