### PR TITLE
Fix leaking objc

### DIFF
--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -249,6 +249,7 @@ Device::~Device() {
   for (auto& l : library_map_) {
     l.second->release();
   }
+  stream_map_.clear();
   device_->release();
 }
 


### PR DESCRIPTION
Minor fix so that `OBJC_DEBUG_MISSING_POOLS=YES` runs clean most of the time.