### PR TITLE
Limit compile buffers

### DIFF
--- a/python/tests/mpi_test_distributed.py
+++ b/python/tests/mpi_test_distributed.py
@@ -177,6 +177,7 @@ class TestDistributed(mlx_tests.MLXTestCase):
     def test_donation(self):
         x = mx.random.normal((1024,))
         mx.eval(x)
+        mx.synchronize(mx.default_stream(mx.default_device()))
 
         mx.metal.reset_peak_memory()
         scale = mx.array(2.0)

--- a/python/tests/test_load.py
+++ b/python/tests/test_load.py
@@ -385,6 +385,7 @@ class TestLoad(mlx_tests.MLXTestCase):
         mx.eval(x)
         save_file = os.path.join(self.test_dir, "donation.npy")
         mx.save(save_file, x)
+        mx.synchronize(mx.default_stream(mx.default_device()))
 
         mx.metal.reset_peak_memory()
         scale = mx.array(2.0)


### PR DESCRIPTION
Limits the number of input/output buffers for compiled primitive to avoid crashing in Metal. 

Closes #1880 

Note this is an approximation in that we still break the primitive in the case that the computation fans out to many possible inputs and then fans back in to just a few. It should be a rare case ... but there could be more optimal approaches to deal with that. It seems overly complex for now though.

Another option is to use Metal argument buffers which could hold unlimited buffers. The problem with this approach is that there are some limitations with Metal 2 / VMs. We [removed argument encoders](https://github.com/ml-explore/mlx/pull/683) for that reason. It's possible they can be made to work, not certain.