### PR TITLE
Fix `compile_commands.json` doesn't recognize nanobind include

### DIFF
--- a/python/src/CMakeLists.txt
+++ b/python/src/CMakeLists.txt
@@ -51,6 +51,7 @@ set_target_properties(
              ${MLX_PYTHON_BINDINGS_OUTPUT_DIRECTORY})
 
 target_link_libraries(core PRIVATE mlx)
+target_include_directories(core PRIVATE nanobind::nanobind)
 target_compile_definitions(core PRIVATE _VERSION_=${MLX_VERSION})
 
 if(BUILD_SHARED_LIBS)


### PR DESCRIPTION
## Proposed changes

clangd doesn't catch nanobind include
<img width="599" alt="image" src="https://github.com/user-attachments/assets/07590fb2-8d73-4437-a075-9cfb37d0c2cc" />

now `compile_commands.json` detects nanobind include well.

## Checklist

Put an `x` in the boxes that apply.

- [ ] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
