### PR TITLE
causal vector sdpa

### DIFF
--- a/mlx/fast.cpp
+++ b/mlx/fast.cpp
@@ -568,7 +568,6 @@ array scaled_dot_product_attention(
     const array& values,
     const float scale,
     const std::variant<std::monostate, std::string, array>& mask /* = {}*/,
-    const std::optional<int> memory_efficient_threshold,
     StreamOrDevice s) {
   for (const auto& tensor : {queries, keys, values}) {
     if (tensor.ndim() != 4) {
@@ -654,13 +653,6 @@ array scaled_dot_product_attention(
   auto k = astype(keys, final_type, s);
   auto v = astype(values, final_type, s);
 
-  /* Generic implementation for use cases that Metal implementation does not
-   * support. */
-  int threshold = 32; // TODO: Fix after dev
-  if (memory_efficient_threshold.has_value()) {
-    threshold = std::max(1, memory_efficient_threshold.value());
-  }
-
   auto fallback = [scale, final_type, n_q_heads, n_kv_heads, do_causal, s](
                       const std::vector<array>& inputs) {
     auto q = multiply(array(scale, inputs[0].dtype()), inputs[0], s);
@@ -730,9 +722,8 @@ array scaled_dot_product_attention(
   const bool sdpa_full_supported_mask = !has_mask || has_arr_mask ||
       (query_sequence_length <= key_sequence_length && do_causal);
 
-  const bool supports_sdpa_full = query_sequence_length >= threshold &&
-      sdpa_full_supported_mask && sdpa_full_supported_head_dim &&
-      stream.device == Device::gpu;
+  const bool supports_sdpa_full = sdpa_full_supported_mask &&
+      sdpa_full_supported_head_dim && stream.device == Device::gpu;
 
   const bool supports_sdpa_vector = (query_sequence_length <= 8) &&
       (query_sequence_length <= key_sequence_length) &&

--- a/mlx/fast.cpp
+++ b/mlx/fast.cpp
@@ -725,7 +725,8 @@ array scaled_dot_product_attention(
   const bool sdpa_full_supported_head_dim = query_head_dim == value_head_dim &&
       (query_head_dim == 64 || query_head_dim == 80 || query_head_dim == 128);
 
-  const bool sdpa_vector_supported_mask = (!has_mask || has_bool_mask);
+  const bool sdpa_vector_supported_mask =
+      !has_mask || has_bool_mask || do_causal;
   const bool sdpa_full_supported_mask = !has_mask || has_arr_mask ||
       (query_sequence_length <= key_sequence_length && do_causal);
 

--- a/mlx/fast.h
+++ b/mlx/fast.h
@@ -49,7 +49,6 @@ array scaled_dot_product_attention(
     const array& values,
     const float scale,
     const std::variant<std::monostate, std::string, array>& mask = {},
-    const std::optional<int> memory_efficient_threshold = std::nullopt,
     StreamOrDevice s = {});
 
 std::tuple<array, array, array> affine_quantize(

--- a/python/src/fast.cpp
+++ b/python/src/fast.cpp
@@ -131,7 +131,6 @@ void init_fast(nb::module_& parent_module) {
       nb::kw_only(),
       "scale"_a,
       "mask"_a = nb::none(),
-      "memory_efficient_threshold"_a = nb::none(),
       "stream"_a = nb::none(),
       nb::sig(
           "def scaled_dot_product_attention(q: array, k: array, v: array, *, scale: float,  mask: Union[None, str, array] = None, stream: Union[None, Stream, Device] = None) -> array"),
@@ -164,10 +163,10 @@ void init_fast(nb::module_& parent_module) {
             k (array): Keys with shape ``[B, N_kv, T_kv, D]``.
             v (array): Values with shape ``[B, N_kv, T_kv, D]``.
             scale (float): Scale for queries (typically ``1.0 / sqrt(q.shape(-1)``)
-            mask (Union[None, str, array], optional): A causal, boolean or additive 
-               mask to apply to the query-key scores. The mask can have at most 4 
-               dimensions and must be broadcast-compatible with the shape 
-               ``[B, N, T_q, T_kv]``. If an additive mask is given its type must 
+            mask (Union[None, str, array], optional): A causal, boolean or additive
+               mask to apply to the query-key scores. The mask can have at most 4
+               dimensions and must be broadcast-compatible with the shape
+               ``[B, N, T_q, T_kv]``. If an additive mask is given its type must
                promote to the promoted type of ``q``, ``k``, and ``v``.
         Returns:
             array: The output array.

--- a/python/tests/test_fast_sdpa.py
+++ b/python/tests/test_fast_sdpa.py
@@ -95,7 +95,13 @@ def prepare_inputs(B, qL, kL, D, qH, kH, mask, transpose, dtype):
 def mlx_primitives_sdpa(q, k, v, scale, mask=None):
     p = (q * scale) @ k.transpose(0, 1, 3, 2)
     if mask is not None:
-        if mask.dtype == mx.bool_:
+        if mask == "causal":
+            q_offset = max(0, k.shape[2] - q.shape[2])
+            q_indices = mx.arange(q_offset, q_offset + q.shape[2])
+            k_indices = mx.arange(k.shape[2])
+            mask = q_indices[:, None] >= k_indices[None]
+            p = mx.where(mask, p, mx.finfo(mx.float32).min)
+        elif mask.dtype == mx.bool_:
             p = mx.where(mask, p, mx.finfo(mx.float32).min)
         else:
             p += mask
@@ -342,6 +348,7 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
             mx.array([True] * (L - 10) + [False] * 10),
             mx.random.uniform(shape=(Nq, 1, L)) > 0.2,
             mx.random.uniform(shape=(L, 1, Nq)).T > 0.2,
+            "causal",
         ]
         for m in masks:
             ref = mlx_primitives_sdpa(q, k, v, scale, mask=m)
@@ -366,6 +373,7 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
             mx.array([True] * (L - 10) + [False] * 10),
             mx.random.uniform(shape=(Nq, 1, L)) > 0.2,
             mx.random.uniform(shape=(L, 1, Nq)).T > 0.2,
+            "causal",
         ]
         for m in masks:
             ref = mlx_primitives_sdpa(q, k, v, scale, mask=m)
@@ -396,6 +404,7 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
             mx.array([True] * (L - 10) + [False] * 10),
             mx.random.uniform(shape=(Nq, 1, L)) > 0.2,
             mx.random.uniform(shape=(L, 1, Nq)).T > 0.2,
+            "causal",
         ]
         for m in masks:
             ref = mlx_primitives_sdpa(q, k, v, scale, mask=m)
@@ -420,6 +429,7 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
             mx.array([True] * (L - 10) + [False] * 10),
             mx.random.uniform(shape=(Nq, 1, L)) > 0.2,
             mx.random.uniform(shape=(L, 1, Nq)).T > 0.2,
+            "causal",
         ]
         for m in masks:
             ref = mlx_primitives_sdpa(q, k, v, scale, mask=m)

--- a/python/tests/test_fast_sdpa.py
+++ b/python/tests/test_fast_sdpa.py
@@ -182,7 +182,10 @@ class TestFastSelfAttentionSDPA(mlx_tests.MLXTestCase):
 
                 reference = mlx_primitives_sdpa_with_gqa(q_mlx, k_mlx, v_mlx, scale)
                 o_mlx = mx.fast.scaled_dot_product_attention(
-                    q_mlx, k_mlx, v_mlx, scale=scale, memory_efficient_threshold=2
+                    q_mlx,
+                    k_mlx,
+                    v_mlx,
+                    scale=scale,
                 )
 
                 self.assertListEqual(list(reference.shape), list(o_mlx.shape))


### PR DESCRIPTION
Adds the causal option to the fast vector sdpa. Since we use `"causal"` in MLX LM now we no longer route to the fast SDPA when the query length is more than 1 (e.g. for spec decoding).

Also got rid of the memory efficient threshold. Since we don't really need this.. and in general it's good not to dispatch differently based on the shape of the input (for e.g. shapeless compilation).