### PR TITLE
Search mlx.metallib in macOS framework "Resources" dir

### DIFF
--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -1,5 +1,6 @@
 // Copyright © 2023-2024 Apple Inc.
 
+#include <array>
 #include <cstdlib>
 #include <sstream>
 
@@ -16,6 +17,22 @@
 #include "mlx/utils.h"
 
 namespace mlx::core::metal {
+
+std::string search_colocated_mtllib(
+    const fs::path& dli_path,
+    const std::string& lib_name) {
+  auto dir_name = dli_path.parent_path();
+  std::array search_list{
+      dir_name / lib_name,
+      dir_name / "Resources" / lib_name // in macOS framework
+  };
+  for (const auto& lib_path : search_list) {
+    if (fs::exists(lib_path)) {
+      return lib_path.c_str();
+    }
+  }
+  return "";
+}
 
 namespace {
 

--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -1,6 +1,5 @@
 // Copyright © 2023-2024 Apple Inc.
 
-#include <array>
 #include <cstdlib>
 #include <sstream>
 
@@ -17,22 +16,6 @@
 #include "mlx/utils.h"
 
 namespace mlx::core::metal {
-
-std::string search_colocated_mtllib(
-    const fs::path& dli_path,
-    const std::string& lib_name) {
-  auto dir_name = dli_path.parent_path();
-  std::array search_list{
-      dir_name / lib_name,
-      dir_name / "Resources" / lib_name // in macOS framework
-  };
-  for (const auto& lib_path : search_list) {
-    if (fs::exists(lib_path)) {
-      return lib_path.c_str();
-    }
-  }
-  return "";
-}
 
 namespace {
 

--- a/mlx/backend/metal/device.h
+++ b/mlx/backend/metal/device.h
@@ -21,18 +21,14 @@ namespace mlx::core::metal {
 
 // Note, this function must be left inline in a header so that it is not
 // dynamically linked.
-inline std::string get_colocated_mtllib_path(const std::string& lib_name) {
+inline std::string get_binary_directory() {
   Dl_info info;
-  std::string mtllib_path;
-  std::string lib_ext = lib_name + ".metallib";
-
-  int success = dladdr((void*)get_colocated_mtllib_path, &info);
+  std::string directory;
+  int success = dladdr((void*)get_binary_directory, &info);
   if (success) {
-    auto mtllib = fs::path(info.dli_fname).remove_filename() / lib_ext;
-    mtllib_path = mtllib.c_str();
+    directory = fs::path(info.dli_fname).remove_filename().c_str();
   }
-
-  return mtllib_path;
+  return directory;
 }
 
 using MTLFCList =

--- a/mlx/backend/metal/device.h
+++ b/mlx/backend/metal/device.h
@@ -19,6 +19,10 @@ namespace fs = std::filesystem;
 
 namespace mlx::core::metal {
 
+std::string search_colocated_mtllib(
+    const fs::path& dli_path,
+    const std::string& lib_name);
+
 // Note, this function must be left inline in a header so that it is not
 // dynamically linked.
 inline std::string get_colocated_mtllib_path(const std::string& lib_name) {
@@ -28,8 +32,7 @@ inline std::string get_colocated_mtllib_path(const std::string& lib_name) {
 
   int success = dladdr((void*)get_colocated_mtllib_path, &info);
   if (success) {
-    auto mtllib = fs::path(info.dli_fname).remove_filename() / lib_ext;
-    mtllib_path = mtllib.c_str();
+    mtllib_path = search_colocated_mtllib(fs::path(info.dli_fname), lib_ext);
   }
 
   return mtllib_path;

--- a/mlx/backend/metal/device.h
+++ b/mlx/backend/metal/device.h
@@ -19,10 +19,6 @@ namespace fs = std::filesystem;
 
 namespace mlx::core::metal {
 
-std::string search_colocated_mtllib(
-    const fs::path& dli_path,
-    const std::string& lib_name);
-
 // Note, this function must be left inline in a header so that it is not
 // dynamically linked.
 inline std::string get_colocated_mtllib_path(const std::string& lib_name) {
@@ -32,7 +28,8 @@ inline std::string get_colocated_mtllib_path(const std::string& lib_name) {
 
   int success = dladdr((void*)get_colocated_mtllib_path, &info);
   if (success) {
-    mtllib_path = search_colocated_mtllib(fs::path(info.dli_fname), lib_ext);
+    auto mtllib = fs::path(info.dli_fname).remove_filename() / lib_ext;
+    mtllib_path = mtllib.c_str();
   }
 
   return mtllib_path;


### PR DESCRIPTION
## Proposed changes

`get_colocated_mtllib_path` returns the metallib in the directory of executable, but macOS frameworks put it in `Resources` dir.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
