### PR TITLE
Fix compilation error on Windows

### DIFF
--- a/mlx/backend/cpu/jit_compiler.cpp
+++ b/mlx/backend/cpu/jit_compiler.cpp
@@ -54,7 +54,7 @@ struct VisualStudioInfo {
       std::string value = line.substr(pos + 1);
       if (name == "LIB") {
         libpaths = str_split(value, ';');
-      } else if (name == "VCToolsInstallDir") {
+      } else if (name == "VCToolsInstallDir" || name == "VCTOOLSINSTALLDIR") {
         cl_exe = fmt::format("{0}\\bin\\Host{1}\\{1}\\cl.exe", value, arch);
       }
     }

--- a/mlx/backend/cpu/simd/base_simd.h
+++ b/mlx/backend/cpu/simd/base_simd.h
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <cmath>
 #include <complex>
+#include <functional>
 
 namespace mlx::core::simd {
 template <typename T, int N>


### PR DESCRIPTION
The env name can be full uppercased on some systems.

The `std::negate` needs `functional` header.