### PR TITLE
[CUDA] Set current device before cudaGraphLaunch

### DIFF
--- a/mlx/backend/cuda/device.h
+++ b/mlx/backend/cuda/device.h
@@ -93,6 +93,7 @@ class CommandEncoder {
   void insert_graph_dependencies(GraphNode node);
   void insert_graph_dependencies(std::vector<GraphNode> nodes);
 
+  Device& device_;
   CudaStream stream_;
   cudaGraph_t graph_;
   Worker worker_;


### PR DESCRIPTION
This makes sure the graph is launched in the correct device under a multi-device environment.

Also moves the code of `Device::get_command_encoder` up as it is in the middle of `CommandEncoder` method definitions.