### PR TITLE
Return const ref in array::data_shared_ptr

### DIFF
--- a/mlx/array.h
+++ b/mlx/array.h
@@ -339,11 +339,11 @@ class array {
     return allocator::allocator().size(buffer());
   }
 
-  // Return a copy of the shared pointer
-  // to the array::Data struct
-  std::shared_ptr<Data> data_shared_ptr() const {
+  // Return the shared pointer to the array::Data struct
+  const std::shared_ptr<Data>& data_shared_ptr() const {
     return array_desc_->data;
   }
+
   // Return a raw pointer to the arrays data
   template <typename T>
   T* data() {


### PR DESCRIPTION
There are 2 cases for calling this method:

1. `buffers.insert(in.data_shared_ptr())`
2. `auto it = buffers.find(arr.data_shared_ptr())`

For case 1 there is no change, for case 2 we can avoid creating a temporary shared_ptr.