### PR TITLE
[CUDA] Put version in ptx cache dir path

### DIFF
--- a/mlx/backend/cuda/jit_module.cpp
+++ b/mlx/backend/cuda/jit_module.cpp
@@ -2,6 +2,7 @@
 
 #include "mlx/backend/cuda/jit_module.h"
 #include "mlx/backend/cuda/device.h"
+#include "mlx/version.h"
 
 #include "cuda_jit_sources.h"
 
@@ -53,10 +54,11 @@ const std::string& cuda_home() {
 const std::filesystem::path& ptx_cache_dir() {
   static std::filesystem::path cache = []() -> std::filesystem::path {
     std::filesystem::path cache;
-    if (auto c = std::getenv("MLX_PTX_CACHE"); c) {
+    if (auto c = std::getenv("MLX_PTX_CACHE_DIR"); c) {
       cache = c;
     } else {
-      cache = std::filesystem::temp_directory_path() / "mlx" / "ptx";
+      cache =
+          std::filesystem::temp_directory_path() / "mlx" / version() / "ptx";
     }
     if (!std::filesystem::exists(cache)) {
       std::error_code error;


### PR DESCRIPTION
This makes sure the compilation cache gets invalidated when MLX is updated. The downside is when doing local development the `/tmp/mlx/` could be filled with lots of dirs since date and commit are part of the version too.

Also renames the `MLX_PTX_CACHE` env to `MLX_PTX_CACHE_DIR` make it more intuitive, since it sets the cache dir path instead of cache options.