### PR TITLE
[CUDA] --compress-mode requires CUDA 12.8

### DIFF
--- a/mlx/backend/cuda/CMakeLists.txt
+++ b/mlx/backend/cuda/CMakeLists.txt
@@ -88,7 +88,9 @@ endif()
 target_compile_options(
   mlx PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:--Wno-deprecated-gpu-targets>")
 
-if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.4.0)
+# Use stronger binaries compression. This feature was introduced in CUDA 12.8
+# and requires drivers released after CUDA 12.4.
+if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.8.0)
   target_compile_options(
     mlx PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:--compress-mode=size>")
 endif()


### PR DESCRIPTION
The `--compress-mode` flag was introduced in CUDA 12.8, which you can verify with the NVCC docs:

12.8: https://docs.nvidia.com/cuda/archive/12.8.0/cuda-compiler-driver-nvcc/index.html#compress-mode-default-size-speed-balance-none-compress-mode
12.6: https://docs.nvidia.com/cuda/archive/12.6.3/cuda-compiler-driver-nvcc/index.html#no-compress-no-compress

The [latest doc](https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#compress-mode-default-size-speed-balance-none-compress-mode) mentions that:

> This option is not compatible with drivers released before CUDA Toolkit’s 12.4 Release.

which actually means the compressed binary requires a driver compatible with CUDA 12.4 to run, which was the version introduced support for binary compression but not the NVCC `--compress-mode` flag. The famous PR https://github.com/pytorch/pytorch/pull/157791 was misguided.

So a concern with this feature is it would require CUDA 12.4 compatible driver to run MLX.