### PR TITLE
Fix unreachable warning

### DIFF
--- a/python/mlx/nn/losses.py
+++ b/python/mlx/nn/losses.py
@@ -10,7 +10,7 @@ Reduction = Literal["none", "mean", "sum"]
 
 def _reduce(loss: mx.array, reduction: Reduction = "none"):
     if reduction not in get_args(Reduction):
-        raise ValueError("Invalid reduction. Must be 'none', 'mean', or 'sum'.")
+        raise ValueError(f"Invalid reduction. Must be one of {get_args(Reduction)}.")
 
     if reduction == "mean":
         return mx.mean(loss)

--- a/python/mlx/nn/losses.py
+++ b/python/mlx/nn/losses.py
@@ -1,7 +1,7 @@
 # Copyright © 2023 Apple Inc.
 
 import math
-from typing import Literal, Optional
+from typing import Literal, Optional, get_args
 
 import mlx.core as mx
 
@@ -9,14 +9,15 @@ Reduction = Literal["none", "mean", "sum"]
 
 
 def _reduce(loss: mx.array, reduction: Reduction = "none"):
+    if reduction not in get_args(Reduction):
+        raise ValueError("Invalid reduction. Must be 'none', 'mean', or 'sum'.")
+
     if reduction == "mean":
         return mx.mean(loss)
     elif reduction == "sum":
         return mx.sum(loss)
     elif reduction == "none":
         return loss
-    else:
-        raise ValueError("Invalid reduction. Must be 'none', 'mean', or 'sum'.")
 
 
 def cross_entropy(


### PR DESCRIPTION
## Proposed changes

The editor reports code is not reachable. We are using a Literal type and it will introduce static type check. It makes the lint confusing I think.

<img width="676" alt="iShot_2025-03-07_20 40 27" src="https://github.com/user-attachments/assets/e60d5361-cc45-4b5f-a61c-82dadf203ee8" />

- This change also removes the duplicate string collection for `Reduction`.

```python
>>> z = f"Invalid reduction. Must be one of {get_args(Reduction)}."
>>> z
"Invalid reduction. Must be one of ('none', 'mean', 'sum')."
```
- Fail fast might be better than we compare several times and finally it fails.
## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
