### PR TITLE
Do not define MLX_VERSION globally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ if(NOT MLX_VERSION)
   string(REGEX MATCH "#define MLX_VERSION_PATCH ([0-9]+)" _ "${_mlx_h_version}")
   set(_patch ${CMAKE_MATCH_1})
   set(MLX_PROJECT_VERSION "${_major}.${_minor}.${_patch}")
+  set(MLX_VERSION ${MLX_PROJECT_VERSION})
 else()
   string(REGEX REPLACE "^([0-9]+\.[0-9]+\.[0-9]+).*" "\\1" MLX_PROJECT_VERSION
                        ${MLX_VERSION})
@@ -40,8 +41,6 @@ option(MLX_BUILD_SAFETENSORS "Include support for safetensors format" ON)
 option(MLX_BUILD_BLAS_FROM_SOURCE "Build OpenBLAS from source code" OFF)
 option(MLX_METAL_JIT "Use JIT compilation for Metal kernels" OFF)
 option(BUILD_SHARED_LIBS "Build mlx as a shared library" OFF)
-
-add_compile_definitions("MLX_VERSION=${MLX_VERSION}")
 
 # --------------------- Processor tests -------------------------
 message(

--- a/mlx/CMakeLists.txt
+++ b/mlx/CMakeLists.txt
@@ -17,8 +17,12 @@ target_sources(
           ${CMAKE_CURRENT_SOURCE_DIR}/transforms.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/utils.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/linalg.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/version.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/backend/metal/metal.h)
+
+# Define MLX_VERSION only in the version.cpp file.
+add_library(mlx_version STATIC ${CMAKE_CURRENT_SOURCE_DIR}/version.cpp)
+target_compile_definitions(mlx_version PRIVATE MLX_VERSION="${MLX_VERSION}")
+target_link_libraries(mlx PRIVATE $<BUILD_INTERFACE:mlx_version>)
 
 if(MSVC)
   # Disable some MSVC warnings to speed up compilation.

--- a/mlx/version.cpp
+++ b/mlx/version.cpp
@@ -2,15 +2,10 @@
 
 #include <string>
 
-#include "mlx/version.h"
-
-#define STRINGIFY(x) #x
-#define TOSTRING(x) STRINGIFY(x)
-
 namespace mlx::core {
 
 std::string version() {
-  return TOSTRING(MLX_VERSION);
+  return MLX_VERSION;
 }
 
 } // namespace mlx::core


### PR DESCRIPTION
A global MLX_VERSION define would trigger a recompilation of the whole project every time when bumping the version.

Also fix MLX_VERSION being empty when not building from `setup.py`.