### PR TITLE
Report number of missing parameters

### DIFF
--- a/python/mlx/nn/layers/base.py
+++ b/python/mlx/nn/layers/base.py
@@ -174,11 +174,13 @@ class Module(dict):
             new_weights = dict(weights)
             curr_weights = dict(tree_flatten(self.parameters()))
             if extras := (new_weights.keys() - curr_weights.keys()):
-                extras = " ".join(extras)
-                raise ValueError(f"Received parameters not in model: {extras}.")
+                num_extra = len(extras)
+                extras = ",\n".join(sorted(extras))
+                raise ValueError(f"Received {num_extra} parameters not in model: \n{extras}.")
             if missing := (curr_weights.keys() - new_weights.keys()):
-                missing = " ".join(missing)
-                raise ValueError(f"Missing parameters: {missing}.")
+                num_missing = len(missing)
+                missing = ",\n".join(sorted(missing))
+                raise ValueError(f"Missing {num_missing} parameters: \n{missing}.")
             for k, v in curr_weights.items():
                 v_new = new_weights[k]
                 if not isinstance(v_new, mx.array):

--- a/python/mlx/nn/layers/base.py
+++ b/python/mlx/nn/layers/base.py
@@ -176,7 +176,9 @@ class Module(dict):
             if extras := (new_weights.keys() - curr_weights.keys()):
                 num_extra = len(extras)
                 extras = ",\n".join(sorted(extras))
-                raise ValueError(f"Received {num_extra} parameters not in model: \n{extras}.")
+                raise ValueError(
+                    f"Received {num_extra} parameters not in model: \n{extras}."
+                )
             if missing := (curr_weights.keys() - new_weights.keys()):
                 num_missing = len(missing)
                 missing = ",\n".join(sorted(missing))


### PR DESCRIPTION
## Proposed changes

When translating a model from `PyTorch`, it can be hard to align the model structures correctly (e.g `mlx` `nn.Sequential` introduces a `.layers` prefix, `PyTorch` does not. 

Currently this is reported as:
```
 Missing parameters: vision_tower.blocks.layers.3.layers.35.norm.bias vision_tower.blocks.layers.3.layers.7.attn.key.norm.running_mean 
```

This PR updates it to:
```
ValueError: Missing 935 parameters:
vision_tower.blocks.layers.0.layers.0.bn1.bias,
vision_tower.blocks.layers.0.layers.0.bn1.running_mean,
```

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
