### PR TITLE
lower memory uniform sampling

### DIFF
--- a/mlx/random.cpp
+++ b/mlx/random.cpp
@@ -150,18 +150,18 @@ array uniform(
       case float16:
         return std::make_pair(
             array(below_one<float16_t>(), float16),
-            array(std::numeric_limits<uint16_t>::max(), float32));
+            array(std::numeric_limits<uint32_t>::max(), float32));
       case bfloat16:
         return std::make_pair(
             array(below_one<bfloat16_t>(), bfloat16),
-            array(std::numeric_limits<uint16_t>::max(), float32));
+            array(std::numeric_limits<uint16_t>::max(), bfloat16));
       default:
         throw std::runtime_error("[uniform] Unsupported type.");
     }
   };
 
   auto [upper, maxval] = get_limits();
-  auto out = bits(shape, size_of(dtype), key, stream);
+  auto out = bits(shape, size_of(maxval.dtype()), key, stream);
   out = astype(divide(out, maxval, stream), dtype, stream);
   out = minimum(out, upper, stream);
   return add(multiply(range, out, stream), lo, stream);

--- a/tests/random_tests.cpp
+++ b/tests/random_tests.cpp
@@ -350,7 +350,7 @@ TEST_CASE("test random uniform") {
   // Check float16
   {
     auto key = random::key(0);
-    auto out = random::uniform({100}, float16, key);
+    auto out = random::uniform({1000}, float16, key);
     CHECK_EQ(out.dtype(), float16);
     CHECK(all(less(out, array(1.0f))).item<bool>());
     CHECK(all(greater_equal(out, array(0.0f))).item<bool>());
@@ -360,7 +360,7 @@ TEST_CASE("test random uniform") {
 
   {
     auto key = random::key(0);
-    auto out = random::uniform({100}, bfloat16, key);
+    auto out = random::uniform({1000}, bfloat16, key);
     CHECK_EQ(out.dtype(), bfloat16);
     CHECK(all(less(out, array(1.0f))).item<bool>());
     CHECK(all(greater_equal(out, array(0.0f))).item<bool>());


### PR DESCRIPTION
```python
import mlx.core as mx
vocabSize = 10000
hiddenSize = 2048
w = mx.random.uniform(shape=[vocabSize, hiddenSize], dtype=mx.bfloat16)
mx.eval(w)
print(mx.get_peak_memory() / 2**20)
```

Uses 117MB insteed of 156MB. The uniform sampling is basically equivalent to sampling then `asytpe`. But this is pretty important to get well distributed samples. Updated normal and laplace to do the same.