### PR TITLE
Fix typo; Fix lint warning when reuse the same name

### DIFF
--- a/python/mlx/optimizers/optimizers.py
+++ b/python/mlx/optimizers/optimizers.py
@@ -79,7 +79,7 @@ class Optimizer:
 
         Args:
             parameter (mx.array): A single parameter that will be optimized.
-            state (dict): The optimizer's state
+            state (dict): The optimizer's state.
         """
         raise NotImplementedError()
 

--- a/python/mlx/optimizers/optimizers.py
+++ b/python/mlx/optimizers/optimizers.py
@@ -50,19 +50,19 @@ class Optimizer:
             dict_keys(['step', 'learning_rate', 'weight', 'bias'])
         """
 
-        # Iniatilize the optimizer state to match the parameter state
+        # Initialize the optimizer state to match the parameter state
         def update_state(params, state):
             if isinstance(params, (list, tuple)):
                 state = list(state)
                 for i in range(len(state)):
                     state[i] = update_state(params[i], state[i])
                 if len(state) != len(params):
-                    state.extend(tree_map(lambda x: {}, params[len(state) :]))
+                    state.extend(tree_map(lambda _: {}, params[len(state) :]))
                 return type(params)(state)
             elif isinstance(params, dict):
                 for k, v in params.items():
                     if k not in state:
-                        state[k] = tree_map(lambda x: {}, v)
+                        state[k] = tree_map(lambda _: {}, v)
                     else:
                         state[k] = update_state(v, state[k])
                 return state
@@ -79,6 +79,7 @@ class Optimizer:
 
         Args:
             parameter (mx.array): A single parameter that will be optimized.
+            state (dict): The optimizer's state
         """
         raise NotImplementedError()
 
@@ -148,10 +149,10 @@ class Optimizer:
         """
         if isinstance(param, Callable):
             self._schedulers[name] = param
-            param = param(self.step)
+            parameter = param(self.step)
         else:
-            param = mx.array(param)
-        self.state[name] = param
+            parameter = mx.array(param)
+        self.state[name] = parameter
 
 
 class MultiOptimizer(Optimizer):


### PR DESCRIPTION
## Proposed changes

- Fix typo
- Fix the lint warning when reusing the `param` name
- Update docstring

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
