### PR TITLE
fix version and expose command queue getter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,14 @@
 cmake_minimum_required(VERSION 3.25)
 
 if(NOT MLX_VERSION)
-  set(MLX_VERSION 0.23.1)
-  set(MLX_PROJECT_VERSION ${MLX_VERSION})
+  file(STRINGS "mlx/version.h" _mlx_h_version REGEX "^#define MLX_VERSION_.*$")
+  string(REGEX MATCH "#define MLX_VERSION_MAJOR ([0-9]+)" _ "${_mlx_h_version}")
+  set(_major ${CMAKE_MATCH_1})
+  string(REGEX MATCH "#define MLX_VERSION_MINOR ([0-9]+)" _ "${_mlx_h_version}")
+  set(_minor ${CMAKE_MATCH_1})
+  string(REGEX MATCH "#define MLX_VERSION_PATCH ([0-9]+)" _ "${_mlx_h_version}")
+  set(_patch ${CMAKE_MATCH_1})
+  set(MLX_PROJECT_VERSION "${_major}.${_minor}.${_patch}")
 else()
   string(REGEX REPLACE "^([0-9]+\.[0-9]+\.[0-9]+).*" "\\1" MLX_PROJECT_VERSION
                        ${MLX_VERSION})
@@ -35,17 +41,7 @@ option(MLX_BUILD_BLAS_FROM_SOURCE "Build OpenBLAS from source code" OFF)
 option(MLX_METAL_JIT "Use JIT compilation for Metal kernels" OFF)
 option(BUILD_SHARED_LIBS "Build mlx as a shared library" OFF)
 
-math(
-  EXPR
-  MLX_VERSION_NUMERIC
-  "1000000 * ${PROJECT_VERSION_MAJOR} + 1000 * ${PROJECT_VERSION_MINOR} + ${PROJECT_VERSION_PATCH}"
-  OUTPUT_FORMAT DECIMAL)
-add_compile_definitions(
-  "MLX_VERSION=${MLX_VERSION}"
-  "MLX_VERSION_MAJOR=${PROJECT_VERSION_MAJOR}"
-  "MLX_VERSION_MINOR=${PROJECT_VERSION_MINOR}"
-  "MLX_VERSION_PATCH=${PROJECT_VERSION_PATCH}"
-  "MLX_VERSION_NUMERIC=${MLX_VERSION_NUMERIC}")
+add_compile_definitions("MLX_VERSION=${MLX_VERSION}")
 
 # --------------------- Processor tests -------------------------
 message(

--- a/mlx/CMakeLists.txt
+++ b/mlx/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(
           ${CMAKE_CURRENT_SOURCE_DIR}/transforms.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/utils.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/linalg.cpp
+          ${CMAKE_CURRENT_SOURCE_DIR}/version.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/backend/metal/metal.h)
 
 if(MSVC)

--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -254,9 +254,6 @@ Device::~Device() {
 
 void Device::new_queue(int index) {
   auto thread_pool = metal::new_scoped_memory_pool();
-
-  // Multiple threads can ask the device for queues
-  // We lock this as a critical section for safety
   auto q = device_->newCommandQueue(MAX_BUFFERS_PER_QUEUE);
   debug_set_stream_queue_label(q, index);
   if (!q) {
@@ -267,6 +264,10 @@ void Device::new_queue(int index) {
   if (residency_set_ != nullptr) {
     q->addResidencySet(residency_set_);
   }
+}
+
+MTL::CommandQueue* Device::get_queue(Stream stream) {
+  return get_stream_(stream.index).queue;
 }
 
 bool Device::command_buffer_needs_commit(int index) {

--- a/mlx/backend/metal/device.h
+++ b/mlx/backend/metal/device.h
@@ -178,6 +178,9 @@ class Device {
   }
 
   void new_queue(int index);
+
+  MTL::CommandQueue* get_queue(Stream stream);
+
   MTL::CommandBuffer* get_command_buffer(int index);
   bool command_buffer_needs_commit(int index);
   void commit_command_buffer(int index);

--- a/mlx/version.cpp
+++ b/mlx/version.cpp
@@ -1,0 +1,16 @@
+// Copyright © 2025 Apple Inc.
+
+#include <string>
+
+#include "mlx/version.h"
+
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+
+namespace mlx::core {
+
+std::string version() {
+  return TOSTRING(MLX_VERSION);
+}
+
+} // namespace mlx::core

--- a/mlx/version.h
+++ b/mlx/version.h
@@ -1,32 +1,20 @@
-// Copyright © 2023-2024 Apple Inc.
+// Copyright © 2025 Apple Inc.
 
 #pragma once
 
-#include <string>
-
-#define STRINGIFY(x) #x
-#define TOSTRING(x) STRINGIFY(x)
+#define MLX_VERSION_MAJOR 0
+#define MLX_VERSION_MINOR 24
+#define MLX_VERSION_PATCH 2
+#define MLX_VERSION_NUMERIC \
+  (100000 * MLX_VERSION_MAJOR + 1000 * MLX_VERSION_MINOR + MLX_VERSION_PATCH)
 
 namespace mlx::core {
 
-constexpr const char* version() {
-  return TOSTRING(MLX_VERSION);
-}
-
-constexpr int version_major() {
-  return MLX_VERSION_MAJOR;
-}
-
-constexpr int version_minor() {
-  return MLX_VERSION_MINOR;
-}
-
-constexpr int version_patch() {
-  return MLX_VERSION_PATCH;
-}
-
-constexpr int version_numeric() {
-  return MLX_VERSION_NUMERIC;
-}
+/* A string representation of the MLX version in the format
+ * "major.minor.patch".
+ *
+ * For dev builds, the version will include the suffix ".devYYYYMMDD+hash"
+ */
+std::string version();
 
 } // namespace mlx::core


### PR DESCRIPTION
Fixes the versions in the header so that downstream code can actually use them without setting the defines (which kind of defeats the purpose). Also they broke compiling with MLX as a library without setting the defines.

- Swap where we defining C++ version to version.h and reading it in CMake
- Use a compiled `version()` rather than inline in the header


Exposes command queue for setting properties (note this is an internal MLX API). It can be used like so:
```C++
  auto stream = default_stream(mx::Device::gpu);
  auto& d = mx::metal::device(mx::Device::gpu);
  MTL::CommandQueue* q = d.get_queue(stream);

  // Set some stuff on q here.

  return 0;
}
```

