### PR TITLE
Fix and cleanup event signal/wait for metal

### DIFF
--- a/mlx/backend/metal/event.h
+++ b/mlx/backend/metal/event.h
@@ -1,0 +1,10 @@
+// Copyright © 2024 Apple Inc.
+#pragma once
+
+namespace mlx::core {
+
+void encode_wait(Event e);
+
+void encode_signal(Event e);
+
+} // namespace mlx::core

--- a/mlx/backend/metal/primitives.cpp
+++ b/mlx/backend/metal/primitives.cpp
@@ -9,6 +9,7 @@
 #include "mlx/backend/common/utils.h"
 #include "mlx/backend/metal/copy.h"
 #include "mlx/backend/metal/device.h"
+#include "mlx/backend/metal/event.h"
 #include "mlx/backend/metal/kernels.h"
 #include "mlx/backend/metal/slicing.h"
 #include "mlx/backend/metal/utils.h"
@@ -263,12 +264,7 @@ void Load::eval_gpu(const std::vector<array>& inputs, array& out) {
     out.event().signal();
   };
   scheduler::enqueue(io_stream(), std::move(signal_task));
-  auto& d = metal::device(stream().device);
-  d.end_encoding(stream().index);
-  auto command_buffer = d.get_command_buffer(stream().index);
-  command_buffer->encodeWait(
-      static_cast<MTL::Event*>(out.event().raw_event().get()),
-      out.event().value());
+  encode_wait(out.event());
 }
 
 void NumberOfElements::eval_gpu(const std::vector<array>& inputs, array& out) {


### PR DESCRIPTION
Events should be held in completion handler so we know they are not destroyed too early. Previously this would crash with internal error:

```python
a = mx.ones((5, 5))
for _ in range(10):
    a = mx.distributed.all_sum(a)
mx.eval(a)

tic = time.perf_counter()
for _ in range(10):
    a = mx.distributed.all_sum(a)
mx.eval(a)
```