### PR TITLE
Do not check event.is_signaled() in eval_impl

### DIFF
--- a/mlx/transforms.cpp
+++ b/mlx/transforms.cpp
@@ -208,9 +208,7 @@ array eval_impl(std::vector<array> outputs, bool async) {
         // output arrays stream
         fences[it->second].wait(stream, in);
       } else if (in.event().valid()) {
-        if (in.event().is_signaled()) {
-          in.detach_event();
-        } else if (in.event().stream() != stream) {
+        if (in.event().stream() != stream) {
           // Use event to wait across async eval
           in.event().wait(stream);
         }


### PR DESCRIPTION
Checking `event.is_signaled()` in CUDA backend can be expensive because it is reading a value in CPU which is usually updated by GPU, and it would involve host-device memory copy and possible locks.

It also seems to have positive effects in Metal backend, I ran `./build/examples/cpp/logistic_regression` for a few times and the average it/s seemed to improve from 2140 to 2160.