### PR TITLE
Remove Event::Signal()

### DIFF
--- a/mlx/event.h
+++ b/mlx/event.h
@@ -16,9 +16,6 @@ class Event {
   // Wait for the event to be signaled at its current value
   void wait();
 
-  // Signal the event at its current value
-  void signal();
-
   // Wait in the given stream for the event to be signaled at its current value
   void wait(Stream stream);
 


### PR DESCRIPTION
This method is not used anywhere, and it can not be implemented with cudaEvent. 