### PR TITLE
Allow quant layer to be unfrozen

### DIFF
--- a/python/mlx/nn/layers/quantized.py
+++ b/python/mlx/nn/layers/quantized.py
@@ -193,12 +193,6 @@ class QuantizedLinear(Module):
         # Freeze this model's parameters
         self.freeze()
 
-    def unfreeze(self, *args, **kwargs):
-        """Wrap unfreeze so that we unfreeze any layers we might contain but
-        our parameters will remain frozen."""
-        super().unfreeze(*args, **kwargs)
-        self.freeze(recurse=False)
-
     def _extra_repr(self):
         out_dims, in_dims = self.weight.shape
         in_dims *= 32 // self.bits

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -8,7 +8,7 @@ import mlx.core as mx
 import mlx.nn as nn
 import mlx_tests
 import numpy as np
-from mlx.utils import tree_flatten, tree_map
+from mlx.utils import tree_flatten, tree_map, tree_reduce
 
 
 class TestBase(mlx_tests.MLXTestCase):
@@ -197,6 +197,13 @@ class TestBase(mlx_tests.MLXTestCase):
         self.assertTrue(isinstance(m.layers[0], nn.Embedding))
         self.assertTrue(isinstance(m.layers[1], nn.ReLU))
         self.assertTrue(isinstance(m.layers[2], nn.QuantizedLinear))
+
+    def test_quantize_freeze(self):
+        lin = nn.Linear(512, 512)
+        qlin = lin.to_quantized()
+        qlin.unfreeze(keys=["scales"])
+        size = tree_reduce(lambda acc, p: acc + p.size, qlin.trainable_parameters(), 0)
+        self.assertTrue(size > 0)
 
     def test_grad_of_module(self):
         class Model(nn.Module):


### PR DESCRIPTION
Allow parameters in quant linear layer to be unfrozen.

The over-ridden `unfreeze` wasn't really doing much for us anyway since it doesn't get called by parent models. So it only stops quant layers from being unfrozen if you call `unfreeze` directly.

I'm not sure if we want to force the `weight` to stay frozen if you call `unfreeze()` directly without any keys. We could add it back for both the linear layer (and add it for the embedding layer).