### PR TITLE
Fix ring of 2 and allow scalars in API

### DIFF
--- a/python/src/distributed.cpp
+++ b/python/src/distributed.cpp
@@ -10,6 +10,8 @@
 #include "mlx/distributed/distributed.h"
 #include "mlx/distributed/ops.h"
 
+#include "python/src/utils.h"
+
 namespace mx = mlx::core;
 namespace nb = nanobind;
 using namespace nb::literals;
@@ -86,7 +88,11 @@ void init_distributed(nb::module_& parent_module) {
 
   m.def(
       "all_sum",
-      &mx::distributed::all_sum,
+      [](const ScalarOrArray& x,
+         std::optional<mx::distributed::Group> group,
+         mx::StreamOrDevice s) {
+        return mx::distributed::all_sum(to_array(x), group, s);
+      },
       "x"_a,
       nb::kw_only(),
       "group"_a = nb::none(),
@@ -112,7 +118,11 @@ void init_distributed(nb::module_& parent_module) {
 
   m.def(
       "all_gather",
-      &mx::distributed::all_gather,
+      [](const ScalarOrArray& x,
+         std::optional<mx::distributed::Group> group,
+         mx::StreamOrDevice s) {
+        return mx::distributed::all_gather(to_array(x), group, s);
+      },
       "x"_a,
       nb::kw_only(),
       "group"_a = nb::none(),
@@ -139,7 +149,12 @@ void init_distributed(nb::module_& parent_module) {
 
   m.def(
       "send",
-      &mx::distributed::send,
+      [](const ScalarOrArray& x,
+         int dst,
+         std::optional<mx::distributed::Group> group,
+         mx::StreamOrDevice s) {
+        return mx::distributed::send(to_array(x), dst, group, s);
+      },
       "x"_a,
       "dst"_a,
       nb::kw_only(),
@@ -195,7 +210,12 @@ void init_distributed(nb::module_& parent_module) {
 
   m.def(
       "recv_like",
-      &mx::distributed::recv_like,
+      [](const ScalarOrArray& x,
+         int src,
+         std::optional<mx::distributed::Group> group,
+         mx::StreamOrDevice s) {
+        return mx::distributed::recv_like(to_array(x), src, group, s);
+      },
       "x"_a,
       "src"_a,
       nb::kw_only(),


### PR DESCRIPTION
As the title suggests this makes 3 changes:

1. Fix the send/recv for a ring of size 2. This slipped the tests that check for a ring of 8 perhaps we should write tests for various ring sizes.
2. Change the `mx.distributed` ops to accept python values. This is a convenience when writing eval and/or training loops where we can gather or sum scalars across nodes with something like `mx.distributed.all_sum(loss) / mx.distributed.all_sum(count)` where the above are python scalars.
3. Enable TCP_NODELAY for the sockets that may improve latency for small all reductions and send/recv.