### PR TITLE
Fix fft testcase when comparing real numbers

### DIFF
--- a/python/tests/test_fft.py
+++ b/python/tests/test_fft.py
@@ -316,7 +316,11 @@ class TestFFT(mlx_tests.MLXTestCase):
 
             dfdx = mx.grad(f)(x)
             dgdx = torch.func.grad(g)(torch.tensor(x))
-            self.assertLess((dfdx - dgdx).abs().max() / dgdx.abs().mean(), 1e-4)
+            if dfdx.dtype == mx.complex64:
+                self.assertLess((dfdx - dgdx).abs().max() / dgdx.abs().mean(), 1e-4)
+            else:
+                dgdx_mx = mx.array(dgdx.detach().cpu().numpy())
+                self.assertLess((dfdx - dgdx_mx).abs().max() / dgdx_mx.abs().mean(), 1e-4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Proposed changes
Current test case of fft complains of using a imag from a real number.
"RuntimeError: imag is not implemented for tensors with non-complex dtypes."
Reproduce with: 
 python -m unittest test_fft.py -k test_fft_grads
## Checklist

Put an `x` in the boxes that apply.

- [ x ] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ x ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] I have updated the necessary documentation (if needed)
