### PR TITLE
Wire cache

### DIFF
--- a/mlx/backend/metal/allocator.h
+++ b/mlx/backend/metal/allocator.h
@@ -18,7 +18,7 @@ namespace {
 
 class BufferCache {
  public:
-  BufferCache(MTL::Device* device);
+  BufferCache(ResidencySet& residency_set);
   ~BufferCache();
 
   MTL::Buffer* reuse_from_cache(size_t size);
@@ -42,13 +42,11 @@ class BufferCache {
   void add_at_head(BufferHolder* to_add);
   void remove_from_list(BufferHolder* to_remove);
 
-  MTL::Device* device_;
-  MTL::Heap* heap_{nullptr};
-
   std::multimap<size_t, BufferHolder*> buffer_pool_;
   BufferHolder* head_;
   BufferHolder* tail_;
   size_t pool_size_;
+  ResidencySet& residency_set_;
 };
 
 } // namespace


### PR DESCRIPTION
Keep cache memory wired if wired limit is set.

This helps a decent amount when training on longer sequences / larger batch sizes.

Lora fine tuning benchmark on a Llama 1B with batch size 4 and sequence length ~2048:

Pre: Tokens/sec 1819.193
Post (wire limit with wired cache): Tokens/sec 2082.386

Didn't notice any change in LLM inference (which is the only other place we use the wired limit as far as I know).