### PR TITLE
Fix obsured warning

### DIFF
--- a/python/mlx/nn/layers/base.py
+++ b/python/mlx/nn/layers/base.py
@@ -598,9 +598,7 @@ class Module(dict):
               parameters to the new dtype.
         """
         if predicate is None:
-
-            def predicate(_):
-                return True
+            predicate = lambda _: True
 
         self.apply(lambda x: x.astype(dtype) if predicate(x.dtype) else x)
 


### PR DESCRIPTION
## Proposed changes

Fix the warning:

<img width="717" alt="iShot_2025-03-08_18 59 36" src="https://github.com/user-attachments/assets/9e6f9c4a-8ffb-4cfb-9050-66b292748934" />

We created a same value which introduces the warning.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
