### PR TITLE
Install linux with mlx[cuda] and mlx[cpu]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,21 +329,28 @@ jobs:
             << parameters.build_env >> MLX_BUILD_COMMON=1 \
               python -m build --wheel --outdir wheelhouse
       - when:
+          condition:
+            equal: ["3.9", << parameters.python_version >>]
+          steps:
+            - run:
+                name: Build common package
+                command: |
+                  source env/bin/activate
+                  << parameters.build_env >> MLX_BUILD_COMMON=1 \
+                    python -m build --wheel --outdir wheelhouse
+      - when:
           condition: << parameters.build_env >>
           steps:
             - run:
                 name: Upload packages
                 command: |
                   source env/bin/activate
-                  twine upload wheelhouse/*
+                  twine upload wheelhouse/*.whl
       - store_artifacts:
           path: wheelhouse/
 
   build_cuda_release:
     parameters:
-      python_version:
-        type: string
-        default: "3.9"
       build_env:
         type: string
         default: ""
@@ -364,10 +371,6 @@ jobs:
             pip install patchelf
             pip install build
             pip install twine
-            << parameters.build_env >> \
-              CMAKE_ARGS="-DMLX_BUILD_CUDA=ON -DCMAKE_CUDA_COMPILER=`which nvcc`" \
-              pip install ".[dev]" -v
-            python setup.py generate_stubs
             << parameters.build_env >> \
               CMAKE_ARGS="-DMLX_BUILD_CUDA=ON -DCMAKE_CUDA_COMPILER=`which nvcc`" \
               python -m build --wheel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,9 +336,10 @@ jobs:
             pip install typing_extensions
             python setup.py generate_stubs
             << parameters.extra_env >> python -m build --wheel
-            << parameters.extra_env >> MLX_BUILD_COMMON=1 python -m build --wheel
             auditwheel show dist/*
             auditwheel repair dist/* --plat manylinux_2_31_x86_64
+            << parameters.extra_env >> MLX_BUILD_COMMON=1 \
+              python -m build --wheel --outdir wheelhouse
       - run:
           name: Upload packages
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,10 +336,11 @@ jobs:
             pip install typing_extensions
             python setup.py generate_stubs
             << parameters.extra_env >> python -m build --wheel
+            << parameters.extra_env >> MLX_BUILD_COMMON=1 python -m build --wheel
             auditwheel show dist/*
             auditwheel repair dist/* --plat manylinux_2_31_x86_64
       - run:
-          name: Upload package
+          name: Upload packages
           command: |
             source env/bin/activate
             twine upload wheelhouse/*

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,7 +272,17 @@ jobs:
           name: Build Python package
           command: |
             source env/bin/activate
-            << parameters.build_env >> python -m build -w
+            << parameters.build_env >> MLX_BUILD_STAGE=1 python -m build -w
+      - when:
+          condition:
+            equal: ["3.9", << parameters.python_version >>]
+          steps:
+            - run:
+                name: Build common package
+                command: |
+                  source env/bin/activate
+                  python setup.py clean --all
+                  << parameters.build_env >> MLX_BUILD_STAGE=2 python -m build -w
       - when:
           condition: << parameters.build_env >>
           steps:
@@ -292,42 +302,39 @@ jobs:
       build_env:
         type: string
         default: ""
-    docker:
-      - image: ubuntu:20.04
+    machine:
+      image: ubuntu-2204:current
+      resource_class: large
     steps:
       - checkout
       - run:
           name: Build wheel
           command: |
             PYTHON=python<< parameters.python_version >>
-            apt-get update
-            apt-get upgrade -y
-            DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata
-            apt-get install -y apt-utils
-            apt-get install -y software-properties-common
-            add-apt-repository -y ppa:deadsnakes/ppa
-            apt-get install -y $PYTHON $PYTHON-dev $PYTHON-full
-            apt-get install -y libblas-dev liblapack-dev liblapacke-dev
-            apt-get install -y build-essential git
+            export DEBIAN_FRONTEND=noninteractive
+            export NEEDRESTART_MODE=a
+            sudo apt-get update
+            sudo apt-get upgrade -y
+            TZ=Etc/UTC sudo apt-get -y install tzdata
+            sudo apt-get install -y apt-utils
+            sudo apt-get install -y software-properties-common
+            sudo add-apt-repository -y ppa:deadsnakes/ppa
+            sudo apt-get install -y $PYTHON $PYTHON-dev $PYTHON-full
+            sudo apt-get install -y libblas-dev liblapack-dev liblapacke-dev
+            sudo apt-get install -y build-essential git
             $PYTHON -m venv env
             source env/bin/activate
             pip install --upgrade pip
             pip install --upgrade cmake
-            pip install nanobind==2.4.0
-            pip install --upgrade setuptools
-            pip install numpy
             pip install auditwheel
             pip install patchelf
             pip install build
             pip install twine
-            << parameters.build_env >> pip install . -v
+            << parameters.build_env >> pip install ".[dev]" -v
             pip install typing_extensions
             python setup.py generate_stubs
-            << parameters.build_env >> python -m build --wheel
-            auditwheel show dist/*
-            auditwheel repair dist/* --plat manylinux_2_31_x86_64
-            << parameters.build_env >> MLX_BUILD_COMMON=1 \
-              python -m build --wheel --outdir wheelhouse
+            MLX_BUILD_STAGE=1 << parameters.build_env >> python -m build -w
+            bash python/scripts/repair_linux.sh
       - when:
           condition:
             equal: ["3.9", << parameters.python_version >>]
@@ -336,8 +343,10 @@ jobs:
                 name: Build common package
                 command: |
                   source env/bin/activate
-                  << parameters.build_env >> MLX_BUILD_COMMON=1 \
-                    python -m build --wheel --outdir wheelhouse
+                  python setup.py clean --all
+                  << parameters.build_env >> MLX_BUILD_STAGE=2 \
+                    python -m build -w
+                  auditwheel repair dist/mlx_cpu*.whl --plat manylinux_2_35_x86_64
       - when:
           condition: << parameters.build_env >>
           steps:
@@ -371,9 +380,9 @@ jobs:
             pip install patchelf
             pip install build
             pip install twine
-            << parameters.build_env >> \
+            << parameters.build_env >> MLX_BUILD_STAGE=2 \
               CMAKE_ARGS="-DMLX_BUILD_CUDA=ON -DCMAKE_CUDA_COMPILER=`which nvcc`" \
-              python -m build --wheel
+              python -m build -w
             bash python/scripts/repair_cuda.sh
       - when:
           condition: << parameters.build_env >>
@@ -506,7 +515,6 @@ workflows:
               ignore: /.*/
           matrix:
             parameters:
-              python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
               build_env: ["PYPI_RELEASE=1"]
 
   prb:
@@ -587,20 +595,7 @@ workflows:
                 xcode_version: "15.0.0"
                 python_version: "3.13"
       - build_linux_release:
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
           matrix:
             parameters:
               python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-      - build_cuda_release:
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
-          matrix:
-            parameters:
-              python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+      - build_cuda_release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,18 +7,6 @@ parameters:
   nightly_build:
     type: boolean
     default: false
-  weekly_build:
-    type: boolean
-    default: false
-  test_release:
-    type: boolean
-    default: false
-  linux_release:
-    type: boolean
-    default: false
-  cuda_release:
-    type: boolean
-    default: false
 
 jobs:
   build_documentation:
@@ -301,9 +289,9 @@ jobs:
       python_version:
         type: string
         default: "3.9"
-      extra_env:
+      build_env:
         type: string
-        default: "DEV_RELEASE=1"
+        default: ""
     docker:
       - image: ubuntu:20.04
     steps:
@@ -332,19 +320,22 @@ jobs:
             pip install patchelf
             pip install build
             pip install twine
-            << parameters.extra_env >> pip install . -v
+            << parameters.build_env >> pip install . -v
             pip install typing_extensions
             python setup.py generate_stubs
-            << parameters.extra_env >> python -m build --wheel
+            << parameters.build_env >> python -m build --wheel
             auditwheel show dist/*
             auditwheel repair dist/* --plat manylinux_2_31_x86_64
-            << parameters.extra_env >> MLX_BUILD_COMMON=1 \
+            << parameters.build_env >> MLX_BUILD_COMMON=1 \
               python -m build --wheel --outdir wheelhouse
-      - run:
-          name: Upload packages
-          command: |
-            source env/bin/activate
-            twine upload wheelhouse/*
+      - when:
+          condition: << parameters.build_env >>
+          steps:
+            - run:
+                name: Upload packages
+                command: |
+                  source env/bin/activate
+                  twine upload wheelhouse/*
       - store_artifacts:
           path: wheelhouse/
 
@@ -353,9 +344,9 @@ jobs:
       python_version:
         type: string
         default: "3.9"
-      extra_env:
+      build_env:
         type: string
-        default: "DEV_RELEASE=1"
+        default: ""
     machine:
       image: linux-cuda-12:default
       resource_class: gpu.nvidia.small.gen2
@@ -366,25 +357,29 @@ jobs:
           command: |
             sudo apt-get update
             sudo apt-get install libblas-dev liblapack-dev liblapacke-dev
+            sudo apt-get install zip
             python -m venv env
             source env/bin/activate
             pip install auditwheel
             pip install patchelf
             pip install build
             pip install twine
-            << parameters.extra_env >> \
+            << parameters.build_env >> \
               CMAKE_ARGS="-DMLX_BUILD_CUDA=ON -DCMAKE_CUDA_COMPILER=`which nvcc`" \
               pip install ".[dev]" -v
             python setup.py generate_stubs
-            << parameters.extra_env >> \
+            << parameters.build_env >> \
               CMAKE_ARGS="-DMLX_BUILD_CUDA=ON -DCMAKE_CUDA_COMPILER=`which nvcc`" \
               python -m build --wheel
             bash python/scripts/repair_cuda.sh
-      - run:
-          name: Upload package
-          command: |
-            source env/bin/activate
-            twine upload wheelhouse/*.whl
+      - when:
+          condition: << parameters.build_env >>
+          steps:
+            - run:
+                name: Upload package
+                command: |
+                  source env/bin/activate
+                  twine upload wheelhouse/*.whl
       - store_artifacts:
           path: wheelhouse/
 
@@ -396,8 +391,6 @@ workflows:
             pattern: "^(?!pull/)[-\\w]+$"
             value: << pipeline.git.branch >>
         - not: << pipeline.parameters.nightly_build >>
-        - not: << pipeline.parameters.weekly_build >>
-        - not: << pipeline.parameters.test_release >>
     jobs:
       - mac_build_and_test:
           matrix:
@@ -411,8 +404,6 @@ workflows:
     when:
       and:
         - not: << pipeline.parameters.nightly_build >>
-        - not: << pipeline.parameters.weekly_build >>
-        - not: << pipeline.parameters.test_release >>
     jobs:
       - build_release:
           filters:
@@ -503,7 +494,17 @@ workflows:
           matrix:
             parameters:
               python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-              extra_env: ["PYPI_RELEASE=1"]
+              build_env: ["PYPI_RELEASE=1"]
+      - build_cuda_release:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+          matrix:
+            parameters:
+              python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+              build_env: ["PYPI_RELEASE=1"]
 
   prb:
     when:
@@ -582,99 +583,21 @@ workflows:
               - macosx_deployment_target: "15.0"
                 xcode_version: "15.0.0"
                 python_version: "3.13"
-  weekly_build:
-    when:
-      and:
-        - equal: [ main, << pipeline.git.branch >> ]
-        - << pipeline.parameters.weekly_build >>
-    jobs:
-      - build_release:
-          matrix:
-            parameters:
-              python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-              macosx_deployment_target: ["13.5", "14.0", "15.0"]
-              build_env: ["DEV_RELEASE=1"]
-              xcode_version: ["16.2.0", "15.0.0"]
-            exclude:
-              - macosx_deployment_target: "13.5"
-                xcode_version: "16.2.0"
-                python_version: "3.9"
-                build_env: "DEV_RELEASE=1"
-              - macosx_deployment_target: "13.5"
-                xcode_version: "16.2.0"
-                python_version: "3.10"
-                build_env: "DEV_RELEASE=1"
-              - macosx_deployment_target: "13.5"
-                xcode_version: "16.2.0"
-                python_version: "3.11"
-                build_env: "DEV_RELEASE=1"
-              - macosx_deployment_target: "13.5"
-                xcode_version: "16.2.0"
-                python_version: "3.12"
-                build_env: "DEV_RELEASE=1"
-              - macosx_deployment_target: "13.5"
-                xcode_version: "16.2.0"
-                python_version: "3.13"
-                build_env: "DEV_RELEASE=1"
-              - macosx_deployment_target: "14.0"
-                xcode_version: "15.0.0"
-                python_version: "3.9"
-                build_env: "DEV_RELEASE=1"
-              - macosx_deployment_target: "14.0"
-                xcode_version: "15.0.0"
-                python_version: "3.10"
-                build_env: "DEV_RELEASE=1"
-              - macosx_deployment_target: "14.0"
-                xcode_version: "15.0.0"
-                python_version: "3.11"
-                build_env: "DEV_RELEASE=1"
-              - macosx_deployment_target: "14.0"
-                xcode_version: "15.0.0"
-                python_version: "3.12"
-                build_env: "DEV_RELEASE=1"
-              - macosx_deployment_target: "14.0"
-                xcode_version: "15.0.0"
-                python_version: "3.13"
-                build_env: "DEV_RELEASE=1"
-              - macosx_deployment_target: "15.0"
-                xcode_version: "15.0.0"
-                python_version: "3.9"
-                build_env: "DEV_RELEASE=1"
-              - macosx_deployment_target: "15.0"
-                xcode_version: "15.0.0"
-                python_version: "3.10"
-                build_env: "DEV_RELEASE=1"
-              - macosx_deployment_target: "15.0"
-                xcode_version: "15.0.0"
-                python_version: "3.11"
-                build_env: "DEV_RELEASE=1"
-              - macosx_deployment_target: "15.0"
-                xcode_version: "15.0.0"
-                python_version: "3.12"
-                build_env: "DEV_RELEASE=1"
-              - macosx_deployment_target: "15.0"
-                xcode_version: "15.0.0"
-                python_version: "3.13"
-                build_env: "DEV_RELEASE=1"
-  linux_test_release:
-    when:
-      and:
-        - equal: [ main, << pipeline.git.branch >> ]
-        - << pipeline.parameters.linux_release >>
-    jobs:
       - build_linux_release:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
           matrix:
             parameters:
               python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-              extra_env: ["PYPI_RELEASE=1"]
-  cuda_test_release:
-    when:
-      and:
-        - equal: [ main, << pipeline.git.branch >> ]
-        - << pipeline.parameters.cuda_release >>
-    jobs:
       - build_cuda_release:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
           matrix:
             parameters:
               python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-              extra_env: ["PYPI_RELEASE=1"]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,10 +64,8 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
       message(WARNING "Building for x86_64 arch is not officially supported.")
     endif()
   endif()
-
 else()
   set(MLX_BUILD_METAL OFF)
-  message(WARNING "MLX is prioritised for Apple silicon systems using macOS.")
 endif()
 
 # ----------------------------- Lib -----------------------------

--- a/docs/src/install.rst
+++ b/docs/src/install.rst
@@ -38,8 +38,16 @@ and SM 7.0 (Volta) and up. To install MLX with CUDA support, run:
 
 .. code-block:: shell
 
-    pip install mlx-cuda
+    pip install "mlx[cuda]"
 
+CPU only (Linux)
+^^^^^^^^^^^^^^^^
+
+For a CPU-only version of MLX that runs on Linux use:
+
+.. code-block:: shell
+
+    pip install "mlx[cpu]"
 
 Troubleshooting
 ^^^^^^^^^^^^^^^

--- a/docs/src/install.rst
+++ b/docs/src/install.rst
@@ -23,13 +23,6 @@ To install from PyPI you must meet the following requirements:
     MLX is only available on devices running macOS >= 13.5
     It is highly recommended to use macOS 14 (Sonoma)
 
-
-MLX is also available on conda-forge. To install MLX with conda do:
-
-.. code-block:: shell
-
-   conda install conda-forge::mlx
-
 CUDA
 ^^^^
 
@@ -40,7 +33,7 @@ and SM 7.0 (Volta) and up. To install MLX with CUDA support, run:
 
     pip install "mlx[cuda]"
 
-CPU only (Linux)
+CPU-only (Linux)
 ^^^^^^^^^^^^^^^^
 
 For a CPU-only version of MLX that runs on Linux use:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "setuptools>=42",
+  "setuptools>=80",
   "nanobind==2.4.0",
   "cmake>=3.25",
 ]

--- a/python/scripts/repair_cuda.sh
+++ b/python/scripts/repair_cuda.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 auditwheel repair dist/* \
-  --plat manylinux_2_35_x86_64 \
+  --plat manylinux_2_39_x86_64 \
   --exclude libcublas* \
   --exclude libnvrtc* \
   -w wheel_tmp
@@ -12,10 +12,12 @@ cd wheel_tmp
 repaired_wheel=$(find . -name "*.whl" -print -quit)
 unzip -q "${repaired_wheel}"
 rm "${repaired_wheel}"
-core_so=$(find mlx -name "core*.so" -print -quit)
-rpath=$(patchelf --print-rpath "${core_so}")
-rpath=$rpath:\$ORIGIN/../nvidia/cublas/lib:\$ORIGIN/../nvidia/cuda_nvrtc/lib
-patchelf --force-rpath --set-rpath "$rpath" "$core_so"
+mlx_so="mlx/lib/libmlx.so"
+rpath=$(patchelf --print-rpath "${mlx_so}")
+base="\$ORIGIN/../../nvidia"
+rpath=$rpath:${base}/cublas/lib:${base}/cuda_nvrtc/lib
+patchelf --force-rpath --set-rpath "$rpath" "$mlx_so"
+python ../python/scripts/repair_record.py ${mlx_so}
 
 # Re-zip the repaired wheel
 zip -r -q "../wheelhouse/${repaired_wheel}" .

--- a/python/scripts/repair_cuda.sh
+++ b/python/scripts/repair_cuda.sh
@@ -3,15 +3,19 @@
 auditwheel repair dist/* \
   --plat manylinux_2_35_x86_64 \
   --exclude libcublas* \
-  --exclude libnvrtc*
+  --exclude libnvrtc* \
+  -w wheel_tmp
 
-cd wheelhouse
+
+mkdir wheelhouse
+cd wheel_tmp
 repaired_wheel=$(find . -name "*.whl" -print -quit)
 unzip -q "${repaired_wheel}"
+rm "${repaired_wheel}"
 core_so=$(find mlx -name "core*.so" -print -quit)
 rpath=$(patchelf --print-rpath "${core_so}")
 rpath=$rpath:\$ORIGIN/../nvidia/cublas/lib:\$ORIGIN/../nvidia/cuda_nvrtc/lib
 patchelf --force-rpath --set-rpath "$rpath" "$core_so"
 
 # Re-zip the repaired wheel
-zip -r -q "${repaired_wheel}" .
+zip -r -q "../wheelhouse/${repaired_wheel}" .

--- a/python/scripts/repair_linux.sh
+++ b/python/scripts/repair_linux.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+auditwheel repair dist/* \
+  --plat manylinux_2_35_x86_64 \
+  --exclude libmlx* \
+  -w wheel_tmp
+
+mkdir wheelhouse
+cd wheel_tmp
+repaired_wheel=$(find . -name "*.whl" -print -quit)
+unzip -q "${repaired_wheel}"
+rm "${repaired_wheel}"
+core_so=$(find mlx -name "core*.so" -print -quit)
+rpath="\$ORIGIN/lib"
+patchelf --force-rpath --set-rpath "$rpath" "$core_so"
+python ../python/scripts/repair_record.py ${core_so}
+
+# Re-zip the repaired wheel
+zip -r -q "../wheelhouse/${repaired_wheel}" .

--- a/python/scripts/repair_record.py
+++ b/python/scripts/repair_record.py
@@ -1,0 +1,33 @@
+import base64
+import glob
+import hashlib
+import sys
+
+filename = sys.argv[1]
+
+
+# Compute the new hash and size
+def urlsafe_b64encode(data: bytes) -> bytes:
+    return base64.urlsafe_b64encode(data).rstrip(b"=")
+
+
+hasher = hashlib.sha256()
+with open(filename, "rb") as f:
+    data = f.read()
+    hasher.update(data)
+hash_str = urlsafe_b64encode(hasher.digest()).decode("ascii")
+size = len(data)
+
+# Update the record file
+record_file = glob.glob("*/RECORD")[0]
+with open(record_file, "r") as f:
+    lines = [l.split(",") for l in f.readlines()]
+
+for l in lines:
+    if filename == l[0]:
+        l[1] = hash_str
+        l[2] = f"{size}\n"
+
+with open(record_file, "w") as f:
+    for l in lines:
+        f.write(",".join(l))

--- a/setup.py
+++ b/setup.py
@@ -171,6 +171,7 @@ if __name__ == "__main__":
     packages = [
         "mlx",
         "mlx.nn",
+        "mlx.nn.layers",
         "mlx.optimizers",
     ]
 
@@ -218,10 +219,9 @@ if __name__ == "__main__":
         ]
     }
 
-    test = "-awni-test"
     if not is_release or build_macos:
         _setup(
-            name="mlx" + test,
+            name="mlx",
             include_package_data=True,
             packages=packages,
             extras_require=extras,
@@ -230,10 +230,10 @@ if __name__ == "__main__":
             cmdclass={"build_ext": CMakeBuild, "generate_stubs": GenerateStubs},
         )
     elif build_common:
-        extras["cpu"] = [f"mlx-cpu{test}=={version}"]
-        extras["cuda"] = [f"mlx-cuda{test}=={version}"]
+        extras["cpu"] = [f"mlx-cpu=={version}"]
+        extras["cuda"] = [f"mlx-cuda=={version}"]
         _setup(
-            name="mlx" + test,
+            name="mlx",
             packages=["mlx"],
             extras_require=extras,
             entry_points=entry_points,
@@ -241,7 +241,7 @@ if __name__ == "__main__":
         )
     else:
         _setup(
-            name="mlx-cuda" if build_cuda else "mlx-cpu" + test,
+            name="mlx-cuda" if build_cuda else "mlx-cpu",
             include_package_data=True,
             packages=packages,
             extras_require=extras,

--- a/setup.py
+++ b/setup.py
@@ -218,9 +218,10 @@ if __name__ == "__main__":
         ]
     }
 
+    test = "-awni-test"
     if not is_release or build_macos:
         _setup(
-            name="mlx",
+            name="mlx" + test,
             include_package_data=True,
             packages=packages,
             extras_require=extras,
@@ -229,18 +230,18 @@ if __name__ == "__main__":
             cmdclass={"build_ext": CMakeBuild, "generate_stubs": GenerateStubs},
         )
     elif build_common:
-        extras["cpu"] = [f"mlx-cpu=={version}"]
-        extras["cuda"] = [f"mlx-cuda=={version}"]
+        extras["cpu"] = [f"mlx-cpu{test}=={version}"]
+        extras["cuda"] = [f"mlx-cuda{test}=={version}"]
         _setup(
-            name="mlx",
-            include_package_data=False,
+            name="mlx" + test,
             packages=["mlx"],
             extras_require=extras,
             entry_points=entry_points,
+            exclude_package_data=package_data,
         )
     else:
         _setup(
-            name="mlx-cuda" if build_cuda else "mlx-cpu",
+            name="mlx-cuda" if build_cuda else "mlx-cpu" + test,
             include_package_data=True,
             packages=packages,
             extras_require=extras,


### PR DESCRIPTION
This changes the way we install backends:

We build four packages:
- mlx-cpu
- mlx-cuda
- mlx-metal
- mlx 

The top-level `mlx` package is basically a shell for the dependency management. So you can do:

- `pip install mlx` to install MLX for macOS with Metal backend
- `pip install "mlx[cpu]"` to install MLX for linux on the CPU.
- `pip install "mlx[cuda]"` to install MLX for linux with the CUDA back-end

For local builds nothing should change. For PyPi release the build now goes in two stages:
- Build the back-end package. This is python version independent but platform and back-end dependent.
- Build the mlx core python binding package. This is platform and version dependent, but back-end independent.