### PR TITLE
Cycle leak break

### DIFF
--- a/python/src/CMakeLists.txt
+++ b/python/src/CMakeLists.txt
@@ -17,6 +17,7 @@ nanobind_add_module(
   ${CMAKE_CURRENT_SOURCE_DIR}/indexing.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/load.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/metal.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/mlx_func.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ops.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/stream.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/transforms.cpp

--- a/python/src/mlx.cpp
+++ b/python/src/mlx.cpp
@@ -26,7 +26,7 @@ NB_MODULE(core, m) {
 
   auto reprlib_fix = nb::module_::import_("mlx._reprlib_fix");
   nb::module_::import_("mlx._os_warning");
-  nb::set_leak_warnings(false);
+  //  nb::set_leak_warnings(false);
 
   init_device(m);
   init_stream(m);

--- a/python/src/mlx.cpp
+++ b/python/src/mlx.cpp
@@ -7,6 +7,7 @@
 
 namespace nb = nanobind;
 
+void init_mlx_func(nb::module_&);
 void init_array(nb::module_&);
 void init_device(nb::module_&);
 void init_stream(nb::module_&);
@@ -26,8 +27,9 @@ NB_MODULE(core, m) {
 
   auto reprlib_fix = nb::module_::import_("mlx._reprlib_fix");
   nb::module_::import_("mlx._os_warning");
-  //  nb::set_leak_warnings(false);
+  nb::set_leak_warnings(false);
 
+  init_mlx_func(m);
   init_device(m);
   init_stream(m);
   init_array(m);

--- a/python/src/mlx_func.cpp
+++ b/python/src/mlx_func.cpp
@@ -1,0 +1,108 @@
+// Copyright © 2025 Apple Inc.
+
+#include "python/src/mlx_func.h"
+
+// A garbage collected function which wraps nb::cpp_function
+// See https://github.com/wjakob/nanobind/discussions/919
+
+struct gc_func {
+  PyObject_HEAD
+      // Vector call implementation that forwards calls to nanobind
+      PyObject* (*vectorcall)(PyObject*, PyObject* const*, size_t, PyObject*);
+  // The function itself
+  PyObject* func;
+  // A non-owning reference to dependencies owned by 'func'
+  std::vector<PyObject*> deps;
+};
+
+int gc_func_tp_traverse(PyObject* self, visitproc visit, void* arg) {
+  gc_func* w = (gc_func*)self;
+  Py_VISIT(w->func);
+  for (auto d : w->deps) {
+    Py_VISIT(d);
+  }
+  Py_VISIT(Py_TYPE(self));
+  return 0;
+};
+
+int gc_func_tp_clear(PyObject* self) {
+  gc_func* w = (gc_func*)self;
+  Py_CLEAR(w->func);
+  return 0;
+}
+
+PyObject* gc_func_get_doc(PyObject* self, void*) {
+  return PyObject_GetAttrString(((gc_func*)self)->func, "__doc__");
+}
+
+PyObject* gc_func_get_sig(PyObject* self, void*) {
+  return PyObject_GetAttrString(((gc_func*)self)->func, "__nb_signature__");
+}
+
+PyObject* gc_func_vectorcall(
+    PyObject* self,
+    PyObject* const* args,
+    size_t nargs,
+    PyObject* kwnames) {
+  return PyObject_Vectorcall(((gc_func*)self)->func, args, nargs, kwnames);
+}
+
+void gc_func_dealloc(PyObject* self) {
+  PyObject_GC_UnTrack(self);
+  Py_XDECREF(((gc_func*)self)->func);
+  PyObject_GC_Del(self);
+}
+
+static PyMemberDef gc_func_members[] = {
+    {"__vectorcalloffset__",
+     T_PYSSIZET,
+     (Py_ssize_t)offsetof(gc_func, vectorcall),
+     READONLY,
+     nullptr},
+    {nullptr, 0, 0, 0, nullptr}};
+
+static PyGetSetDef gc_func_getset[] = {
+    {"__doc__", gc_func_get_doc, nullptr, nullptr, nullptr},
+    {"__nb_signature__", gc_func_get_sig, nullptr, nullptr, nullptr},
+    {nullptr, nullptr, nullptr, nullptr, nullptr}};
+
+static PyObject* gc_func_getattro(PyObject* self, PyObject* name_) {
+  gc_func* w = (gc_func*)self;
+  auto f = PyCFunction(PyType_GetSlot(Py_TYPE(w->func), Py_tp_getattro));
+  return f(w->func, name_);
+}
+
+// Table of custom type slots we want to install
+PyType_Slot gc_func_slots[] = {
+    {Py_tp_traverse, (void*)gc_func_tp_traverse},
+    {Py_tp_clear, (void*)gc_func_tp_clear},
+    {Py_tp_getset, (void*)gc_func_getset},
+    {Py_tp_getattro, (void*)gc_func_getattro},
+    {Py_tp_members, (void*)gc_func_members},
+    {Py_tp_call, (void*)PyVectorcall_Call},
+    {Py_tp_dealloc, (void*)gc_func_dealloc},
+    {0, 0}};
+
+static PyType_Spec gc_func_spec = {
+    /* .name = */ "mlx.gc_func",
+    /* .basicsize = */ (int)sizeof(gc_func),
+    /* .itemsize = */ 0,
+    /* .flags = */ Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | NB_HAVE_VECTORCALL,
+    /* .slots = */ gc_func_slots};
+
+static PyTypeObject* gc_func_tp = nullptr;
+
+nb::callable mlx_func(nb::object func, std::vector<PyObject*> deps) {
+  gc_func* r = (gc_func*)PyType_GenericAlloc(gc_func_tp, 0);
+  r->func = func.inc_ref().ptr();
+  r->deps = std::move(deps);
+  r->vectorcall = gc_func_vectorcall;
+  return nb::steal<nb::callable>((PyObject*)r);
+}
+
+void init_mlx_func(nb::module_& m) {
+  gc_func_tp = (PyTypeObject*)PyType_FromSpec(&gc_func_spec);
+  if (!gc_func_tp) {
+    nb::raise("Could not register MLX function type.");
+  }
+}

--- a/python/src/mlx_func.h
+++ b/python/src/mlx_func.h
@@ -1,0 +1,24 @@
+// Copyright © 2025 Apple Inc.
+
+#pragma once
+
+#include <vector>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/function.h>
+
+namespace nb = nanobind;
+using namespace nb::literals;
+
+nb::callable mlx_func(nb::object func, std::vector<PyObject*> deps);
+
+template <typename F, typename... Deps>
+nb::callable mlx_func(F func, Deps&&... deps) {
+  return mlx_func(
+      nb::cpp_function(std::move(func)), std::vector<PyObject*>{deps.ptr()...});
+}
+
+template <typename... Deps>
+nb::callable mlx_func(nb::object func, Deps&&... deps) {
+  return mlx_func(std::move(func), std::vector<PyObject*>{deps.ptr()...});
+}

--- a/python/tests/test_compile.py
+++ b/python/tests/test_compile.py
@@ -1,5 +1,6 @@
 # Copyright © 2023-2024 Apple Inc.
 
+import gc
 import io
 import unittest
 from functools import partial
@@ -925,6 +926,32 @@ class TestCompile(mlx_tests.MLXTestCase):
 
         self.assertEqual(out[0].shape, (3, 1, 4, 2))
         self.assertEqual(out[1].shape, (2, 2, 5))
+
+    def test_leaks(self):
+        if mx.metal.is_available():
+            mem_pre = mx.metal.get_active_memory()
+        else:
+            mem_pre = 0
+
+        def outer():
+            d = {}
+
+            def f(x):
+                return d["x"]
+
+            d["f"] = mx.compile(f)
+            d["x"] = mx.array([0] * 1000)
+
+        for _ in range(5):
+            outer()
+            gc.collect()
+
+        if mx.metal.is_available():
+            mem_post = mx.metal.get_active_memory()
+        else:
+            mem_post = 0
+
+        self.assertEqual(mem_pre, mem_post)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Enable Python garbage collector to break reference cycles with MLX function transformations and other custom MLX objects which hold references Python objects.

There are two mechanisms. For functions which were built with `nb::cpp_function` we now use `mlx_func` as a light-weight wrapper with garbage collection. Python object dependencies have to be registered on construction like so:

```
mlx_fun(wrapped_fun, dep1, dep2, ...)
```

For classes that hold `nb::object`, `nb::callable` etc. we install Python cycle breaking functions in the type slots.

Closes #1832 

Thanks a ton to @wjakob for the help implementing this (see discussion https://github.com/wjakob/nanobind/discussions/919)