### PR TITLE
Remove static initializers

### DIFF
--- a/mlx/3rdparty/pocketfft.h
+++ b/mlx/3rdparty/pocketfft.h
@@ -537,7 +537,11 @@ inline size_t &num_threads()
   static thread_local size_t num_threads_=1;
   return num_threads_;
   }
-static const size_t max_threads = std::max(1u, std::thread::hardware_concurrency());
+inline const size_t &max_threads()
+  {
+  static thread_local const size_t max_threads_ = std::max(1u, std::thread::hardware_concurrency());
+  return max_threads_;
+  }
 
 class latch
   {
@@ -721,7 +725,7 @@ class thread_pool
       workers_(nthreads)
       { create_threads(); }
 
-    thread_pool(): thread_pool(max_threads) {}
+    thread_pool(): thread_pool(max_threads()) {}
 
     ~thread_pool() { shutdown(); }
 
@@ -786,7 +790,7 @@ template <typename Func>
 void thread_map(size_t nthreads, Func f)
   {
   if (nthreads == 0)
-    nthreads = max_threads;
+    nthreads = max_threads();
 
   if (nthreads == 1)
     { f(); return; }

--- a/mlx/3rdparty/pocketfft.h
+++ b/mlx/3rdparty/pocketfft.h
@@ -537,11 +537,7 @@ inline size_t &num_threads()
   static thread_local size_t num_threads_=1;
   return num_threads_;
   }
-inline const size_t &max_threads()
-  {
-  static thread_local const size_t max_threads_ = std::max(1u, std::thread::hardware_concurrency());
-  return max_threads_;
-  }
+static const size_t max_threads = std::max(1u, std::thread::hardware_concurrency());
 
 class latch
   {
@@ -725,7 +721,7 @@ class thread_pool
       workers_(nthreads)
       { create_threads(); }
 
-    thread_pool(): thread_pool(max_threads()) {}
+    thread_pool(): thread_pool(max_threads) {}
 
     ~thread_pool() { shutdown(); }
 
@@ -790,7 +786,7 @@ template <typename Func>
 void thread_map(size_t nthreads, Func f)
   {
   if (nthreads == 0)
-    nthreads = max_threads();
+    nthreads = max_threads;
 
   if (nthreads == 1)
     { f(); return; }

--- a/mlx/device.cpp
+++ b/mlx/device.cpp
@@ -5,11 +5,14 @@
 
 namespace mlx::core {
 
-static Device default_device_{
-    metal::is_available() ? Device::gpu : Device::cpu};
+Device& mutable_default_device() {
+  static Device default_device{
+      metal::is_available() ? Device::gpu : Device::cpu};
+  return default_device;
+}
 
 const Device& default_device() {
-  return default_device_;
+  return mutable_default_device();
 }
 
 void set_default_device(const Device& d) {
@@ -17,7 +20,7 @@ void set_default_device(const Device& d) {
     throw std::invalid_argument(
         "[set_default_device] Cannot set gpu device without gpu backend.");
   }
-  default_device_ = d;
+  mutable_default_device() = d;
 }
 
 bool operator==(const Device& lhs, const Device& rhs) {

--- a/mlx/io/load.cpp
+++ b/mlx/io/load.cpp
@@ -335,7 +335,10 @@ ThreadPool& thread_pool() {
   return pool_;
 }
 
-ThreadPool ParallelFileReader::thread_pool_{4};
+ThreadPool& ParallelFileReader::thread_pool() {
+  static ThreadPool thread_pool{4};
+  return thread_pool;
+}
 
 void ParallelFileReader::read(char* data, size_t n) {
   while (n != 0) {
@@ -371,7 +374,8 @@ void ParallelFileReader::read(char* data, size_t n, size_t offset) {
       break;
     } else {
       size_t m = batch_size_;
-      futs.emplace_back(thread_pool_.enqueue(readfn, offset, m, data));
+      futs.emplace_back(
+          ParallelFileReader::thread_pool().enqueue(readfn, offset, m, data));
       data += m;
       n -= m;
       offset += m;

--- a/mlx/io/load.h
+++ b/mlx/io/load.h
@@ -100,8 +100,10 @@ class ParallelFileReader : public Reader {
   }
 
  private:
+  static ThreadPool& thread_pool();
+
+ private:
   static constexpr size_t batch_size_ = 1 << 25;
-  static ThreadPool thread_pool_;
   int fd_;
   std::string label_;
 };

--- a/mlx/io/load.h
+++ b/mlx/io/load.h
@@ -100,10 +100,8 @@ class ParallelFileReader : public Reader {
   }
 
  private:
-  static ThreadPool& thread_pool();
-
- private:
   static constexpr size_t batch_size_ = 1 << 25;
+  static ThreadPool& thread_pool();
   int fd_;
   std::string label_;
 };

--- a/mlx/transforms.cpp
+++ b/mlx/transforms.cpp
@@ -42,8 +42,8 @@ class Synchronizer : public Primitive {
 // are currently under a function transformation and the retain_graph()
 // function which returns true if we are forced to retain the graph during
 // evaluation.
-std::vector<char>& detail::InTracing::trace_stack() {
-  static std::vector<char> trace_stack_;
+std::vector<std::pair<char, char>>& detail::InTracing::trace_stack() {
+  static std::vector<std::pair<char, char>> trace_stack_;
   return trace_stack_;
 }
 int detail::InTracing::grad_counter{0};

--- a/mlx/transforms.cpp
+++ b/mlx/transforms.cpp
@@ -42,7 +42,10 @@ class Synchronizer : public Primitive {
 // are currently under a function transformation and the retain_graph()
 // function which returns true if we are forced to retain the graph during
 // evaluation.
-std::vector<std::pair<char, char>> detail::InTracing::trace_stack{};
+std::vector<char>& detail::InTracing::trace_stack() {
+  static std::vector<char> trace_stack_;
+  return trace_stack_;
+}
 int detail::InTracing::grad_counter{0};
 int detail::RetainGraph::tracing_counter{0};
 

--- a/mlx/transforms_impl.h
+++ b/mlx/transforms_impl.h
@@ -22,19 +22,19 @@ std::vector<array> vmap_replace(
 struct InTracing {
   explicit InTracing(bool dynamic = false, bool grad = false) {
     grad_counter += grad;
-    trace_stack.push_back({dynamic, grad});
+    trace_stack().push_back({dynamic, grad});
   }
   ~InTracing() {
-    grad_counter -= trace_stack.back().second;
+    grad_counter -= trace_stack().back().second;
     trace_stack.pop_back();
   }
 
   static bool in_tracing() {
-    return !trace_stack.empty();
+    return !trace_stack().empty();
   }
   static bool in_dynamic_tracing() {
     // compile is always and only the outer-most transform
-    return in_tracing() && trace_stack.front().first;
+    return in_tracing() && trace_stack().front().first;
   }
 
   static bool in_grad_tracing() {
@@ -43,7 +43,7 @@ struct InTracing {
 
  private:
   static int grad_counter;
-  static std::vector<std::pair<char, char>> trace_stack;
+  static std::vector<char>& trace_stack();
 };
 
 struct RetainGraph {

--- a/mlx/transforms_impl.h
+++ b/mlx/transforms_impl.h
@@ -26,7 +26,7 @@ struct InTracing {
   }
   ~InTracing() {
     grad_counter -= trace_stack().back().second;
-    trace_stack.pop_back();
+    trace_stack().pop_back();
   }
 
   static bool in_tracing() {
@@ -43,7 +43,7 @@ struct InTracing {
 
  private:
   static int grad_counter;
-  static std::vector<char>& trace_stack();
+  static std::vector<std::pair<char, char>>& trace_stack();
 };
 
 struct RetainGraph {


### PR DESCRIPTION
## Proposed changes

Trying to eliminate most of static initializers to reduce overhead during app launch. These were found by "-Werror=global-constructors"

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
