### PR TITLE
Adjust nn layer init with kaiming_init

### DIFF
--- a/python/mlx/nn/layers/linear.py
+++ b/python/mlx/nn/layers/linear.py
@@ -55,7 +55,6 @@ class Linear(Module):
         super().__init__()
         init_fn = init.he_uniform()
         self.weight = init_fn(mx.zeros((output_dims, input_dims)))
-
         if bias:
             self.bias = init_fn(mx.zeros((output_dims,)))
 
@@ -108,7 +107,6 @@ class Bilinear(Module):
         super().__init__()
         init_fn = init.he_uniform()
         self.weight = init_fn(mx.zeros((output_dims, input_dims)))
-
         if bias:
             self.bias = init_fn(mx.zeros((output_dims,)))
 

--- a/python/mlx/nn/layers/linear.py
+++ b/python/mlx/nn/layers/linear.py
@@ -45,9 +45,17 @@ class Linear(Module):
           not use a bias. Default is ``True``.
     """
 
-    def __init__(self, input_dims: int, output_dims: int, bias: bool = True) -> None:
+    def __init__(
+        self,
+        input_dims: int,
+        output_dims: int,
+        bias: bool = True,
+        kaiming_init: bool = False,
+    ) -> None:
         super().__init__()
-        scale = math.sqrt(1.0 / input_dims)
+        scale = (
+            math.sqrt(6.0 / input_dims) if kaiming_init else math.sqrt(1.0 / input_dims)
+        )
         self.weight = mx.random.uniform(
             low=-scale,
             high=scale,
@@ -97,13 +105,24 @@ class Bilinear(Module):
         output_dims (int): The dimensionality of the output features
         bias (bool, optional): If set to ``False`` then the layer will
           not use a bias. Default is ``True``.
+        kaiming_init (bool, optional): If ``True``, uses Kaiming uniform initialization
+          compatible with ReLU activations (matches PyTorch). Default is ``False``.
     """
 
     def __init__(
-        self, input1_dims: int, input2_dims: int, output_dims: int, bias: bool = True
+        self,
+        input1_dims: int,
+        input2_dims: int,
+        output_dims: int,
+        bias: bool = True,
+        kaiming_init: bool = False,
     ) -> None:
         super().__init__()
-        scale = math.sqrt(1.0 / input1_dims)
+        scale = (
+            math.sqrt(6.0 / input1_dims)
+            if kaiming_init
+            else math.sqrt(1.0 / input1_dims)
+        )
         self.weight = mx.random.uniform(
             low=-scale,
             high=scale,

--- a/python/mlx/nn/layers/linear.py
+++ b/python/mlx/nn/layers/linear.py
@@ -43,6 +43,8 @@ class Linear(Module):
         output_dims (int): The dimensionality of the output features
         bias (bool, optional): If set to ``False`` then the layer will
           not use a bias. Default is ``True``.
+        kaiming_init (bool, optional): If ``True``, uses Kaiming uniform initialization
+        compatible with ReLU activations (matches PyTorch). Default is ``False``.
     """
 
     def __init__(

--- a/python/mlx/nn/layers/linear.py
+++ b/python/mlx/nn/layers/linear.py
@@ -4,6 +4,7 @@ import math
 from typing import Any
 
 import mlx.core as mx
+import mlx.nn.init as init
 from mlx.nn.layers.base import Module
 from mlx.nn.layers.quantized import QuantizedLinear
 
@@ -43,8 +44,6 @@ class Linear(Module):
         output_dims (int): The dimensionality of the output features
         bias (bool, optional): If set to ``False`` then the layer will
           not use a bias. Default is ``True``.
-        kaiming_init (bool, optional): If ``True``, uses Kaiming uniform initialization
-        compatible with ReLU activations (matches PyTorch). Default is ``False``.
     """
 
     def __init__(
@@ -52,23 +51,13 @@ class Linear(Module):
         input_dims: int,
         output_dims: int,
         bias: bool = True,
-        kaiming_init: bool = False,
     ) -> None:
         super().__init__()
-        scale = (
-            math.sqrt(6.0 / input_dims) if kaiming_init else math.sqrt(1.0 / input_dims)
-        )
-        self.weight = mx.random.uniform(
-            low=-scale,
-            high=scale,
-            shape=(output_dims, input_dims),
-        )
+        init_fn = init.he_uniform()
+        self.weight = init_fn(mx.zeros((output_dims, input_dims)))
+
         if bias:
-            self.bias = mx.random.uniform(
-                low=-scale,
-                high=scale,
-                shape=(output_dims,),
-            )
+            self.bias = init_fn(mx.zeros((output_dims,)))
 
     def _extra_repr(self) -> str:
         return f"input_dims={self.weight.shape[1]}, output_dims={self.weight.shape[0]}, bias={'bias' in self}"
@@ -107,8 +96,6 @@ class Bilinear(Module):
         output_dims (int): The dimensionality of the output features
         bias (bool, optional): If set to ``False`` then the layer will
           not use a bias. Default is ``True``.
-        kaiming_init (bool, optional): If ``True``, uses Kaiming uniform initialization
-          compatible with ReLU activations (matches PyTorch). Default is ``False``.
     """
 
     def __init__(
@@ -117,25 +104,13 @@ class Bilinear(Module):
         input2_dims: int,
         output_dims: int,
         bias: bool = True,
-        kaiming_init: bool = False,
     ) -> None:
         super().__init__()
-        scale = (
-            math.sqrt(6.0 / input1_dims)
-            if kaiming_init
-            else math.sqrt(1.0 / input1_dims)
-        )
-        self.weight = mx.random.uniform(
-            low=-scale,
-            high=scale,
-            shape=(output_dims, input2_dims, input1_dims),
-        )
+        init_fn = init.he_uniform()
+        self.weight = init_fn(mx.zeros((output_dims, input_dims)))
+
         if bias:
-            self.bias = mx.random.uniform(
-                low=-scale,
-                high=scale,
-                shape=(output_dims,),
-            )
+            self.bias = init_fn(mx.zeros((output_dims,)))
 
     def _extra_repr(self) -> str:
         out, in2, in1 = self.weight.shape

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -226,12 +226,6 @@ class TestLayers(mlx_tests.MLXTestCase):
         outputs = layer(inputs)
         self.assertEqual(outputs.shape, (10, 8))
 
-    def test_linear_kaiming_init(self):
-        inputs = mx.zeros((10, 4))
-        layer = nn.Linear(input_dims=4, output_dims=8, kaiming_init=True)
-        outputs = layer(inputs)
-        self.assertEqual(outputs.shape, (10, 8))
-
     def test_bilinear(self):
         inputs1 = mx.zeros((10, 2))
         inputs2 = mx.zeros((10, 4))

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -226,6 +226,12 @@ class TestLayers(mlx_tests.MLXTestCase):
         outputs = layer(inputs)
         self.assertEqual(outputs.shape, (10, 8))
 
+    def test_linear_kaiming_init(self):
+        inputs = mx.zeros((10, 4))
+        layer = nn.Linear(input_dims=4, output_dims=8, kaiming_init=True)
+        outputs = layer(inputs)
+        self.assertEqual(outputs.shape, (10, 8))
+
     def test_bilinear(self):
         inputs1 = mx.zeros((10, 2))
         inputs2 = mx.zeros((10, 4))


### PR DESCRIPTION
## Proposed changes

Issue: https://github.com/ml-explore/mlx/issues/2001

This PR adds support  Kaiming uniform initialization in the Linear and Bilinear layers of MLX. This brings MLX in line with initialization practices used by PyTorch and others, especially beneficial for models using ReLU activations.

## Checklist


- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
