### PR TITLE
Fix cpu compile

### DIFF
--- a/mlx/backend/cpu/make_compiled_preamble.sh
+++ b/mlx/backend/cpu/make_compiled_preamble.sh
@@ -18,13 +18,16 @@ if [ "$CLANG" = "TRUE" ]; then
 #include <complex>
 #include <cstdint>
 #include <vector>
+#ifdef __ARM_FEATURE_FP16_SCALAR_ARITHMETIC
+#include <arm_fp16.h>
+#endif
 EOM
-CC_FLAGS="-arch ${ARCH}"
+CC_FLAGS="-arch ${ARCH} -nobuiltininc -nostdinc"
 else
 CC_FLAGS="-std=c++17"
 fi
 
-CONTENT=$($GCC $CC_FLAGS -I "$SRCDIR" -E "$SRCDIR/mlx/backend/cpu/compiled_preamble.h" 2>/dev/null)
+CONTENT=$($GCC $CC_FLAGS -I "$SRCDIR" -E -P "$SRCDIR/mlx/backend/cpu/compiled_preamble.h" 2>/dev/null)
 
 cat << EOF > "$OUTPUT_FILE"
 const char* get_kernel_preamble() {

--- a/python/tests/test_compile.py
+++ b/python/tests/test_compile.py
@@ -953,6 +953,7 @@ class TestCompile(mlx_tests.MLXTestCase):
         self.assertEqual(out[1].shape, (2, 2, 5))
 
     def test_leaks(self):
+        gc.collect()
         if mx.metal.is_available():
             mem_pre = mx.metal.get_active_memory()
         else:


### PR DESCRIPTION
In some cases CPU-only compile was broken on macOS (e.g. when building C++ from source without python).

Tracked this down to different behavior from `/usr/bin/cc` and `/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ ` (which is quite odd since they should be the same).

But explicitly specifying the flags is better anyway since it shrinks the size of the compiled preamble.