### PR TITLE
Add a device parameter to malloc_or_wait

### DIFF
--- a/mlx/allocator.cpp
+++ b/mlx/allocator.cpp
@@ -41,17 +41,17 @@ size_t CommonAllocator::size(Buffer buffer) const {
   return *static_cast<size_t*>(buffer.ptr());
 }
 
-Buffer malloc_or_wait(size_t size) {
-  auto buffer = allocator().malloc(size);
+Buffer malloc_or_wait(const Device& device, size_t size) {
+  auto buffer = allocator().malloc(device, size);
 
   while (size && !buffer.ptr() && scheduler::n_active_tasks() > 0) {
     scheduler::wait_for_one();
-    buffer = allocator().malloc(size);
+    buffer = allocator().malloc(device, size);
   }
 
   // Try swapping if needed
   if (size && !buffer.ptr()) {
-    buffer = allocator().malloc(size, /* allow_swap = */ true);
+    buffer = allocator().malloc(device, size, /* allow_swap = */ true);
   }
 
   if (size && !buffer.ptr()) {

--- a/mlx/allocator.h
+++ b/mlx/allocator.h
@@ -4,6 +4,8 @@
 
 #include <cstdlib>
 
+#include "mlx/device.h"
+
 namespace mlx::core::allocator {
 
 // Simple wrapper around buffer pointers
@@ -34,12 +36,19 @@ void free(Buffer buffer);
 
 // Wait for running tasks to finish and free up memory
 // if allocation fails
-Buffer malloc_or_wait(size_t size);
+Buffer malloc_or_wait(const Device& device, size_t size);
+inline Buffer malloc_or_wait(size_t size) {
+  return malloc_or_wait(Device::cpu, size);
+}
 
 class Allocator {
   /** Abstract base class for a memory allocator. */
  public:
   virtual Buffer malloc(size_t size, bool allow_swap = false) = 0;
+  virtual Buffer
+  malloc(const Device& device, size_t size, bool allow_swap = false) {
+    return malloc(size, allow_swap);
+  }
   virtual void free(Buffer buffer) = 0;
   virtual size_t size(Buffer buffer) const = 0;
 

--- a/mlx/backend/common/binary.h
+++ b/mlx/backend/common/binary.h
@@ -6,6 +6,7 @@
 #include "mlx/allocator.h"
 #include "mlx/array.h"
 #include "mlx/backend/common/utils.h"
+#include "mlx/primitives.h"
 
 #include "mlx/backend/common/simd/simd.h"
 
@@ -47,10 +48,14 @@ void set_binary_op_output_data(
     bool donate_with_move = false) {
   bool b_donatable = is_donatable(b, out);
   bool a_donatable = is_donatable(a, out);
+  const Device& device = out.primitive().device();
   switch (bopt) {
     case BinaryOpType::ScalarScalar:
       out.set_data(
-          allocator::malloc_or_wait(out.itemsize()), 1, a.strides(), a.flags());
+          allocator::malloc_or_wait(device, out.itemsize()),
+          1,
+          a.strides(),
+          a.flags());
       break;
     case BinaryOpType::ScalarVector:
       if (b_donatable) {
@@ -61,7 +66,7 @@ void set_binary_op_output_data(
         }
       } else {
         out.set_data(
-            allocator::malloc_or_wait(b.data_size() * out.itemsize()),
+            allocator::malloc_or_wait(device, b.data_size() * out.itemsize()),
             b.data_size(),
             b.strides(),
             b.flags());
@@ -76,7 +81,7 @@ void set_binary_op_output_data(
         }
       } else {
         out.set_data(
-            allocator::malloc_or_wait(a.data_size() * out.itemsize()),
+            allocator::malloc_or_wait(device, a.data_size() * out.itemsize()),
             a.data_size(),
             a.strides(),
             a.flags());
@@ -97,7 +102,7 @@ void set_binary_op_output_data(
         }
       } else {
         out.set_data(
-            allocator::malloc_or_wait(a.data_size() * out.itemsize()),
+            allocator::malloc_or_wait(device, a.data_size() * out.itemsize()),
             a.data_size(),
             a.strides(),
             a.flags());
@@ -118,7 +123,7 @@ void set_binary_op_output_data(
           out.copy_shared_buffer(b);
         }
       } else {
-        out.set_data(allocator::malloc_or_wait(out.nbytes()));
+        out.set_data(allocator::malloc_or_wait(device, out.nbytes()));
       }
       break;
   }

--- a/mlx/backend/common/ternary.h
+++ b/mlx/backend/common/ternary.h
@@ -1,9 +1,11 @@
 // Copyright © 2023 Apple Inc.
 
 #pragma once
+
 #include "mlx/allocator.h"
 #include "mlx/array.h"
 #include "mlx/backend/common/utils.h"
+#include "mlx/primitives.h"
 
 namespace mlx::core {
 
@@ -52,15 +54,19 @@ void set_ternary_op_output_data(
     return false;
   };
 
+  const Device& device = out.primitive().device();
   switch (topt) {
     case TernaryOpType::ScalarScalarScalar:
       out.set_data(
-          allocator::malloc_or_wait(out.itemsize()), 1, b.strides(), b.flags());
+          allocator::malloc_or_wait(device, out.itemsize()),
+          1,
+          b.strides(),
+          b.flags());
       break;
     case TernaryOpType::VectorVectorVector:
       if (!(maybe_donate(a) || maybe_donate(b) || maybe_donate(c))) {
         out.set_data(
-            allocator::malloc_or_wait(out.itemsize() * b.data_size()),
+            allocator::malloc_or_wait(device, out.itemsize() * b.data_size()),
             b.data_size(),
             b.strides(),
             b.flags());
@@ -71,7 +77,7 @@ void set_ternary_op_output_data(
       if (!((a.flags().row_contiguous && maybe_donate(a)) ||
             (b.flags().row_contiguous && maybe_donate(b)) ||
             (c.flags().row_contiguous && maybe_donate(c)))) {
-        out.set_data(allocator::malloc_or_wait(out.nbytes()));
+        out.set_data(allocator::malloc_or_wait(device, out.nbytes()));
       }
       break;
   }


### PR DESCRIPTION
This PR adds a `device` parameter to `malloc`s, which makes the code written for unified memory backend also usable for general gpu backend (https://github.com/ml-explore/mlx/pull/1789).