### PR TITLE
MPI docs nit

### DIFF
--- a/docs/src/usage/distributed.rst
+++ b/docs/src/usage/distributed.rst
@@ -57,7 +57,7 @@ with the Anaconda package manager as follows:
 
 .. code:: shell
 
-    $ conda install openmpi
+    $ conda install conda-forge::openmpi
 
 Installing with Homebrew may require specifying the location of ``libmpi.dyld``
 so that MLX can find it and load it at runtime. This can simply be achieved by


### PR DESCRIPTION
Change the conda install channel for openmpi

Notices the default channel uses mpi 4.0.1 and was last [updated almost three years ago](https://anaconda.org/anaconda/openmpi).

The conda-forge channel uses a [more recent openmpi](https://anaconda.org/conda-forge/openmpi) (2 days old) and seems to be maintained.

This also resolves some linker warnings I was seeing on newer mac OS:

```
dyld[80502]: symbol '__ZTINSt3__13pmr15memory_resourceE' missing from root that overrides /usr/lib/libc++.1.dylib. Use of that symbol in /System/Library/PrivateFrameworks/caulk.framework/Versions/A/caulk is being set to 0xBAD4007.
```