### PR TITLE
fix: Fix `TypeToDtype<double>` to return `float64`

### DIFF
--- a/mlx/dtype.cpp
+++ b/mlx/dtype.cpp
@@ -149,7 +149,7 @@ TypeToDtype<float>::operator Dtype() {
 
 template <>
 TypeToDtype<double>::operator Dtype() {
-  return float32;
+  return float64;
 }
 
 template <>

--- a/tests/array_tests.cpp
+++ b/tests/array_tests.cpp
@@ -178,6 +178,11 @@ TEST_CASE("test array types") {
     basic_dtype_test(float, float32);
   }
 
+  // float64
+  {
+    basic_dtype_test(double, float64);
+  }
+
   // bfloat16
   {
     basic_dtype_test(bfloat16_t, bfloat16);


### PR DESCRIPTION
## Proposed changes

Closes: #1994 

This PR addresses the problem where a scalar array of type `float32` is returned when attempting create a scalar array of type `float64`

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
