### PR TITLE
reduce vjp for all and any

### DIFF
--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -3548,7 +3548,7 @@ std::vector<array> Reduce::vjp(
   }
 
   else {
-    throw std::runtime_error("Reduce type VJP not yet implemented.");
+    return {zeros_like(in, stream())};
   }
 }
 


### PR DESCRIPTION
As title. Send zeros through for convenience / consistency with other ops.. though one should usually use stop gradient.