### PR TITLE
Allow different value dimensions in sdpa_vector

### DIFF
--- a/benchmarks/python/sdpa_vector_bench.py
+++ b/benchmarks/python/sdpa_vector_bench.py
@@ -8,14 +8,23 @@ L = 16384
 H = 32
 H_k = H // 4
 D = 128
+V = 128
 dtype = mx.float16
 loops = 10
 
 
-def attention(q, k, v, mask=None):
+def upproject(x, w):
+    if w is None:
+        return x
+    else:
+        return x @ w.T
+
+
+def attention(q, k, v, mask=None, w=None):
     def _sdpa(q, k, v):
         B, Hq, L, D = q.shape
         _, Hk, S, _ = k.shape
+        _, _, _, V = v.shape
         q = q.reshape(B, Hk, Hq // Hk, L, D)
         k = k[:, :, None, :, :]
         v = v[:, :, None, :, :]
@@ -25,16 +34,18 @@ def attention(q, k, v, mask=None):
             s = mx.where(m, s, mx.finfo(s.dtype).min)
         p = mx.softmax(s.astype(mx.float32), axis=-1).astype(s.dtype)
         o = p @ v
-        return o.reshape(B, Hq, L, D)
+        return o.reshape(B, Hq, L, V)
 
     for i in range(loops):
         q = _sdpa(q, k, v)
+        q = upproject(q, w)
     return q
 
 
-def sdpa(q, k, v, mask=None):
+def sdpa(q, k, v, mask=None, w=None):
     for i in range(loops):
         q = mx.fast.scaled_dot_product_attention(q, k, v, scale=1.0, mask=mask)
+        q = upproject(q, w)
     return q
 
 
@@ -42,34 +53,37 @@ def time_self_attention_primitives():
     mx.random.seed(3)
     q = mx.random.uniform(shape=(1, H, 1, D)).astype(dtype)
     k = mx.random.uniform(shape=(1, H_k, L, D)).astype(dtype)
-    v = mx.random.uniform(shape=(1, H_k, L, D)).astype(dtype)
-    mx.eval(q, k, v)
-    time_fn(attention, q, k, v)
+    v = mx.random.uniform(shape=(1, H_k, L, V)).astype(dtype)
+    w = mx.random.uniform(shape=(D, V)).astype(dtype) if V != D else None
+    mx.eval(q, k, v, w)
+    time_fn(attention, q, k, v, w=w)
 
 
 def time_self_attention_sdpa():
     mx.random.seed(3)
     q = mx.random.uniform(shape=(1, H, 1, D)).astype(dtype)
     k = mx.random.uniform(shape=(1, H_k, L, D)).astype(dtype)
-    v = mx.random.uniform(shape=(1, H_k, L, D)).astype(dtype)
-    mx.eval(q, k, v)
-    time_fn(sdpa, q, k, v)
+    v = mx.random.uniform(shape=(1, H_k, L, V)).astype(dtype)
+    w = mx.random.uniform(shape=(D, V)).astype(dtype) if V != D else None
+    mx.eval(q, k, v, w)
+    time_fn(sdpa, q, k, v, w=w)
 
 
 def time_self_attention_sdpa_with_mask():
     mx.random.seed(3)
     q = mx.random.uniform(shape=(1, H, 1, D)).astype(dtype)
     k = mx.random.uniform(shape=(1, H_k, L, D)).astype(dtype)
-    v = mx.random.uniform(shape=(1, H_k, L, D)).astype(dtype)
+    v = mx.random.uniform(shape=(1, H_k, L, V)).astype(dtype)
+    w = mx.random.uniform(shape=(D, V)).astype(dtype) if V != D else None
     mask = mx.full((L,), True)
     mask[L // 2 :] = False
-    mx.eval(q, k, v, mask)
+    mx.eval(q, k, v, mask, w)
 
     def sdpa_mask(*args):
-        return sdpa(*args, mask=mask)
+        return sdpa(*args, mask=mask, w=w)
 
     def attention_mask(*args):
-        return attention(*args, mask=mask)
+        return attention(*args, mask=mask, w=w)
 
     time_fn(attention_mask, q, k, v)
     time_fn(sdpa_mask, q, k, v)

--- a/mlx/backend/metal/kernels/scaled_dot_product_attention.metal
+++ b/mlx/backend/metal/kernels/scaled_dot_product_attention.metal
@@ -7,15 +7,35 @@ using namespace metal;
 
 // clang-format off
 // SDPA vector instantiations
-#define instantiate_sdpa_vector(type, head_dim)                                   \
-  instantiate_kernel("sdpa_vector_" #type "_" #head_dim, sdpa_vector, type, head_dim)          \
-  instantiate_kernel("sdpa_vector_2pass_1_" #type "_" #head_dim, sdpa_vector_2pass_1, type, head_dim)  \
-  instantiate_kernel("sdpa_vector_2pass_2_" #type "_" #head_dim, sdpa_vector_2pass_2, type, head_dim)
+#define instantiate_sdpa_vector_aggregation(type, value_dim) \
+  instantiate_kernel(                                        \
+      "sdpa_vector_2pass_2_" #type "_" #value_dim,           \
+      sdpa_vector_2pass_2,                                   \
+      type,                                                  \
+      value_dim)
 
-#define instantiate_sdpa_vector_heads(type) \
-  instantiate_sdpa_vector(type, 64)         \
-  instantiate_sdpa_vector(type, 96)         \
-  instantiate_sdpa_vector(type, 128)
+#define instantiate_sdpa_vector(type, qk_dim, value_dim)       \
+  instantiate_kernel(                                          \
+      "sdpa_vector_" #type "_" #qk_dim "_" #value_dim,         \
+      sdpa_vector,                                             \
+      type,                                                    \
+      qk_dim,                                                  \
+      value_dim)                                               \
+  instantiate_kernel(                                          \
+      "sdpa_vector_2pass_1_" #type "_" #qk_dim "_" #value_dim, \
+      sdpa_vector_2pass_1,                                     \
+      type,                                                    \
+      qk_dim,                                                  \
+      value_dim)
+
+#define instantiate_sdpa_vector_heads(type)      \
+  instantiate_sdpa_vector(type, 64, 64)          \
+  instantiate_sdpa_vector(type, 96, 96)          \
+  instantiate_sdpa_vector(type, 128, 128)        \
+  instantiate_sdpa_vector(type, 192, 128)        \
+  instantiate_sdpa_vector_aggregation(type, 64)  \
+  instantiate_sdpa_vector_aggregation(type, 96)  \
+  instantiate_sdpa_vector_aggregation(type, 128)
 
 instantiate_sdpa_vector_heads(float)
 instantiate_sdpa_vector_heads(bfloat16_t)

--- a/mlx/backend/metal/kernels/scaled_dot_product_attention.metal
+++ b/mlx/backend/metal/kernels/scaled_dot_product_attention.metal
@@ -32,7 +32,6 @@ using namespace metal;
   instantiate_sdpa_vector(type, 64, 64)          \
   instantiate_sdpa_vector(type, 96, 96)          \
   instantiate_sdpa_vector(type, 128, 128)        \
-  instantiate_sdpa_vector(type, 192, 128)        \
   instantiate_sdpa_vector_aggregation(type, 64)  \
   instantiate_sdpa_vector_aggregation(type, 96)  \
   instantiate_sdpa_vector_aggregation(type, 128)

--- a/mlx/backend/metal/scaled_dot_product_attention.cpp
+++ b/mlx/backend/metal/scaled_dot_product_attention.cpp
@@ -124,6 +124,8 @@ void sdpa_vector(
   kname += get_type_string(q.dtype());
   kname += "_";
   kname += std::to_string(q.shape(-1));
+  kname += "_";
+  kname += std::to_string(v.shape(-1));
 
   // Compute the necessary sizes
   int gqa_factor = q.shape(1) / k.shape(1);
@@ -185,6 +187,8 @@ void sdpa_vector_2pass(
   kname += get_type_string(q.dtype());
   kname += "_";
   kname += std::to_string(q.shape(-1));
+  kname += "_";
+  kname += std::to_string(v.shape(-1));
 
   // Compute the necessary sizes
   int gqa_factor = q.shape(1) / k.shape(1);
@@ -256,7 +260,7 @@ void sdpa_vector_2pass(
   kname += "sdpa_vector_2pass_2_";
   kname += get_type_string(q.dtype());
   kname += "_";
-  kname += std::to_string(q.shape(-1));
+  kname += std::to_string(v.shape(-1));
 
   // Get the kernel
   kernel = d.get_kernel(kname);
@@ -332,7 +336,7 @@ void ScaledDotProductAttention::eval_gpu(
     const auto& v = copy_unless(is_contiguous_except_seq_len, v_pre);
 
     // Donate the query if possible
-    if (q.is_donatable()) {
+    if (q.is_donatable() && q.size() == o.size()) {
       o.move_shared_buffer(q);
     } else {
       o.set_data(allocator::malloc_or_wait(o.nbytes()));

--- a/mlx/fast.cpp
+++ b/mlx/fast.cpp
@@ -685,10 +685,8 @@ array scaled_dot_product_attention(
   const size_t query_sequence_length = q.shape(2);
 
   const bool sdpa_vector_supported_head_dim =
-      (query_head_dim == value_head_dim &&
-       (query_head_dim == 64 || query_head_dim == 96 ||
-        query_head_dim == 128)) ||
-      (query_head_dim == 192 && value_head_dim == 128);
+      query_head_dim == value_head_dim &&
+      (query_head_dim == 64 || query_head_dim == 96 || query_head_dim == 128);
   const bool sdpa_full_supported_head_dim = query_head_dim == value_head_dim &&
       (query_head_dim == 64 || query_head_dim == 80);
 

--- a/mlx/fast.cpp
+++ b/mlx/fast.cpp
@@ -684,23 +684,22 @@ array scaled_dot_product_attention(
   const size_t query_head_dim = q.shape(-1);
   const size_t query_sequence_length = q.shape(2);
 
-  bool implementation_supports_use_case = query_head_dim == value_head_dim;
-
   const bool sdpa_vector_supported_head_dim =
-      query_head_dim == 64 || query_head_dim == 96 || query_head_dim == 128;
-  const bool sdpa_full_supported_head_dim =
-      query_head_dim == 64 || query_head_dim == 80;
+      (query_head_dim == value_head_dim &&
+       (query_head_dim == 64 || query_head_dim == 96 ||
+        query_head_dim == 128)) ||
+      (query_head_dim == 192 && value_head_dim == 128);
+  const bool sdpa_full_supported_head_dim = query_head_dim == value_head_dim &&
+      (query_head_dim == 64 || query_head_dim == 80);
 
-  const bool supports_sdpa_full = query_sequence_length >= threshold &&
-      !mask.has_value() && sdpa_full_supported_head_dim &&
-      stream.device == Device::gpu;
+  const bool supports_sdpa_full = query_sequence_length >= threshold && !mask &&
+      sdpa_full_supported_head_dim && stream.device == Device::gpu;
 
-  const bool supported_mask = !mask || (mask->dtype() == bool_);
   const bool supports_sdpa_vector = query_sequence_length == 1 &&
-      supported_mask && sdpa_vector_supported_head_dim &&
+      (!mask || mask->dtype() == bool_) && sdpa_vector_supported_head_dim &&
       stream.device == Device::gpu;
 
-  implementation_supports_use_case &=
+  const bool implementation_supports_use_case =
       supports_sdpa_full || supports_sdpa_vector;
 
   std::vector<array> inputs = {q, k, v};

--- a/python/tests/test_fast_sdpa.py
+++ b/python/tests/test_fast_sdpa.py
@@ -262,6 +262,7 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
             )
             self.assertTrue(mx.allclose(ref, out, atol=1e-4, rtol=1e-4))
 
+    @unittest.skip("Different head and value dims is not enabled")
     def test_fast_sdpa_vector_value_dims(self):
         D = 192
         V = 128

--- a/python/tests/test_fast_sdpa.py
+++ b/python/tests/test_fast_sdpa.py
@@ -262,6 +262,22 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
             )
             self.assertTrue(mx.allclose(ref, out, atol=1e-4, rtol=1e-4))
 
+    def test_fast_sdpa_vector_value_dims(self):
+        D = 192
+        V = 128
+        Nq = 4
+        Nkv = 1
+        scale = 1.0
+        mx.random.seed(0)
+
+        for L in [43, 128, 237, 8192]:
+            q = 5e-1 * mx.random.normal(shape=(1, Nq, 1, D))
+            k = 5e-1 * mx.random.normal(shape=(1, Nkv, L, D))
+            v = 5e-1 * mx.random.normal(shape=(1, Nkv, L, V))
+            ref = mlx_primitives_sdpa(q, k, v, scale)
+            out = mx.fast.scaled_dot_product_attention(q, k, v, scale=scale)
+            self.assertTrue(mx.allclose(ref, out, atol=1e-4, rtol=1e-4))
+
 
 if __name__ == "__main__":
     unittest.main(failfast=True)


### PR DESCRIPTION
As title. Specifically it adds a kernel for 192 query/key dimensions and 128 value dimensions.

On the M2 Ultra the speed ups are as follows (over non fused sdpa):

**With GQA**
![speedup_gqa](https://github.com/user-attachments/assets/a44953bf-cebd-408d-bf2e-3e6b5af8ed19)

**Without GQA**
![speedup](https://github.com/user-attachments/assets/50a46ed5-3ee0-499e-b1f9-81bcd511c88b)

