### PR TITLE
More donation take 2

### DIFF
--- a/mlx/array.cpp
+++ b/mlx/array.cpp
@@ -122,7 +122,6 @@ void array::wait() {
       detach_event();
     }
     set_status(Status::available);
-    detach_event();
   }
 }
 

--- a/mlx/array.cpp
+++ b/mlx/array.cpp
@@ -122,6 +122,7 @@ void array::wait() {
       detach_event();
     }
     set_status(Status::available);
+    detach_event();
   }
 }
 

--- a/mlx/backend/cpu/eval.cpp
+++ b/mlx/backend/cpu/eval.cpp
@@ -28,8 +28,7 @@ void finalize(
   auto& encoder = cpu::get_command_encoder(s);
   encoder.dispatch([s,
                     buffers = std::move(retain_buffers),
-                    temps = std::move(encoder.temporaries())]() {
-  });
+                    temps = std::move(encoder.temporaries())]() {});
 }
 
 } // namespace mlx::core::cpu

--- a/mlx/backend/cpu/eval.cpp
+++ b/mlx/backend/cpu/eval.cpp
@@ -20,21 +20,16 @@ void eval(array& arr) {
     }
     arr.primitive().eval_cpu(arr.inputs(), outputs);
   }
+}
 
-  std::unordered_set<std::shared_ptr<array::Data>> buffers;
-  for (auto& in : arr.inputs()) {
-    buffers.insert(in.data_shared_ptr());
-  }
-  for (auto& s : arr.siblings()) {
-    buffers.insert(s.data_shared_ptr());
-  }
-  // Remove the output if it was donated to by an input
-  if (auto it = buffers.find(arr.data_shared_ptr()); it != buffers.end()) {
-    buffers.erase(it);
-  }
+void finalize(
+    Stream s,
+    std::unordered_set<std::shared_ptr<array::Data>> retain_buffers) {
   auto& encoder = cpu::get_command_encoder(s);
-  encoder.dispatch([buffers = std::move(buffers),
-                    temps = std::move(encoder.temporaries())]() {});
+  encoder.dispatch([s,
+                    buffers = std::move(retain_buffers),
+                    temps = std::move(encoder.temporaries())]() {
+  });
 }
 
 } // namespace mlx::core::cpu

--- a/mlx/backend/cpu/eval.h
+++ b/mlx/backend/cpu/eval.h
@@ -2,11 +2,16 @@
 
 #pragma once
 
+#include <unordered_set>
+
 #include "mlx/array.h"
 #include "mlx/stream.h"
 
 namespace mlx::core::cpu {
 
 void eval(array& arr);
+void finalize(
+    Stream s,
+    std::unordered_set<std::shared_ptr<array::Data>> retain_buffers);
 
 } // namespace mlx::core::cpu

--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -1,5 +1,4 @@
 // Copyright © 2023-2024 Apple Inc.
-
 #include <cstdlib>
 #include <sstream>
 

--- a/mlx/backend/metal/metal_impl.h
+++ b/mlx/backend/metal/metal_impl.h
@@ -4,6 +4,7 @@
 
 #include <future>
 #include <memory>
+#include <unordered_set>
 
 #include "mlx/array.h"
 #include "mlx/stream.h"
@@ -15,7 +16,10 @@ void new_stream(Stream stream);
 std::unique_ptr<void, std::function<void(void*)>> new_scoped_memory_pool();
 
 void eval(array& arr);
-void finalize(Stream s);
+void finalize(
+    Stream s,
+    std::unordered_set<std::shared_ptr<array::Data>> retain_buffers,
+    bool force_commit);
 void synchronize(Stream s);
 
 } // namespace mlx::core::metal

--- a/mlx/backend/no_metal/metal.cpp
+++ b/mlx/backend/no_metal/metal.cpp
@@ -21,7 +21,10 @@ void eval(array&) {
       "[metal::eval] Cannot eval on GPU without metal backend");
 }
 
-void finalize(Stream) {
+void finalize(
+    Stream,
+    std::unordered_set<std::shared_ptr<array::Data>> retain_buffers,
+    bool) {
   throw std::runtime_error(
       "[metal::finalize] Cannot finalize GPU without metal backend");
 }

--- a/python/tests/mlx_distributed_tests.py
+++ b/python/tests/mlx_distributed_tests.py
@@ -65,21 +65,18 @@ class MLXDistributedCommonTestCase(mlx_tests.MLXTestCase):
 
     def test_donation(self):
         x = mx.random.normal((1024,))
+        scale = mx.array(2.0)
         mx.eval(x)
         mx.synchronize()
 
         mx.reset_peak_memory()
-        scale = mx.array(2.0)
-        y = mx.distributed.all_sum(x)
-        mx.eval(y)
-        mx.synchronize()
-        all_sum_only = mx.get_peak_memory()
-        y = mx.distributed.all_sum(x) * scale
-        mx.eval(y)
-        mx.synchronize()
-        all_sum_with_binary = mx.get_peak_memory()
 
-        self.assertEqual(all_sum_only, all_sum_with_binary)
+        # Everything should be donated so peak memory is unchanged
+        x = mx.distributed.all_sum(x) * scale
+        mx.eval(x)
+        mx.synchronize()
+
+        self.assertEqual(mx.get_peak_memory(), 0)
 
     def test_shard_linear(self):
         # Seed the prng to have the same inputs and weights generated everywhere

--- a/python/tests/test_load.py
+++ b/python/tests/test_load.py
@@ -391,9 +391,12 @@ class TestLoad(mlx_tests.MLXTestCase):
         scale = mx.array(2.0)
         y = mx.load(save_file)
         mx.eval(y)
+
+        mx.synchronize()
         load_only = mx.get_peak_memory()
         y = mx.load(save_file) * scale
         mx.eval(y)
+        mx.synchronize()
         load_with_binary = mx.get_peak_memory()
 
         self.assertEqual(load_only, load_with_binary)


### PR DESCRIPTION
This is a redux of https://github.com/ml-explore/mlx/pull/1858

- The race condition of checking use counts is mitigated since the checks are done on the main thread now
- Use weak pointers to hold references to other inputs to avoid breaking async eval. Another option is to just use a more restrictive policy when doing async eval and avoid this complexity.
- Also moves all the buffer retention logic from the CPU / GPU task submission to the main thread since it's all duplicated now.

Comment from #1858 still applies (copied below):

Previously if an input didn't get donated it was held by the command buffer and no longer eligible for donation.

So sequences like:

```python
a = x + y
b = mx.abs(x)
```

Assuming `x` didn't get donated to `a` then it is impossible for it to be donated to `b`.

This changes that by removing buffers that are safe to not hold in the command buffer.