### PR TITLE
Feat: Allow per-target Metal debug flags

### DIFF
--- a/cmake/extension.cmake
+++ b/cmake/extension.cmake
@@ -11,13 +11,14 @@ include(CMakeParseArguments)
 # Args: TARGET: Custom target to be added for the metal library TITLE: Name of
 # the .metallib OUTPUT_DIRECTORY: Where to place ${TITLE}.metallib SOURCES: List
 # of source files INCLUDE_DIRS: List of include dirs DEPS: List of dependency
-# files (like headers)
+# files (like headers) DEBUG: Boolean, if true, enables debug compile options
+# for this specific library. If not provided, uses global MLX_METAL_DEBUG.
 #
 # clang format on
 
 macro(mlx_build_metallib)
   # Parse args
-  set(oneValueArgs TARGET TITLE OUTPUT_DIRECTORY)
+  set(oneValueArgs TARGET TITLE OUTPUT_DIRECTORY DEBUG)
   set(multiValueArgs SOURCES INCLUDE_DIRS DEPS)
   cmake_parse_arguments(MTLLIB "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
@@ -26,6 +27,9 @@ macro(mlx_build_metallib)
 
   # Collect compile options
   set(MTLLIB_COMPILE_OPTIONS -Wall -Wextra -fno-fast-math -Wno-c++17-extensions)
+  if(MLX_METAL_DEBUG OR MTLLIB_DEBUG)
+    set(MTLLIB_COMPILE_OPTIONS ${MTLLIB_COMPILE_OPTIONS} -gline-tables-only -frecord-sources)
+  endif()
 
   # Prepare metallib build command
   add_custom_command(

--- a/cmake/extension.cmake
+++ b/cmake/extension.cmake
@@ -28,7 +28,8 @@ macro(mlx_build_metallib)
   # Collect compile options
   set(MTLLIB_COMPILE_OPTIONS -Wall -Wextra -fno-fast-math -Wno-c++17-extensions)
   if(MLX_METAL_DEBUG OR MTLLIB_DEBUG)
-    set(MTLLIB_COMPILE_OPTIONS ${MTLLIB_COMPILE_OPTIONS} -gline-tables-only -frecord-sources)
+    set(MTLLIB_COMPILE_OPTIONS ${MTLLIB_COMPILE_OPTIONS} -gline-tables-only
+                               -frecord-sources)
   endif()
 
   # Prepare metallib build command


### PR DESCRIPTION
## Summary
This PR adds the ability to enable Metal debug flags individually per Metal library target, rather than only globally.

## Changes
- Adds a new `DEBUG` parameter to the `mlx_build_metallib` macro
- When `DEBUG` is set to true for a specific Metal library, it enables debug compile options for that target only
- Debug flags include `-gline-tables-only` and `-frecord-sources` which are important for debugging Metal code
- Maintains backward compatibility with the global `MLX_METAL_DEBUG` flag
- Updates documentation to explain the new option

## Benefits
This change allows developers to selectively enable debugging for specific Metal libraries they're working on, without impacting performance of other Metal libraries in the project. This is particularly useful when debugging custom Metal kernels in a limited part of the codebase.

## Test plan
- Tested by building a Metal library with DEBUG=ON and verifying debug symbols were included
- Confirmed that other Metal libraries without DEBUG set don't include debug symbols when MLX_METAL_DEBUG is OFF
- Verified that setting MLX_METAL_DEBUG=ON still enables debug for all Metal libraries

## Related context
This is a standalone feature that improves Metal development and debugging workflow.