### PR TITLE
`mx.repeat` with variable number of repetitions, issue #1785

### DIFF
--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -19,6 +19,7 @@ MLX was developed with contributions from the following individuals:
 - Gleb Pobudzey: Added the `where` primitive, and groups in 1D and 2D convolutions.
 - Paul Paczuski: Improved stability of BCE loss calculation
 - Max-Heinrich Laves: Added `conv_transpose1d`, `conv_transpose2d`, and `conv_transpose3d` ops.
+- Jakub Kislinger: Added support for vector repeats in `repeat` operation.
 
 <a href="https://github.com/ml-explore/mlx/graphs/contributors">
   <img class="dark-light" src="https://contrib.rocks/image?repo=ml-explore/mlx&anon=0&columns=20&max=100&r=true" />

--- a/mlx/ops.h
+++ b/mlx/ops.h
@@ -245,6 +245,12 @@ array stack(const std::vector<array>& arrays, StreamOrDevice s = {});
 /** Repeat an array along an axis. */
 array repeat(const array& arr, int repeats, int axis, StreamOrDevice s = {});
 array repeat(const array& arr, int repeats, StreamOrDevice s = {});
+array repeat(
+    const array& arr,
+    std::vector<int> repeats,
+    int axis,
+    StreamOrDevice s = {});
+array repeat(const array& arr, std::vector<int> repeats, StreamOrDevice s = {});
 
 array tile(const array& arr, std::vector<int> reps, StreamOrDevice s = {});
 

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -2963,13 +2963,22 @@ void init_ops(nb::module_& m) {
   m.def(
       "repeat",
       [](const mx::array& array,
-         int repeats,
+         const std::variant<int, std::vector<int>>& repeats,
          std::optional<int> axis,
          mx::StreamOrDevice s) {
-        if (axis.has_value()) {
-          return mx::repeat(array, repeats, axis.value(), s);
+        if (auto rep = std::get_if<int>(&repeats); rep) {
+          if (axis.has_value()) {
+            return mx::repeat(array, *rep, axis.value(), s);
+          } else {
+            return mx::repeat(array, *rep, s);
+          }
         } else {
-          return mx::repeat(array, repeats, s);
+          auto r = std::get<std::vector<int>>(repeats);
+          if (axis.has_value()) {
+            return mx::repeat(array, r, axis.value(), s);
+          } else {
+            return mx::repeat(array, r, s);
+          }
         }
       },
       nb::arg(),

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -2993,7 +2993,9 @@ void init_ops(nb::module_& m) {
 
         Args:
             array (array): Input array.
-            repeats (int): The number of repetitions for each element.
+            repeats (int or list(int)): The number of repetitions for each element.
+              If a list is passed its size should correspond to the size along axis.
+              Each element represent number of repetitions for given index in array.
             axis (int, optional): The axis in which to repeat the array along. If
               unspecified it uses the flattened array of the input and repeats
               along axis 0.

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -2237,6 +2237,25 @@ class TestOps(mlx_tests.MLXTestCase):
             np.repeat,
             axis=0,
         )
+        # Test repeat for vector repeat input with single number
+        self.assertCmpNumpy([data, [2]], mx.repeat, np.repeat)
+        # Test repeat for vector repeat input with single number with given axis 0
+        self.assertCmpNumpy([data, [2]], mx.repeat, np.repeat, axis=0)
+        # Test repeat for vector repeat input with single number with given axis 1
+        self.assertCmpNumpy([data, [2]], mx.repeat, np.repeat, axis=1)
+        # Test repeat for vector repeat input
+        self.assertCmpNumpy(
+            [mx.array([[0, 1], [4, 2], [2, 3]]), [1, 0, 2, 1, 2, 1]],
+            mx.repeat,
+            np.repeat,
+        )
+        # Test repeat for vector repeat input with given axis 0
+        self.assertCmpNumpy([data, [1, 0, 2]], mx.repeat, np.repeat, axis=0)
+        # Test repeat for vector repeat input with given axis 1
+        self.assertCmpNumpy([data, [1, 3]], mx.repeat, np.repeat, axis=1)
+        # Test repeat with mx input for repeat
+        ar = mx.array([1, 2, 3, 4])
+        self.assertCmpNumpy([ar, ar], mx.repeat, np.repeat)
 
     def test_tensordot(self):
         # No fp16 matmuls on common cpu backend


### PR DESCRIPTION
## Proposed changes

Fixes https://github.com/ml-explore/mlx/issues/1785

Implementation of `mx.repeat` for variable number of repetitions. I also updated checking of axis in a method `tile`, which was only using duplicit code already implemented elsewhere.

Finally I added tests to check the new functionality

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
