### PR TITLE
Add missing funcs to docs

### DIFF
--- a/docs/src/python/ops.rst
+++ b/docs/src/python/ops.rst
@@ -36,10 +36,12 @@ Operations
    bitwise_or
    bitwise_xor
    block_masked_mm
+   broadcast_arrays
    broadcast_to
    ceil
    clip
    concatenate
+   contiguous
    conj
    conjugate
    convolve

--- a/docs/src/python/transforms.rst
+++ b/docs/src/python/transforms.rst
@@ -9,6 +9,7 @@ Transforms
   :toctree: _autosummary
 
    eval
+   async_eval
    compile
    custom_function
    disable_compile

--- a/python/src/random.cpp
+++ b/python/src/random.cpp
@@ -467,7 +467,7 @@ void init_random(nb::module_& parent_module) {
             array: The output array of random values.
       )pbdoc");
   m.def(
-      "permuation",
+      "permutation",
       [](const std::variant<nb::int_, mx::array>& x,
          int axis,
          const std::optional<mx::array>& key_,


### PR DESCRIPTION
## Proposed changes

Follow up to https://github.com/ml-explore/mlx/pull/2020, was curious if there were others (didn't realize it was an easy fix to add them).

There are a couple I wasn't sure if are intended to be in the docs:
- checkpoint
- concat + permute_dims (aliases)

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
