### PR TITLE
Patch small pool init

### DIFF
--- a/mlx/backend/cuda/allocator.cpp
+++ b/mlx/backend/cuda/allocator.cpp
@@ -30,8 +30,11 @@ SmallSizePool::SmallSizePool() {
   next_free_ = buffer_;
 
   CHECK_CUDA_ERROR(cudaMallocManaged(&data_, small_pool_size));
-  CHECK_CUDA_ERROR(
-      cudaMemAdvise(data_, small_pool_size, cudaMemAdviseSetReadMostly, 0));
+  auto status =
+      cudaMemAdvise(data_, small_pool_size, cudaMemAdviseSetReadMostly, 0);
+  if (status != cudaSuccess && status != cudaErrorInvalidValue) {
+    throw std::runtime_error("Unable to initialize small allocator pool");
+  }
 
   auto curr = next_free_;
   for (size_t i = 1; i < num_blocks; ++i) {


### PR DESCRIPTION
Unclear why this doesn't work on the modal labs T4 GPUs..

Seems likely unrelated to MLX as a simple repro below also fails. Didn't find any more useful info in the documentation / internet..

```c++
#include <cuda.h>
#include <cuda_runtime.h>
#include <iostream>

int main() {
    void* data;
    size_t size = 8; 
    cudaError_t cudaStatus = cudaMallocManaged(&data, size);

    if (cudaStatus != cudaSuccess) {
        std::cerr << "malloc failed: " << cudaGetErrorString(cudaStatus) << std::endl;
        return 1;
    }
    cudaStatus = cudaMemAdvise(data, size, cudaMemAdviseSetReadMostly, 0);

    if (cudaStatus != cudaSuccess) {
        std::cerr << "memAdvise failed: " << cudaGetErrorString(cudaStatus) << std::endl;
        return 1;
    }

    return 0;
}
```