### PR TITLE
Raise an exception in the rope op if input is integer

### DIFF
--- a/mlx/fast.cpp
+++ b/mlx/fast.cpp
@@ -348,6 +348,11 @@ array rope(
         << x.ndim() << " dimensions.";
     throw std::invalid_argument(msg.str());
   }
+  if (!issubdtype(x.dtype(), floating)) {
+    std::ostringstream msg;
+    msg << "[rope] Input must be a floating type but got " << x.dtype() << ".";
+    throw std::invalid_argument(msg.str());
+  }
   if (offset.size() != 1) {
     std::ostringstream msg;
     msg << "[rope] offset must be a scalar but has shape " << offset.shape()

--- a/python/tests/test_fast.py
+++ b/python/tests/test_fast.py
@@ -167,6 +167,8 @@ class TestFast(mlx_tests.MLXTestCase):
             )
 
     def test_rope_with_freqs(self):
+        mx.random.seed(0)
+
         # Check throws
         T = 4
         dims = 8

--- a/python/tests/test_fast.py
+++ b/python/tests/test_fast.py
@@ -158,6 +158,14 @@ class TestFast(mlx_tests.MLXTestCase):
         )
         self.assertLess(mx.abs(rx - rx_fast).max(), tolerances[mx.float32])
 
+        # Test raises with integer inputs
+        dims, _, base, scale, offset, traditional = defaults
+        x = (mx.random.uniform(shape=(2, T, dims)) * 10).astype(mx.int32)
+        with self.assertRaises(ValueError):
+            y = mx.fast.rope(
+                x, dims, traditional=traditional, base=base, scale=scale, offset=offset
+            )
+
     def test_rope_with_freqs(self):
         # Check throws
         T = 4


### PR DESCRIPTION
We could implicitly cast but I think that makes a bit more sense. It is very likely that someone accidentally is passing ints in.