### PR TITLE
return library if it is successfully loaded

### DIFF
--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -166,6 +166,7 @@ MTL::Library* load_library(
           << error->localizedDescription()->utf8String();
       throw std::runtime_error(msg.str());
     }
+    return lib;
   }
 
   // We have been given a path so try to load from lib_path / lib_name.metallib
@@ -178,6 +179,7 @@ MTL::Library* load_library(
           << "> with error " << error->localizedDescription()->utf8String();
       throw std::runtime_error(msg.str());
     }
+    return lib;
   }
 
   // Try to load the colocated library


### PR DESCRIPTION
## Proposed changes

The logic doesn't look right: if the library gets loaded, it will proceed to load it from other directories.

I had to manually copy the metallib to the site-packages/mlx/lib in my own project as it didn't get picked up: https://github.com/skyzh/tiny-llm/blob/c64e9ef52f16c052b4f245f3b08a70d09677f7cc/build_ext.sh#L5

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
