### PR TITLE
Use same accumulation precision in gemv as gemm

### DIFF
--- a/mlx/backend/metal/kernels/gemv.metal
+++ b/mlx/backend/metal/kernels/gemv.metal
@@ -86,7 +86,7 @@ struct GEMVKernel {
       for (int tn = 0; tn < TN; tn++) {
         dst[tn] = src_offset + tn < src_size
             ? static_cast<U>(src[src_offset + tn])
-            : 0;
+            : U(0);
       }
     }
   }

--- a/mlx/backend/metal/kernels/gemv_masked.h
+++ b/mlx/backend/metal/kernels/gemv_masked.h
@@ -117,7 +117,7 @@ struct GEMVKernel {
       for (int tn = 0; tn < TN; tn++) {
         dst[tn] = src_offset + tn < src_size
             ? static_cast<U>(src[src_offset + tn])
-            : 0;
+            : U(0);
       }
     }
   }

--- a/python/tests/test_blas.py
+++ b/python/tests/test_blas.py
@@ -1146,6 +1146,18 @@ class TestBlas(mlx_tests.MLXTestCase):
             self.assertEqual(r.shape, t.shape)
             self.assertTrue(mx.allclose(r, t, atol=1e-4).item())
 
+    def test_gemv_gemm_same_precision(self):
+        mx.random.seed(0)
+        N = 256
+        if mx.metal.is_available():
+            t = mx.bfloat16
+            a = mx.random.normal([1, N]).astype(t)
+            b = mx.concatenate([a, a], axis=0).astype(t)
+            c = mx.random.normal([N, 64]).astype(t)
+            out_gemv = a @ c
+            out_gemm = (b @ c)[0]
+            self.assertTrue(mx.allclose(out_gemv, out_gemm))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This changes the gemv to accumulate in a higher precision which matches the behavior of gemm.

I think this is the right thing to do in general and will close #1958 

The benchmarks are confusing and need some investigation though.

For BF16 it's noticeably slower but for fp16 the speed is unchanged 🤔 . In both cases the math should be easily hidden by loading time so the bf16 result doesn't make sense.