### PR TITLE
Fixed 32-bit platform support for distributed/ring implementation

### DIFF
--- a/mlx/distributed/ring/ring.cpp
+++ b/mlx/distributed/ring/ring.cpp
@@ -624,7 +624,7 @@ class RingGroup : public GroupImpl {
           std::min(
               sockets_right_.size() + sockets_left_.size(),
               nbytes / min_send_size),
-          1UL);
+          size_t(1));
       size_t bytes_per_gather = ceildiv(nbytes, n_gathers);
       std::vector<std::future<void>> all_gathers;
       for (int i = 0; i < n_gathers; i++) {
@@ -739,7 +739,7 @@ class RingGroup : public GroupImpl {
           std::min(
               sockets_right_.size() + sockets_left_.size(),
               nbytes / (size_ * min_send_size)),
-          1UL);
+          size_t(1));
       size_t step = ceildiv(size, n_reduces);
       std::vector<std::future<void>> all_sums;
 
@@ -776,8 +776,8 @@ class RingGroup : public GroupImpl {
     // We split the data into `size_` segments of size `segment_size` and each
     // of these in smaller segments of ALL_SUM_SIZE which we 'll call packets.
     size_t segment_size = ceildiv(data_size, size_);
-    size_t BUFFER_SIZE =
-        std::max(32768UL, std::min(ALL_SUM_SIZE / sizeof(T), segment_size / 2));
+    size_t BUFFER_SIZE = std::max(
+        size_t(32768), std::min(ALL_SUM_SIZE / sizeof(T), segment_size / 2));
     size_t n_packets = ceildiv(segment_size, BUFFER_SIZE);
 
     // Initial segments
@@ -896,7 +896,8 @@ class RingGroup : public GroupImpl {
 
   void
   send(const std::vector<int>& sockets, const char* data, size_t data_size) {
-    size_t segment_size = std::max(1024UL, ceildiv(data_size, sockets.size()));
+    size_t segment_size =
+        std::max(size_t(1024), ceildiv(data_size, sockets.size()));
     std::vector<std::future<void>> sends;
     for (int i = 0; i < sockets.size(); i++) {
       if (i * segment_size >= data_size) {
@@ -913,7 +914,8 @@ class RingGroup : public GroupImpl {
   }
 
   void recv(const std::vector<int>& sockets, char* data, size_t data_size) {
-    size_t segment_size = std::max(1024UL, ceildiv(data_size, sockets.size()));
+    size_t segment_size =
+        std::max(size_t(1024), ceildiv(data_size, sockets.size()));
     std::vector<std::future<void>> recvs;
     for (int i = 0; i < sockets.size(); i++) {
       if (i * segment_size >= data_size) {


### PR DESCRIPTION
## Proposed changes

Fixed 32-bit platform support for distributed/ring implementation

Replaced unsigned long integer literals with size_t literals in ring implementation, e.g., 1UL with size_t(1).

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
