### PR TITLE
Fix layernorm race condition

### DIFF
--- a/mlx/backend/metal/kernels/layer_norm.metal
+++ b/mlx/backend/metal/kernels/layer_norm.metal
@@ -31,6 +31,7 @@ inline void threadgroup_sum(
   for (int i = 0; i < N; i++) {
     x[i] = simd_sum(x[i]);
   }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
   if (simd_lane_id == 0) {
     for (int i = 0; i < N; i++) {
       xs[N * simd_group_id + i] = x[i];


### PR DESCRIPTION
Closes #2333.

There is a race in `threadgroup_sum` because we are doing two passes and using the same shared memory to accumulate in. So basically when we write the normalizer all threads must have finished reading the mean.