### PR TITLE
Fix `update_modules()` when providing a subset

### DIFF
--- a/python/mlx/nn/layers/base.py
+++ b/python/mlx/nn/layers/base.py
@@ -413,7 +413,7 @@ class Module(dict):
                             f'Module does not have sub-module named "{k}".'
                         )
             elif isinstance(modules, list):
-                for i in range(len(dst)):
+                for i in range(len(modules)):
                     current_value = dst[i]
                     new_value = modules[i]
                     if self.is_module(current_value) and self.is_module(new_value):

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -259,6 +259,11 @@ class TestBase(mlx_tests.MLXTestCase):
         with self.assertRaises(ValueError):
             m = m.update_modules({"list": ["hi"]})
 
+        # Allow updating a strict subset
+        m = nn.Sequential(nn.Linear(3, 3), nn. Linear(3, 3))
+        m.update_modules({"layers": [{}, nn.Linear(3, 4)]})
+        self.assertEqual(m.layers[1].weight.shape, (4, 3))
+
 
 class TestLayers(mlx_tests.MLXTestCase):
     def test_identity(self):

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -260,7 +260,7 @@ class TestBase(mlx_tests.MLXTestCase):
             m = m.update_modules({"list": ["hi"]})
 
         # Allow updating a strict subset
-        m = nn.Sequential(nn.Linear(3, 3), nn. Linear(3, 3))
+        m = nn.Sequential(nn.Linear(3, 3), nn.Linear(3, 3))
         m.update_modules({"layers": [{}, nn.Linear(3, 4)]})
         self.assertEqual(m.layers[1].weight.shape, (4, 3))
 


### PR DESCRIPTION
`update_modules()` like `update()` should allow a subset of modules but when it comes to lists it requires an entry for each element in the list.

The change matches the behavior of `update()`.