### PR TITLE
Adds nuclear norm support

### DIFF
--- a/mlx/linalg.cpp
+++ b/mlx/linalg.cpp
@@ -112,8 +112,16 @@ inline array matrix_norm(
   if (ord == "f" || ord == "fro") {
     return l2_norm(a, axis, keepdims, s);
   } else if (ord == "nuc") {
-    throw std::runtime_error(
-        "[linalg::norm] Nuclear norm not yet implemented.");
+    auto a_moveaxis = moveaxis(a, axis[1], -1, s);
+    a_moveaxis = moveaxis(
+        a_moveaxis, (axis[0] > axis[1] ? axis[0] - 1 : axis[0]), -2, s);
+    auto nuclear_norm = sum(svd(a_moveaxis, false, s).at(0), -1, false, s);
+    if (keepdims) {
+      std::vector<int> sorted_axes(axis);
+      std::sort(sorted_axes.begin(), sorted_axes.end());
+      nuclear_norm = expand_dims(nuclear_norm, sorted_axes, s);
+    }
+    return nuclear_norm;
   } else {
     std::ostringstream msg;
     msg << "[linalg::norm] Invalid ord value '" << ord << "' for matrix norm.";
@@ -210,7 +218,8 @@ std::pair<array, array> qr(const array& a, StreamOrDevice s /* = {} */) {
   return std::make_pair(out[0], out[1]);
 }
 
-std::vector<array> svd(const array& a, StreamOrDevice s /* = {} */) {
+std::vector<array>
+svd(const array& a, bool compute_uv /* = true */, StreamOrDevice s /* = {} */) {
   check_cpu_stream(s, "[linalg::svd]");
   if (a.dtype() != float32) {
     std::ostringstream msg;
@@ -230,13 +239,21 @@ std::vector<array> svd(const array& a, StreamOrDevice s /* = {} */) {
   const auto n = a.shape(-1);
   const auto rank = a.ndim();
 
-  auto u_shape = a.shape();
-  u_shape[rank - 2] = m;
-  u_shape[rank - 1] = m;
-
   auto s_shape = a.shape();
   s_shape.pop_back();
   s_shape[rank - 2] = std::min(m, n);
+
+  if (!compute_uv) {
+    return array::make_arrays(
+        {s_shape},
+        {a.dtype()},
+        std::make_shared<SVD>(to_stream(s), compute_uv),
+        {a});
+  }
+
+  auto u_shape = a.shape();
+  u_shape[rank - 2] = m;
+  u_shape[rank - 1] = m;
 
   auto vt_shape = a.shape();
   vt_shape[rank - 2] = n;
@@ -245,7 +262,7 @@ std::vector<array> svd(const array& a, StreamOrDevice s /* = {} */) {
   return array::make_arrays(
       {u_shape, s_shape, vt_shape},
       {a.dtype(), a.dtype(), a.dtype()},
-      std::make_shared<SVD>(to_stream(s)),
+      std::make_shared<SVD>(to_stream(s), compute_uv),
       {a});
 }
 
@@ -337,7 +354,7 @@ array pinv(const array& a, StreamOrDevice s /* = {} */) {
   int m = a.shape(-2);
   int n = a.shape(-1);
   int k = std::min(m, n);
-  auto outs = linalg::svd(a, s);
+  auto outs = linalg::svd(a, true, s);
   array U = outs[0];
   array S = outs[1];
   array V = outs[2];

--- a/mlx/linalg.cpp
+++ b/mlx/linalg.cpp
@@ -260,11 +260,11 @@ svd(const array& a, bool compute_uv, StreamOrDevice s /* = {} */) {
   s_shape[rank - 2] = std::min(m, n);
 
   if (!compute_uv) {
-    return array::make_arrays(
-        {s_shape},
-        {a.dtype()},
+    return {array(
+        std::move(s_shape),
+        std::move(a.dtype()),
         std::make_shared<SVD>(to_stream(s), compute_uv),
-        {a});
+        {a})};
   }
 
   auto u_shape = a.shape();

--- a/mlx/linalg.h
+++ b/mlx/linalg.h
@@ -62,7 +62,8 @@ norm(const array& a, int axis, bool keepdims = false, StreamOrDevice s = {}) {
 
 std::pair<array, array> qr(const array& a, StreamOrDevice s = {});
 
-std::vector<array> svd(const array& a, StreamOrDevice s = {});
+std::vector<array>
+svd(const array& a, bool compute_uv = true, StreamOrDevice s = {});
 
 array inv(const array& a, StreamOrDevice s = {});
 

--- a/mlx/linalg.h
+++ b/mlx/linalg.h
@@ -63,7 +63,10 @@ norm(const array& a, int axis, bool keepdims = false, StreamOrDevice s = {}) {
 std::pair<array, array> qr(const array& a, StreamOrDevice s = {});
 
 std::vector<array>
-svd(const array& a, bool compute_uv = true, StreamOrDevice s = {});
+svd(const array& a, bool compute_uv, StreamOrDevice s /* = {} */);
+inline std::vector<array> svd(const array& a, StreamOrDevice s = {}) {
+  return svd(a, true, s);
+}
 
 array inv(const array& a, StreamOrDevice s = {});
 

--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -4940,7 +4940,7 @@ std::pair<std::vector<array>, std::vector<int>> SVD::vmap(
     const std::vector<int>& axes) {
   auto ax = axes[0] >= 0 ? 0 : -1;
   auto a = axes[0] > 0 ? moveaxis(inputs[0], axes[0], 0, stream()) : inputs[0];
-  return {{linalg::svd(a, stream())}, {ax, ax, ax}};
+  return {{linalg::svd(a, true, stream())}, {ax, ax, ax}};
 }
 
 std::pair<std::vector<array>, std::vector<int>> Inverse::vmap(

--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -4940,7 +4940,8 @@ std::pair<std::vector<array>, std::vector<int>> SVD::vmap(
     const std::vector<int>& axes) {
   auto ax = axes[0] >= 0 ? 0 : -1;
   auto a = axes[0] > 0 ? moveaxis(inputs[0], axes[0], 0, stream()) : inputs[0];
-  return {{linalg::svd(a, true, stream())}, {ax, ax, ax}};
+  std::vector<int> new_axes(compute_uv_ ? 3 : 1, ax);
+  return {linalg::svd(a, compute_uv_, stream()), std::move(new_axes)};
 }
 
 std::pair<std::vector<array>, std::vector<int>> Inverse::vmap(

--- a/mlx/primitives.h
+++ b/mlx/primitives.h
@@ -2287,7 +2287,8 @@ class QRF : public Primitive {
 /* SVD primitive. */
 class SVD : public Primitive {
  public:
-  explicit SVD(Stream stream) : Primitive(stream) {}
+  explicit SVD(Stream stream, bool compute_uv)
+      : Primitive(stream), compute_uv_(compute_uv) {}
 
   void eval_cpu(const std::vector<array>& inputs, std::vector<array>& outputs)
       override;
@@ -2296,6 +2297,12 @@ class SVD : public Primitive {
 
   DEFINE_VMAP()
   DEFINE_PRINT(SVD)
+  auto state() const {
+    return compute_uv_;
+  }
+
+ private:
+  bool compute_uv_;
 };
 
 /* Matrix inversion primitive. */

--- a/mlx/random.cpp
+++ b/mlx/random.cpp
@@ -244,7 +244,7 @@ array multivariate_normal(
 
   // Compute the square-root of the covariance matrix, using the SVD
   auto covariance = astype(cov, float32, stream);
-  auto SVD = linalg::svd(covariance, stream);
+  auto SVD = linalg::svd(covariance, true, stream);
   auto std = astype(
       matmul(
           multiply(

--- a/python/src/linalg.cpp
+++ b/python/src/linalg.cpp
@@ -229,14 +229,15 @@ void init_linalg(nb::module_& parent_module) {
 
         Args:
             a (array): Input array.
-            stream (Stream, optional): Stream or device. Defaults to ``None``
-              in which case the default stream of the default device is used.
             compute_uv (bool, optional): If ``True``, return the ``U``, ``S``, and ``Vt`` components.
               If ``False``, return only the ``S`` array. Default: ``True``.
+            stream (Stream, optional): Stream or device. Defaults to ``None``
+              in which case the default stream of the default device is used.
 
         Returns:
-            tuple(array, array, array): If compute_uv is ``True`` returns the ``U``, ``S``, and ``Vt`` matrices, 
-            such that ``A = U @ diag(S) @ Vt``. array: If compute_uv is ``False`` returns singular values array ``S``.
+            Union[tuple(array, ...), array]:
+              If compute_uv is ``True`` returns the ``U``, ``S``, and ``Vt`` matrices, such that 
+              ``A = U @ diag(S) @ Vt``. If compute_uv is ``False`` returns singular values array ``S``.
       )pbdoc");
   m.def(
       "inv",

--- a/python/src/linalg.cpp
+++ b/python/src/linalg.cpp
@@ -92,6 +92,7 @@ void init_linalg(nb::module_& parent_module) {
           =====  ============================  ==========================
           None   Frobenius norm                2-norm
           'fro'  Frobenius norm                --
+          'nuc'  nuclear norm                  --
           inf    max(sum(abs(x), axis=1))      max(abs(x))
           -inf   min(sum(abs(x), axis=1))      min(abs(x))
           0      --                            sum(x != 0)
@@ -101,9 +102,6 @@ void init_linalg(nb::module_& parent_module) {
           -2     smallest singular value       as below
           other  --                            sum(abs(x)**ord)**(1./ord)
           =====  ============================  ==========================
-
-          .. warning::
-            Nuclear norm and norms based on singular values are not yet implemented.
 
           The Frobenius norm is given by [1]_:
 
@@ -206,15 +204,22 @@ void init_linalg(nb::module_& parent_module) {
       )pbdoc");
   m.def(
       "svd",
-      [](const mx::array& a, mx::StreamOrDevice s /* = {} */) {
-        const auto result = mx::linalg::svd(a, s);
-        return nb::make_tuple(result.at(0), result.at(1), result.at(2));
+      [](const mx::array& a,
+         bool compute_uv /* = true */,
+         mx::StreamOrDevice s /* = {} */) -> nb::object {
+        const auto result = mx::linalg::svd(a, compute_uv, s);
+        if (result.size() == 1) {
+          return nb::cast(result.at(0));
+        } else {
+          return nb::make_tuple(result.at(0), result.at(1), result.at(2));
+        }
       },
       "a"_a,
+      "compute_uv"_a = true,
       nb::kw_only(),
       "stream"_a = nb::none(),
       nb::sig(
-          "def svd(a: array, *, stream: Union[None, Stream, Device] = None) -> Tuple[array, array, array]"),
+          "def svd(a: array, compute_uv: bool = True, *, stream: Union[None, Stream, Device] = None) -> Tuple[array, array, array]"),
       R"pbdoc(
         The Singular Value Decomposition (SVD) of the input matrix.
 
@@ -226,10 +231,12 @@ void init_linalg(nb::module_& parent_module) {
             a (array): Input array.
             stream (Stream, optional): Stream or device. Defaults to ``None``
               in which case the default stream of the default device is used.
+            compute_uv (bool, optional): If ``True``, return the ``U``, ``S``, and ``Vt`` components.
+              If ``False``, return only the ``S`` array. Default: ``True``.
 
         Returns:
-            tuple(array, array, array): The ``U``, ``S``, and ``Vt`` matrices, such that
-            ``A = U @ diag(S) @ Vt``
+            tuple(array, array, array): If compute_uv is ``True`` returns the ``U``, ``S``, and ``Vt`` matrices, 
+            such that ``A = U @ diag(S) @ Vt``. array: If compute_uv is ``False`` returns singular values array ``S``.
       )pbdoc");
   m.def(
       "inv",

--- a/python/tests/test_linalg.py
+++ b/python/tests/test_linalg.py
@@ -12,11 +12,11 @@ import numpy as np
 class TestLinalg(mlx_tests.MLXTestCase):
     def test_norm(self):
         vector_ords = [None, 0.5, 0, 1, 2, 3, -1, float("inf"), -float("inf")]
-        matrix_ords = [None, "fro", -1, 1, float("inf"), -float("inf")]
+        matrix_ords = [None, "fro", "nuc", -1, 1, float("inf"), -float("inf")]
 
         for shape in [(3,), (2, 3), (2, 3, 3)]:
-            x_mx = mx.arange(1, math.prod(shape) + 1).reshape(shape)
-            x_np = np.arange(1, math.prod(shape) + 1).reshape(shape)
+            x_mx = mx.arange(1, math.prod(shape) + 1, dtype=mx.float32).reshape(shape)
+            x_np = np.arange(1, math.prod(shape) + 1, dtype=np.float32).reshape(shape)
             # Test when at least one axis is provided
             for num_axes in range(1, len(shape)):
                 if num_axes == 1:
@@ -26,11 +26,12 @@ class TestLinalg(mlx_tests.MLXTestCase):
                 for axis in itertools.combinations(range(len(shape)), num_axes):
                     for keepdims in [True, False]:
                         for o in ords:
+                            stream = mx.cpu if o == "nuc" else mx.default_device()
                             out_np = np.linalg.norm(
                                 x_np, ord=o, axis=axis, keepdims=keepdims
                             )
                             out_mx = mx.linalg.norm(
-                                x_mx, ord=o, axis=axis, keepdims=keepdims
+                                x_mx, ord=o, axis=axis, keepdims=keepdims, stream=stream
                             )
                             with self.subTest(
                                 shape=shape, ord=o, axis=axis, keepdims=keepdims
@@ -138,6 +139,13 @@ class TestLinalg(mlx_tests.MLXTestCase):
             mx.allclose(U[:, : len(S)] @ mx.diag(S) @ Vt, A, rtol=1e-5, atol=1e-7)
         )
 
+        S = mx.linalg.svd(A, compute_uv=False, stream=mx.cpu)
+        self.assertTrue(
+            mx.allclose(
+                mx.linalg.norm(S), mx.linalg.norm(A, ord="fro"), rtol=1e-5, atol=1e-7
+            )
+        )
+
         # Multiple matrices
         B = A + 10.0
         AB = mx.stack([A, B])
@@ -145,6 +153,17 @@ class TestLinalg(mlx_tests.MLXTestCase):
         for M, U, S, Vt in zip([A, B], Us, Ss, Vts):
             self.assertTrue(
                 mx.allclose(U[:, : len(S)] @ mx.diag(S) @ Vt, M, rtol=1e-5, atol=1e-7)
+            )
+
+        Ss = mx.linalg.svd(AB, compute_uv=False, stream=mx.cpu)
+        for M, S in zip([A, B], Ss):
+            self.assertTrue(
+                mx.allclose(
+                    mx.linalg.norm(S),
+                    mx.linalg.norm(M, ord="fro"),
+                    rtol=1e-5,
+                    atol=1e-7,
+                )
             )
 
     def test_inverse(self):

--- a/python/tests/test_linalg.py
+++ b/python/tests/test_linalg.py
@@ -12,7 +12,7 @@ import numpy as np
 class TestLinalg(mlx_tests.MLXTestCase):
     def test_norm(self):
         vector_ords = [None, 0.5, 0, 1, 2, 3, -1, float("inf"), -float("inf")]
-        matrix_ords = [None, "fro", "nuc", -1, 1, float("inf"), -float("inf")]
+        matrix_ords = [None, "fro", "nuc", -1, 1, -2, 2, float("inf"), -float("inf")]
 
         for shape in [(3,), (2, 3), (2, 3, 3)]:
             x_mx = mx.arange(1, math.prod(shape) + 1, dtype=mx.float32).reshape(shape)
@@ -26,7 +26,9 @@ class TestLinalg(mlx_tests.MLXTestCase):
                 for axis in itertools.combinations(range(len(shape)), num_axes):
                     for keepdims in [True, False]:
                         for o in ords:
-                            stream = mx.cpu if o == "nuc" else mx.default_device()
+                            stream = (
+                                mx.cpu if o in ["nuc", -2, 2] else mx.default_device()
+                            )
                             out_np = np.linalg.norm(
                                 x_np, ord=o, axis=axis, keepdims=keepdims
                             )
@@ -134,7 +136,7 @@ class TestLinalg(mlx_tests.MLXTestCase):
 
     def test_svd_decomposition(self):
         A = mx.array([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]], dtype=mx.float32)
-        U, S, Vt = mx.linalg.svd(A, stream=mx.cpu)
+        U, S, Vt = mx.linalg.svd(A, compute_uv=True, stream=mx.cpu)
         self.assertTrue(
             mx.allclose(U[:, : len(S)] @ mx.diag(S) @ Vt, A, rtol=1e-5, atol=1e-7)
         )
@@ -149,7 +151,7 @@ class TestLinalg(mlx_tests.MLXTestCase):
         # Multiple matrices
         B = A + 10.0
         AB = mx.stack([A, B])
-        Us, Ss, Vts = mx.linalg.svd(AB, stream=mx.cpu)
+        Us, Ss, Vts = mx.linalg.svd(AB, compute_uv=True, stream=mx.cpu)
         for M, U, S, Vt in zip([A, B], Us, Ss, Vts):
             self.assertTrue(
                 mx.allclose(U[:, : len(S)] @ mx.diag(S) @ Vt, M, rtol=1e-5, atol=1e-7)

--- a/tests/linalg_tests.cpp
+++ b/tests/linalg_tests.cpp
@@ -243,7 +243,9 @@ TEST_CASE("[mlx.core.linalg.norm] double ord") {
             .item<bool>());
   CHECK(allclose(
             norm(x, -2.0, std::vector<int>{1, 2}, false, Device::cpu),
-            array({3.78331e-08, 2.65557e-07}))
+            array({4.979028e-16, 7.009628e-16}),
+            /* rtol = */ 1e-5,
+            /* atol = */ 1e-6)
             .item<bool>());
 }
 

--- a/tests/linalg_tests.cpp
+++ b/tests/linalg_tests.cpp
@@ -100,7 +100,7 @@ TEST_CASE("[mlx.core.linalg.norm] double ord") {
       norm(x, -std::numeric_limits<double>::infinity()).item<float>(),
       doctest::Approx(expected));
 
-  x = reshape(arange(9), {3, 3});
+  x = reshape(arange(9, float32), {3, 3});
 
   CHECK(allclose(
             norm(x, 2.0, 0, false),
@@ -129,10 +129,34 @@ TEST_CASE("[mlx.core.linalg.norm] double ord") {
   CHECK_EQ(
       norm(x, -1.0, std::vector<int>{1, 0}).item<float>(),
       doctest::Approx(3.0));
+  CHECK_EQ(
+      norm(x, 2.0, std::vector<int>{0, 1}, false, Device::cpu).item<float>(),
+      doctest::Approx(14.226707));
+  CHECK_EQ(
+      norm(x, 2.0, std::vector<int>{1, 0}, false, Device::cpu).item<float>(),
+      doctest::Approx(14.226707));
+  CHECK_EQ(
+      norm(x, -2.0, std::vector<int>{0, 1}, false, Device::cpu).item<float>(),
+      doctest::Approx(0.0));
+  CHECK_EQ(
+      norm(x, -2.0, std::vector<int>{1, 0}, false, Device::cpu).item<float>(),
+      doctest::Approx(0.0));
   CHECK_EQ(norm(x, 1.0, std::vector<int>{0, 1}, true).shape(), Shape{1, 1});
   CHECK_EQ(norm(x, 1.0, std::vector<int>{1, 0}, true).shape(), Shape{1, 1});
   CHECK_EQ(norm(x, -1.0, std::vector<int>{0, 1}, true).shape(), Shape{1, 1});
   CHECK_EQ(norm(x, -1.0, std::vector<int>{1, 0}, true).shape(), Shape{1, 1});
+  CHECK_EQ(
+      norm(x, 2.0, std::vector<int>{0, 1}, true, Device::cpu).shape(),
+      Shape{1, 1});
+  CHECK_EQ(
+      norm(x, 2.0, std::vector<int>{1, 0}, true, Device::cpu).shape(),
+      Shape{1, 1});
+  CHECK_EQ(
+      norm(x, -2.0, std::vector<int>{0, 1}, true, Device::cpu).shape(),
+      Shape{1, 1});
+  CHECK_EQ(
+      norm(x, -2.0, std::vector<int>{1, 0}, true, Device::cpu).shape(),
+      Shape{1, 1});
 
   CHECK_EQ(
       norm(x, -1.0, std::vector<int>{-2, -1}, false).item<float>(),
@@ -140,8 +164,14 @@ TEST_CASE("[mlx.core.linalg.norm] double ord") {
   CHECK_EQ(
       norm(x, 1.0, std::vector<int>{-2, -1}, false).item<float>(),
       doctest::Approx(15.0));
+  CHECK_EQ(
+      norm(x, -2.0, std::vector<int>{-2, -1}, false, Device::cpu).item<float>(),
+      doctest::Approx(0.0));
+  CHECK_EQ(
+      norm(x, 2.0, std::vector<int>{-2, -1}, false, Device::cpu).item<float>(),
+      doctest::Approx(14.226707));
 
-  x = reshape(arange(18), {2, 3, 3});
+  x = reshape(arange(18, float32), {2, 3, 3});
   CHECK_THROWS(norm(x, 2.0, std::vector{0, 1, 2}));
   CHECK(allclose(
             norm(x, 3.0, 0),
@@ -199,6 +229,22 @@ TEST_CASE("[mlx.core.linalg.norm] double ord") {
             .item<bool>());
   CHECK(allclose(norm(x, -1.0, std::vector<int>{1, 2}), array({9, 36}))
             .item<bool>());
+  CHECK(allclose(
+            norm(x, 2.0, std::vector<int>{0, 1}, false, Device::cpu),
+            array({22.045408, 24.155825, 26.318918}))
+            .item<bool>());
+  CHECK(allclose(
+            norm(x, 2.0, std::vector<int>{1, 2}, false, Device::cpu),
+            array({14.226707, 39.759212}))
+            .item<bool>());
+  CHECK(allclose(
+            norm(x, -2.0, std::vector<int>{0, 1}, false, Device::cpu),
+            array({3, 2.7378995, 2.5128777}))
+            .item<bool>());
+  CHECK(allclose(
+            norm(x, -2.0, std::vector<int>{1, 2}, false, Device::cpu),
+            array({3.78331e-08, 2.65557e-07}))
+            .item<bool>());
 }
 
 TEST_CASE("[mlx.core.linalg.norm] string ord") {
@@ -228,14 +274,6 @@ TEST_CASE("[mlx.core.linalg.norm] string ord") {
             array({14.28285686, 39.7617907}))
             .item<bool>());
   CHECK(allclose(
-            norm(x, "nuc", std::vector<int>{0, 1}, false, Device::cpu),
-            array({25.045408, 26.893724, 28.831797}))
-            .item<bool>());
-  CHECK(allclose(
-            norm(x, "nuc", std::vector<int>{1, 2}, false, Device::cpu),
-            array({15.491934, 40.211937}))
-            .item<bool>());
-  CHECK(allclose(
             norm(x, "f", std::vector<int>{0, 1}),
             array({22.24859546, 24.31049156, 26.43860813}))
             .item<bool>());
@@ -250,6 +288,18 @@ TEST_CASE("[mlx.core.linalg.norm] string ord") {
   CHECK(allclose(
             norm(x, "f", std::vector<int>{2, 1}),
             array({14.28285686, 39.7617907}))
+            .item<bool>());
+  CHECK(allclose(
+            norm(x, "nuc", std::vector<int>{0, 1}, false, Device::cpu),
+            array({25.045408, 26.893724, 28.831797}))
+            .item<bool>());
+  CHECK(allclose(
+            norm(x, "nuc", std::vector<int>{1, 2}, false, Device::cpu),
+            array({15.491934, 40.211937}))
+            .item<bool>());
+  CHECK(allclose(
+            norm(x, "nuc", std::vector<int>{-2, -1}, false, Device::cpu),
+            array({15.491934, 40.211937}))
             .item<bool>());
 }
 

--- a/tests/vmap_tests.cpp
+++ b/tests/vmap_tests.cpp
@@ -466,15 +466,19 @@ TEST_CASE("test vmap scatter") {
 }
 
 TEST_CASE("test vmap SVD") {
-  auto fun = [](std::vector<array> inputs) {
+  auto svd_full = [](std::vector<array> inputs) {
     return linalg::svd(inputs.at(0), true, Device::cpu);
+  };
+
+  auto svd_singular = [](std::vector<array> inputs) {
+    return linalg::svd(inputs.at(0), false, Device::cpu);
   };
 
   auto a = astype(reshape(arange(24), {3, 4, 2}), float32);
 
   // vmap over the second axis.
   {
-    auto out = vmap(fun, /* in_axes = */ {1})({a});
+    auto out = vmap(svd_full, /* in_axes = */ {1})({a});
     const auto& U = out.at(0);
     const auto& S = out.at(1);
     const auto& Vt = out.at(2);
@@ -486,7 +490,7 @@ TEST_CASE("test vmap SVD") {
 
   // vmap over the third axis.
   {
-    auto out = vmap(fun, /* in_axes = */ {2})({a});
+    auto out = vmap(svd_full, /* in_axes = */ {2})({a});
     const auto& U = out.at(0);
     const auto& S = out.at(1);
     const auto& Vt = out.at(2);
@@ -494,6 +498,21 @@ TEST_CASE("test vmap SVD") {
     CHECK_EQ(U.shape(), Shape{a.shape(2), a.shape(0), a.shape(0)});
     CHECK_EQ(S.shape(), Shape{a.shape(2), a.shape(0)});
     CHECK_EQ(Vt.shape(), Shape{a.shape(2), a.shape(1), a.shape(1)});
+  }
+
+  // test singular values
+  {
+    auto out = vmap(svd_singular, /* in_axes = */ {1})({a});
+    const auto& S = out.at(0);
+
+    CHECK_EQ(S.shape(), Shape{a.shape(1), a.shape(2)});
+  }
+
+  {
+    auto out = vmap(svd_singular, /* in_axes = */ {2})({a});
+    const auto& S = out.at(0);
+
+    CHECK_EQ(S.shape(), Shape{a.shape(2), a.shape(0)});
   }
 }
 

--- a/tests/vmap_tests.cpp
+++ b/tests/vmap_tests.cpp
@@ -467,7 +467,7 @@ TEST_CASE("test vmap scatter") {
 
 TEST_CASE("test vmap SVD") {
   auto fun = [](std::vector<array> inputs) {
-    return linalg::svd(inputs.at(0), Device::cpu);
+    return linalg::svd(inputs.at(0), true, Device::cpu);
   };
 
   auto a = astype(reshape(arange(24), {3, 4, 2}), float32);


### PR DESCRIPTION
## Proposed changes

resolves #1791 by adding support for nuclear norm to `mx.linalg.norm`.

approach adds `compute_uv` parameter to `mx.linalg.svd` following the [np.linalg.svd](https://numpy.org/doc/2.2/reference/generated/numpy.linalg.svd.html) docs. this removes unnecessary calculation of `U` and `Vt` components improving nuclear norm efficiency.
