### PR TITLE
Fix imag() vjp

### DIFF
--- a/python/tests/test_autograd.py
+++ b/python/tests/test_autograd.py
@@ -606,7 +606,7 @@ class TestAutograd(mlx_tests.MLXTestCase):
 
         x = mx.array([0.0 + 1j, 1.0 + 0.0j, 0.5 + 0.5j])
         dfdx = mx.grad(fun)(x)
-        self.assertTrue(mx.allclose(dfdx, -2j * mx.ones_like(x)))
+        self.assertTrue(mx.allclose(dfdx, 2j * mx.ones_like(x)))
 
     def test_flatten_unflatten_vjps(self):
         def fun(x):


### PR DESCRIPTION
As title. It also fixes the matmul even though our matmul actually dispatches to real matmuls so the fix isn't really needed. Let me know if you think I should remove it from the matmul.

Closes #2366.
