### PR TITLE
Fix shapeless export to throw on dim mismatch

### DIFF
--- a/mlx/export.cpp
+++ b/mlx/export.cpp
@@ -470,6 +470,9 @@ bool FunctionTable::match(
     if (x.dtype() != y.dtype()) {
       return false;
     }
+    if (x.ndim() != y.ndim()) {
+      return false;
+    }
     if (!shapeless && x.shape() != y.shape()) {
       return false;
     }


### PR DESCRIPTION
For some reason the dim check didn't make it into the export. Now the behavior matches shapeless compile.

Closes #2124