### PR TITLE
Add advice to use miniconda if editable package fails. (#1846)

### DIFF
--- a/docs/src/install.rst
+++ b/docs/src/install.rst
@@ -47,6 +47,31 @@ should be ``arm``. If it is ``i386`` (and you have M series machine) then you
 are using a non-native Python. Switch your Python to a native Python. A good
 way to do this is with `Conda <https://stackoverflow.com/q/65415996>`_.
 
+*The installation of the editable package fails.*
+
+If the following command fails:
+
+.. code-block:: shell
+
+  CMAKE_BUILD_PARALLEL_LEVEL=8 pip install -e ".[dev]"
+
+then check your Python environment is consistent.
+
+Using miniconda is the recommended way to manage your Python environment.
+Assuming you have the brew package manager installed, and are using zsh 
+as your shell, try:
+
+.. code-block:: shell
+
+    brew install --cask miniconda
+    conda init "$(basename "${SHELL}")"
+    source ~/.zshrc
+    conda create --name myenv python=3.13.0
+    conda activate myenv
+    pip install --upgrade pip
+    CMAKE_BUILD_PARALLEL_LEVEL=8 pip install ".[dev]"
+    CMAKE_BUILD_PARALLEL_LEVEL=8 pip install -e ".[dev]"
+
 
 Build from source
 -----------------


### PR DESCRIPTION
## Proposed changes

This change adds advice for those affected by #1846 
The installation/build process works for different python versions if minconda was used to consistently version the environment.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

The revised documentation looks like this:
<img width="905" alt="revised-documentation" src="https://github.com/user-attachments/assets/c277846d-ab10-45c0-99d6-6c27f132e9eb" />
