### PR TITLE
Resolved ambiguity in mlx::core::take_along_axis

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -3081,7 +3081,7 @@ array take_along_axis(
   axis = axis < 0 ? a.ndim() + axis : axis;
 
   // Broadcast indices and input ignoring the take axis
-  auto inputs = broadcast_arrays({a, indices}, {axis - int(a.ndim())}, s);
+  auto inputs = broadcast_arrays({a, indices}, std::vector<int>{axis - int(a.ndim())}, s);
 
   auto out_shape = inputs[1].shape();
   return array(

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -3081,7 +3081,8 @@ array take_along_axis(
   axis = axis < 0 ? a.ndim() + axis : axis;
 
   // Broadcast indices and input ignoring the take axis
-  auto inputs = broadcast_arrays({a, indices}, std::vector<int>{axis - int(a.ndim())}, s);
+  auto inputs =
+      broadcast_arrays({a, indices}, std::vector<int>{axis - int(a.ndim())}, s);
 
   auto out_shape = inputs[1].shape();
   return array(

--- a/tests/random_tests.cpp
+++ b/tests/random_tests.cpp
@@ -556,7 +556,7 @@ TEST_CASE("test random bernoulli") {
 
   p = array({0.1, 0.2, 0.3});
   // Ask for the wrong shape => throws
-  CHECK_THROWS_AS(random::bernoulli(p, Shape({2})), std::invalid_argument);
+  CHECK_THROWS_AS(random::bernoulli(p, Shape{2}), std::invalid_argument);
 
   // Check wrong key type or shape
   auto key = array({0, 0}, {1, 2});


### PR DESCRIPTION
## Proposed changes

Resolved ambiguity in mlx::core::take_along_axis

Detected by GCC 10 on riscv64-linux-gnu, cf. https://buildkite.com/julialang/yggdrasil/builds/17038#0194c5fc-ae8d-4c1d-96de-0d949c662922/6-19667


## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
