### PR TITLE
Add random normal distribution for complex numbers

### DIFF
--- a/mlx/random.cpp
+++ b/mlx/random.cpp
@@ -176,6 +176,27 @@ array uniform(
       array(0.0, dtype), array(1.0, dtype), shape, dtype, key, to_stream(s));
 }
 
+inline array complex_normal(
+    Shape shape,
+    const float loc,
+    const float scale,
+    const std::optional<array>& key,
+    StreamOrDevice s) {
+  auto stream = to_stream(s);
+  auto low = above_minus_one_with_default(float32);
+  auto high = array(1.0f, float32);
+  shape.push_back(2);
+  auto samples =
+      erfinv(uniform(low, high, shape, float32, key, stream), stream);
+  if (scale != 1.0) {
+    samples = multiply(array(scale, float32), samples, stream);
+  }
+  if (loc != 0.0) {
+    samples = add(array(loc, float32), samples, stream);
+  }
+  return squeeze(view(samples, complex64, stream), -1, stream);
+}
+
 array normal(
     const Shape& shape,
     Dtype dtype,
@@ -183,15 +204,16 @@ array normal(
     const float scale /* = 1.0 */,
     const std::optional<array>& key /*= nullopt */,
     StreamOrDevice s /* = {} */) {
+  if (dtype == complex64) {
+    return complex_normal(shape, loc, scale, key, s);
+  }
+
   auto stream = to_stream(s);
   auto low = above_minus_one_with_default(dtype);
   auto high = array(1.0f, dtype);
   auto samples = uniform(low, high, shape, dtype, key, stream);
-  samples =
-      multiply(array(std::sqrt(2.0), dtype), erfinv(samples, stream), stream);
-  if (scale != 1.0) {
-    samples = multiply(array(scale, dtype), samples, stream);
-  }
+  samples = multiply(
+      array(std::sqrt(2.0) * scale, dtype), erfinv(samples, stream), stream);
   if (loc != 0.0) {
     samples = add(array(loc, dtype), samples, stream);
   }

--- a/mlx/random.cpp
+++ b/mlx/random.cpp
@@ -215,11 +215,12 @@ array normal(
   auto samples = uniform(low, high, shape, dtype, key, stream);
   auto applied_scale = array(std::sqrt(2.0), dtype);
   if (scale.has_value()) {
-    applied_scale = multiply(applied_scale, *scale, stream);
+    applied_scale =
+        multiply(applied_scale, astype(*scale, dtype, stream), stream);
   }
   samples = multiply(applied_scale, erfinv(samples, stream), stream);
   if (loc.has_value()) {
-    samples = add(*loc, samples, stream);
+    samples = add(astype(*loc, dtype, stream), samples, stream);
   }
   return samples;
 }

--- a/mlx/random.h
+++ b/mlx/random.h
@@ -100,7 +100,7 @@ array normal(
     const std::optional<array>& scale,
     const std::optional<array>& key,
     StreamOrDevice s = {});
-array normal(
+inline array normal(
     const Shape& shape,
     Dtype dtype,
     const float loc,

--- a/mlx/random.h
+++ b/mlx/random.h
@@ -96,10 +96,22 @@ inline array uniform(
 array normal(
     const Shape& shape,
     Dtype dtype,
+    const std::optional<array>& loc,
+    const std::optional<array>& scale,
+    const std::optional<array>& key,
+    StreamOrDevice s = {});
+array normal(
+    const Shape& shape,
+    Dtype dtype,
     const float loc,
     const float scale,
     const std::optional<array>& key = std::nullopt,
-    StreamOrDevice s = {});
+    StreamOrDevice s = {}) {
+  auto loc_ = loc == 0 ? std::nullopt : std::make_optional(array(loc, dtype));
+  auto scale_ =
+      scale == 1 ? std::nullopt : std::make_optional(array(scale, dtype));
+  return normal(shape, dtype, loc_, scale_, key, s);
+}
 inline array normal(
     const Shape& shape,
     const float loc,
@@ -113,13 +125,13 @@ inline array normal(
     const Dtype dtype,
     const std::optional<array>& key = std::nullopt,
     StreamOrDevice s = {}) {
-  return normal(shape, dtype, 0.0, 1.0, key, s);
+  return normal(shape, dtype, std::nullopt, std::nullopt, key, s);
 }
 inline array normal(
     const Shape& shape,
     const std::optional<array>& key = std::nullopt,
     StreamOrDevice s = {}) {
-  return normal(shape, float32, 0.0, 1.0, key, s);
+  return normal(shape, float32, std::nullopt, std::nullopt, key, s);
 }
 
 /** Generate samples from a multivariate normal distribution. **/

--- a/python/tests/test_random.py
+++ b/python/tests/test_random.py
@@ -352,6 +352,19 @@ class TestRandom(mlx_tests.MLXTestCase):
         x = mx.random.permutation(mx.array([[1]]))
         self.assertEqual(x.shape, (1, 1))
 
+    def test_complex_normal(self):
+        sample = mx.random.normal(tuple(), dtype=mx.complex64)
+        self.assertEqual(sample.shape, tuple())
+        self.assertEqual(sample.dtype, mx.complex64)
+
+        sample = mx.random.normal((1, 2, 3, 4), dtype=mx.complex64)
+        self.assertEqual(sample.shape, (1, 2, 3, 4))
+        self.assertEqual(sample.dtype, mx.complex64)
+
+        sample = mx.random.normal((1, 2, 3, 4), dtype=mx.complex64, scale=2.0, loc=3.0)
+        self.assertEqual(sample.shape, (1, 2, 3, 4))
+        self.assertEqual(sample.dtype, mx.complex64)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/test_random.py
+++ b/python/tests/test_random.py
@@ -365,6 +365,22 @@ class TestRandom(mlx_tests.MLXTestCase):
         self.assertEqual(sample.shape, (1, 2, 3, 4))
         self.assertEqual(sample.dtype, mx.complex64)
 
+        sample = mx.random.normal(
+            (1, 2, 3, 4), dtype=mx.complex64, scale=2.0, loc=3.0 + 1j
+        )
+        self.assertEqual(sample.shape, (1, 2, 3, 4))
+        self.assertEqual(sample.dtype, mx.complex64)
+
+    def test_broadcastable_scale_loc(self):
+        b = mx.random.normal((10, 2))
+        sample = mx.random.normal((2, 10, 2), loc=b, scale=b)
+        mx.eval(sample)
+        self.assertEqual(sample.shape, (2, 10, 2))
+
+        with self.assertRaises(ValueError):
+            b = mx.random.normal((10,))
+            sample = mx.random.normal((2, 10, 2), loc=b, scale=b)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/test_random.py
+++ b/python/tests/test_random.py
@@ -381,6 +381,12 @@ class TestRandom(mlx_tests.MLXTestCase):
             b = mx.random.normal((10,))
             sample = mx.random.normal((2, 10, 2), loc=b, scale=b)
 
+        b = mx.random.normal((3, 1, 2))
+        sample = mx.random.normal((3, 4, 2), dtype=mx.float16, loc=b, scale=b)
+        mx.eval(sample)
+        self.assertEqual(sample.shape, (3, 4, 2))
+        self.assertEqual(sample.dtype, mx.float16)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
As title plus it makes `loc` and `scale` broadcastable arrays to `shape` as discussed in #2170. Closes #2170 .