### PR TITLE
Update smooth_l1_loss in losses.py

### DIFF
--- a/python/mlx/nn/losses.py
+++ b/python/mlx/nn/losses.py
@@ -373,7 +373,7 @@ def smooth_l1_loss(
             f"targets shape {targets.shape}."
         )
 
-    diff = predictions - targets
+    diff = mx.abs(predictions - targets)
     loss = mx.where(
         diff < beta, 0.5 * mx.square(diff) / beta, mx.abs(diff) - 0.5 * beta
     )


### PR DESCRIPTION
According the definition of smooth_l1_loss, the line 

`diff = predictions - targets`

Should be updated to 

`diff = mx.abs(predictions - targets)`

After the modification, the result is consistent with PyTorch smooth_l1_loss

## Proposed changes

Please include a description of the problem or feature this PR is addressing. If there is a corresponding issue, include the issue #.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
