### PR TITLE
Fix building with uv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+uv.lock
 
 # vim
 *.swp

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,6 @@
 include CMakeLists.txt
+include mlx.pc.in
 recursive-include mlx/ *
+include cmake/*
 include python/src/*
 include python/mlx/py.typed # support type hinting as in PEP-561


### PR DESCRIPTION
Add missing files needed for building from source distribution, which is used when using uv.

I also added `uv.lock` to gitignore - as long as mlx does not use uv for releasing, it should be ignored for people building with uv.