### PR TITLE
Fix typo in randint docstring

### DIFF
--- a/python/src/random.cpp
+++ b/python/src/random.cpp
@@ -253,7 +253,7 @@ void init_random(nb::module_& parent_module) {
 
         The values are sampled with equal probability from the integers in
         half-open interval ``[low, high)``. The lower and upper bound can be
-        scalars or arrays and must be roadcastable to ``shape``.
+        scalars or arrays and must be broadcastable to ``shape``.
 
         Args:
             low (scalar or array): Lower bound of the interval.


### PR DESCRIPTION
This commit fixes a typo in the docstring for mlx.core.random.randint() by changing "roadcastable" to "broadcastable".

## Proposed changes

Please include a description of the problem or feature this PR is addressing. If there is a corresponding issue, include the issue #.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
