### PR TITLE
Tune quant dispatch

### DIFF
--- a/mlx/backend/metal/kernels/quantized.h
+++ b/mlx/backend/metal/kernels/quantized.h
@@ -586,13 +586,13 @@ METAL_FUNC void qmv_quad_impl(
   // Adjust positions
   const int in_vec_size_w = in_vec_size / pack_factor;
   const int in_vec_size_g = in_vec_size / group_size;
-  const int out_row = tid.x * quads_per_simd * results_per_quadgroup + quad_gid;
+  const int out_row = tid.y * quads_per_simd * results_per_quadgroup + quad_gid;
 
   w += out_row * in_vec_size_w + quad_lid * packs_per_thread;
   scales += out_row * in_vec_size_g + quad_lid / scale_step_per_thread;
   biases += out_row * in_vec_size_g + quad_lid / scale_step_per_thread;
-  x += tid.y * in_vec_size + quad_lid * values_per_thread;
-  y += tid.y * out_vec_size + out_row;
+  x += tid.x * in_vec_size + quad_lid * values_per_thread;
+  y += tid.x * out_vec_size + out_row;
 
   U sum = load_vector<T, U, values_per_thread, bits>(x, x_thread);
 


### PR DESCRIPTION
Tune quant dispatch conditions to qmv vs qmm.

The optimal is both machine and matrix size dependent unfortunately so this is only an approximation. It's conservative in that we continue to route to the qmm unless it's pretty clear that there is a speedup to be had.

In the plots below:
- x-axis is batch size
- y-axis is time in milliseconds
- dashed line is qmm
- solid line is qmv

Here's a benchmark comparing the two at size = 4096 on a few machines:

<img width="1037" alt="Screenshot 2025-04-01 at 8 08 00 AM" src="https://github.com/user-attachments/assets/7b8327ea-4a31-4a46-94fa-2763eb42b356" />

Another benchmark for just M2 Ultra for 3 different sized matrices:

<img width="1235" alt="Screenshot 2025-04-01 at 8 09 12 AM" src="https://github.com/user-attachments/assets/9c1e1398-e819-4583-b290-c5f124994e4c" />

Same benchmark on M3 Max:

<img width="1227" alt="Screenshot 2025-04-01 at 8 09 35 AM" src="https://github.com/user-attachments/assets/90067895-403f-45f1-b342-47ffa6ed66ec" />
