### PR TITLE
Fix cuda arg reduce

### DIFF
--- a/mlx/utils.h
+++ b/mlx/utils.h
@@ -149,6 +149,11 @@ inline bool metal_fast_synch() {
   return metal_fast_synch;
 }
 
+inline bool enable_tf32() {
+  static bool enable_tf32_ = get_var("MLX_ENABLE_TF32", 1);
+  return enable_tf32_;
+}
+
 } // namespace env
 
 } // namespace mlx::core


### PR DESCRIPTION
Fix arg reduce.

FYI @zcbenz and others: `blockdim.z` cannot be larger than 64.

I also added a `MLX_ENABLE_TF32` which by default is on. And use tensor cores for fp32 when it's on.

Also fix the fp16 gemm. I think it needs the higher precision reduction otherwise it is not very good. It still uses tensorcores.. (checked with a benchmark).