### PR TITLE
fix input coherent kernel launch

### DIFF
--- a/mlx/backend/metal/fence.cpp
+++ b/mlx/backend/metal/fence.cpp
@@ -138,7 +138,7 @@ void Fence::update(Stream stream, const array& x) {
   compute_encoder.set_compute_pipeline_state(kernel);
   compute_encoder.set_input_array(x, 0);
   compute_encoder.set_bytes(nthreads, 1);
-  compute_encoder.dispatch_threadgroups(group_dims, grid_dims);
+  compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
 
   // Barrier on previous kernels
   compute_encoder.barrier();


### PR DESCRIPTION
As title.

Thanks @angeloskath for the repro:

```python
import mlx.core as mx

x = mx.ones((1024 * 1024 + 1))
mx.eval(x)

x = mx.add(x, 2, stream=mx.gpu)
x = mx.subtract(x, 2, stream=mx.cpu)
x = mx.multiply(x, 2, stream=mx.gpu)
mx.eval(x)

print((x == 2).all())
```