### PR TITLE
update the formula of smooth_l1_loss

### DIFF
--- a/python/mlx/nn/losses.py
+++ b/python/mlx/nn/losses.py
@@ -352,7 +352,7 @@ def smooth_l1_loss(
     .. math::
 
       l = \begin{cases}
-            0.5 (x - y)^2, & \text{if } (x - y) < \beta \\
+            0.5 (x - y)^2 / \beta, & \text{if } |x - y| < \beta \\
             |x - y| - 0.5 \beta, & \text{otherwise}
           \end{cases}
 


### PR DESCRIPTION
## Proposed changes

The formula in the function smooth_l1_loss is incorrect and also inconsistent with the code. 
original formula
```
      l = \begin{cases}
            0.5 (x - y)^2, & \text{if } (x - y) < \beta \\
            |x - y| - 0.5 \beta, & \text{otherwise}
          \end{cases}
```

updated formula
```
      l = \begin{cases}
            0.5 (x - y)^2 / \beta, & \text{if } |x - y| < \beta \\
            |x - y| - 0.5 \beta, & \text{otherwise}
          \end{cases}
```


## Checklist

Put an `x` in the boxes that apply.

- [ x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
