### PR TITLE
Avoid invoking allocator::malloc when creating CUDA event

### DIFF
--- a/mlx/backend/cuda/allocator.h
+++ b/mlx/backend/cuda/allocator.h
@@ -34,6 +34,9 @@ class CudaAllocator : public allocator::Allocator {
   // buffers there would result in dead lock.
   void register_this_thread();
 
+  // Call cudaFree in the safe thread.
+  void cuda_free(void* buf);
+
   size_t get_active_memory() const;
   size_t get_peak_memory() const;
   void reset_peak_memory();
@@ -46,8 +49,6 @@ class CudaAllocator : public allocator::Allocator {
  private:
   CudaAllocator();
   friend CudaAllocator& allocator();
-
-  void cuda_free(CudaBuffer* buf);
 
   std::mutex worker_mutex_;
   std::unique_ptr<Worker> worker_;

--- a/mlx/backend/cuda/event.cu
+++ b/mlx/backend/cuda/event.cu
@@ -1,5 +1,6 @@
 // Copyright © 2024 Apple Inc.
 
+#include "mlx/backend/cuda/allocator.h"
 #include "mlx/backend/cuda/device.h"
 #include "mlx/backend/cuda/event.h"
 #include "mlx/backend/cuda/utils.h"
@@ -111,12 +112,12 @@ __global__ void event_signal_kernel(SharedEvent::Atomic* ac, uint64_t value) {
 
 SharedEvent::SharedEvent() {
   // Allocate cuda::atomic on managed memory.
-  allocator::Buffer buffer = allocator::malloc(sizeof(Atomic));
-  Atomic* ac = static_cast<Atomic*>(buffer.raw_ptr());
+  Atomic* ac;
+  CHECK_CUDA_ERROR(cudaMallocManaged(&ac, sizeof(Atomic)));
   new (ac) Atomic(0);
-  ac_ = std::shared_ptr<Atomic>(ac, [buffer](Atomic* ptr) {
+  ac_ = std::shared_ptr<Atomic>(ac, [](Atomic* ptr) {
     ptr->~Atomic();
-    allocator::free(buffer);
+    allocator().cuda_free(ptr);
   });
 }
 


### PR DESCRIPTION
Use raw `cudaMallocManaged` API instead of `allocator::malloc` to allocate memory in CUDA backend's `SharedEvent`, also slightly refactor `CudaAllocator::cuda_free` so it takes a raw pointer instead of `CudaBuffer` wrapper.

This change is needed because `allocator::malloc` could create `SharedEvent` (caused by `buffer_cache_.release_cached_buffers` → `CudaAllocator::free` → `new Worker`) which would then call `allocator::malloc` again, there is no recursion call but the mutex would be locked twice and results in dead lock. We can work around it by using a recursive mutex, but I think it is better breaking the circle.

The downside is `SharedEvent` no longer benefits from buffer cache, but we should have a separate event cache instead if event creation is costly.