### PR TITLE
Compiler warnings are errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,6 @@ endif()
 add_compile_definitions("MLX_VERSION=${MLX_VERSION}")
 
 # --------------------- Processor tests -------------------------
-
 message(
   STATUS
     "Building MLX for ${CMAKE_SYSTEM_PROCESSOR} processor on ${CMAKE_SYSTEM_NAME}"
@@ -64,6 +63,7 @@ include(FetchContent)
 cmake_policy(SET CMP0135 NEW)
 
 add_library(mlx)
+set_target_properties(mlx PROPERTIES COMPILE_WARNING_AS_ERROR ON)
 
 if(MLX_BUILD_METAL)
   set(METAL_LIB "-framework Metal")

--- a/mlx/backend/cpu/gemms/bnns.cpp
+++ b/mlx/backend/cpu/gemms/bnns.cpp
@@ -43,6 +43,8 @@ void matmul_bnns(
 
   BNNSDataType bnns_dtype = to_bnns_dtype(out.dtype());
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   const BNNSLayerParametersBroadcastMatMul gemm_params{
       /* float alpha = */ alpha,
       /* float beta = */ beta,
@@ -124,6 +126,7 @@ void matmul_bnns(
   }
 
   BNNSFilterDestroy(bnns_filter);
+#pragma GCC diagnostic pop
 }
 
 template <>


### PR DESCRIPTION
Warnings are errors. We have pretty relaxed warning settings in MLX so this shouldn't be too strict, but if it is annoying we can also enable it only for our CI or something like that.