### PR TITLE
Sdpa specialization for head dim 256

### DIFF
--- a/mlx/backend/metal/kernels/scaled_dot_product_attention.metal
+++ b/mlx/backend/metal/kernels/scaled_dot_product_attention.metal
@@ -32,9 +32,11 @@ using namespace metal;
   instantiate_sdpa_vector(type, 64, 64)          \
   instantiate_sdpa_vector(type, 96, 96)          \
   instantiate_sdpa_vector(type, 128, 128)        \
+  instantiate_sdpa_vector(type, 256, 256)        \
   instantiate_sdpa_vector_aggregation(type, 64)  \
   instantiate_sdpa_vector_aggregation(type, 96)  \
-  instantiate_sdpa_vector_aggregation(type, 128)
+  instantiate_sdpa_vector_aggregation(type, 128) \
+  instantiate_sdpa_vector_aggregation(type, 256)
 
 instantiate_sdpa_vector_heads(float)
 instantiate_sdpa_vector_heads(bfloat16_t)

--- a/mlx/fast.cpp
+++ b/mlx/fast.cpp
@@ -720,7 +720,8 @@ array scaled_dot_product_attention(
 
   const bool sdpa_vector_supported_head_dim =
       query_head_dim == value_head_dim &&
-      (query_head_dim == 64 || query_head_dim == 96 || query_head_dim == 128);
+      (query_head_dim == 64 || query_head_dim == 96 || query_head_dim == 128 ||
+       query_head_dim == 256);
   const bool sdpa_full_supported_head_dim = query_head_dim == value_head_dim &&
       (query_head_dim == 64 || query_head_dim == 80 || query_head_dim == 128);
 


### PR DESCRIPTION
The Gemma3 models use a head dim of 256 so it seems worth adding a specialization for it.

There is a reasonable speedup.. given the trivial addition / cost it seems worth while. Benchmarks on M4 Max generating 512 tokens.


Model | Prompt | Pre tok/sec | Post tok/sec
------ | ----- | ---- |  -----
1B 4bit | short (14 toks) | 280.46 | 308.223
1B 4bit | long (17k toks) | 264.660 | 284.337
4B 4bit | short (14 toks) | 140.80 | 142.64
4B 4bit | long (17k toks) | 112.419 | 120.819