### PR TITLE
Split broadcast so it is always fused in compile

### DIFF
--- a/python/tests/test_compile.py
+++ b/python/tests/test_compile.py
@@ -5,6 +5,7 @@ import io
 import math
 import unittest
 from functools import partial
+from io import StringIO
 
 import mlx.core as mx
 import mlx_tests
@@ -990,6 +991,28 @@ class TestCompile(mlx_tests.MLXTestCase):
             y = fun(x).item()
             y_compiled = mx.compile(fun)(x).item()
             self.assertEqual(y, y_compiled)
+
+    def test_shared_broadcast(self):
+        def fun(x, y, z):
+            yy = mx.broadcast_to(y, z.shape)
+            return (x + yy * z), yy.sum()
+
+        a = mx.random.normal((10, 10))
+        b = mx.array(0.1)
+        c = mx.random.normal((10, 10))
+        mx.eval(a, b, c)
+        fc = mx.compile(fun)
+        d = fc(a, b, c)
+
+        s = StringIO()
+        mx.export_to_dot(s, a=a, b=b, c=c, d1=d[0], d2=d[1])
+        s.seek(0)
+        s = s.read()
+
+        self.assertTrue("CompiledBroadcastMultiplyAdd" in s)
+        d_hat = fun(a, b, c)
+        self.assertTrue(mx.array_equal(d[0], d_hat[0]))
+        self.assertTrue(mx.array_equal(d[1], d_hat[1]))
 
 
 if __name__ == "__main__":

--- a/python/tests/test_compile.py
+++ b/python/tests/test_compile.py
@@ -1011,8 +1011,8 @@ class TestCompile(mlx_tests.MLXTestCase):
 
         self.assertTrue("CompiledBroadcastMultiplyAdd" in s)
         d_hat = fun(a, b, c)
-        self.assertTrue(mx.array_equal(d[0], d_hat[0]))
-        self.assertTrue(mx.array_equal(d[1], d_hat[1]))
+        self.assertTrue(mx.allclose(d[0], d_hat[0]))
+        self.assertTrue(mx.allclose(d[1], d_hat[1]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
What this does becomes clear with an example. For the following function

```python
def f(a, b, c):
    bb = mx.broadcast_to(b, c.shape)
    return (a + bb * c), bb.sum()
```

the compiled graph changes as follows

![broadcast_small](https://github.com/user-attachments/assets/c82029cc-7db8-49c1-8242-dff880bdc3e3)

Benchmarking on transformer training the speedup is consistent but minimal (~3%-4%) across M2, M2 Ultra and A100.

Splitting broadcast is safe because it is in principle a noop, but we could consider splitting some copies (astype) and redoing them if it will allow us to fuse more things.

@awni I tried to think if there is a possibility of messing up the graph but I think it is ok since to split a broadcast means we certainly are going to produce a fused primitive.