### PR TITLE
Einsum ellipsis

### DIFF
--- a/mlx/einsum.cpp
+++ b/mlx/einsum.cpp
@@ -669,7 +669,7 @@ std::pair<std::vector<PathNode>, PathInfo> einsum_path_helper(
     bool have_ellipsis = false;
     int cnt_before = 0, cnt_after = 0;
     for (int i = 0; i < subscript.size(); i++) {
-      if (!isalpha(subscripts[i])) {
+      if (!isalpha(subscript[i])) {
         if (i + 2 >= subscript.size() || subscript[i] != '.' ||
             subscript[i + 1] != '.' || subscript[i + 2] != '.') {
           std::ostringstream msg;

--- a/mlx/einsum.cpp
+++ b/mlx/einsum.cpp
@@ -71,6 +71,7 @@ std::pair<std::vector<std::string>, std::string> parse(std::string subscripts) {
   } else {
     // Implicit mode:
     // - repeats are summed
+    // - ellipses are placed in the beginning of the output
     // - remaining output axes are ordered alphabetically
     lhs = subscripts;
     std::unordered_map<char, int> temp;
@@ -78,6 +79,11 @@ std::pair<std::vector<std::string>, std::string> parse(std::string subscripts) {
       if (c == ',') {
         continue;
       }
+      if (c == '.' && rhs.empty()) {
+        rhs += "...";
+        continue;
+      }
+
       auto inserted = temp.insert({c, 0});
       inserted.first->second++;
     }

--- a/mlx/einsum.cpp
+++ b/mlx/einsum.cpp
@@ -706,21 +706,11 @@ std::pair<std::vector<PathNode>, PathInfo> einsum_path_helper(
       } else {
         ellipsis_length = max_ellipsis_length;
       }
-      std::string new_subscript;
-      new_subscript.reserve(cnt_before + cnt_after + ellipsis_length);
-      new_subscript.insert(
-          new_subscript.end(),
-          subscript.begin(),
-          subscript.begin() + cnt_before);
-      new_subscript.insert(
-          new_subscript.end(),
+      subscript.replace(
+          subscript.begin() + cnt_before,
+          subscript.begin() + cnt_before + 3,
           remaining_chars.end() - ellipsis_length,
           remaining_chars.end());
-      new_subscript.insert(
-          new_subscript.end(),
-          subscript.begin() + cnt_before + 3,
-          subscript.end());
-      subscript = std::move(new_subscript);
     }
   };
 

--- a/python/tests/test_einsum.py
+++ b/python/tests/test_einsum.py
@@ -331,6 +331,11 @@ class TestEinsum(mlx_tests.MLXTestCase):
             ("abhh->abh", "...hh->...h"),
             ("abhh->abh", "...hh->...h"),
             ("bch,abcj->abchj", "...h,...j->...hj"),
+            ("bc,cd->bd", "...c,cd"),
+            ("abc,acd->bd", "...bc,...cd"),
+            ("abcd,c->abd", "...cd,c"),
+            ("abcd,c->abd", "...cd,c..."),
+            ("abcd,c->abd", "...cd,c...->d..."),
         ]
         for test_case in tests:
             inputs = inputs_for_case(test_case[0])

--- a/python/tests/test_einsum.py
+++ b/python/tests/test_einsum.py
@@ -336,6 +336,13 @@ class TestEinsum(mlx_tests.MLXTestCase):
             ("abcd,c->abd", "...cd,c"),
             ("abcd,c->abd", "...cd,c..."),
             ("abcd,c->abd", "...cd,c...->d..."),
+            ("abc,b->abc", "ab...,b...->ab..."),
+            ("abc,b->abc", "ab...,...b->ab..."),
+            ("abc,b->abc", "ab...,b->ab..."),
+            ("ab,bc->ac", "ab...,b...->a..."),
+            ("ab,bc->ac", "ab...,...bc->a...c"),
+            ("ab,bc->ac", "ab,b...->a..."),
+            ("abcdef,defg->abcg", "...def,defg->...g"),
         ]
         for test_case in tests:
             inputs = inputs_for_case(test_case[0])

--- a/python/tests/test_einsum.py
+++ b/python/tests/test_einsum.py
@@ -313,6 +313,39 @@ class TestEinsum(mlx_tests.MLXTestCase):
             mx_out = mx.einsum(test_case, *inputs)
             self.assertTrue(np.allclose(mx_out, np_out, rtol=1e-4, atol=1e-4))
 
+    def test_ellipses(self):
+        size_dict = dict(zip("abcdefghij", [2, 3, 4, 5, 2, 3, 4, 5, 2, 3]))
+
+        def inputs_for_case(test_case):
+            inputs = test_case.split("->")[0].split(",")
+            return [
+                mx.random.uniform(shape=tuple(size_dict[c] for c in inp))
+                for inp in inputs
+            ]
+
+        tests = [
+            ("abc->ab", "...c->..."),
+            ("abcd->ad", "a...d->..."),
+            ("abij,abgj->abig", "...ij,...gj->...ig"),
+            ("abij,abgj->abig", "...ij,...gj->..."),
+            ("abhh->abh", "...hh->...h"),
+            ("abhh->abh", "...hh->...h"),
+            ("bch,abcj->abchj", "...h,...j->...hj"),
+        ]
+        for test_case in tests:
+            inputs = inputs_for_case(test_case[0])
+            np_out = np.einsum(test_case[1], *inputs)
+            mx_out = mx.einsum(test_case[1], *inputs)
+            self.assertTrue(np.allclose(mx_out, np_out, rtol=1e-4, atol=1e-4))
+
+        error_tests = [
+            ("abc,abc->ab", "a...b...c,a...b...c->abc"),
+        ]
+        for test_case in error_tests:
+            inputs = inputs_for_case(test_case[0])
+            with self.assertRaises(ValueError):
+                mx.einsum(test_case[1], *inputs)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #1717.

I added the tests I could think of but maybe I am missing an important case? Also this adds lines 653 to 665 which will run every time even if we don't have an ellipsis. I could instead move them into 701 and run them the first time to encounter an ellipsis. This way the overhead of parsing the ellipsis should be even less. Let me know if you prefer that.