### PR TITLE
Stop fence term

### DIFF
--- a/mlx/backend/metal/fence.cpp
+++ b/mlx/backend/metal/fence.cpp
@@ -34,6 +34,12 @@ Fence::Fence(const Stream& stream) : stream_(stream) {
   }
 }
 
+Fence::~Fence() {
+  if (use_fast_) {
+    cpu_value()[0] = INT_MAX;
+  }
+}
+
 void Fence::wait_gpu(array& x) {
   gpu_count_++;
   auto& d = metal::device(stream_.device);

--- a/mlx/backend/metal/fence.h
+++ b/mlx/backend/metal/fence.h
@@ -21,6 +21,7 @@ namespace mlx::core {
 class Fence {
  public:
   Fence(const Stream& stream);
+  ~Fence();
 
   void update_gpu(const array& x);
   void wait_gpu(array& x);

--- a/mlx/backend/metal/kernels/fence.metal
+++ b/mlx/backend/metal/kernels/fence.metal
@@ -29,7 +29,10 @@ constexpr constant metal::thread_scope thread_scope_system =
 [[kernel]] void fence_update(
     volatile coherent(system) device uint* timestamp [[buffer(0)]],
     constant uint& value [[buffer(1)]]) {
-  timestamp[0] = value;
+  uint tmp = timestamp[0];
+  if (tmp < value) {
+    timestamp[0] = value;
+  }
   metal::atomic_thread_fence(
       metal::mem_flags::mem_device,
       metal::memory_order_seq_cst,


### PR DESCRIPTION
Make sure that we don't leave any kernels waiting for a value that won't be updated by updating in the destructor.

Also fix `update_gpu` to only ever increase the fence value.