### PR TITLE
Add type hint for _extra_repr

### DIFF
--- a/python/mlx/nn/layers/base.py
+++ b/python/mlx/nn/layers/base.py
@@ -81,7 +81,7 @@ class Module(dict):
         """
         return self
 
-    def _extra_repr(self):
+    def _extra_repr(self) -> str:
         return ""
 
     def __repr__(self):


### PR DESCRIPTION
## Proposed changes

Missing type hint on the base class makes the lint treat them as a mismatch.
<img width="809" alt="iShot_2025-03-09_20 57 30" src="https://github.com/user-attachments/assets/a293bf29-75f9-43d2-8b67-730e3d8c5bbf" />

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
