### PR TITLE
Optimizing Complex Matrix Multiplication using Karatsuba’s Algorithm 

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -2862,20 +2862,30 @@ array matmul(
         << " second input with shape " << b.shape() << ".";
     throw std::invalid_argument(msg.str());
   }
+
+// complex matmul using Karatsuba's Algorithm
+
+if (a.dtype() == complex64 && b.dtype() == complex64) {
+  // Extract real and imaginary parts
+  auto a_real = real(a, s);
+  auto a_imag = imag(a, s);
+  auto b_real = real(b, s);
+  auto b_imag = imag(b, s);
+
+  // Compute real and imaginary components of the result
+  auto m1 = matmul(a_real, b_real, s);
+  auto m2 = matmul(a_imag, b_imag, s);
+  auto m3 = matmul(add(a_real, a_imag, s), add(b_real, b_imag, s), s);
+
+  auto c_real = subtract(m1, m2, s);
+  auto c_imag = subtract(m3, add(m1, m2, s), s);
+
+  return add(c_real, multiply(array(complex64_t{0, 1}, complex64), c_imag, s), s);
+}
+
   // Type promotion
   auto out_type = promote_types(a.dtype(), b.dtype());
-  // Complex matmul in terms of real matmuls
-  if (out_type == complex64) {
-    auto a_real = real(a, s);
-    auto b_real = real(b, s);
-    auto a_imag = imag(a, s);
-    auto b_imag = imag(b, s);
-    auto c_real =
-        subtract(matmul(a_real, b_real, s), matmul(a_imag, b_imag, s), s);
-    auto c_imag = add(matmul(a_real, b_imag, s), matmul(a_imag, b_real, s), s);
-    return add(
-        c_real, multiply(array(complex64_t{0, 1}, complex64), c_imag, s), s);
-  }
+ 
 
   if (!issubdtype(out_type, floating)) {
     std::ostringstream msg;

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -2864,8 +2864,7 @@ array matmul(
   }
 
   // complex matmul using Karatsuba's Algorithm
-
-  if (a.dtype() == complex64 && b.dtype() == complex64) {
+  if (a.dtype() == complex64 || b.dtype() == complex64) {
     // Extract real and imaginary parts
     auto a_real = real(a, s);
     auto a_imag = imag(a, s);

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -2863,29 +2863,29 @@ array matmul(
     throw std::invalid_argument(msg.str());
   }
 
-// complex matmul using Karatsuba's Algorithm
+  // complex matmul using Karatsuba's Algorithm
 
-if (a.dtype() == complex64 && b.dtype() == complex64) {
-  // Extract real and imaginary parts
-  auto a_real = real(a, s);
-  auto a_imag = imag(a, s);
-  auto b_real = real(b, s);
-  auto b_imag = imag(b, s);
+  if (a.dtype() == complex64 && b.dtype() == complex64) {
+    // Extract real and imaginary parts
+    auto a_real = real(a, s);
+    auto a_imag = imag(a, s);
+    auto b_real = real(b, s);
+    auto b_imag = imag(b, s);
 
-  // Compute real and imaginary components of the result
-  auto m1 = matmul(a_real, b_real, s);
-  auto m2 = matmul(a_imag, b_imag, s);
-  auto m3 = matmul(add(a_real, a_imag, s), add(b_real, b_imag, s), s);
+    // Compute real and imaginary components of the result
+    auto m1 = matmul(a_real, b_real, s);
+    auto m2 = matmul(a_imag, b_imag, s);
+    auto m3 = matmul(add(a_real, a_imag, s), add(b_real, b_imag, s), s);
 
-  auto c_real = subtract(m1, m2, s);
-  auto c_imag = subtract(m3, add(m1, m2, s), s);
+    auto c_real = subtract(m1, m2, s);
+    auto c_imag = subtract(m3, add(m1, m2, s), s);
 
-  return add(c_real, multiply(array(complex64_t{0, 1}, complex64), c_imag, s), s);
-}
+    return add(
+        c_real, multiply(array(complex64_t{0, 1}, complex64), c_imag, s), s);
+  }
 
   // Type promotion
   auto out_type = promote_types(a.dtype(), b.dtype());
- 
 
   if (!issubdtype(out_type, floating)) {
     std::ostringstream msg;

--- a/python/tests/test_blas.py
+++ b/python/tests/test_blas.py
@@ -1210,18 +1210,18 @@ class TestBlas(mlx_tests.MLXTestCase):
         self.assertTrue(np.allclose(c, c_np))
 
         # Test addmm
-        M = 16
-        K = 50
-        N = 32
-
-        def rand(shape):
-            return mx.random.uniform(shape=shape) + 1j * mx.random.uniform(shape=shape)
-
         a = rand((M, K))
         b = rand((K, N))
         c = rand((M, N))
         out = mx.addmm(c, a, b, 2.0, 2.0)
         out_np = 2.0 * np.matmul(a, b) + 2.0 * c
+        self.assertTrue(np.allclose(out, out_np))
+
+        # complex with real
+        a = rand((M, K)).real
+        b = rand((K, N))
+        c = mx.matmul(a, b)
+        c_np = np.matmul(a, b)
         self.assertTrue(np.allclose(out, out_np))
 
 


### PR DESCRIPTION
## Proposed changes

This PR updates the existing complex matrix multiplication algorithm to use [Karatsuba’s Algorithm](https://en.wikipedia.org/wiki/Karatsuba_algorithm). The new approach reduces the number of internal matrix multiplications from four to three, combined with a few additional matrix algebra operations. 
The motivation stems from Strassen’s algorithm, which demonstrated that reducing multiplication steps can significantly optimize matrix computations. A similar idea is applied here for complex matrix multiplications.

## Benchmark 

I used the benchmark function called time_fn() inside [“mlx-apple/benchmarks/python/time_utils.py”](https://github.com/thesuryash/mlx/blob/main/benchmarks/python/time_utils.py). The implementation of the complex matmul is located in [“mlx-apple/mlx/ops.cpp”](https://github.com/thesuryash/mlx/blob/main/mlx/ops.cpp) from lines 2868 to 2884.

Performance improvements observed:
- CPU: ~17.70% speedup
- GPU: ~19.30% speedup

<img width="621" alt="Untitled" src="https://github.com/user-attachments/assets/827d8e09-cbac-42cd-9f7a-1496bf54c0f5" />


## Checklist

Put an `x` in the boxes that apply.

- [X] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [X] I have run pre-commit run --all-files to format my code / installed pre-commit prior to committing changes
- N/A I have added tests that prove my fix is effective or that my feature works
- N/A I have updated the necessary documentation (if needed). No changes required

