### PR TITLE
More buffer donation in some cases

### DIFF
--- a/mlx/backend/metal/metal.cpp
+++ b/mlx/backend/metal/metal.cpp
@@ -70,7 +70,11 @@ std::function<void()> make_task(array arr, bool signal) {
     // Erase any input buffers that have a use count > 1
     // to keep them elligible for donation
     for (auto it = buffers.begin(); it != buffers.end();) {
-      if (it->use_count() > 1) {
+      // Always hold buffers which could belong to outputs
+      // TODO: this shouldn't be necessary, but metal validation
+      // complains if buffers get released before the command buffer is
+      // finished, even if the ready signal has fired
+      if (!signal && it->use_count() > 1) {
         it = buffers.erase(it);
       } else {
         ++it;

--- a/python/tests/test_eval.py
+++ b/python/tests/test_eval.py
@@ -175,19 +175,21 @@ class TestEval(mlx_tests.MLXTestCase):
         self.assertEqual(pre, post)
 
     def test_donation_multiple_inputs(self):
-        def fun(its):
-            x = mx.zeros((128, 128))
-            y = mx.zeros((128, 128))
+        def fun(its, x, y):
             for _ in range(its):
                 a = x + y  # y should donate
                 b = x + a  # x should donate
                 x, y = a, b
             return x, y
 
+        x = mx.zeros((128, 128))
+        y = mx.zeros((128, 128))
         mx.metal.reset_peak_memory()
-        mx.eval(fun(2))
+        a, b = fun(2, x, y)
+        mx.eval(a, b)
         mem2 = mx.metal.get_peak_memory()
-        mx.eval(fun(10))
+        a, b = fun(10, x, y)
+        mx.eval(a, b)
         mem10 = mx.metal.get_peak_memory()
         self.assertEqual(mem2, mem10)
 

--- a/python/tests/test_eval.py
+++ b/python/tests/test_eval.py
@@ -174,6 +174,23 @@ class TestEval(mlx_tests.MLXTestCase):
         post = mx.metal.get_peak_memory()
         self.assertEqual(pre, post)
 
+    def test_donation_multiple_inputs(self):
+        def fun(its):
+            x = mx.zeros((128, 128))
+            y = mx.zeros((128, 128))
+            for _ in range(its):
+                a = x + y  # y should donate
+                b = x + a  # x should donate
+                x, y = a, b
+            return x, y
+
+        mx.metal.reset_peak_memory()
+        mx.eval(fun(2))
+        mem2 = mx.metal.get_peak_memory()
+        mx.eval(fun(10))
+        mem10 = mx.metal.get_peak_memory()
+        self.assertEqual(mem2, mem10)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Previously if an input didn't get donated it was held by the command buffer and no longer eligible for donation.

So sequences like:

```python
a = x + y
b = mx.abs(x)
```

Assuming `x` didn't get donated to `a` then it is impossible for it to be donated to `b`.

This changes that by removing buffers that are safe to not hold in the command buffer.

Benchmark on Transformer training:
Command: `python main.py --gpu --batch_size 8`
Pre:   `Iter 20: Train loss 8.181, It/sec 0.853, Peak memory 17.431 (GB)`
Post: `Iter 20: Train loss 8.260, It/sec 0.885, Peak memory 16.330 (GB)`
