### PR TITLE
Align max op nan propagation with NumPy

### DIFF
--- a/benchmarks/cpp/single_ops.cpp
+++ b/benchmarks/cpp/single_ops.cpp
@@ -192,6 +192,17 @@ void time_reductions() {
 
   auto argmin_along_1 = [&a]() { return mx::argmin(a, 1, false); };
   TIME(argmin_along_1);
+
+  auto indices = mlx::core::array({1});
+  auto updates = mlx::core::reshape(mlx::core::array({NAN}), {1, 1, 1});
+  std::vector<int> axes{0};
+  auto b = scatter(a, {indices}, updates, axes);
+  mx::eval(b);
+
+  auto max_along_0 = [&b]() { return mx::max(b, 0, false); };
+  TIME(max_along_0);
+  auto max_along_1 = [&b]() { return mx::max(b, 1, false); };
+  TIME(max_along_1);
 }
 
 void time_gather_scatter() {

--- a/benchmarks/python/single_ops.py
+++ b/benchmarks/python/single_ops.py
@@ -50,11 +50,13 @@ def time_maximum():
     mx.eval(a, b)
     time_fn(mx.maximum, a, b)
 
+
 def time_max():
     a = mx.random.uniform(shape=(32, 1024, 1024))
-    a[1,1] = mx.nan
+    a[1, 1] = mx.nan
     mx.eval(a)
     time_fn(mx.max, a, 0)
+
 
 def time_negative():
     a = mx.random.uniform(shape=(10000, 1000))

--- a/benchmarks/python/single_ops.py
+++ b/benchmarks/python/single_ops.py
@@ -50,6 +50,11 @@ def time_maximum():
     mx.eval(a, b)
     time_fn(mx.maximum, a, b)
 
+def time_max():
+    a = mx.random.uniform(shape=(32, 1024, 1024))
+    a[1,1] = mx.nan
+    mx.eval(a)
+    time_fn(mx.max, a, 0)
 
 def time_negative():
     a = mx.random.uniform(shape=(10000, 1000))
@@ -108,6 +113,7 @@ if __name__ == "__main__":
 
     time_add()
     time_matmul()
+    time_max()
     time_maximum()
     time_exp()
     time_negative()

--- a/mlx/backend/metal/kernels/reduction/ops.h
+++ b/mlx/backend/metal/kernels/reduction/ops.h
@@ -187,10 +187,10 @@ struct Max {
 
   template <typename T>
   T simd_reduce_impl(T val) {
-    if(simd_any(val != val)) {
+    if (simd_any(val != val)) {
       return static_cast<T>(NAN);
     }
-      return simd_max(val);
+    return simd_max(val);
   }
 
   static constexpr constant U init = Limits<U>::min;
@@ -208,21 +208,19 @@ struct Max {
 
   template <typename T>
   metal::enable_if_t<!metal::is_integral_v<T>, T> operator()(T a, T b) {
-    if(metal::isnan(a) || metal::isnan(b)) {
+    if (metal::isnan(a) || metal::isnan(b)) {
       return static_cast<T>(NAN);
     } else {
       return a > b ? a : b;
     }
   }
 
-
   template <>
   complex64_t operator()(complex64_t a, complex64_t b) {
-    if (metal::isnan(a.real) || metal::isnan(a.imag) || metal::isnan(b.real) || metal::isnan(b.imag)) {
+    if (metal::isnan(a.real) || metal::isnan(a.imag) || metal::isnan(b.real) ||
+        metal::isnan(b.imag)) {
       return static_cast<complex64_t>(NAN);
-    }     
+    }
     return a > b ? a : b;
-
   }
-
 };

--- a/mlx/backend/metal/kernels/reduction/ops.h
+++ b/mlx/backend/metal/kernels/reduction/ops.h
@@ -217,10 +217,19 @@ struct Max {
 
   template <>
   complex64_t operator()(complex64_t a, complex64_t b) {
-    if (metal::isnan(a.real) || metal::isnan(a.imag) || metal::isnan(b.real) ||
-        metal::isnan(b.imag)) {
-      return static_cast<complex64_t>(NAN);
+    bool real_is_nan = metal::isnan(a.real) || metal::isnan(b.real);
+    bool imag_is_nan = metal::isnan(a.imag) || metal::isnan(b.imag);
+
+    if (!real_is_nan && !imag_is_nan) {
+      return a > b ? a : b;
+    } else if (real_is_nan && !imag_is_nan) {
+      return complex64_t(
+          static_cast<float>(NAN), a.imag > b.imag ? a.imag : b.imag);
+    } else if (!real_is_nan && imag_is_nan) {
+      return complex64_t(
+          a.real > b.real ? a.real : b.real, static_cast<float>(NAN));
+    } else {
+      return complex64_t(static_cast<float>(NAN), static_cast<float>(NAN));
     }
-    return a > b ? a : b;
   }
 };

--- a/python/tests/test_reduce.py
+++ b/python/tests/test_reduce.py
@@ -168,7 +168,7 @@ class TestReduce(mlx_tests.MLXTestCase):
         for dtype in dtypes:
             with self.subTest(dtype=dtype):
                 x = (mx.random.normal((4, 4))).astype(getattr(mx, dtype))
-                indices = mx.random.randint(0, 4, shape=(6,)).reshape(3,2)
+                indices = mx.random.randint(0, 4, shape=(6,)).reshape(3, 2)
                 for idx in indices:
                     x[*idx] = mx.nan
                 x_np = np.array(x)
@@ -178,6 +178,7 @@ class TestReduce(mlx_tests.MLXTestCase):
                         out = getattr(mx, op)(x, axis=axis)
                         ref = getattr(np, op)(x_np, axis=axis)
                         self.assertTrue(np.array_equal(out, ref, equal_nan=True))
+
 
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner(failfast=True)

--- a/python/tests/test_reduce.py
+++ b/python/tests/test_reduce.py
@@ -179,6 +179,37 @@ class TestReduce(mlx_tests.MLXTestCase):
                         ref = getattr(np, op)(x_np, axis=axis)
                         self.assertTrue(np.array_equal(out, ref, equal_nan=True))
 
+    def test_nanpropagation_complex64(self):
+        complex_array_1 = mx.array(
+            [1 + 1j, 2 + 2j, 3 + 3j, mx.nan + 4j], dtype=mx.complex64
+        ).reshape(2, 2)
+        complex_array_2 = mx.array(
+            [1 + 1j, 2 + 2j, 3 + mx.nan * 1j, 4 + 4j], dtype=mx.complex64
+        ).reshape(2, 2)
+        complex_array_3 = mx.array(
+            [1 + 1j, 2 + mx.nan * 1j, 3 + 3j, 4 + 4j], dtype=mx.complex64
+        ).reshape(2, 2)
+        complex_array_4 = mx.array(
+            [mx.nan + 1j, 2 + 2j, 3 + 3j, 4 + 4j], dtype=mx.complex64
+        ).reshape(2, 2)
+
+        np_arrays = [
+            np.array(complex_array_1),
+            np.array(complex_array_2),
+            np.array(complex_array_3),
+            np.array(complex_array_4),
+        ]
+
+        for mx_arr, np_arr in zip(
+            [complex_array_1, complex_array_2, complex_array_3, complex_array_4],
+            np_arrays,
+        ):
+            for axis in [0, 1]:
+                for op in ["max"]:
+                    out = getattr(mx, op)(mx_arr, axis=axis)
+                    ref = getattr(np, op)(np_arr, axis=axis)
+                    self.assertTrue(np.array_equal(out, ref, equal_nan=True))
+
 
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner(failfast=True)

--- a/python/tests/test_reduce.py
+++ b/python/tests/test_reduce.py
@@ -153,6 +153,31 @@ class TestReduce(mlx_tests.MLXTestCase):
         x = x.transpose(1, 0, 2, 3, 4, 5, 6, 7, 8, 9)
         check(x, (1, 3, 5, 7, 9))
 
+    def test_nanpropagation(self):
+        dtypes = [
+            "uint8",
+            "uint16",
+            "uint32",
+            "int8",
+            "int16",
+            "int32",
+            "float16",
+            "float32",
+        ]
+
+        for dtype in dtypes:
+            with self.subTest(dtype=dtype):
+                x = (mx.random.normal((4, 4))).astype(getattr(mx, dtype))
+                indices = mx.random.randint(0, 4, shape=(6,)).reshape(3,2)
+                for idx in indices:
+                    x[*idx] = mx.nan
+                x_np = np.array(x)
+
+                for op in ["max"]:
+                    for axis in [0, 1]:
+                        out = getattr(mx, op)(x, axis=axis)
+                        ref = getattr(np, op)(x_np, axis=axis)
+                        self.assertTrue(np.array_equal(out, ref, equal_nan=True))
 
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner(failfast=True)

--- a/tests/ops_tests.cpp
+++ b/tests/ops_tests.cpp
@@ -1024,6 +1024,10 @@ TEST_CASE("test reduction ops") {
     x = array({true, true, true, false, true, false}, {2, 3});
     CHECK(array_equal(min(x, 1), array({true, false})).item<bool>());
     CHECK(array_equal(min(x, 0), array({false, true, false})).item<bool>());
+
+    x = array({1.0f, NAN, 3.0f});
+    CHECK(isnan(max(x).item<float>()));
+
   }
 
   // Test logsumexp

--- a/tests/ops_tests.cpp
+++ b/tests/ops_tests.cpp
@@ -1025,8 +1025,9 @@ TEST_CASE("test reduction ops") {
     CHECK(array_equal(min(x, 1), array({true, false})).item<bool>());
     CHECK(array_equal(min(x, 0), array({false, true, false})).item<bool>());
 
-    x = array({1.0f, NAN, 3.0f, 4.0f, 5.0f, 6.0f});
-    CHECK(isnan(max(x).item<float>()));
+    x = array({1.0f, NAN, 3.0f, 4.0f, 5.0f, 6.0f}, {2, 3});
+    CHECK(array_equal(max(x, 0), array({4.0f, NAN, 6.0f}), true).item<bool>());
+    CHECK(array_equal(max(x, 1), array({NAN, 6.0f}), true).item<bool>());
   }
 
   // Test logsumexp

--- a/tests/ops_tests.cpp
+++ b/tests/ops_tests.cpp
@@ -1025,7 +1025,7 @@ TEST_CASE("test reduction ops") {
     CHECK(array_equal(min(x, 1), array({true, false})).item<bool>());
     CHECK(array_equal(min(x, 0), array({false, true, false})).item<bool>());
 
-    x = array({1.0f, NAN, 3.0f});
+    x = array({1.0f, NAN, 3.0f, 4.0f, 5.0f, 6.0f});
     CHECK(isnan(max(x).item<float>()));
 
   }

--- a/tests/ops_tests.cpp
+++ b/tests/ops_tests.cpp
@@ -1027,7 +1027,6 @@ TEST_CASE("test reduction ops") {
 
     x = array({1.0f, NAN, 3.0f, 4.0f, 5.0f, 6.0f});
     CHECK(isnan(max(x).item<float>()));
-
   }
 
   // Test logsumexp


### PR DESCRIPTION
## Proposed changes

Propagating NaNs in the `max` op according to numpy expectations. Circumvents MSLs tendency to avoid addressing NaNs with explicit checks. Addresses issue: #577 

Adds template specializations to `operator()` member in Max to address NaNs for non-integral types and `complex64` type separately. `simd_reduce_impl` uses the inequality property outlined in MSL specification section 3.1 §6 to check if any thread has data containing NaN and if so returns NaN.

Added unittests for functionality matching expected NaN propagation rules for both C++ and python side.

Added benchmarking both on python and C++ sides to allow verification of the effects from the additional NaN checking. Using the following benchmark before and after the changes in this PR produces the results below, indicating the effect should be relatively small.

```
void time_max() {
  auto a = mx::random::normal({10000, 10000});
  auto indices = mlx::core::array({1});
  auto updates = mlx::core::reshape(mlx::core::array({NAN}), {1, 1, 1});
  std::vector<int> axes{0};

  auto b = scatter(a, {indices}, updates, axes);
  mx::eval(b);

  auto max_along_0 = [&b]() { return mx::max(b, 0, false); };
  TIME(max_along_0);

  auto max_along_1 = [&b]() { return mx::max(b, 1, false); };
  TIME(max_along_1);
}
```

Produced values for three repeated measurements with minimal background activity on an M2 Air device as follows

```
// Before changes 
Benchmarks for Device(gpu, 0)
Timing max_along_0 ... 7.0018 msec
Timing max_along_1 ... 4.9778 msec
Benchmarks for Device(gpu, 0)
Timing max_along_0 ... 7.012 msec
Timing max_along_1 ... 4.9994 msec
Benchmarks for Device(gpu, 0)
Timing max_along_0 ... 6.983 msec
Timing max_along_1 ... 5.0911 msec

// After changes
Benchmarks for Device(gpu, 0)
Timing max_along_0 ... 7.015 msec
Timing max_along_1 ... 5.0204 msec
Benchmarks for Device(gpu, 0)
Timing max_along_0 ... 7.023 msec
Timing max_along_1 ... 5.0087 msec
Benchmarks for Device(gpu, 0)
Timing max_along_0 ... 7.0377 msec
Timing max_along_1 ... 4.9938 msec
```

Possible missing topics that need addressing:
I did not address the `atomic_update` nan-propagation as I didn't manage to find a readily available test case exercising the code path and wasn't exactly sure of what the expected behavior should be there.

If the changes look good, it should be trivial to extend the same treatment for min op to bring it to parity with numpy as well.

## Checklist

Put an `x` in the boxes that apply.

- [ x ] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ x ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] I have updated the necessary documentation (if needed)
