### PR TITLE
fix: hold gil before calling tree_cache().clear()

### DIFF
--- a/python/src/transforms.cpp
+++ b/python/src/transforms.cpp
@@ -1503,6 +1503,8 @@ void init_transforms(nb::module_& m) {
   // Register static Python object cleanup before the interpreter exits
   auto atexit = nb::module_::import_("atexit");
   atexit.attr("register")(nb::cpp_function([]() {
+    nb::gil_scoped_acquire gil;
+
     tree_cache().clear();
     mx::detail::compile_clear_cache();
   }));


### PR DESCRIPTION
## Proposed changes

Please include a description of the problem or feature this PR is addressing. If there is a corresponding issue, include the issue #.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
