### PR TITLE
Fix building cpp benchmarks on Linux

### DIFF
--- a/benchmarks/cpp/irregular_strides.cpp
+++ b/benchmarks/cpp/irregular_strides.cpp
@@ -1,5 +1,6 @@
 // Copyright © 2023 Apple Inc.
 
+#include <cstring>
 #include <iostream>
 #include <sstream>
 


### PR DESCRIPTION
Fix building error on some distributions:

```console
/home/zhao_cheng/codes/mlx/benchmarks/cpp/irregular_strides.cpp: In function ‘int main(int, char**)’:
/home/zhao_cheng/codes/mlx/benchmarks/cpp/irregular_strides.cpp:189:21: error: ‘strcmp’ was not declared in this scope
  189 |     bool use_gpu = !strcmp(argv[1], "gpu");
      |                     ^~~~~~
/home/zhao_cheng/codes/mlx/benchmarks/cpp/irregular_strides.cpp:8:1: note: ‘strcmp’ is defined in header ‘<cstring>’; did you forget to ‘#include <cstring>’?
    7 | #include "time_utils.h"
  +++ |+#include <cstring>
    8 | 
```