### PR TITLE
Remove test of converting negative float to uint

### DIFF
--- a/tests/creations_tests.cpp
+++ b/tests/creations_tests.cpp
@@ -139,14 +139,6 @@ TEST_CASE("test astype") {
     y = astype(x, int32);
     CHECK_EQ(y.dtype(), int32);
     CHECK_EQ(y.item<int>(), -3);
-
-    y = astype(x, uint32);
-    CHECK_EQ(y.dtype(), uint32);
-
-    // Use std::copy since the result is platform dependent
-    uint32_t v;
-    std::copy(x.data<float>(), x.data<float>() + 1, &v);
-    CHECK_EQ(y.item<uint32_t>(), v);
   }
 }
 


### PR DESCRIPTION
Close https://github.com/ml-explore/mlx/issues/2015.

It is an [undefined behavior](https://embeddeduse.com/2013/08/25/casting-a-negative-float-to-an-unsigned-int/#cast-became-undefined) that GPU and CPU may give different results.