### PR TITLE
wait_for_one should wait for task to finish

### DIFF
--- a/mlx/scheduler.h
+++ b/mlx/scheduler.h
@@ -129,7 +129,7 @@ class Scheduler {
     int n_tasks_old = n_active_tasks();
     if (n_tasks_old > 1) {
       completion_cv.wait(lk, [this, n_tasks_old] {
-        return this->n_active_tasks() != n_tasks_old;
+        return this->n_active_tasks() < n_tasks_old;
       });
     }
   }


### PR DESCRIPTION
Make `wait_for_one` wait for one task to finish, see https://github.com/ml-explore/mlx/discussions/1941 for discussions on this.

Potentially it could make some work slower as the scheduler now actually waits until active tasks becomes lesser.