### PR TITLE
fix(backend): Include algorithm library in Allocator

### DIFF
--- a/mlx/backend/no_metal/allocator.cpp
+++ b/mlx/backend/no_metal/allocator.cpp
@@ -1,5 +1,6 @@
 // Copyright © 2023 Apple Inc.
 
+#include <algorithm>
 #include <mutex>
 
 #include "mlx/allocator.h"


### PR DESCRIPTION
## Proposed changes

After this change: https://github.com/ml-explore/mlx/pull/1988, I notice the following error in the Linux container build:

```
 [ 76%] Building CXX object CMakeFiles/mlx.dir/mlx/backend/no_metal/allocator.cpp.o
#22 35.67   /home/mpiuser/mlx/mlx/backend/no_metal/allocator.cpp: In member function ‘virtual mlx::core::allocator::Buffer mlx::core::allocator::CommonAllocator::malloc(size_t)’:
#22 35.67   /home/mpiuser/mlx/mlx/backend/no_metal/allocator.cpp:83:23: error: ‘max’ is not a member of ‘std’
#22 35.67      83 |   peak_memory_ = std::max(active_memory_, peak_memory_);
#22 35.67         |                       ^~~
#22 35.67   gmake[2]: *** [CMakeFiles/mlx.dir/build.make:989: CMakeFiles/mlx.dir/mlx/backend/no_metal/allocator.cpp.o] Error 1
#22 35.67   gmake[2]: *** Waiting for unfinished jobs....
```

Error is similar to this one: https://github.com/ml-explore/mlx-data/pull/83


/assign @awni @angeloskath

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
