### PR TITLE
Gather mm new kernel and small refactoring

### DIFF
--- a/benchmarks/python/gather_mm_bench.py
+++ b/benchmarks/python/gather_mm_bench.py
@@ -47,17 +47,14 @@ def time_gather_mm():
         if sort:
             x, idx, inv_order = gather_sort(x, indices)
         for _ in range(2):
-            x = mx.gather_mm(x, w.swapaxes(-1, -2), rhs_indices=idx)
+            x = mx.gather_mm(
+                x, w.swapaxes(-1, -2), rhs_indices=idx, sorted_indices=sort
+            )
         if sort:
             x = scatter_unsort(x, inv_order, indices.shape)
         return x
 
-    # import pdb
-    # pdb.set_trace()
-    # y1 = gather_mm(x, w, indices, True)
-    # y2 = gather_mm_simulate(x, w, indices)
-
-    # time_fn(gather_mm, x, w, indices, False)
+    time_fn(gather_mm, x, w, indices, False)
     time_fn(gather_mm, x, w, indices, True)
     time_fn(gather_mm, x, w, sorted_indices, False)
 

--- a/benchmarks/python/gather_mm_bench.py
+++ b/benchmarks/python/gather_mm_bench.py
@@ -55,8 +55,8 @@ def time_gather_mm():
         return x
 
     time_fn(gather_mm, x, w, indices, False)
-    time_fn(gather_mm, x, w, indices, True)
     time_fn(gather_mm, x, w, sorted_indices, False)
+    time_fn(gather_mm, x, w, indices, True)
 
     x = mx.random.normal((N * I, K)) / 1024**0.5
     w = mx.random.normal((M, K)) / 1024**0.5

--- a/benchmarks/python/gather_mm_bench.py
+++ b/benchmarks/python/gather_mm_bench.py
@@ -25,6 +25,15 @@ def scatter_unsort(x, inv_order, shape=None):
     return x
 
 
+def gather_mm_simulate(x, w, indices):
+    x, idx, inv_order = gather_sort(x, indices)
+    for i in range(2):
+        y = mx.concatenate([x[i] @ w[j].T for i, j in enumerate(idx.tolist())], axis=0)
+        x = y[:, None]
+    x = scatter_unsort(x, inv_order, indices.shape)
+    return x
+
+
 def time_gather_mm():
     x = mx.random.normal((N, 1, 1, K)) / 1024**0.5
     w = mx.random.normal((E, M, K)) / 1024**0.5
@@ -43,7 +52,12 @@ def time_gather_mm():
             x = scatter_unsort(x, inv_order, indices.shape)
         return x
 
-    time_fn(gather_mm, x, w, indices, False)
+    # import pdb
+    # pdb.set_trace()
+    # y1 = gather_mm(x, w, indices, True)
+    # y2 = gather_mm_simulate(x, w, indices)
+
+    # time_fn(gather_mm, x, w, indices, False)
     time_fn(gather_mm, x, w, indices, True)
     time_fn(gather_mm, x, w, sorted_indices, False)
 

--- a/benchmarks/python/gather_mm_bench.py
+++ b/benchmarks/python/gather_mm_bench.py
@@ -1,0 +1,63 @@
+# Copyright © 2023-2024 Apple Inc.
+
+import mlx.core as mx
+from time_utils import time_fn
+
+N = 1024
+K = 1024
+M = 1024
+E = 32
+I = 4
+
+
+def gather_sort(x, indices):
+    N, M = indices.shape
+    indices = indices.flatten()
+    order = mx.argsort(indices)
+    inv_order = mx.argsort(order)
+    return x.flatten(0, -3)[order // M], indices[order], inv_order
+
+
+def scatter_unsort(x, inv_order, shape=None):
+    x = x[inv_order]
+    if shape is not None:
+        x = mx.unflatten(x, 0, shape)
+    return x
+
+
+def time_gather_mm():
+    x = mx.random.normal((N, 1, 1, K)) / 1024**0.5
+    w = mx.random.normal((E, M, K)) / 1024**0.5
+    indices = (mx.random.uniform(shape=(N, I)) * E).astype(mx.uint32)
+    sorted_indices = mx.sort(indices.flatten()).reshape(N, I)
+    mx.eval(x, w, indices, sorted_indices)
+
+    def gather_mm(x, w, indices, sort):
+        idx = indices
+        inv_order = None
+        if sort:
+            x, idx, inv_order = gather_sort(x, indices)
+        for _ in range(2):
+            x = mx.gather_mm(x, w.swapaxes(-1, -2), rhs_indices=idx)
+        if sort:
+            x = scatter_unsort(x, inv_order, indices.shape)
+        return x
+
+    time_fn(gather_mm, x, w, indices, False)
+    time_fn(gather_mm, x, w, indices, True)
+    time_fn(gather_mm, x, w, sorted_indices, False)
+
+    x = mx.random.normal((N * I, K)) / 1024**0.5
+    w = mx.random.normal((M, K)) / 1024**0.5
+    mx.eval(x, w)
+
+    def equivalent_matmul(x, w):
+        for _ in range(2):
+            x = x @ w.T
+        return x
+
+    time_fn(equivalent_matmul, x, w)
+
+
+if __name__ == "__main__":
+    time_gather_mm()

--- a/benchmarks/python/gather_mm_bench.py
+++ b/benchmarks/python/gather_mm_bench.py
@@ -4,7 +4,7 @@ import mlx.core as mx
 from time_utils import time_fn
 
 N = 1024
-K = 1024
+D = 1024
 M = 1024
 E = 32
 I = 4
@@ -35,39 +35,39 @@ def gather_mm_simulate(x, w, indices):
 
 
 def time_gather_mm():
-    x = mx.random.normal((N, 1, 1, K)) / 1024**0.5
-    w = mx.random.normal((E, M, K)) / 1024**0.5
+    x = mx.random.normal((N, 1, 1, D)) / 1024**0.5
+    w1 = mx.random.normal((E, M, D)) / 1024**0.5
+    w2 = mx.random.normal((E, D, M)) / 1024**0.5
     indices = (mx.random.uniform(shape=(N, I)) * E).astype(mx.uint32)
     sorted_indices = mx.sort(indices.flatten()).reshape(N, I)
-    mx.eval(x, w, indices, sorted_indices)
+    mx.eval(x, w1, w2, indices, sorted_indices)
 
-    def gather_mm(x, w, indices, sort):
+    def gather_mm(x, w1, w2, indices, sort):
         idx = indices
         inv_order = None
         if sort:
             x, idx, inv_order = gather_sort(x, indices)
-        for _ in range(2):
-            x = mx.gather_mm(
-                x, w.swapaxes(-1, -2), rhs_indices=idx, sorted_indices=sort
-            )
+        x = mx.gather_mm(x, w1.swapaxes(-1, -2), rhs_indices=idx, sorted_indices=sort)
+        x = mx.gather_mm(x, w2.swapaxes(-1, -2), rhs_indices=idx, sorted_indices=sort)
         if sort:
             x = scatter_unsort(x, inv_order, indices.shape)
         return x
 
-    time_fn(gather_mm, x, w, indices, False)
-    time_fn(gather_mm, x, w, sorted_indices, False)
-    time_fn(gather_mm, x, w, indices, True)
+    time_fn(gather_mm, x, w1, w2, indices, False)
+    time_fn(gather_mm, x, w1, w2, sorted_indices, False)
+    time_fn(gather_mm, x, w1, w2, indices, True)
 
-    x = mx.random.normal((N * I, K)) / 1024**0.5
-    w = mx.random.normal((M, K)) / 1024**0.5
-    mx.eval(x, w)
+    x = mx.random.normal((N * I, D)) / 1024**0.5
+    w1 = mx.random.normal((M, D)) / 1024**0.5
+    w2 = mx.random.normal((D, M)) / 1024**0.5
+    mx.eval(x, w1, w2)
 
-    def equivalent_matmul(x, w):
-        for _ in range(2):
-            x = x @ w.T
+    def equivalent_matmul(x, w1, w2):
+        x = x @ w1.T
+        x = x @ w2.T
         return x
 
-    time_fn(equivalent_matmul, x, w)
+    time_fn(equivalent_matmul, x, w1, w2)
 
 
 if __name__ == "__main__":

--- a/mlx/backend/common/CMakeLists.txt
+++ b/mlx/backend/common/CMakeLists.txt
@@ -1,6 +1,7 @@
 target_sources(
   mlx
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/compiled.cpp
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/broadcasting.cpp
+          ${CMAKE_CURRENT_SOURCE_DIR}/compiled.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/common.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/load.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/reduce.cpp

--- a/mlx/backend/common/broadcasting.cpp
+++ b/mlx/backend/common/broadcasting.cpp
@@ -1,0 +1,24 @@
+// Copyright © 2024 Apple Inc.
+
+#include "mlx/backend/common/utils.h"
+
+namespace mlx::core {
+
+void broadcast(const array& in, array& out) {
+  if (out.size() == 0) {
+    out.set_data(nullptr);
+    return;
+  }
+  Strides strides(out.ndim(), 0);
+  int diff = out.ndim() - in.ndim();
+  for (int i = in.ndim() - 1; i >= 0; --i) {
+    strides[i + diff] = (in.shape()[i] == 1) ? 0 : in.strides()[i];
+  }
+  auto flags = in.flags();
+  if (out.size() > in.size()) {
+    flags.row_contiguous = flags.col_contiguous = false;
+  }
+  out.copy_shared_buffer(in, strides, flags, in.data_size());
+}
+
+} // namespace mlx::core

--- a/mlx/backend/common/broadcasting.h
+++ b/mlx/backend/common/broadcasting.h
@@ -1,0 +1,11 @@
+// Copyright © 2024 Apple Inc.
+
+#pragma once
+
+#include "mlx/array.h"
+
+namespace mlx::core {
+
+void broadcast(const array& in, array& out);
+
+} // namespace mlx::core

--- a/mlx/backend/common/common.cpp
+++ b/mlx/backend/common/common.cpp
@@ -1,6 +1,7 @@
 // Copyright © 2024 Apple Inc.
 #include <cassert>
 
+#include "mlx/backend/common/broadcasting.h"
 #include "mlx/backend/common/utils.h"
 #include "mlx/primitives.h"
 
@@ -40,23 +41,6 @@ void AsStrided::eval(const std::vector<array>& inputs, array& out) {
   size_t data_size = out.size();
 
   return out.copy_shared_buffer(in, strides_, flags, data_size, offset_);
-}
-
-void broadcast(const array& in, array& out) {
-  if (out.size() == 0) {
-    out.set_data(nullptr);
-    return;
-  }
-  Strides strides(out.ndim(), 0);
-  int diff = out.ndim() - in.ndim();
-  for (int i = in.ndim() - 1; i >= 0; --i) {
-    strides[i + diff] = (in.shape()[i] == 1) ? 0 : in.strides()[i];
-  }
-  auto flags = in.flags();
-  if (out.size() > in.size()) {
-    flags.row_contiguous = flags.col_contiguous = false;
-  }
-  out.copy_shared_buffer(in, strides, flags, in.data_size());
 }
 
 void Broadcast::eval(const std::vector<array>& inputs, array& out) {

--- a/mlx/backend/metal/CMakeLists.txt
+++ b/mlx/backend/metal/CMakeLists.txt
@@ -61,6 +61,7 @@ if(MLX_METAL_JIT)
     kernels/steel/gemm/transforms.h)
   make_jit_source(steel/gemm/kernels/steel_gemm_fused)
   make_jit_source(steel/gemm/kernels/steel_gemm_masked kernels/steel/defines.h)
+  make_jit_source(steel/gemm/kernels/steel_gemm_gather)
   make_jit_source(steel/gemm/kernels/steel_gemm_splitk)
   make_jit_source(
     steel/conv/conv

--- a/mlx/backend/metal/jit/includes.h
+++ b/mlx/backend/metal/jit/includes.h
@@ -33,6 +33,7 @@ const char* gemm();
 const char* steel_gemm_fused();
 const char* steel_gemm_masked();
 const char* steel_gemm_splitk();
+const char* steel_gemm_gather();
 const char* conv();
 const char* steel_conv();
 const char* steel_conv_general();

--- a/mlx/backend/metal/jit_kernels.cpp
+++ b/mlx/backend/metal/jit_kernels.cpp
@@ -584,6 +584,40 @@ MTL::ComputePipelineState* get_steel_gemm_masked_kernel(
   return d.get_kernel(kernel_name, lib);
 }
 
+MTL::ComputePipelineState* get_steel_gemm_gather_kernel(
+    metal::Device& d,
+    const std::string& kernel_name,
+    const std::string& hash_name,
+    const metal::MTLFCList& func_consts,
+    const array& out,
+    bool transpose_a,
+    bool transpose_b,
+    int bm,
+    int bn,
+    int bk,
+    int wm,
+    int wn) {
+  const auto& lib_name = kernel_name;
+  auto lib = d.get_library(lib_name, [&]() {
+    std::ostringstream kernel_source;
+    kernel_source << metal::utils() << metal::gemm()
+                  << metal::steel_gemm_gather()
+                  << get_template_definition(
+                         lib_name,
+                         "gemm",
+                         get_type_string(out.dtype()),
+                         bm,
+                         bn,
+                         bk,
+                         wm,
+                         wn,
+                         transpose_a,
+                         transpose_b);
+    return kernel_source.str();
+  });
+  return d.get_kernel(kernel_name, lib, hash_name, func_consts);
+}
+
 MTL::ComputePipelineState* get_gemv_masked_kernel(
     metal::Device& d,
     const std::string& kernel_name,

--- a/mlx/backend/metal/jit_kernels.cpp
+++ b/mlx/backend/metal/jit_kernels.cpp
@@ -479,6 +479,40 @@ MTL::ComputePipelineState* get_steel_gemm_fused_kernel(
   return d.get_kernel(kernel_name, lib, hash_name, func_consts);
 }
 
+MTL::ComputePipelineState* get_steel_gemm_gather_kernel(
+    metal::Device& d,
+    const std::string& kernel_name,
+    const std::string& hash_name,
+    const metal::MTLFCList& func_consts,
+    const array& out,
+    bool transpose_a,
+    bool transpose_b,
+    int bm,
+    int bn,
+    int bk,
+    int wm,
+    int wn) {
+  const auto& lib_name = kernel_name;
+  auto lib = d.get_library(lib_name, [&]() {
+    std::ostringstream kernel_source;
+    kernel_source << metal::utils() << metal::gemm()
+                  << metal::steel_gemm_gather()
+                  << get_template_definition(
+                         lib_name,
+                         "gemm",
+                         get_type_string(out.dtype()),
+                         bm,
+                         bn,
+                         bk,
+                         wm,
+                         wn,
+                         transpose_a,
+                         transpose_b);
+    return kernel_source.str();
+  });
+  return d.get_kernel(kernel_name, lib, hash_name, func_consts);
+}
+
 MTL::ComputePipelineState* get_steel_gemm_splitk_kernel(
     metal::Device& d,
     const std::string& kernel_name,

--- a/mlx/backend/metal/kernels.h
+++ b/mlx/backend/metal/kernels.h
@@ -160,6 +160,20 @@ MTL::ComputePipelineState* get_steel_gemm_masked_kernel(
     bool mn_aligned,
     bool k_aligned);
 
+MTL::ComputePipelineState* get_steel_gemm_gather_kernel(
+    metal::Device& d,
+    const std::string& kernel_name,
+    const std::string& hash_name,
+    const metal::MTLFCList& func_consts,
+    const array& out,
+    bool transpose_a,
+    bool transpose_b,
+    int bm,
+    int bn,
+    int bk,
+    int wm,
+    int wn);
+
 MTL::ComputePipelineState* get_steel_conv_kernel(
     metal::Device& d,
     const std::string& kernel_name,

--- a/mlx/backend/metal/kernels.h
+++ b/mlx/backend/metal/kernels.h
@@ -172,7 +172,8 @@ MTL::ComputePipelineState* get_steel_gemm_gather_kernel(
     int bn,
     int bk,
     int wm,
-    int wn);
+    int wn,
+    bool rhs);
 
 MTL::ComputePipelineState* get_steel_conv_kernel(
     metal::Device& d,

--- a/mlx/backend/metal/kernels/CMakeLists.txt
+++ b/mlx/backend/metal/kernels/CMakeLists.txt
@@ -69,6 +69,7 @@ set(STEEL_HEADERS
     steel/gemm/loader.h
     steel/gemm/transforms.h
     steel/gemm/kernels/steel_gemm_fused.h
+    steel/gemm/kernels/steel_gemm_gather.h
     steel/gemm/kernels/steel_gemm_masked.h
     steel/gemm/kernels/steel_gemm_splitk.h
     steel/utils/type_traits.h
@@ -116,6 +117,7 @@ if(NOT MLX_METAL_JIT)
   build_kernel(steel/conv/kernels/steel_conv ${STEEL_HEADERS})
   build_kernel(steel/conv/kernels/steel_conv_general ${STEEL_HEADERS})
   build_kernel(steel/gemm/kernels/steel_gemm_fused ${STEEL_HEADERS})
+  build_kernel(steel/gemm/kernels/steel_gemm_gather ${STEEL_HEADERS})
   build_kernel(steel/gemm/kernels/steel_gemm_masked ${STEEL_HEADERS})
   build_kernel(steel/gemm/kernels/steel_gemm_splitk ${STEEL_HEADERS})
   build_kernel(gemv_masked steel/utils.h)

--- a/mlx/backend/metal/kernels/steel/gemm/kernels/steel_gemm_fused.h
+++ b/mlx/backend/metal/kernels/steel/gemm/kernels/steel_gemm_fused.h
@@ -15,10 +15,6 @@ constant bool align_M [[function_constant(200)]];
 constant bool align_N [[function_constant(201)]];
 constant bool align_K [[function_constant(202)]];
 
-constant bool do_gather [[function_constant(300)]];
-
-constant bool gather_bias = do_gather && use_out_source;
-
 // clang-format off
 template <
     typename T,
@@ -39,12 +35,6 @@ template <
     const constant GEMMAddMMParams* addmm_params [[buffer(5), function_constant(use_out_source)]],
     const constant int* batch_shape [[buffer(6)]],
     const constant int64_t* batch_strides [[buffer(7)]],
-    const constant uint32_t* lhs_indices [[buffer(10), function_constant(do_gather)]],
-    const constant uint32_t* rhs_indices [[buffer(11), function_constant(do_gather)]],
-    const constant uint32_t* C_indices [[buffer(12), function_constant(gather_bias)]],
-    const constant int* operand_shape [[buffer(13), function_constant(do_gather)]],
-    const constant int64_t* operand_strides [[buffer(14), function_constant(do_gather)]],
-    const constant packed_int3& operand_batch_ndim [[buffer(15), function_constant(do_gather)]],
     uint simd_lane_id [[thread_index_in_simdgroup]],
     uint simd_group_id [[simdgroup_index_in_threadgroup]],
     uint3 tid [[threadgroup_position_in_grid]],
@@ -81,84 +71,26 @@ template <
   }
 
   // Adjust for batch
+  if (has_batch) {
+    const constant auto* A_bstrides = batch_strides;
+    const constant auto* B_bstrides = batch_strides + params->batch_ndim;
 
-  // Handle gather
-  if (do_gather) {
-    // Read indices
-    uint32_t indx_A, indx_B, indx_C;
+    ulong2 batch_offsets = elem_to_loc_broadcast(
+        tid.z, batch_shape, A_bstrides, B_bstrides, params->batch_ndim);
 
-    if (has_batch) {
-      const constant auto* indx_A_bstrides = batch_strides;
-      const constant auto* indx_B_bstrides = batch_strides + params->batch_ndim;
-
-      ulong2 indx_offsets = elem_to_loc_broadcast(
-          tid.z,
-          batch_shape,
-          indx_A_bstrides,
-          indx_B_bstrides,
-          params->batch_ndim);
-      indx_A = lhs_indices[indx_offsets.x];
-      indx_B = rhs_indices[indx_offsets.y];
-
-      if (use_out_source) {
-        const constant auto* indx_C_bstrides =
-            indx_B_bstrides + params->batch_ndim;
-        auto indx_offset_C = elem_to_loc(
-            tid.z, batch_shape, indx_C_bstrides, params->batch_ndim);
-        indx_C = C_indices[indx_offset_C];
-      }
-    } else {
-      indx_A = lhs_indices[params->batch_stride_a * tid.z];
-      indx_B = rhs_indices[params->batch_stride_b * tid.z];
-
-      if (use_out_source) {
-        indx_C = C_indices[addmm_params->batch_stride_c * tid.z];
-      }
-    }
-
-    // Translate indices to offsets
-    int batch_ndim_A = operand_batch_ndim.x;
-    const constant int* batch_shape_A = operand_shape;
-    const constant auto* batch_strides_A = operand_strides;
-    A += elem_to_loc(indx_A, batch_shape_A, batch_strides_A, batch_ndim_A);
-
-    int batch_ndim_B = operand_batch_ndim.y;
-    const constant int* batch_shape_B = batch_shape_A + batch_ndim_A;
-    const constant auto* batch_strides_B = batch_strides_A + batch_ndim_A;
-    B += elem_to_loc(indx_B, batch_shape_B, batch_strides_B, batch_ndim_B);
+    A += batch_offsets.x;
+    B += batch_offsets.y;
 
     if (use_out_source) {
-      int batch_ndim_C = operand_batch_ndim.z;
-      const constant int* batch_shape_C = batch_shape_B + batch_ndim_B;
-      const constant auto* batch_strides_C = batch_strides_B + batch_ndim_B;
-      C += elem_to_loc(indx_C, batch_shape_C, batch_strides_C, batch_ndim_C);
+      const constant auto* C_bstrides = B_bstrides + params->batch_ndim;
+      C += elem_to_loc(tid.z, batch_shape, C_bstrides, params->batch_ndim);
     }
+  } else {
+    A += params->batch_stride_a * tid.z;
+    B += params->batch_stride_b * tid.z;
 
-  }
-
-  // Handle regular batch
-  else {
-    if (has_batch) {
-      const constant auto* A_bstrides = batch_strides;
-      const constant auto* B_bstrides = batch_strides + params->batch_ndim;
-
-      ulong2 batch_offsets = elem_to_loc_broadcast(
-          tid.z, batch_shape, A_bstrides, B_bstrides, params->batch_ndim);
-
-      A += batch_offsets.x;
-      B += batch_offsets.y;
-
-      if (use_out_source) {
-        const constant auto* C_bstrides = B_bstrides + params->batch_ndim;
-        C += elem_to_loc(tid.z, batch_shape, C_bstrides, params->batch_ndim);
-      }
-    } else {
-      A += params->batch_stride_a * tid.z;
-      B += params->batch_stride_b * tid.z;
-
-      if (use_out_source) {
-        C += addmm_params->batch_stride_c * tid.z;
-      }
+    if (use_out_source) {
+      C += addmm_params->batch_stride_c * tid.z;
     }
   }
 

--- a/mlx/backend/metal/kernels/steel/gemm/kernels/steel_gemm_gather.h
+++ b/mlx/backend/metal/kernels/steel/gemm/kernels/steel_gemm_gather.h
@@ -19,8 +19,8 @@ template <
 [[kernel, max_total_threads_per_threadgroup(WM* WN * 32)]] void gather_mm_rhs(
     const device T* A [[buffer(0)]],
     const device T* B [[buffer(1)]],
-    device T* C [[buffer(2)]],
-    const device uint32_t* rhs_indices [[buffer(3)]],
+    const device uint32_t* rhs_indices [[buffer(2)]],
+    device T* C [[buffer(3)]],
     const constant GEMMParams* params [[buffer(4)]],
     uint simd_lane_id [[thread_index_in_simdgroup]],
     uint simd_group_id [[simdgroup_index_in_threadgroup]],
@@ -43,7 +43,8 @@ template <
   using loader_b_t = typename gemm_kernel::loader_b_t;
   using mma_t = typename gemm_kernel::mma_t;
 
-  if (params->tiles_n <= tid.x || params->tiles_m <= tid.y) {
+  if (params->tiles_n <= static_cast<int>(tid.x) ||
+      params->tiles_m <= static_cast<int>(tid.y)) {
     return;
   }
 
@@ -57,159 +58,189 @@ template <
   const size_t c_row_long = size_t(c_row);
   const size_t c_col_long = size_t(c_col);
 
-  A += transpose_a ? c_row_long : c_row_long * params->lda;
-  C += c_row_long * params->ldd + c_col_long;
-
-  // NOTE: This assumes that each thread reads from 1 row at most so this
-  //       should change and be in the block loader rather than in here.
-  constexpr int n_reads = BK * BN / (WM * WN * 32);
-  constexpr int threads_per_row = (transpose_b) ? BN / n_reads : BK / n_reads;
-  if (align_M) {
-    const int64_t offset = params->batch_stride_b *
-        (rhs_indices
-             [c_row + (simd_group_id * 32 + simd_lane_id) / threads_per_row]);
-    B += offset + (transpose_b ? c_col_long * params->ldb : c_col_long);
-  } else {
-    const int m = c_row + (simd_group_id * 32 + simd_lane_id) / threads_per_row;
-    const int64_t offset = params->batch_stride_b *
-        ((m < params->M) ? rhs_indices[m] : rhs_indices[params->M - 1]);
-    B += offset + (transpose_b ? c_col_long * params->ldb : c_col_long);
-  }
-
-  threadgroup_barrier(mem_flags::mem_none);
-
-  // Prepare threadgroup mma operation
-  thread mma_t mma_op(simd_group_id, simd_lane_id);
-
-  // Prepare threadgroup loading operations
-  thread loader_a_t loader_a(A, params->lda, As, simd_group_id, simd_lane_id);
-  thread loader_b_t loader_b(B, params->ldb, Bs, simd_group_id, simd_lane_id);
-
   // Prepare threadgroup bounds
   const short tgp_bm = align_M ? BM : short(min(BM, params->M - c_row));
   const short tgp_bn = align_N ? BN : short(min(BN, params->N - c_col));
 
-  // Prepare iterations
-  const int gemm_k_iterations = params->gemm_k_iterations_aligned;
+  A += transpose_a ? c_row_long : c_row_long * params->lda;
+  B += transpose_b ? c_col_long * params->ldb : c_col_long;
+  C += c_row_long * params->ldd + c_col_long;
 
-  // Do unaligned K iterations first
-  if (!align_K) {
-    const int k_last = params->gemm_k_iterations_aligned * BK;
-    const int k_remain = params->K - k_last;
-    const size_t k_jump_a =
-        transpose_a ? params->lda * size_t(k_last) : size_t(k_last);
-    const size_t k_jump_b =
-        transpose_b ? size_t(k_last) : params->ldb * size_t(k_last);
-
-    // Move loader source ahead to end
-    loader_a.src += k_jump_a;
-    loader_b.src += k_jump_b;
-
-    // Load tile
-    const short2 tile_dims_A =
-        transpose_a ? short2(tgp_bm, k_remain) : short2(k_remain, tgp_bm);
-    const short2 tile_dims_B =
-        transpose_b ? short2(k_remain, tgp_bn) : short2(tgp_bn, k_remain);
-
-    loader_a.load_safe(tile_dims_A);
-    loader_b.load_safe(tile_dims_B);
-
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-
-    // Do matmul
-    mma_op.mma(As, Bs);
-
-    // Reset source back to start
-    loader_a.src -= k_jump_a;
-    loader_b.src -= k_jump_b;
+  // Calculate the number of unique matmuls
+  uint32_t unique_indices[4];
+  short offsets[5];
+  unique_indices[0] = rhs_indices[c_row];
+  offsets[0] = 0;
+  int j = 0;
+  for (int i = 1; i < tgp_bm; i++) {
+    if (rhs_indices[c_row + i] != unique_indices[j]) {
+      j++;
+      offsets[j] = i;
+      unique_indices[j] = rhs_indices[c_row + i];
+    }
   }
+  int n_unique = j + 1;
+  offsets[n_unique] = tgp_bm;
 
-  // Matrix level aligned never check
-  if (align_M && align_N) {
-    for (int k = 0; k < gemm_k_iterations; k++) {
+  threadgroup_barrier(mem_flags::mem_none);
+
+  for (int n = 0; n < n_unique; n++) {
+    // Prepare threadgroup mma operation
+    thread mma_t mma_op(simd_group_id, simd_lane_id);
+
+    // Prepare threadgroup loading operations
+    thread loader_a_t loader_a(A, params->lda, As, simd_group_id, simd_lane_id);
+    thread loader_b_t loader_b(
+        B + unique_indices[n] * params->batch_stride_b,
+        params->ldb,
+        Bs,
+        simd_group_id,
+        simd_lane_id);
+
+    // Prepare iterations
+    const int gemm_k_iterations = params->gemm_k_iterations_aligned;
+
+    // Do unaligned K iterations first
+    if (!align_K) {
+      const int k_last = params->gemm_k_iterations_aligned * BK;
+      const int k_remain = params->K - k_last;
+      const size_t k_jump_a =
+          transpose_a ? params->lda * size_t(k_last) : size_t(k_last);
+      const size_t k_jump_b =
+          transpose_b ? size_t(k_last) : params->ldb * size_t(k_last);
+
+      // Move loader source ahead to end
+      loader_a.src += k_jump_a;
+      loader_b.src += k_jump_b;
+
+      // Load tile
+      const short2 tile_dims_A =
+          transpose_a ? short2(tgp_bm, k_remain) : short2(k_remain, tgp_bm);
+      const short2 tile_dims_B =
+          transpose_b ? short2(k_remain, tgp_bn) : short2(tgp_bn, k_remain);
+
+      loader_a.load_safe(tile_dims_A);
+      loader_b.load_safe(tile_dims_B);
+
       threadgroup_barrier(mem_flags::mem_threadgroup);
 
-      // Load elements into threadgroup
-      loader_a.load_unsafe();
-      loader_b.load_unsafe();
-
-      threadgroup_barrier(mem_flags::mem_threadgroup);
-
-      // Multiply and accumulate threadgroup elements
+      // Do matmul
       mma_op.mma(As, Bs);
 
-      // Prepare for next iteration
-      loader_a.next();
-      loader_b.next();
+      // Reset source back to start
+      loader_a.src -= k_jump_a;
+      loader_b.src -= k_jump_b;
     }
 
-    // Store results to device memory
-    return mma_op.store_result(C, params->ldd);
-  } else {
-    const short lbk = 0;
+    // Matrix level aligned never check
+    if (align_M && align_N) {
+      for (int k = 0; k < gemm_k_iterations; k++) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
 
-    // Tile aligned don't check
-    if ((align_M || tgp_bm == BM) && (align_N || tgp_bn == BN)) {
-      gemm_kernel::gemm_loop(
-          As,
-          Bs,
-          gemm_k_iterations,
-          loader_a,
-          loader_b,
-          mma_op,
-          tgp_bm,
-          tgp_bn,
-          lbk,
-          LoopAlignment<true, true, true>{});
-      return mma_op.store_result(C, params->ldd);
-    }
+        // Load elements into threadgroup
+        loader_a.load_unsafe();
+        loader_b.load_unsafe();
 
-    // Tile partially aligned check rows
-    else if (align_N || tgp_bn == BN) {
-      gemm_kernel::gemm_loop(
-          As,
-          Bs,
-          gemm_k_iterations,
-          loader_a,
-          loader_b,
-          mma_op,
-          tgp_bm,
-          tgp_bn,
-          lbk,
-          LoopAlignment<false, true, true>{});
-      return mma_op.store_result(C, params->ldd);
-    }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
 
-    // Tile partially aligned check cols
-    else if (align_M || tgp_bm == BM) {
-      gemm_kernel::gemm_loop(
-          As,
-          Bs,
-          gemm_k_iterations,
-          loader_a,
-          loader_b,
-          mma_op,
-          tgp_bm,
-          tgp_bn,
-          lbk,
-          LoopAlignment<true, false, true>{});
-      return mma_op.store_result(C, params->ldd);
-    }
+        // Multiply and accumulate threadgroup elements
+        mma_op.mma(As, Bs);
 
-    // Nothing aligned so check both rows and cols
-    else {
-      gemm_kernel::gemm_loop(
-          As,
-          Bs,
-          gemm_k_iterations,
-          loader_a,
-          loader_b,
-          mma_op,
-          tgp_bm,
-          tgp_bn,
-          lbk,
-          LoopAlignment<false, false, true>{});
-      return mma_op.store_result(C, params->ldd);
+        // Prepare for next iteration
+        loader_a.next();
+        loader_b.next();
+      }
+
+      // Store results to device memory
+      if (offsets[n + 1] - offsets[n] == BM) {
+        mma_op.store_result(C, params->ldd);
+      } else {
+        mma_op.store_result_slice(
+            C, params->ldd, short2(0, offsets[n]), short2(BN, offsets[n + 1]));
+      }
+    } else {
+      const short lbk = 0;
+
+      // Tile aligned don't check
+      if ((align_M || tgp_bm == BM) && (align_N || tgp_bn == BN)) {
+        gemm_kernel::gemm_loop(
+            As,
+            Bs,
+            gemm_k_iterations,
+            loader_a,
+            loader_b,
+            mma_op,
+            tgp_bm,
+            tgp_bn,
+            lbk,
+            LoopAlignment<true, true, true>{});
+        if (offsets[n + 1] - offsets[n] == BM) {
+          mma_op.store_result(C, params->ldd);
+        } else {
+          mma_op.store_result_slice(
+              C,
+              params->ldd,
+              short2(0, offsets[n]),
+              short2(BN, offsets[n + 1]));
+        }
+      }
+
+      // Tile partially aligned check rows
+      else if (align_N || tgp_bn == BN) {
+        gemm_kernel::gemm_loop(
+            As,
+            Bs,
+            gemm_k_iterations,
+            loader_a,
+            loader_b,
+            mma_op,
+            tgp_bm,
+            tgp_bn,
+            lbk,
+            LoopAlignment<false, true, true>{});
+        mma_op.store_result_slice(
+            C, params->ldd, short2(0, offsets[n]), short2(BN, offsets[n + 1]));
+      }
+
+      // Tile partially aligned check cols
+      else if (align_M || tgp_bm == BM) {
+        gemm_kernel::gemm_loop(
+            As,
+            Bs,
+            gemm_k_iterations,
+            loader_a,
+            loader_b,
+            mma_op,
+            tgp_bm,
+            tgp_bn,
+            lbk,
+            LoopAlignment<true, false, true>{});
+        mma_op.store_result_slice(
+            C,
+            params->ldd,
+            short2(0, offsets[n]),
+            short2(tgp_bn, offsets[n + 1]));
+      }
+
+      // Nothing aligned so check both rows and cols
+      else {
+        gemm_kernel::gemm_loop(
+            As,
+            Bs,
+            gemm_k_iterations,
+            loader_a,
+            loader_b,
+            mma_op,
+            tgp_bm,
+            tgp_bn,
+            lbk,
+            LoopAlignment<false, false, true>{});
+        mma_op.store_result_slice(
+            C,
+            params->ldd,
+            short2(0, offsets[n]),
+            short2(tgp_bn, offsets[n + 1]));
+      }
     }
   }
 }

--- a/mlx/backend/metal/kernels/steel/gemm/kernels/steel_gemm_gather.h
+++ b/mlx/backend/metal/kernels/steel/gemm/kernels/steel_gemm_gather.h
@@ -2,6 +2,7 @@
 
 using namespace mlx::steel;
 
+constant bool has_batch [[function_constant(10)]];
 constant bool align_M [[function_constant(200)]];
 constant bool align_N [[function_constant(201)]];
 constant bool align_K [[function_constant(202)]];
@@ -233,6 +234,226 @@ template <
         mma_op.store_result_slice(
             C, params->ldd, short2(0, offset), short2(tgp_bn, offset_next));
       }
+    }
+  }
+}
+
+template <
+    typename T,
+    int BM,
+    int BN,
+    int BK,
+    int WM,
+    int WN,
+    bool transpose_a,
+    bool transpose_b,
+    typename AccumType = float>
+[[kernel, max_total_threads_per_threadgroup(WM* WN * 32)]] void gather_mm(
+    const device T* A [[buffer(0)]],
+    const device T* B [[buffer(1)]],
+    const device uint32_t* lhs_indices [[buffer(2)]],
+    const device uint32_t* rhs_indices [[buffer(3)]],
+    device T* C [[buffer(4)]],
+    const constant GEMMParams* params [[buffer(5)]],
+    const constant int* indices_shape [[buffer(6)]],
+    const constant int64_t* lhs_strides [[buffer(7)]],
+    const constant int64_t* rhs_strides [[buffer(8)]],
+    const constant int& batch_ndim_a [[buffer(9)]],
+    const constant int* batch_shape_a [[buffer(10)]],
+    const constant int64_t* batch_strides_a [[buffer(11)]],
+    const constant int& batch_ndim_b [[buffer(12)]],
+    const constant int* batch_shape_b [[buffer(13)]],
+    const constant int64_t* batch_strides_b [[buffer(14)]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint3 tid [[threadgroup_position_in_grid]]) {
+  using gemm_kernel = GEMMKernel<
+      T,
+      T,
+      BM,
+      BN,
+      BK,
+      WM,
+      WN,
+      transpose_a,
+      transpose_b,
+      true,
+      true,
+      AccumType>;
+
+  using loader_a_t = typename gemm_kernel::loader_a_t;
+  using loader_b_t = typename gemm_kernel::loader_b_t;
+  using mma_t = typename gemm_kernel::mma_t;
+
+  if (params->tiles_n <= static_cast<int>(tid.x) ||
+      params->tiles_m <= static_cast<int>(tid.y)) {
+    return;
+  }
+
+  // Move A and B to the locations pointed by lhs_indices and rhs_indices.
+  uint32_t indx_A, indx_B;
+  if (has_batch) {
+    ulong2 indices_offsets = elem_to_loc_broadcast(
+        tid.z, indices_shape, lhs_strides, rhs_strides, params->batch_ndim);
+    indx_A = lhs_indices[indices_offsets.x];
+    indx_B = rhs_indices[indices_offsets.y];
+  } else {
+    indx_A = lhs_indices[params->batch_stride_a * tid.z];
+    indx_B = rhs_indices[params->batch_stride_b * tid.z];
+  }
+  A += elem_to_loc(indx_A, batch_shape_a, batch_strides_a, batch_ndim_a);
+  B += elem_to_loc(indx_B, batch_shape_b, batch_strides_b, batch_ndim_b);
+  C += params->batch_stride_d * tid.z;
+
+  // Prepare threadgroup memory
+  threadgroup T As[gemm_kernel::tgp_mem_size_a];
+  threadgroup T Bs[gemm_kernel::tgp_mem_size_b];
+
+  // Just make sure everybody's finished with the indexing math above.
+  threadgroup_barrier(mem_flags::mem_none);
+
+  // Find block in A, B, C
+  const int c_row = tid.y * BM;
+  const int c_col = tid.x * BN;
+  const size_t c_row_long = size_t(c_row);
+  const size_t c_col_long = size_t(c_col);
+
+  A += transpose_a ? c_row_long : c_row_long * params->lda;
+  B += transpose_b ? c_col_long * params->ldb : c_col_long;
+  C += c_row_long * params->ldd + c_col_long;
+
+  // Prepare threadgroup mma operation
+  thread mma_t mma_op(simd_group_id, simd_lane_id);
+
+  // Prepare threadgroup loading operations
+  thread loader_a_t loader_a(A, params->lda, As, simd_group_id, simd_lane_id);
+  thread loader_b_t loader_b(B, params->ldb, Bs, simd_group_id, simd_lane_id);
+
+  // Prepare threadgroup bounds
+  const short tgp_bm = align_M ? BM : short(min(BM, params->M - c_row));
+  const short tgp_bn = align_N ? BN : short(min(BN, params->N - c_col));
+
+  // Prepare iterations
+  int gemm_k_iterations = params->gemm_k_iterations_aligned;
+
+  // Do unaligned K iterations first
+  if (!align_K) {
+    const int k_last = params->gemm_k_iterations_aligned * BK;
+    const int k_remain = params->K - k_last;
+    const size_t k_jump_a =
+        transpose_a ? params->lda * size_t(k_last) : size_t(k_last);
+    const size_t k_jump_b =
+        transpose_b ? size_t(k_last) : params->ldb * size_t(k_last);
+
+    // Move loader source ahead to end
+    loader_a.src += k_jump_a;
+    loader_b.src += k_jump_b;
+
+    // Load tile
+    const short2 tile_dims_A =
+        transpose_a ? short2(tgp_bm, k_remain) : short2(k_remain, tgp_bm);
+    const short2 tile_dims_B =
+        transpose_b ? short2(k_remain, tgp_bn) : short2(tgp_bn, k_remain);
+
+    loader_a.load_safe(tile_dims_A);
+    loader_b.load_safe(tile_dims_B);
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Do matmul
+    mma_op.mma(As, Bs);
+
+    // Reset source back to start
+    loader_a.src -= k_jump_a;
+    loader_b.src -= k_jump_b;
+  }
+
+  // Matrix level aligned never check
+  if (align_M && align_N) {
+    for (int k = 0; k < gemm_k_iterations; k++) {
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+
+      // Load elements into threadgroup
+      loader_a.load_unsafe();
+      loader_b.load_unsafe();
+
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+
+      // Multiply and accumulate threadgroup elements
+      mma_op.mma(As, Bs);
+
+      // Prepare for next iteration
+      loader_a.next();
+      loader_b.next();
+    }
+
+    // Store results to device memory
+    mma_op.store_result(C, params->ldd);
+  } else {
+    const short lbk = 0;
+
+    // Tile aligned don't check
+    if ((align_M || tgp_bm == BM) && (align_N || tgp_bn == BN)) {
+      gemm_kernel::gemm_loop(
+          As,
+          Bs,
+          gemm_k_iterations,
+          loader_a,
+          loader_b,
+          mma_op,
+          tgp_bm,
+          tgp_bn,
+          lbk,
+          LoopAlignment<true, true, true>{});
+      mma_op.store_result(C, params->ldd);
+    }
+
+    // Tile partially aligned check rows
+    else if (align_N || tgp_bn == BN) {
+      gemm_kernel::gemm_loop(
+          As,
+          Bs,
+          gemm_k_iterations,
+          loader_a,
+          loader_b,
+          mma_op,
+          tgp_bm,
+          tgp_bn,
+          lbk,
+          LoopAlignment<false, true, true>{});
+      mma_op.store_result_safe(C, params->ldd, short2(tgp_bn, tgp_bm));
+    }
+
+    // Tile partially aligned check cols
+    else if (align_M || tgp_bm == BM) {
+      gemm_kernel::gemm_loop(
+          As,
+          Bs,
+          gemm_k_iterations,
+          loader_a,
+          loader_b,
+          mma_op,
+          tgp_bm,
+          tgp_bn,
+          lbk,
+          LoopAlignment<true, false, true>{});
+      mma_op.store_result_safe(C, params->ldd, short2(tgp_bn, tgp_bm));
+    }
+
+    // Nothing aligned so check both rows and cols
+    else {
+      gemm_kernel::gemm_loop(
+          As,
+          Bs,
+          gemm_k_iterations,
+          loader_a,
+          loader_b,
+          mma_op,
+          tgp_bm,
+          tgp_bn,
+          lbk,
+          LoopAlignment<false, false, true>{});
+      mma_op.store_result_safe(C, params->ldd, short2(tgp_bn, tgp_bm));
     }
   }
 }

--- a/mlx/backend/metal/kernels/steel/gemm/kernels/steel_gemm_gather.h
+++ b/mlx/backend/metal/kernels/steel/gemm/kernels/steel_gemm_gather.h
@@ -1,0 +1,215 @@
+// Copyright © 2024 Apple Inc.
+
+using namespace mlx::steel;
+
+constant bool align_M [[function_constant(200)]];
+constant bool align_N [[function_constant(201)]];
+constant bool align_K [[function_constant(202)]];
+
+template <
+    typename T,
+    int BM,
+    int BN,
+    int BK,
+    int WM,
+    int WN,
+    bool transpose_a,
+    bool transpose_b,
+    typename AccumType = float>
+[[kernel, max_total_threads_per_threadgroup(WM* WN * 32)]] void gather_mm_rhs(
+    const device T* A [[buffer(0)]],
+    const device T* B [[buffer(1)]],
+    device T* C [[buffer(2)]],
+    const device uint32_t* rhs_indices [[buffer(3)]],
+    const constant GEMMParams* params [[buffer(4)]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint3 tid [[threadgroup_position_in_grid]]) {
+  using gemm_kernel = GEMMKernel<
+      T,
+      T,
+      BM,
+      BN,
+      BK,
+      WM,
+      WN,
+      transpose_a,
+      transpose_b,
+      true,
+      true,
+      AccumType>;
+
+  using loader_a_t = typename gemm_kernel::loader_a_t;
+  using loader_b_t = typename gemm_kernel::loader_b_t;
+  using mma_t = typename gemm_kernel::mma_t;
+
+  if (params->tiles_n <= tid.x || params->tiles_m <= tid.y) {
+    return;
+  }
+
+  // Prepare threadgroup memory
+  threadgroup T As[gemm_kernel::tgp_mem_size_a];
+  threadgroup T Bs[gemm_kernel::tgp_mem_size_b];
+
+  // Find the block in A, B, C
+  const int c_row = tid.y * BM;
+  const int c_col = tid.x * BN;
+  const size_t c_row_long = size_t(c_row);
+  const size_t c_col_long = size_t(c_col);
+
+  A += transpose_a ? c_row_long : c_row_long * params->lda;
+  C += c_row_long * params->ldd + c_col_long;
+
+  // NOTE: This assumes that each thread reads from 1 row at most so this
+  //       should change and be in the block loader rather than in here.
+  constexpr int n_reads = BK * BN / (WM * WN * 32);
+  constexpr int threads_per_row = (transpose_b) ? BN / n_reads : BK / n_reads;
+  if (align_M) {
+    const int64_t offset = params->batch_stride_b *
+        (rhs_indices
+             [c_row + (simd_group_id * 32 + simd_lane_id) / threads_per_row]);
+    B += offset + (transpose_b ? c_col_long * params->ldb : c_col_long);
+  } else {
+    const int m = c_row + (simd_group_id * 32 + simd_lane_id) / threads_per_row;
+    const int64_t offset = params->batch_stride_b *
+        ((m < params->M) ? rhs_indices[m] : rhs_indices[params->M - 1]);
+    B += offset + (transpose_b ? c_col_long * params->ldb : c_col_long);
+  }
+
+  threadgroup_barrier(mem_flags::mem_none);
+
+  // Prepare threadgroup mma operation
+  thread mma_t mma_op(simd_group_id, simd_lane_id);
+
+  // Prepare threadgroup loading operations
+  thread loader_a_t loader_a(A, params->lda, As, simd_group_id, simd_lane_id);
+  thread loader_b_t loader_b(B, params->ldb, Bs, simd_group_id, simd_lane_id);
+
+  // Prepare threadgroup bounds
+  const short tgp_bm = align_M ? BM : short(min(BM, params->M - c_row));
+  const short tgp_bn = align_N ? BN : short(min(BN, params->N - c_col));
+
+  // Prepare iterations
+  const int gemm_k_iterations = params->gemm_k_iterations_aligned;
+
+  // Do unaligned K iterations first
+  if (!align_K) {
+    const int k_last = params->gemm_k_iterations_aligned * BK;
+    const int k_remain = params->K - k_last;
+    const size_t k_jump_a =
+        transpose_a ? params->lda * size_t(k_last) : size_t(k_last);
+    const size_t k_jump_b =
+        transpose_b ? size_t(k_last) : params->ldb * size_t(k_last);
+
+    // Move loader source ahead to end
+    loader_a.src += k_jump_a;
+    loader_b.src += k_jump_b;
+
+    // Load tile
+    const short2 tile_dims_A =
+        transpose_a ? short2(tgp_bm, k_remain) : short2(k_remain, tgp_bm);
+    const short2 tile_dims_B =
+        transpose_b ? short2(k_remain, tgp_bn) : short2(tgp_bn, k_remain);
+
+    loader_a.load_safe(tile_dims_A);
+    loader_b.load_safe(tile_dims_B);
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Do matmul
+    mma_op.mma(As, Bs);
+
+    // Reset source back to start
+    loader_a.src -= k_jump_a;
+    loader_b.src -= k_jump_b;
+  }
+
+  // Matrix level aligned never check
+  if (align_M && align_N) {
+    for (int k = 0; k < gemm_k_iterations; k++) {
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+
+      // Load elements into threadgroup
+      loader_a.load_unsafe();
+      loader_b.load_unsafe();
+
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+
+      // Multiply and accumulate threadgroup elements
+      mma_op.mma(As, Bs);
+
+      // Prepare for next iteration
+      loader_a.next();
+      loader_b.next();
+    }
+
+    // Store results to device memory
+    return mma_op.store_result(C, params->ldd);
+  } else {
+    const short lbk = 0;
+
+    // Tile aligned don't check
+    if ((align_M || tgp_bm == BM) && (align_N || tgp_bn == BN)) {
+      gemm_kernel::gemm_loop(
+          As,
+          Bs,
+          gemm_k_iterations,
+          loader_a,
+          loader_b,
+          mma_op,
+          tgp_bm,
+          tgp_bn,
+          lbk,
+          LoopAlignment<true, true, true>{});
+      return mma_op.store_result(C, params->ldd);
+    }
+
+    // Tile partially aligned check rows
+    else if (align_N || tgp_bn == BN) {
+      gemm_kernel::gemm_loop(
+          As,
+          Bs,
+          gemm_k_iterations,
+          loader_a,
+          loader_b,
+          mma_op,
+          tgp_bm,
+          tgp_bn,
+          lbk,
+          LoopAlignment<false, true, true>{});
+      return mma_op.store_result(C, params->ldd);
+    }
+
+    // Tile partially aligned check cols
+    else if (align_M || tgp_bm == BM) {
+      gemm_kernel::gemm_loop(
+          As,
+          Bs,
+          gemm_k_iterations,
+          loader_a,
+          loader_b,
+          mma_op,
+          tgp_bm,
+          tgp_bn,
+          lbk,
+          LoopAlignment<true, false, true>{});
+      return mma_op.store_result(C, params->ldd);
+    }
+
+    // Nothing aligned so check both rows and cols
+    else {
+      gemm_kernel::gemm_loop(
+          As,
+          Bs,
+          gemm_k_iterations,
+          loader_a,
+          loader_b,
+          mma_op,
+          tgp_bm,
+          tgp_bn,
+          lbk,
+          LoopAlignment<false, false, true>{});
+      return mma_op.store_result(C, params->ldd);
+    }
+  }
+}

--- a/mlx/backend/metal/kernels/steel/gemm/kernels/steel_gemm_gather.metal
+++ b/mlx/backend/metal/kernels/steel/gemm/kernels/steel_gemm_gather.metal
@@ -20,14 +20,38 @@
       trans_b,                                                                \
       float)
 
-#define instantiate_gather_mm_transpose_helper(iname, itype, oname, otype, bm, bn, bk, wm, wn) \
-  instantiate_gather_mm_rhs(nn, false, false, iname, itype, oname, otype, bm, bn, bk, wm, wn)  \
-  instantiate_gather_mm_rhs(nt, false,  true, iname, itype, oname, otype, bm, bn, bk, wm, wn)  \
-  instantiate_gather_mm_rhs(tn,  true, false, iname, itype, oname, otype, bm, bn, bk, wm, wn)  \
-  instantiate_gather_mm_rhs(tt,  true,  true, iname, itype, oname, otype, bm, bn, bk, wm, wn)
+#define instantiate_gather_mm(tname, trans_a, trans_b, iname, itype, oname, otype, bm, bn, bk, wm, wn) \
+  instantiate_kernel(                                                     \
+      "steel_gather_mm_" #tname "_" #iname "_" #oname "_bm" #bm "_bn" #bn \
+      "_bk" #bk "_wm" #wm "_wn" #wn,                                      \
+      gather_mm,                                                          \
+      itype,                                                              \
+      bm,                                                                 \
+      bn,                                                                 \
+      bk,                                                                 \
+      wm,                                                                 \
+      wn,                                                                 \
+      trans_a,                                                            \
+      trans_b,                                                            \
+      float)
 
-#define instantiate_gather_mm_shapes_helper(iname, itype, oname, otype)                \
-  instantiate_gather_mm_transpose_helper(iname, itype, oname, otype, 16, 64, 16, 1, 2)
+#define instantiate_gather_mm_rhs_transpose_helper(iname, itype, oname, otype, bm, bn, bk, wm, wn) \
+  instantiate_gather_mm_rhs(nn, false, false, iname, itype, oname, otype, bm, bn, bk, wm, wn)  \
+  instantiate_gather_mm_rhs(nt, false,  true, iname, itype, oname, otype, bm, bn, bk, wm, wn)
+
+#define instantiate_gather_mm_transpose_helper(iname, itype, oname, otype, bm, bn, bk, wm, wn) \
+  instantiate_gather_mm(nn, false, false, iname, itype, oname, otype, bm, bn, bk, wm, wn)      \
+  instantiate_gather_mm(nt, false, true , iname, itype, oname, otype, bm, bn, bk, wm, wn)      \
+  instantiate_gather_mm(tn, true , false, iname, itype, oname, otype, bm, bn, bk, wm, wn)      \
+  instantiate_gather_mm(tt, true , true , iname, itype, oname, otype, bm, bn, bk, wm, wn)
+
+#define instantiate_gather_mm_shapes_helper(iname, itype, oname, otype)                     \
+  instantiate_gather_mm_rhs_transpose_helper(iname, itype, oname, otype, 16, 64, 16, 1, 2)  \
+  instantiate_gather_mm_transpose_helper(iname, itype, oname, otype, 64, 64, 16, 2, 2)      \
+  instantiate_gather_mm_transpose_helper(iname, itype, oname, otype, 64, 64, 16, 1, 2)      \
+  instantiate_gather_mm_transpose_helper(iname, itype, oname, otype, 64, 32, 32, 2, 2)      \
+  instantiate_gather_mm_transpose_helper(iname, itype, oname, otype, 32, 64, 16, 1, 2)      \
+  instantiate_gather_mm_transpose_helper(iname, itype, oname, otype, 32, 32, 16, 2, 2)
 // clang-format on
 
 instantiate_gather_mm_shapes_helper(float16, half, float16, half);

--- a/mlx/backend/metal/kernels/steel/gemm/kernels/steel_gemm_gather.metal
+++ b/mlx/backend/metal/kernels/steel/gemm/kernels/steel_gemm_gather.metal
@@ -4,8 +4,8 @@
 #include "mlx/backend/metal/kernels/steel/gemm/kernels/steel_gemm_gather.h"
 #include "mlx/backend/metal/kernels/utils.h"
 
-#define instantiate_gather_mm_rhs(                                            \
-    tname, trans_a, trans_b, iname, itype, oname, otype, bm, bn, bk, wm, wn)  \
+// clang-format off
+#define instantiate_gather_mm_rhs(tname, trans_a, trans_b, iname, itype, oname, otype, bm, bn, bk, wm, wn) \
   instantiate_kernel(                                                         \
       "steel_gather_mm_rhs_" #tname "_" #iname "_" #oname "_bm" #bm "_bn" #bn \
       "_bk" #bk "_wm" #wm "_wn" #wn,                                          \
@@ -20,39 +20,15 @@
       trans_b,                                                                \
       float)
 
-#define instantiate_gather_mm_transpose_helper(                                \
-    iname, itype, oname, otype, bm, bn, bk, wm, wn)                            \
-  instantiate_gather_mm_rhs(                                                   \
-      nn, false, false, iname, itype, oname, otype, bm, bn, bk, wm, wn)        \
-      instantiate_gather_mm_rhs(                                               \
-          nt, false, true, iname, itype, oname, otype, bm, bn, bk, wm, wn)     \
-          instantiate_gather_mm_rhs(                                           \
-              tn, true, false, iname, itype, oname, otype, bm, bn, bk, wm, wn) \
-              instantiate_gather_mm_rhs(                                       \
-                  tt,                                                          \
-                  true,                                                        \
-                  true,                                                        \
-                  iname,                                                       \
-                  itype,                                                       \
-                  oname,                                                       \
-                  otype,                                                       \
-                  bm,                                                          \
-                  bn,                                                          \
-                  bk,                                                          \
-                  wm,                                                          \
-                  wn)
+#define instantiate_gather_mm_transpose_helper(iname, itype, oname, otype, bm, bn, bk, wm, wn) \
+  instantiate_gather_mm_rhs(nn, false, false, iname, itype, oname, otype, bm, bn, bk, wm, wn)  \
+  instantiate_gather_mm_rhs(nt, false,  true, iname, itype, oname, otype, bm, bn, bk, wm, wn)  \
+  instantiate_gather_mm_rhs(tn,  true, false, iname, itype, oname, otype, bm, bn, bk, wm, wn)  \
+  instantiate_gather_mm_rhs(tt,  true,  true, iname, itype, oname, otype, bm, bn, bk, wm, wn)
 
-#define instantiate_gather_mm_shapes_helper(iname, itype, oname, otype) \
-  instantiate_gather_mm_transpose_helper(                               \
-      iname, itype, oname, otype, 64, 64, 16, 2, 2)                     \
-      instantiate_gather_mm_transpose_helper(                           \
-          iname, itype, oname, otype, 64, 64, 16, 1, 2)                 \
-          instantiate_gather_mm_transpose_helper(                       \
-              iname, itype, oname, otype, 64, 32, 32, 2, 2)             \
-              instantiate_gather_mm_transpose_helper(                   \
-                  iname, itype, oname, otype, 32, 64, 16, 1, 2)         \
-                  instantiate_gather_mm_transpose_helper(               \
-                      iname, itype, oname, otype, 32, 32, 16, 2, 2)
+#define instantiate_gather_mm_shapes_helper(iname, itype, oname, otype)                \
+  instantiate_gather_mm_transpose_helper(iname, itype, oname, otype, 16, 64, 16, 1, 2)
+// clang-format on
 
 instantiate_gather_mm_shapes_helper(float16, half, float16, half);
 instantiate_gather_mm_shapes_helper(bfloat16, bfloat16_t, bfloat16, bfloat16_t);

--- a/mlx/backend/metal/kernels/steel/gemm/kernels/steel_gemm_gather.metal
+++ b/mlx/backend/metal/kernels/steel/gemm/kernels/steel_gemm_gather.metal
@@ -1,0 +1,59 @@
+// Copyright © 2024 Apple Inc.
+
+#include "mlx/backend/metal/kernels/steel/gemm/gemm.h"
+#include "mlx/backend/metal/kernels/steel/gemm/kernels/steel_gemm_gather.h"
+#include "mlx/backend/metal/kernels/utils.h"
+
+#define instantiate_gather_mm_rhs(                                            \
+    tname, trans_a, trans_b, iname, itype, oname, otype, bm, bn, bk, wm, wn)  \
+  instantiate_kernel(                                                         \
+      "steel_gather_mm_rhs_" #tname "_" #iname "_" #oname "_bm" #bm "_bn" #bn \
+      "_bk" #bk "_wm" #wm "_wn" #wn,                                          \
+      gather_mm_rhs,                                                          \
+      itype,                                                                  \
+      bm,                                                                     \
+      bn,                                                                     \
+      bk,                                                                     \
+      wm,                                                                     \
+      wn,                                                                     \
+      trans_a,                                                                \
+      trans_b,                                                                \
+      float)
+
+#define instantiate_gather_mm_transpose_helper(                                \
+    iname, itype, oname, otype, bm, bn, bk, wm, wn)                            \
+  instantiate_gather_mm_rhs(                                                   \
+      nn, false, false, iname, itype, oname, otype, bm, bn, bk, wm, wn)        \
+      instantiate_gather_mm_rhs(                                               \
+          nt, false, true, iname, itype, oname, otype, bm, bn, bk, wm, wn)     \
+          instantiate_gather_mm_rhs(                                           \
+              tn, true, false, iname, itype, oname, otype, bm, bn, bk, wm, wn) \
+              instantiate_gather_mm_rhs(                                       \
+                  tt,                                                          \
+                  true,                                                        \
+                  true,                                                        \
+                  iname,                                                       \
+                  itype,                                                       \
+                  oname,                                                       \
+                  otype,                                                       \
+                  bm,                                                          \
+                  bn,                                                          \
+                  bk,                                                          \
+                  wm,                                                          \
+                  wn)
+
+#define instantiate_gather_mm_shapes_helper(iname, itype, oname, otype) \
+  instantiate_gather_mm_transpose_helper(                               \
+      iname, itype, oname, otype, 64, 64, 16, 2, 2)                     \
+      instantiate_gather_mm_transpose_helper(                           \
+          iname, itype, oname, otype, 64, 64, 16, 1, 2)                 \
+          instantiate_gather_mm_transpose_helper(                       \
+              iname, itype, oname, otype, 64, 32, 32, 2, 2)             \
+              instantiate_gather_mm_transpose_helper(                   \
+                  iname, itype, oname, otype, 32, 64, 16, 1, 2)         \
+                  instantiate_gather_mm_transpose_helper(               \
+                      iname, itype, oname, otype, 32, 32, 16, 2, 2)
+
+instantiate_gather_mm_shapes_helper(float16, half, float16, half);
+instantiate_gather_mm_shapes_helper(bfloat16, bfloat16_t, bfloat16, bfloat16_t);
+instantiate_gather_mm_shapes_helper(float32, float, float32, float);

--- a/mlx/backend/metal/kernels/steel/gemm/kernels/steel_gemm_gather.metal
+++ b/mlx/backend/metal/kernels/steel/gemm/kernels/steel_gemm_gather.metal
@@ -1,10 +1,10 @@
 // Copyright © 2024 Apple Inc.
 
+// clang-format off
+#include "mlx/backend/metal/kernels/utils.h"
 #include "mlx/backend/metal/kernels/steel/gemm/gemm.h"
 #include "mlx/backend/metal/kernels/steel/gemm/kernels/steel_gemm_gather.h"
-#include "mlx/backend/metal/kernels/utils.h"
 
-// clang-format off
 #define instantiate_gather_mm_rhs(tname, trans_a, trans_b, iname, itype, oname, otype, bm, bn, bk, wm, wn) \
   instantiate_kernel(                                                         \
       "steel_gather_mm_rhs_" #tname "_" #iname "_" #oname "_bm" #bm "_bn" #bn \

--- a/mlx/backend/metal/matmul.cpp
+++ b/mlx/backend/metal/matmul.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <iostream> // TODO: Remove
 #include <numeric>
 #include <sstream>
 
@@ -1818,6 +1817,7 @@ void gather_mm(
   hash_name.reserve(128);
   concatenate(
       hash_name,
+      base_name,
       "_has_batch_",
       has_batch ? 't' : 'n',
       "_align_M_",

--- a/mlx/backend/metal/matmul.cpp
+++ b/mlx/backend/metal/matmul.cpp
@@ -1558,6 +1558,24 @@ void GatherMM::eval_gpu(const std::vector<array>& inputs, array& out) {
 
   /////////////////////////////////////////////////////////////////////////////
   // Gemv specialization
+  if (M == 1) {
+    // Determine dispatch kernel
+    int bm = 64, bn = 64, bk = 16;
+    int wm = 2, wn = 2;
+
+    char devc = d.get_architecture().back();
+    GEMM_TPARAM_MACRO(devc)
+
+    std::string kname;
+    kname.reserve(128);
+    kname += "steel_gather_mm_rhs_n";
+    kname += transpose_b ? 't' : 'n';
+    kname += '_';
+    kname += type_to_name(a);
+    kname += '_';
+
+    return;
+  }
 
   // Route to gemv if needed
   if (std::min(M, N) == 1) {

--- a/mlx/backend/metal/matmul.cpp
+++ b/mlx/backend/metal/matmul.cpp
@@ -116,10 +116,10 @@ ensure_row_contiguous(const array& x, metal::Device& d, const Stream& s) {
   }
 }
 
-inline array
+inline std::tuple<bool, int64_t, array>
 ensure_batch_contiguous(const array& x, metal::Device& d, const Stream& s) {
   if (x.flags().row_contiguous) {
-    return x;
+    return std::make_tuple(false, x.strides()[x.ndim() - 2], x);
   }
 
   bool rc = true;
@@ -127,13 +127,22 @@ ensure_batch_contiguous(const array& x, metal::Device& d, const Stream& s) {
     rc &= x.strides()[i + 1] * x.shape(i) == x.strides()[i];
   }
   if (rc) {
-    return x;
+    auto stx = x.strides()[x.ndim() - 2];
+    auto sty = x.strides()[x.ndim() - 1];
+    auto K = x.shape(-2);
+    auto N = x.shape(-1);
+    if (sty == 1 && (N != 1 || stx == N)) {
+      return std::make_tuple(false, stx, x);
+    }
+    if (stx == 1 && (N != 1 || sty == K)) {
+      return std::make_tuple(true, sty, x);
+    }
   }
 
   array x_copy(x.shape(), x.dtype(), nullptr, {});
   copy_gpu(x, x_copy, CopyType::General, s);
   d.add_temporary(x_copy, s.index);
-  return x_copy;
+  return std::make_tuple(false, x_copy.strides()[x_copy.ndim() - 2], x_copy);
 }
 
 } // namespace
@@ -1503,12 +1512,10 @@ void gather_mm_rhs(
     const array& b_,
     const array& indices_,
     array& out,
-    bool transpose_b,
-    int ldb,
     metal::Device& d,
     const Stream& s) {
   array indices = ensure_row_contiguous(indices_, d, s);
-  array b = ensure_batch_contiguous(b_, d, s);
+  auto [transpose_b, ldb, b] = ensure_batch_contiguous(b_, d, s);
 
   // Broadcast a with indices. If we are here that means lhs_indices were not
   // provided so the lhs_indices are implied to be the shape of a broadcasted
@@ -1607,7 +1614,7 @@ void gather_mm_rhs(
       /* const int N = */ N,
       /* const int K = */ K,
       /* const int lda = */ lda,
-      /* const int ldb = */ ldb,
+      /* const int ldb = */ static_cast<int>(ldb),
       /* const int ldd = */ N,
       /* const int tiles_n = */ (N + bn - 1) / bn,
       /* const int tiles_m = */ (M + bm - 1) / bm,
@@ -1632,18 +1639,137 @@ void gather_mm_rhs(
   compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
 }
 
+void gather_mv(
+    const array& mat_,
+    const array& vec_,
+    const array& mat_indices_,
+    const array& vec_indices_,
+    array& out,
+    int N,
+    int K,
+    bool is_mv,
+    metal::Device& d,
+    const Stream& s) {
+  // Copy if needed
+  std::vector<array> copies;
+  auto [transpose_mat, mat_cols, mat] =
+      check_transpose(copies, s, mat_, N == 1);
+  auto [transpose_vec, vec_cols, vec] = check_transpose(copies, s, vec_, true);
+  d.add_temporaries(std::move(copies), s.index);
+
+  // If we are doing vector matrix instead of matrix vector we need to flip the
+  // matrix transposition. Basically m @ v = v @ m.T assuming that v is treated
+  // as a one dimensional array.
+  transpose_mat = (!is_mv) ^ transpose_mat;
+
+  // Define some shapes
+  int in_vector_len = K;
+  int out_vector_len = N;
+  int mat_ld = mat_cols;
+
+  int batch_size_out = out.size() / N;
+  int batch_ndim = out.ndim() - 2;
+  int batch_ndim_mat = mat.ndim() - 2;
+  int batch_ndim_vec = vec.ndim() - 2;
+  Strides index_strides = vec_indices_.strides();
+  index_strides.insert(
+      index_strides.end(),
+      mat_indices_.strides().begin(),
+      mat_indices_.strides().end());
+
+  // Determine dispatch kernel
+  int tm = 4, tn = 4;
+  int sm = 1, sn = 32;
+  int bm = 1, bn = 1;
+  int n_out_per_tgp;
+  std::ostringstream kname;
+
+  if (transpose_mat) {
+    if (in_vector_len >= 8192 && out_vector_len >= 2048) {
+      sm = 4;
+      sn = 8;
+    } else {
+      sm = 8;
+      sn = 4;
+    }
+
+    if (out_vector_len >= 2048) {
+      bn = 16;
+    } else if (out_vector_len >= 512) {
+      bn = 4;
+    } else {
+      bn = 2;
+    }
+
+    // Specialized kernel for very small outputs
+    tn = out_vector_len < tn ? 1 : tn;
+
+    n_out_per_tgp = bn * sn * tn;
+    kname << "gemv_t_gather_" << type_to_name(out);
+
+  } else {
+    bm = out_vector_len >= 4096 ? 8 : 4;
+    sn = 32;
+
+    // Specialized kernel for very small outputs
+    tm = out_vector_len < tm ? 1 : tm;
+
+    n_out_per_tgp = bm * sm * tm;
+    kname << "gemv_gather_" << type_to_name(out);
+  }
+
+  kname << "_bm" << bm << "_bn" << bn << "_sm" << sm << "_sn" << sn << "_tm"
+        << tm << "_tn" << tn;
+
+  // Encode and dispatch kernel
+  auto& compute_encoder = d.get_command_encoder(s.index);
+  auto kernel = d.get_kernel(kname.str());
+  compute_encoder.set_compute_pipeline_state(kernel);
+
+  int n_tgp = (out_vector_len + n_out_per_tgp - 1) / n_out_per_tgp;
+  MTL::Size group_dims = MTL::Size(32, bn, bm);
+  MTL::Size grid_dims = MTL::Size(n_tgp, 1, batch_size_out);
+
+  compute_encoder.set_input_array(mat, 0);
+  compute_encoder.set_input_array(vec, 1);
+  compute_encoder.set_output_array(out, 3);
+
+  compute_encoder.set_bytes(in_vector_len, 4);
+  compute_encoder.set_bytes(out_vector_len, 5);
+  compute_encoder.set_bytes(mat_ld, 6);
+
+  compute_encoder.set_bytes(batch_ndim, 9);
+  compute_encoder.set_vector_bytes(out.shape(), 10);
+  compute_encoder.set_vector_bytes(index_strides, 11);
+
+  compute_encoder.set_bytes(batch_ndim_vec, 12);
+  compute_encoder.set_vector_bytes(vec.shape(), 13);
+  compute_encoder.set_vector_bytes(vec.strides(), 14);
+
+  compute_encoder.set_bytes(batch_ndim_mat, 15);
+  compute_encoder.set_vector_bytes(mat.shape(), 16);
+  compute_encoder.set_vector_bytes(mat.strides(), 17);
+
+  compute_encoder.set_input_array(vec_indices_, 18);
+  compute_encoder.set_input_array(mat_indices_, 19);
+
+  compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+}
+
 void GatherMM::eval_gpu(const std::vector<array>& inputs, array& out) {
   using namespace mlx::steel;
 
   auto& s = stream();
   auto& d = metal::device(s.device);
 
-  auto& a_pre = inputs[0];
-  auto& b_pre = inputs[1];
+  auto& a = inputs[0];
+  auto& b = inputs[1];
+  auto& lhs_indices = inputs[2];
+  auto& rhs_indices = inputs[3];
 
   // Return 0s if either input is empty
-  if (a_pre.size() == 0 || b_pre.size() == 0) {
-    array zero = array(0, a_pre.dtype());
+  if (a.size() == 0 || b.size() == 0) {
+    array zero = array(0, a.dtype());
     fill_gpu(zero, out, s);
     d.add_temporary(std::move(zero), s.index);
     return;
@@ -1653,324 +1779,158 @@ void GatherMM::eval_gpu(const std::vector<array>& inputs, array& out) {
 
   // Extract shapes strides from inputs and copy in case of non-contiguous
   // vectors.
-  int M = a_pre.shape(-2);
-  int N = b_pre.shape(-1);
-  int K = a_pre.shape(-1);
-
-  std::vector<array> copies;
-  auto [transpose_a, a_cols, a] = check_transpose(copies, s, a_pre, M == 1);
-  auto [transpose_b, b_cols, b] = check_transpose(copies, s, b_pre, N == 1);
-  d.add_temporaries(std::move(copies), s.index);
-
-  int lda = a_cols;
-  int ldb = b_cols;
+  int M = a.shape(-2);
+  int N = b.shape(-1);
+  int K = a.shape(-1);
 
   // We are walking a in order and b is also in order so we can batch up the
   // matmuls and reuse reading a and b.
   if (M == 1 && right_sorted_ == true) {
-    gather_mm_rhs(a, b, inputs[3], out, transpose_b, ldb, d, s);
+    gather_mm_rhs(a, b, rhs_indices, out, d, s);
     return;
   }
 
-  /////////////////////////////////////////////////////////////////////////////
-  // Check and collapse batch dimensions
-
-  auto get_batch_dims = [](const auto& v) {
-    return decltype(v){v.begin(), v.end() - 2};
-  };
-
-  auto& lhs_indices = inputs[2];
-  auto& rhs_indices = inputs[3];
-
-  Shape batch_shape = get_batch_dims(out.shape());
-  Strides batch_strides;
-
-  batch_strides.insert(
-      batch_strides.end(),
-      lhs_indices.strides().begin(),
-      lhs_indices.strides().end());
-  auto lhs_indices_str = batch_strides.empty() ? 0 : batch_strides.back();
-
-  batch_strides.insert(
-      batch_strides.end(),
-      rhs_indices.strides().begin(),
-      rhs_indices.strides().end());
-  auto rhs_indices_str = batch_strides.empty() ? 0 : batch_strides.back();
-
-  int batch_ndim = batch_shape.size();
-
-  if (batch_ndim == 0) {
-    batch_shape = {1};
-    batch_strides = {0};
+  // Route to gather gemv if any of a or b are vectors
+  if (M == 1) {
+    gather_mv(b, a, rhs_indices, lhs_indices, out, N, K, false, d, s);
+    return;
   }
-
-  int batch_ndim_A = a.ndim() - 2;
-  int batch_ndim_B = b.ndim() - 2;
-  std::vector<int> operand_batch_ndim = {batch_ndim_A, batch_ndim_B};
-
-  Shape batch_shape_A = get_batch_dims(a.shape());
-  Strides batch_strides_A = get_batch_dims(a.strides());
-  Shape batch_shape_B = get_batch_dims(b.shape());
-  Strides batch_strides_B = get_batch_dims(b.strides());
-
-  if (batch_ndim_A == 0) {
-    batch_shape_A = {1};
-    batch_strides_A = {0};
-  }
-
-  if (batch_ndim_B == 0) {
-    batch_shape_B = {1};
-    batch_strides_B = {0};
+  if (N == 1) {
+    gather_mv(a, b, lhs_indices, rhs_indices, out, M, K, true, d, s);
+    return;
   }
 
   auto matrix_stride_out = static_cast<int64_t>(M) * N;
   auto batch_size_out = out.size() / matrix_stride_out;
 
-  /////////////////////////////////////////////////////////////////////////////
-  // Gemv specialization
-  // Route to gemv if needed
-  if (std::min(M, N) == 1) {
-    // Collect problem info
-    bool is_b_matrix = N != 1;
+  ///////////////////////////////////////////////////////////////////////////////
+  //// Regular kernel dispatch
 
-    auto& mat = is_b_matrix ? b : a;
-    auto& vec = is_b_matrix ? a : b;
-    bool transpose_mat = is_b_matrix ? !transpose_b : transpose_a;
-    int in_vector_len = K;
-    int out_vector_len = is_b_matrix ? N : M;
+  //// Determine dispatch kernel
+  // int bm = 64, bn = 64, bk = 16;
+  // int wm = 2, wn = 2;
 
-    int mat_cols = transpose_mat ? out_vector_len : in_vector_len;
-    int mat_rows = transpose_mat ? in_vector_len : out_vector_len;
-    int mat_ld = is_b_matrix ? b_cols : a_cols;
+  // char devc = d.get_architecture().back();
+  // GEMM_TPARAM_MACRO(devc)
 
-    auto batch_strides_mat = is_b_matrix ? batch_strides_B : batch_strides_A;
-    auto batch_strides_vec = is_b_matrix ? batch_strides_A : batch_strides_B;
+  //// Prepare kernel name
+  // std::ostringstream kname;
+  // kname << "steel_gemm_fused_" << (transpose_a ? 't' : 'n')
+  //       << (transpose_b ? 't' : 'n') << "_" << type_to_name(a) << "_"
+  //       << type_to_name(out) << "_bm" << bm << "_bn" << bn << "_bk" << bk
+  //       << "_wm" << wm << "_wn" << wn;
 
-    auto batch_shape_mat = is_b_matrix ? batch_shape_B : batch_shape_A;
-    auto batch_shape_vec = is_b_matrix ? batch_shape_A : batch_shape_B;
+  // std::string base_name = kname.str();
 
-    if (!is_b_matrix) {
-      batch_strides = rhs_indices.strides();
-      batch_strides.insert(
-          batch_strides.end(),
-          lhs_indices.strides().begin(),
-          lhs_indices.strides().end());
-    }
+  // const bool has_batch = batch_ndim > 1;
+  // const bool use_out_source = false;
+  // const bool do_axpby = false;
+  // const bool align_M = (M % bm) == 0;
+  // const bool align_N = (N % bn) == 0;
+  // const bool align_K = (K % bk) == 0;
+  // const bool do_gather = true;
 
-    int batch_ndim = batch_shape.size();
+  // metal::MTLFCList func_consts = {
+  //     {&has_batch, MTL::DataType::DataTypeBool, 10},
+  //     {&use_out_source, MTL::DataType::DataTypeBool, 100},
+  //     {&do_axpby, MTL::DataType::DataTypeBool, 110},
+  //     {&align_M, MTL::DataType::DataTypeBool, 200},
+  //     {&align_N, MTL::DataType::DataTypeBool, 201},
+  //     {&align_K, MTL::DataType::DataTypeBool, 202},
+  //     {&do_gather, MTL::DataType::DataTypeBool, 300},
+  // };
 
-    // Determine dispatch kernel
-    int tm = 4, tn = 4;
-    int sm = 1, sn = 32;
-    int bm = 1, bn = 1;
-    int n_out_per_tgp;
-    std::ostringstream kname;
+  //// clang-format off
+  // kname << "_has_batch_" << (has_batch ? 't' : 'n')
+  //       << "_use_out_source_" << (use_out_source ? 't' : 'n')
+  //       << "_do_axpby_" << (do_axpby ? 't' : 'n')
+  //       << "_align_M_" << (align_M ? 't' : 'n')
+  //       << "_align_N_" << (align_N ? 't' : 'n')
+  //       << "_align_K_" << (align_K ? 't' : 'n')
+  //       << "_do_gather_" << (do_gather ? 't' : 'n'); // clang-format on
 
-    if (transpose_mat) {
-      if (in_vector_len >= 8192 && out_vector_len >= 2048) {
-        sm = 4;
-        sn = 8;
-      } else {
-        sm = 8;
-        sn = 4;
-      }
+  // std::string hash_name = kname.str();
 
-      if (out_vector_len >= 2048) {
-        bn = 16;
-      } else if (out_vector_len >= 512) {
-        bn = 4;
-      } else {
-        bn = 2;
-      }
+  //// Encode and dispatch kernel
+  // auto& compute_encoder = d.get_command_encoder(s.index);
+  // auto kernel = get_steel_gemm_fused_kernel(
+  //     d,
+  //     base_name,
+  //     hash_name,
+  //     func_consts,
+  //     out,
+  //     transpose_a,
+  //     transpose_b,
+  //     bm,
+  //     bn,
+  //     bk,
+  //     wm,
+  //     wn);
 
-      // Specialized kernel for very small outputs
-      tn = out_vector_len < tn ? 1 : tn;
+  // compute_encoder.set_compute_pipeline_state(kernel);
 
-      n_out_per_tgp = bn * sn * tn;
-      kname << "gemv_t_gather_" << type_to_name(out);
+  //// Use problem size to determine threadblock swizzle
+  // int tn = (N + bn - 1) / bn;
+  // int tm = (M + bm - 1) / bm;
 
-    } else {
-      bm = out_vector_len >= 4096 ? 8 : 4;
-      sn = 32;
+  //// TODO: Explore device-based tuning for swizzle
+  // int swizzle_log = 0; // tm >= 6 ? 3 : (tm <= 3 ? 0 : 2);
 
-      // Specialized kernel for very small outputs
-      tm = out_vector_len < tm ? 1 : tm;
+  //// Prepare steel matmul params
+  // GEMMParams params{
+  //     /* const int M = */ M,
+  //     /* const int N = */ N,
+  //     /* const int K = */ K,
+  //     /* const int lda = */ lda,
+  //     /* const int ldb = */ ldb,
+  //     /* const int ldd = */ N,
+  //     /* const int tiles_n = */ tn,
+  //     /* const int tiles_m = */ tm,
+  //     /* const int64_t batch_stride_a = */ lhs_indices_str,
+  //     /* const int64_t batch_stride_b = */ rhs_indices_str,
+  //     /* const int64_t batch_stride_d = */ matrix_stride_out,
+  //     /* const int swizzle_log = */ swizzle_log,
+  //     /* const int gemm_k_iterations_aligned = */ (K / bk),
+  //     /* const int batch_ndim = */ batch_ndim};
 
-      n_out_per_tgp = bm * sm * tm;
-      kname << "gemv_gather_" << type_to_name(out);
-    }
+  //// Prepare launch grid params
+  // int tile = 1 << swizzle_log;
+  // tm = (tm + tile - 1) / tile;
+  // tn = tn * tile;
 
-    kname << "_bm" << bm << "_bn" << bn << "_sm" << sm << "_sn" << sn << "_tm"
-          << tm << "_tn" << tn;
+  // MTL::Size group_dims = MTL::Size(32, wn, wm);
+  // MTL::Size grid_dims = MTL::Size(tn, tm, batch_size_out);
 
-    // Encode and dispatch kernel
-    auto& compute_encoder = d.get_command_encoder(s.index);
-    auto kernel = d.get_kernel(kname.str());
-    compute_encoder.set_compute_pipeline_state(kernel);
+  //// Launch kernel
+  // compute_encoder.set_input_array(a, 0);
+  // compute_encoder.set_input_array(b, 1);
+  // compute_encoder.set_output_array(out, 3);
 
-    int n_tgp = (out_vector_len + n_out_per_tgp - 1) / n_out_per_tgp;
-    MTL::Size group_dims = MTL::Size(32, bn, bm);
-    MTL::Size grid_dims = MTL::Size(n_tgp, 1, batch_size_out);
+  // compute_encoder.set_bytes(params, 4);
 
-    compute_encoder.set_input_array(mat, 0);
-    compute_encoder.set_input_array(vec, 1);
-    compute_encoder.set_output_array(out, 3);
+  // compute_encoder.set_vector_bytes(batch_shape, 6);
+  // compute_encoder.set_vector_bytes(batch_strides, 7);
 
-    compute_encoder.set_bytes(in_vector_len, 4);
-    compute_encoder.set_bytes(out_vector_len, 5);
-    compute_encoder.set_bytes(mat_ld, 6);
+  // compute_encoder.set_input_array(lhs_indices, 10);
+  // compute_encoder.set_input_array(rhs_indices, 11);
 
-    compute_encoder.set_bytes(batch_ndim, 9);
-    compute_encoder.set_vector_bytes(batch_shape, 10);
-    compute_encoder.set_vector_bytes(batch_strides, 11);
+  // std::vector operand_shape = batch_shape_A;
+  // operand_shape.insert(
+  //     operand_shape.end(), batch_shape_B.begin(), batch_shape_B.end());
 
-    int batch_ndim_vec = batch_shape_vec.size();
-    compute_encoder.set_bytes(batch_ndim_vec, 12);
-    compute_encoder.set_vector_bytes(batch_shape_vec, 13);
-    compute_encoder.set_vector_bytes(batch_strides_vec, 14);
+  // std::vector operand_strides = batch_strides_A;
+  // operand_strides.insert(
+  //     operand_strides.end(), batch_strides_B.begin(), batch_strides_B.end());
 
-    int batch_ndim_mat = batch_shape_mat.size();
-    compute_encoder.set_bytes(batch_ndim_mat, 15);
-    compute_encoder.set_vector_bytes(batch_shape_mat, 16);
-    compute_encoder.set_vector_bytes(batch_strides_mat, 17);
+  // operand_batch_ndim.push_back(0);
 
-    compute_encoder.set_input_array(lhs_indices, 18 + int(!is_b_matrix));
-    compute_encoder.set_input_array(rhs_indices, 18 + int(is_b_matrix));
+  // compute_encoder.set_vector_bytes(operand_shape, 13);
+  // compute_encoder.set_vector_bytes(operand_strides, 14);
+  // compute_encoder.set_vector_bytes(operand_batch_ndim, 15);
 
-    compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+  // compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
 
-    d.add_temporaries(std::move(copies), s.index);
-    return;
-  }
-
-  /////////////////////////////////////////////////////////////////////////////
-  // Regular kernel dispatch
-
-  // Determine dispatch kernel
-  int bm = 64, bn = 64, bk = 16;
-  int wm = 2, wn = 2;
-
-  char devc = d.get_architecture().back();
-  GEMM_TPARAM_MACRO(devc)
-
-  // Prepare kernel name
-  std::ostringstream kname;
-  kname << "steel_gemm_fused_" << (transpose_a ? 't' : 'n')
-        << (transpose_b ? 't' : 'n') << "_" << type_to_name(a) << "_"
-        << type_to_name(out) << "_bm" << bm << "_bn" << bn << "_bk" << bk
-        << "_wm" << wm << "_wn" << wn;
-
-  std::string base_name = kname.str();
-
-  const bool has_batch = batch_ndim > 1;
-  const bool use_out_source = false;
-  const bool do_axpby = false;
-  const bool align_M = (M % bm) == 0;
-  const bool align_N = (N % bn) == 0;
-  const bool align_K = (K % bk) == 0;
-  const bool do_gather = true;
-
-  metal::MTLFCList func_consts = {
-      {&has_batch, MTL::DataType::DataTypeBool, 10},
-      {&use_out_source, MTL::DataType::DataTypeBool, 100},
-      {&do_axpby, MTL::DataType::DataTypeBool, 110},
-      {&align_M, MTL::DataType::DataTypeBool, 200},
-      {&align_N, MTL::DataType::DataTypeBool, 201},
-      {&align_K, MTL::DataType::DataTypeBool, 202},
-      {&do_gather, MTL::DataType::DataTypeBool, 300},
-  };
-
-  // clang-format off
-  kname << "_has_batch_" << (has_batch ? 't' : 'n')
-        << "_use_out_source_" << (use_out_source ? 't' : 'n')
-        << "_do_axpby_" << (do_axpby ? 't' : 'n')
-        << "_align_M_" << (align_M ? 't' : 'n')
-        << "_align_N_" << (align_N ? 't' : 'n')
-        << "_align_K_" << (align_K ? 't' : 'n')
-        << "_do_gather_" << (do_gather ? 't' : 'n'); // clang-format on
-
-  std::string hash_name = kname.str();
-
-  // Encode and dispatch kernel
-  auto& compute_encoder = d.get_command_encoder(s.index);
-  auto kernel = get_steel_gemm_fused_kernel(
-      d,
-      base_name,
-      hash_name,
-      func_consts,
-      out,
-      transpose_a,
-      transpose_b,
-      bm,
-      bn,
-      bk,
-      wm,
-      wn);
-
-  compute_encoder.set_compute_pipeline_state(kernel);
-
-  // Use problem size to determine threadblock swizzle
-  int tn = (N + bn - 1) / bn;
-  int tm = (M + bm - 1) / bm;
-
-  // TODO: Explore device-based tuning for swizzle
-  int swizzle_log = 0; // tm >= 6 ? 3 : (tm <= 3 ? 0 : 2);
-
-  // Prepare steel matmul params
-  GEMMParams params{
-      /* const int M = */ M,
-      /* const int N = */ N,
-      /* const int K = */ K,
-      /* const int lda = */ lda,
-      /* const int ldb = */ ldb,
-      /* const int ldd = */ N,
-      /* const int tiles_n = */ tn,
-      /* const int tiles_m = */ tm,
-      /* const int64_t batch_stride_a = */ lhs_indices_str,
-      /* const int64_t batch_stride_b = */ rhs_indices_str,
-      /* const int64_t batch_stride_d = */ matrix_stride_out,
-      /* const int swizzle_log = */ swizzle_log,
-      /* const int gemm_k_iterations_aligned = */ (K / bk),
-      /* const int batch_ndim = */ batch_ndim};
-
-  // Prepare launch grid params
-  int tile = 1 << swizzle_log;
-  tm = (tm + tile - 1) / tile;
-  tn = tn * tile;
-
-  MTL::Size group_dims = MTL::Size(32, wn, wm);
-  MTL::Size grid_dims = MTL::Size(tn, tm, batch_size_out);
-
-  // Launch kernel
-  compute_encoder.set_input_array(a, 0);
-  compute_encoder.set_input_array(b, 1);
-  compute_encoder.set_output_array(out, 3);
-
-  compute_encoder.set_bytes(params, 4);
-
-  compute_encoder.set_vector_bytes(batch_shape, 6);
-  compute_encoder.set_vector_bytes(batch_strides, 7);
-
-  compute_encoder.set_input_array(lhs_indices, 10);
-  compute_encoder.set_input_array(rhs_indices, 11);
-
-  std::vector operand_shape = batch_shape_A;
-  operand_shape.insert(
-      operand_shape.end(), batch_shape_B.begin(), batch_shape_B.end());
-
-  std::vector operand_strides = batch_strides_A;
-  operand_strides.insert(
-      operand_strides.end(), batch_strides_B.begin(), batch_strides_B.end());
-
-  operand_batch_ndim.push_back(0);
-
-  compute_encoder.set_vector_bytes(operand_shape, 13);
-  compute_encoder.set_vector_bytes(operand_strides, 14);
-  compute_encoder.set_vector_bytes(operand_batch_ndim, 15);
-
-  compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
-
-  d.add_temporaries(std::move(copies), s.index);
+  // d.add_temporaries(std::move(copies), s.index);
 }
 
 } // namespace mlx::core

--- a/mlx/backend/metal/matmul.cpp
+++ b/mlx/backend/metal/matmul.cpp
@@ -1756,151 +1756,144 @@ void gather_mv(
   compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
 }
 
-// void gather_mm(
-//     const array& a_,
-//     const array& b_,
-//     const array& lhs_indices_,
-//     const array& rhs_indices_,
-//     array& out,
-//     int M,
-//     int N,
-//     int K,
-//     metal::Device& d,
-//     const Stream& s) {
-//   // Copy if needed
-//   std::vector<array> copies;
-//   auto [transpose_a, lda, a] = check_transpose(copies, s, a_, false);
-//   auto [transpose_b, ldb, b] = check_transpose(copies, s, b_, false);
-//   d.add_temporaries(std::move(copies), s.index);
-//
-//   // Determine dispatch kernel
-//   int bm = 64, bn = 64, bk = 16;
-//   int wm = 2, wn = 2;
-//
-//   char devc = d.get_architecture().back();
-//   GEMM_TPARAM_MACRO(devc)
-//
-//   // Prepare kernel name
-//   std::ostringstream kname;
-//   kname << "steel_gemm_fused_" << (transpose_a ? 't' : 'n')
-//         << (transpose_b ? 't' : 'n') << "_" << type_to_name(a) << "_"
-//         << type_to_name(out) << "_bm" << bm << "_bn" << bn << "_bk" << bk
-//         << "_wm" << wm << "_wn" << wn;
-//
-//   std::string base_name = kname.str();
-//
-//   const bool has_batch = batch_ndim > 1;
-//   const bool use_out_source = false;
-//   const bool do_axpby = false;
-//   const bool align_M = (M % bm) == 0;
-//   const bool align_N = (N % bn) == 0;
-//   const bool align_K = (K % bk) == 0;
-//   const bool do_gather = true;
-//
-//   metal::MTLFCList func_consts = {
-//       {&has_batch, MTL::DataType::DataTypeBool, 10},
-//       {&use_out_source, MTL::DataType::DataTypeBool, 100},
-//       {&do_axpby, MTL::DataType::DataTypeBool, 110},
-//       {&align_M, MTL::DataType::DataTypeBool, 200},
-//       {&align_N, MTL::DataType::DataTypeBool, 201},
-//       {&align_K, MTL::DataType::DataTypeBool, 202},
-//       {&do_gather, MTL::DataType::DataTypeBool, 300},
-//   };
-//
-//   // clang-format off
-//   kname << "_has_batch_" << (has_batch ? 't' : 'n')
-//         << "_use_out_source_" << (use_out_source ? 't' : 'n')
-//         << "_do_axpby_" << (do_axpby ? 't' : 'n')
-//         << "_align_M_" << (align_M ? 't' : 'n')
-//         << "_align_N_" << (align_N ? 't' : 'n')
-//         << "_align_K_" << (align_K ? 't' : 'n')
-//         << "_do_gather_" << (do_gather ? 't' : 'n'); // clang-format on
-//
-//   std::string hash_name = kname.str();
-//
-//   // Encode and dispatch kernel
-//   auto& compute_encoder = d.get_command_encoder(s.index);
-//   auto kernel = get_steel_gemm_fused_kernel(
-//       d,
-//       base_name,
-//       hash_name,
-//       func_consts,
-//       out,
-//       transpose_a,
-//       transpose_b,
-//       bm,
-//       bn,
-//       bk,
-//       wm,
-//       wn);
-//
-//   compute_encoder.set_compute_pipeline_state(kernel);
-//
-//   // Use problem size to determine threadblock swizzle
-//   int tn = (N + bn - 1) / bn;
-//   int tm = (M + bm - 1) / bm;
-//
-//   // TODO: Explore device-based tuning for swizzle
-//   int swizzle_log = 0; // tm >= 6 ? 3 : (tm <= 3 ? 0 : 2);
-//
-//   // Prepare steel matmul params
-//   GEMMParams params{
-//       /* const int M = */ M,
-//       /* const int N = */ N,
-//       /* const int K = */ K,
-//       /* const int lda = */ lda,
-//       /* const int ldb = */ ldb,
-//       /* const int ldd = */ N,
-//       /* const int tiles_n = */ tn,
-//       /* const int tiles_m = */ tm,
-//       /* const int64_t batch_stride_a = */ lhs_indices_str,
-//       /* const int64_t batch_stride_b = */ rhs_indices_str,
-//       /* const int64_t batch_stride_d = */ matrix_stride_out,
-//       /* const int swizzle_log = */ swizzle_log,
-//       /* const int gemm_k_iterations_aligned = */ (K / bk),
-//       /* const int batch_ndim = */ batch_ndim};
-//
-//   / Prepare launch grid params
-//   int tile = 1 << swizzle_log;
-//   tm = (tm + tile - 1) / tile;
-//   tn = tn * tile;
-//
-//   MTL::Size group_dims = MTL::Size(32, wn, wm);
-//   MTL::Size grid_dims = MTL::Size(tn, tm, batch_size_out);
-//
-//   // Launch kernel
-//   compute_encoder.set_input_array(a, 0);
-//   compute_encoder.set_input_array(b, 1);
-//   compute_encoder.set_output_array(out, 3);
-//
-//   compute_encoder.set_bytes(params, 4);
-//
-//   compute_encoder.set_vector_bytes(batch_shape, 6);
-//   compute_encoder.set_vector_bytes(batch_strides, 7);
-//
-//   compute_encoder.set_input_array(lhs_indices, 10);
-//   compute_encoder.set_input_array(rhs_indices, 11);
-//
-//   std::vector operand_shape = batch_shape_A;
-//   operand_shape.insert(
-//       operand_shape.end(), batch_shape_B.begin(), batch_shape_B.end());
-//
-//   std::vector operand_strides = batch_strides_A;
-//   operand_strides.insert(
-//       operand_strides.end(), batch_strides_B.begin(), batch_strides_B.end());
-//
-//   operand_batch_ndim.push_back(0);
-//
-//   compute_encoder.set_vector_bytes(operand_shape, 13);
-//   compute_encoder.set_vector_bytes(operand_strides, 14);
-//   compute_encoder.set_vector_bytes(operand_batch_ndim, 15);
-//
-//   compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
-// }
+void gather_mm(
+    const array& a_,
+    const array& b_,
+    const array& lhs_indices,
+    const array& rhs_indices,
+    array& out,
+    int M,
+    int N,
+    int K,
+    metal::Device& d,
+    const Stream& s) {
+  // Copy if needed
+  std::vector<array> copies;
+  auto [transpose_a, lda, a] = check_transpose(copies, s, a_, false);
+  auto [transpose_b, ldb, b] = check_transpose(copies, s, b_, false);
+  d.add_temporaries(std::move(copies), s.index);
+
+  // Determine dispatch kernel
+  int bm = 64, bn = 64, bk = 16;
+  int wm = 2, wn = 2;
+  size_t batch_size_out = out.size() / M / N;
+  int batch_ndim = out.ndim() - 2;
+  int batch_ndim_a = a.ndim() - 2;
+  int batch_ndim_b = b.ndim() - 2;
+
+  char devc = d.get_architecture().back();
+  GEMM_TPARAM_MACRO(devc)
+
+  const bool has_batch = batch_ndim > 1;
+  const bool align_M = (M % bm) == 0;
+  const bool align_N = (N % bn) == 0;
+  const bool align_K = (K % bk) == 0;
+
+  // Define the kernel name
+  std::string base_name;
+  base_name.reserve(128);
+  concatenate(
+      base_name,
+      "steel_gather_mm_",
+      transpose_a ? 't' : 'n',
+      transpose_b ? 't' : 'n',
+      "_",
+      type_to_name(a),
+      "_",
+      type_to_name(out),
+      "_bm",
+      bm,
+      "_bn",
+      bn,
+      "_bk",
+      bk,
+      "_wm",
+      wm,
+      "_wn",
+      wn);
+
+  metal::MTLFCList func_consts = {
+      {&has_batch, MTL::DataType::DataTypeBool, 10},
+      {&align_M, MTL::DataType::DataTypeBool, 200},
+      {&align_N, MTL::DataType::DataTypeBool, 201},
+      {&align_K, MTL::DataType::DataTypeBool, 202},
+  };
+
+  // And the kernel hash that includes the function constants
+  std::string hash_name;
+  hash_name.reserve(128);
+  concatenate(
+      hash_name,
+      "_has_batch_",
+      has_batch ? 't' : 'n',
+      "_align_M_",
+      align_M ? 't' : 'n',
+      "_align_N_",
+      align_N ? 't' : 'n',
+      "_align_K_",
+      align_K ? 't' : 'n');
+
+  // Get and set the kernel
+  auto& compute_encoder = d.get_command_encoder(s.index);
+  auto kernel = get_steel_gemm_gather_kernel(
+      d,
+      base_name,
+      hash_name,
+      func_consts,
+      out,
+      transpose_a,
+      transpose_b,
+      bm,
+      bn,
+      bk,
+      wm,
+      wn);
+  compute_encoder.set_compute_pipeline_state(kernel);
+
+  // Prepare the matmul params
+  steel::GEMMParams params{
+      /* const int M = */ M,
+      /* const int N = */ N,
+      /* const int K = */ K,
+      /* const int lda = */ static_cast<int>(lda),
+      /* const int ldb = */ static_cast<int>(ldb),
+      /* const int ldd = */ N,
+      /* const int tiles_n = */ (N + bn - 1) / bn,
+      /* const int tiles_m = */ (M + bm - 1) / bm,
+      /* const int64_t batch_stride_a = */
+      (batch_ndim > 0) ? lhs_indices.strides()[0] : 0,
+      /* const int64_t batch_stride_b = */
+      (batch_ndim > 0) ? rhs_indices.strides()[0] : 0,
+      /* const int64_t batch_stride_d = */ M * N,
+      /* const int swizzle_log = */ 0,
+      /* const int gemm_k_iterations_aligned = */ (K / bk),
+      /* const int batch_ndim = */ batch_ndim};
+
+  // Prepare the grid
+  MTL::Size group_dims = MTL::Size(32, wn, wm);
+  MTL::Size grid_dims =
+      MTL::Size(params.tiles_n, params.tiles_m, batch_size_out);
+
+  // Launch kernel
+  compute_encoder.set_input_array(a, 0);
+  compute_encoder.set_input_array(b, 1);
+  compute_encoder.set_input_array(lhs_indices, 2);
+  compute_encoder.set_input_array(rhs_indices, 3);
+  compute_encoder.set_output_array(out, 4);
+  compute_encoder.set_bytes(params, 5);
+  compute_encoder.set_vector_bytes(lhs_indices.shape(), 6);
+  compute_encoder.set_vector_bytes(lhs_indices.strides(), 7);
+  compute_encoder.set_vector_bytes(rhs_indices.strides(), 8);
+  compute_encoder.set_bytes(batch_ndim_a, 9);
+  compute_encoder.set_vector_bytes(a.shape(), 10);
+  compute_encoder.set_vector_bytes(a.strides(), 11);
+  compute_encoder.set_bytes(batch_ndim_b, 12);
+  compute_encoder.set_vector_bytes(b.shape(), 13);
+  compute_encoder.set_vector_bytes(b.strides(), 14);
+  compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+}
 
 void GatherMM::eval_gpu(const std::vector<array>& inputs, array& out) {
-  using namespace mlx::steel;
-
   auto& s = stream();
   auto& d = metal::device(s.device);
 
@@ -1942,137 +1935,8 @@ void GatherMM::eval_gpu(const std::vector<array>& inputs, array& out) {
     return;
   }
 
-  auto matrix_stride_out = static_cast<int64_t>(M) * N;
-  auto batch_size_out = out.size() / matrix_stride_out;
-
-  ///////////////////////////////////////////////////////////////////////////////
-  //// Regular kernel dispatch
-
-  //// Determine dispatch kernel
-  // int bm = 64, bn = 64, bk = 16;
-  // int wm = 2, wn = 2;
-
-  // char devc = d.get_architecture().back();
-  // GEMM_TPARAM_MACRO(devc)
-
-  //// Prepare kernel name
-  // std::ostringstream kname;
-  // kname << "steel_gemm_fused_" << (transpose_a ? 't' : 'n')
-  //       << (transpose_b ? 't' : 'n') << "_" << type_to_name(a) << "_"
-  //       << type_to_name(out) << "_bm" << bm << "_bn" << bn << "_bk" << bk
-  //       << "_wm" << wm << "_wn" << wn;
-
-  // std::string base_name = kname.str();
-
-  // const bool has_batch = batch_ndim > 1;
-  // const bool use_out_source = false;
-  // const bool do_axpby = false;
-  // const bool align_M = (M % bm) == 0;
-  // const bool align_N = (N % bn) == 0;
-  // const bool align_K = (K % bk) == 0;
-  // const bool do_gather = true;
-
-  // metal::MTLFCList func_consts = {
-  //     {&has_batch, MTL::DataType::DataTypeBool, 10},
-  //     {&use_out_source, MTL::DataType::DataTypeBool, 100},
-  //     {&do_axpby, MTL::DataType::DataTypeBool, 110},
-  //     {&align_M, MTL::DataType::DataTypeBool, 200},
-  //     {&align_N, MTL::DataType::DataTypeBool, 201},
-  //     {&align_K, MTL::DataType::DataTypeBool, 202},
-  //     {&do_gather, MTL::DataType::DataTypeBool, 300},
-  // };
-
-  //// clang-format off
-  // kname << "_has_batch_" << (has_batch ? 't' : 'n')
-  //       << "_use_out_source_" << (use_out_source ? 't' : 'n')
-  //       << "_do_axpby_" << (do_axpby ? 't' : 'n')
-  //       << "_align_M_" << (align_M ? 't' : 'n')
-  //       << "_align_N_" << (align_N ? 't' : 'n')
-  //       << "_align_K_" << (align_K ? 't' : 'n')
-  //       << "_do_gather_" << (do_gather ? 't' : 'n'); // clang-format on
-
-  // std::string hash_name = kname.str();
-
-  //// Encode and dispatch kernel
-  // auto& compute_encoder = d.get_command_encoder(s.index);
-  // auto kernel = get_steel_gemm_fused_kernel(
-  //     d,
-  //     base_name,
-  //     hash_name,
-  //     func_consts,
-  //     out,
-  //     transpose_a,
-  //     transpose_b,
-  //     bm,
-  //     bn,
-  //     bk,
-  //     wm,
-  //     wn);
-
-  // compute_encoder.set_compute_pipeline_state(kernel);
-
-  //// Use problem size to determine threadblock swizzle
-  // int tn = (N + bn - 1) / bn;
-  // int tm = (M + bm - 1) / bm;
-
-  //// TODO: Explore device-based tuning for swizzle
-  // int swizzle_log = 0; // tm >= 6 ? 3 : (tm <= 3 ? 0 : 2);
-
-  //// Prepare steel matmul params
-  // GEMMParams params{
-  //     /* const int M = */ M,
-  //     /* const int N = */ N,
-  //     /* const int K = */ K,
-  //     /* const int lda = */ lda,
-  //     /* const int ldb = */ ldb,
-  //     /* const int ldd = */ N,
-  //     /* const int tiles_n = */ tn,
-  //     /* const int tiles_m = */ tm,
-  //     /* const int64_t batch_stride_a = */ lhs_indices_str,
-  //     /* const int64_t batch_stride_b = */ rhs_indices_str,
-  //     /* const int64_t batch_stride_d = */ matrix_stride_out,
-  //     /* const int swizzle_log = */ swizzle_log,
-  //     /* const int gemm_k_iterations_aligned = */ (K / bk),
-  //     /* const int batch_ndim = */ batch_ndim};
-
-  //// Prepare launch grid params
-  // int tile = 1 << swizzle_log;
-  // tm = (tm + tile - 1) / tile;
-  // tn = tn * tile;
-
-  // MTL::Size group_dims = MTL::Size(32, wn, wm);
-  // MTL::Size grid_dims = MTL::Size(tn, tm, batch_size_out);
-
-  //// Launch kernel
-  // compute_encoder.set_input_array(a, 0);
-  // compute_encoder.set_input_array(b, 1);
-  // compute_encoder.set_output_array(out, 3);
-
-  // compute_encoder.set_bytes(params, 4);
-
-  // compute_encoder.set_vector_bytes(batch_shape, 6);
-  // compute_encoder.set_vector_bytes(batch_strides, 7);
-
-  // compute_encoder.set_input_array(lhs_indices, 10);
-  // compute_encoder.set_input_array(rhs_indices, 11);
-
-  // std::vector operand_shape = batch_shape_A;
-  // operand_shape.insert(
-  //     operand_shape.end(), batch_shape_B.begin(), batch_shape_B.end());
-
-  // std::vector operand_strides = batch_strides_A;
-  // operand_strides.insert(
-  //     operand_strides.end(), batch_strides_B.begin(), batch_strides_B.end());
-
-  // operand_batch_ndim.push_back(0);
-
-  // compute_encoder.set_vector_bytes(operand_shape, 13);
-  // compute_encoder.set_vector_bytes(operand_strides, 14);
-  // compute_encoder.set_vector_bytes(operand_batch_ndim, 15);
-
-  // compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
-
-  // d.add_temporaries(std::move(copies), s.index);
+  // Route to non specialized gather mm
+  gather_mm(a, b, lhs_indices, rhs_indices, out, M, N, K, d, s);
 }
 
 } // namespace mlx::core

--- a/mlx/backend/metal/matmul.cpp
+++ b/mlx/backend/metal/matmul.cpp
@@ -1597,7 +1597,8 @@ void gather_mm_rhs(
       bn,
       bk,
       wm,
-      wn);
+      wn,
+      true);
   compute_encoder.set_compute_pipeline_state(kernel);
 
   // Prepare the matmul params
@@ -1841,7 +1842,8 @@ void gather_mm(
       bn,
       bk,
       wm,
-      wn);
+      wn,
+      false);
   compute_encoder.set_compute_pipeline_state(kernel);
 
   // Prepare the matmul params

--- a/mlx/backend/metal/matmul.cpp
+++ b/mlx/backend/metal/matmul.cpp
@@ -273,7 +273,6 @@ void steel_matmul_regular(
   const bool align_M = (M % bm) == 0;
   const bool align_N = (N % bn) == 0;
   const bool align_K = (K % bk) == 0;
-  const bool do_gather = false;
 
   metal::MTLFCList func_consts = {
       {&has_batch, MTL::DataType::DataTypeBool, 10},
@@ -282,7 +281,6 @@ void steel_matmul_regular(
       {&align_M, MTL::DataType::DataTypeBool, 200},
       {&align_N, MTL::DataType::DataTypeBool, 201},
       {&align_K, MTL::DataType::DataTypeBool, 202},
-      {&do_gather, MTL::DataType::DataTypeBool, 300},
   };
 
   // clang-format off
@@ -291,8 +289,7 @@ void steel_matmul_regular(
         << "_do_axpby_" << (do_axpby ? 't' : 'n')
         << "_align_M_" << (align_M ? 't' : 'n')
         << "_align_N_" << (align_N ? 't' : 'n')
-        << "_align_K_" << (align_K ? 't' : 'n')
-        << "_do_gather_" << (do_gather ? 't' : 'n'); // clang-format on
+        << "_align_K_" << (align_K ? 't' : 'n'); // clang-format on
 
   std::string hash_name = kname.str();
 
@@ -1018,7 +1015,6 @@ void AddMM::eval_gpu(const std::vector<array>& inputs, array& out) {
   const bool align_M = (M % bm) == 0;
   const bool align_N = (N % bn) == 0;
   const bool align_K = (K % bk) == 0;
-  const bool do_gather = false;
 
   metal::MTLFCList func_consts = {
       {&has_batch, MTL::DataType::DataTypeBool, 10},
@@ -1027,7 +1023,6 @@ void AddMM::eval_gpu(const std::vector<array>& inputs, array& out) {
       {&align_M, MTL::DataType::DataTypeBool, 200},
       {&align_N, MTL::DataType::DataTypeBool, 201},
       {&align_K, MTL::DataType::DataTypeBool, 202},
-      {&do_gather, MTL::DataType::DataTypeBool, 300},
   };
 
   // clang-format off
@@ -1036,8 +1031,7 @@ void AddMM::eval_gpu(const std::vector<array>& inputs, array& out) {
         << "_do_axpby_" << (do_axpby ? 't' : 'n')
         << "_align_M_" << (align_M ? 't' : 'n')
         << "_align_N_" << (align_N ? 't' : 'n')
-        << "_align_K_" << (align_K ? 't' : 'n')
-        << "_do_gather_" << (do_gather ? 't' : 'n'); // clang-format on
+        << "_align_K_" << (align_K ? 't' : 'n'); // clang-format on
 
   std::string hash_name = kname.str();
 

--- a/mlx/backend/metal/nojit_kernels.cpp
+++ b/mlx/backend/metal/nojit_kernels.cpp
@@ -193,6 +193,22 @@ MTL::ComputePipelineState* get_steel_gemm_masked_kernel(
   return d.get_kernel(kernel_name);
 }
 
+MTL::ComputePipelineState* get_steel_gemm_gather_kernel(
+    metal::Device& d,
+    const std::string& kernel_name,
+    const std::string& hash_name,
+    const metal::MTLFCList& func_consts,
+    const array&,
+    bool,
+    bool,
+    int,
+    int,
+    int,
+    int,
+    int) {
+  return d.get_kernel(kernel_name, "mlx", hash_name, func_consts);
+}
+
 MTL::ComputePipelineState* get_gemv_masked_kernel(
     metal::Device& d,
     const std::string& kernel_name,

--- a/mlx/backend/metal/nojit_kernels.cpp
+++ b/mlx/backend/metal/nojit_kernels.cpp
@@ -205,7 +205,8 @@ MTL::ComputePipelineState* get_steel_gemm_gather_kernel(
     int,
     int,
     int,
-    int) {
+    int,
+    bool) {
   return d.get_kernel(kernel_name, "mlx", hash_name, func_consts);
 }
 

--- a/mlx/backend/metal/utils.h
+++ b/mlx/backend/metal/utils.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include "mlx/array.h"
 #include "mlx/backend/metal/device.h"
 #include "mlx/primitives.h"
@@ -59,13 +61,26 @@ inline void debug_set_primitive_buffer_label(
 std::string get_primitive_string(Primitive* primitive);
 
 template <typename T>
+constexpr bool is_numeric_except_char = std::is_arithmetic_v<T> &&
+    !std::is_same_v<T, char> && !std::is_same_v<T, signed char> &&
+    !std::is_same_v<T, unsigned char> && !std::is_same_v<T, wchar_t>;
+
+template <typename T>
 void concatenate(std::string& acc, T first) {
-  acc += first;
+  if constexpr (is_numeric_except_char<T>) {
+    acc += std::to_string(first);
+  } else {
+    acc += first;
+  }
 }
 
 template <typename T, typename... Args>
 void concatenate(std::string& acc, T first, Args... args) {
-  acc += first;
+  if constexpr (is_numeric_except_char<T>) {
+    acc += std::to_string(first);
+  } else {
+    acc += first;
+  }
   concatenate(acc, args...);
 }
 

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -4499,6 +4499,7 @@ array gather_mm(
     array b,
     std::optional<array> lhs_indices_ /* = std::nullopt */,
     std::optional<array> rhs_indices_ /* = std::nullopt */,
+    bool sorted_indices /* = false */,
     StreamOrDevice s /* = {} */) {
   // If no indices, fall back to full matmul
   if (!lhs_indices_ && !rhs_indices_) {
@@ -4574,12 +4575,18 @@ array gather_mm(
   out_shape.push_back(M);
   out_shape.push_back(N);
 
-  // Caculate array
+  // Make the output array
   auto out = array(
       std::move(out_shape),
       out_type,
-      std::make_shared<GatherMM>(to_stream(s)),
-      {a, b, lhs_indices, rhs_indices});
+      std::make_shared<GatherMM>(
+          to_stream(s),
+          sorted_indices && !rhs_indices_,
+          sorted_indices && !lhs_indices_),
+      {std::move(a),
+       std::move(b),
+       std::move(lhs_indices),
+       std::move(rhs_indices)});
 
   // Remove the possibly inserted singleton dimensions
   std::vector<int> axes;

--- a/mlx/ops.h
+++ b/mlx/ops.h
@@ -1399,6 +1399,7 @@ array gather_mm(
     array b,
     std::optional<array> lhs_indices = std::nullopt,
     std::optional<array> rhs_indices = std::nullopt,
+    bool sorted_indices = false,
     StreamOrDevice s = {});
 
 /** Extract a diagonal or construct a diagonal array */

--- a/mlx/primitives.h
+++ b/mlx/primitives.h
@@ -498,7 +498,13 @@ class BlockMaskedMM : public UnaryPrimitive {
 
 class GatherMM : public UnaryPrimitive {
  public:
-  explicit GatherMM(Stream stream) : UnaryPrimitive(stream) {}
+  explicit GatherMM(
+      Stream stream,
+      bool left_sorted = false,
+      bool right_sorted = false)
+      : UnaryPrimitive(stream),
+        left_sorted_(left_sorted),
+        right_sorted_(right_sorted) {}
 
   void eval_cpu(const std::vector<array>& inputs, array& out) override;
   void eval_gpu(const std::vector<array>& inputs, array& out) override;
@@ -510,7 +516,14 @@ class GatherMM : public UnaryPrimitive {
       const std::vector<array>& outputs) override;
 
   DEFINE_PRINT(GatherMM)
-  DEFINE_DEFAULT_IS_EQUIVALENT()
+  bool is_equivalent(const Primitive& other) const override;
+  auto state() const {
+    return std::make_pair(left_sorted_, right_sorted_);
+  }
+
+ private:
+  bool left_sorted_;
+  bool right_sorted_;
 };
 
 class BroadcastAxes : public UnaryPrimitive {

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -4464,9 +4464,10 @@ void init_ops(nb::module_& m) {
       "lhs_indices"_a = nb::none(),
       "rhs_indices"_a = nb::none(),
       nb::kw_only(),
+      "sorted_indices"_a = false,
       "stream"_a = nb::none(),
       nb::sig(
-          "def gather_mm(a: array, b: array, /, lhs_indices: array, rhs_indices: array, *, stream: Union[None, Stream, Device] = None) -> array"),
+          "def gather_mm(a: array, b: array, /, lhs_indices: array, rhs_indices: array, *, sorted_indices: bool = False, stream: Union[None, Stream, Device] = None) -> array"),
       R"pbdoc(
         Matrix multiplication with matrix-level gather.
 
@@ -4485,11 +4486,16 @@ void init_ops(nb::module_& m) {
         For ``b`` with shape ``(B1, B2, ..., BS, M, K)``, ``rhs_indices``
         contains indices from the range ``[0, B1 * B2 * ... * BS)``
 
+        If only one index is passed and it is sorted, the ``sorted_indices``
+        flag can be passed for a possible faster implementation.
+
         Args:
             a (array): Input array.
             b (array): Input array.
             lhs_indices (array, optional): Integer indices for ``a``. Default: ``None``
             rhs_indices (array, optional): Integer indices for ``b``. Default: ``None``
+            sorted_indices (bool, optional): May allow a faster implementation
+              if the passed indices are sorted. Default: ``False``.
 
         Returns:
             array: The output array.

--- a/python/tests/test_blas.py
+++ b/python/tests/test_blas.py
@@ -1108,7 +1108,7 @@ class TestBlas(mlx_tests.MLXTestCase):
             lhs_indices_ = mx.broadcast_to(lhs_indices, (3, 2))
             rhs_indices_ = mx.broadcast_to(rhs_indices, (3, 2))
             M = a.shape[-2]
-            N = b.shape[-2]
+            N = b.shape[-1]
             K = a.shape[-1]
 
             a = a.reshape((-1, M, K))


### PR DESCRIPTION
This is probably good enough to start reviewing. I need to fix the JIT build and also add some benchmark numbers. For now I am only routing matrix vector products but I think small matrices could also be routed there.

So the change list is

- Move gather out of `steel_gemm_fused` so that both are easier to edit
- Refactor GatherMM::eval_gpu to just route so that it is a bit easier to follow and add specializations etc
- Add `store_slice` to `BlockMMA` and the tiles internally so we can store only a slice of the output (a variation of `store_safe` basically)

There is more to be done in refactoring steel and simplifying routing and computing the arguments for matmul, I haven't done much there at all. I am sure Jagrit agrees and has a lot of stuff cooking.