### PR TITLE
No line buffer for mpi jobs

### DIFF
--- a/python/mlx/distributed_run.py
+++ b/python/mlx/distributed_run.py
@@ -253,6 +253,8 @@ def launch_mpi(parser, hosts, args, command):
 
         cmd = [
             mpirun,
+            "--output",
+            ":raw",  # do not line buffer output
             "--hostfile",
             f.name,
             *(["-cwd", args.cwd] if args.cwd else []),


### PR DESCRIPTION
Makes LLM output much nicer when it can actually stream. Also one can control buffering in the Python code by using `flush` or not so it seems preferable to always just rely on that.