### PR TITLE
Add a multi optimizer

### DIFF
--- a/python/mlx/optimizers/optimizers.py
+++ b/python/mlx/optimizers/optimizers.py
@@ -158,8 +158,10 @@ class MultiOptimizer(Optimizer):
     """Wraps a list of optimizers with corresponding weight predicates/filters
     to make it easy to use different optimizers for different weights.
 
-    The predicates take the full "path" of the weight and return True if it
-    should be considered for this optimizer.
+    The predicates take the full "path" of the weight and the weight itself and
+    return True if it should be considered for this optimizer. The last
+    optimizer in the list is a fallback optimizer and no predicate should be
+    given for it.
 
     Args:
         optimizers (list[Optimizer]): A list of optimizers to delegate to
@@ -172,7 +174,9 @@ class MultiOptimizer(Optimizer):
         self._state = {}
 
         if len(filters) != len(optimizers) - 1:
-            raise ValueError(f"Given {len(filters)} but {len(optimizers)-1} needed.")
+            raise ValueError(
+                f"Given {len(filters)} filters but {len(optimizers)-1} needed."
+            )
 
         self.optimizers = optimizers
         self.filters = filters + [lambda *args, **kwargs: True]

--- a/python/mlx/optimizers/optimizers.py
+++ b/python/mlx/optimizers/optimizers.py
@@ -5,7 +5,7 @@ from typing import Callable, List, Optional, Tuple, Union
 
 import mlx.core as mx
 from mlx.nn import Module
-from mlx.utils import tree_map, tree_reduce
+from mlx.utils import tree_flatten, tree_map, tree_merge, tree_reduce, tree_unflatten
 
 
 class Optimizer:
@@ -152,6 +152,75 @@ class Optimizer:
         else:
             param = mx.array(param)
         self.state[name] = param
+
+
+class MultiOptimizer(Optimizer):
+    """Wraps a list of optimizers with corresponding weight predicates/filters
+    to make it easy to use different optimizers for different weights.
+
+    The predicates take the full "path" of the weight and return True if it
+    should be considered for this optimizer.
+
+    Args:
+        optimizers (list[Optimizer]): A list of optimizers to delegate to
+        filters (list[Callable[[str, array], bool]): A list of predicates that
+            should be one less than the provided optimizers.
+    """
+
+    def __init__(self, optimizers, filters: list = []):
+        super().__init__()
+        self._state = {}
+
+        if len(filters) != len(optimizers) - 1:
+            raise ValueError(f"Given {len(filters)} but {len(optimizers)-1} needed.")
+
+        self.optimizers = optimizers
+        self.filters = filters + [lambda *args, **kwargs: True]
+
+    def _split_dictionary(self, gradients: dict):
+        if len(self.optimizers) == 1:
+            return [gradients]
+
+        parts = [[] for _ in range(len(self.optimizers))]
+        flat_gradients = tree_flatten(gradients)
+        for k, g in flat_gradients:
+            for i, fn in enumerate(self.filters):
+                if fn(k, g):
+                    parts[i].append((k, g))
+                    break
+
+        return [tree_unflatten(p) for p in parts]
+
+    def init(self, parameters: dict):
+        for o, p in zip(self.optimizers, self._split_dictionary(parameters)):
+            o.init(p)
+
+    def apply_gradients(self, gradients: dict, parameters: dict):
+        tree = {}
+        for o, g in zip(self.optimizers, self._split_dictionary(gradients)):
+            tree = tree_merge(tree, o.apply_gradients(g, parameters))
+        return tree
+
+    @property
+    def state(self):
+        return {"states": [o.state for o in self.optimizers]}
+
+    @state.setter
+    def state(self, state: dict):
+        if "states" not in state or len(state["states"]) != len(self.optimizers):
+            raise ValueError("Invalid state provided")
+
+        for o, s in zip(self.optimizers, state["states"]):
+            o.state = s
+
+    @property
+    def learning_rate(self):
+        return self.optimizers[0].learning_rate
+
+    @learning_rate.setter
+    def learning_rate(self, learning_rate: Union[float, mx.array]):
+        for o in self.optimizers:
+            o.learning_rate = learning_rate
 
 
 class SGD(Optimizer):

--- a/python/tests/test_tree.py
+++ b/python/tests/test_tree.py
@@ -3,6 +3,7 @@
 import unittest
 
 import mlx.core as mx
+import mlx.nn as nn
 import mlx.utils
 import mlx_tests
 
@@ -21,6 +22,29 @@ class TestTreeUtils(mlx_tests.MLXTestCase):
         flat_tree = mlx.utils.tree_flatten(tree)
         self.assertEqual(list(zip(*flat_tree))[1], vals)
         self.assertEqual(mlx.utils.tree_unflatten(flat_tree), tree)
+
+    def test_merge(self):
+        t1 = {"a": 0}
+        t2 = {"b": 1}
+        t = mlx.utils.tree_merge(t1, t2)
+        self.assertEqual({"a": 0, "b": 1}, t)
+        with self.assertRaises(ValueError):
+            mlx.utils.tree_merge(t1, t1)
+        with self.assertRaises(ValueError):
+            mlx.utils.tree_merge(t, t1)
+
+        mod1 = nn.Sequential(nn.Linear(2, 2), nn.Linear(2, 2))
+        mod2 = nn.Sequential(nn.Linear(2, 2), nn.Linear(2, 2))
+        mod = nn.Sequential(mod1, mod2)
+
+        params1 = {"layers": [mod1.parameters()]}
+        params2 = {"layers": [None, mod2.parameters()]}
+        params = mlx.utils.tree_merge(params1, params2)
+        for (k1, v1), (k2, v2) in zip(
+            mlx.utils.tree_flatten(params), mlx.utils.tree_flatten(mod.parameters())
+        ):
+            self.assertEqual(k1, k2)
+            self.assertTrue(mx.array_equal(v1, v2))
 
 
 if __name__ == "__main__":

--- a/python/tests/test_vmap.py
+++ b/python/tests/test_vmap.py
@@ -345,6 +345,7 @@ class TestVmap(mlx_tests.MLXTestCase):
             )
 
     def test_vmap_inverse(self):
+        mx.random.seed(42)
         a = mx.random.uniform(shape=(3, 4, 4))
 
         cpu_inv = lambda x: mx.linalg.inv(x, stream=mx.cpu)


### PR DESCRIPTION
It mainly adds a convenient way of using more than one optimizer for a single model based on the discussion in #1914.

```python
optimizer = MultiOptimizer(
    [MuonOptimizer(learning_rate=0.02), AdamW(learning_rate=0.001)],
    [lambda name, weight: weight.ndim >= 2]
)
# business as usual
```

As @stockeh demonstrated very nicely, in the issue linked above, it isn't something that is hard to do but it feels a pretty fundamental capability that we may want to make more convenient.

I am not sold on the `MultiOptimizer` approach I wrote (it was the simplest one) so feel free to suggest better strategies if you want.