### PR TITLE
Revise cmake minimum for doctest

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Doctest works fine with cmake 3.5
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+
 FetchContent_Declare(
   doctest
   GIT_REPOSITORY "https://github.com/onqtam/doctest"


### PR DESCRIPTION
As title. Allows MLX to work with cmake 4.0