### PR TITLE
Refactor the lu test

### DIFF
--- a/python/tests/test_linalg.py
+++ b/python/tests/test_linalg.py
@@ -359,36 +359,6 @@ class TestLinalg(mlx_tests.MLXTestCase):
                 mx.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
             )  # Non-square matrix
 
-    def test_lu(self):
-        with self.assertRaises(ValueError):
-            mx.linalg.lu(mx.array(0.0), stream=mx.cpu)
-
-        with self.assertRaises(ValueError):
-            mx.linalg.lu(mx.array([0.0, 1.0]), stream=mx.cpu)
-
-        with self.assertRaises(ValueError):
-            mx.linalg.lu(mx.array([[0, 1], [1, 0]]), stream=mx.cpu)
-
-        # Test 3x3 matrix
-        a = mx.array([[3.0, 1.0, 2.0], [1.0, 8.0, 6.0], [9.0, 2.0, 5.0]])
-        P, L, U = mx.linalg.lu(a, stream=mx.cpu)
-        self.assertTrue(mx.allclose(L[P, :] @ U, a))
-
-        # Test batch dimension
-        a = mx.broadcast_to(a, (5, 5, 3, 3))
-        P, L, U = mx.linalg.lu(a, stream=mx.cpu)
-        L = mx.take_along_axis(L, P[..., None], axis=-2)
-        self.assertTrue(mx.allclose(L @ U, a))
-
-        # Test non-square matrix
-        a = mx.array([[3.0, 1.0, 2.0], [1.0, 8.0, 6.0]])
-        P, L, U = mx.linalg.lu(a, stream=mx.cpu)
-        self.assertTrue(mx.allclose(L[P, :] @ U, a))
-
-        a = mx.array([[3.0, 1.0], [1.0, 8.0], [9.0, 2.0]])
-        P, L, U = mx.linalg.lu(a, stream=mx.cpu)
-        self.assertTrue(mx.allclose(L[P, :] @ U, a))
-
     def test_eigh(self):
         tols = {"atol": 1e-5, "rtol": 1e-5}
 


### PR DESCRIPTION
## Proposed changes
This small PR removes the duplicated `test_lu` from `python/tests/test_linalg.py` which contains the same logic so its redundant.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
