### PR TITLE
Make CI faster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,17 +225,17 @@ jobs:
             curl -sL https://github.com/ccache/ccache/releases/download/v4.11.3/ccache-4.11.3-linux-x86_64.tar.xz | tar xJf -
             sudo mv ccache-4.11.3-linux-x86_64/ccache /usr/bin/ccache
             rm -rf ccache-4.11.3-linux-x86_64
+            curl -LsSf https://astral.sh/uv/install.sh | sh
       - run:
           name: Install Python package
           command: |
-            python3 -m venv env
-            source env/bin/activate
+            uv venv
             CMAKE_ARGS="-DMLX_BUILD_CUDA=ON -DCMAKE_CUDA_COMPILER=`which nvcc`" \
-              pip install -e ".[dev]" -v
+              uv pip install -e ".[dev]"
       - run:
           name: Run Python tests
           command: |
-            source env/bin/activate
+            source .venv/bin/activate
             LOW_MEMORY=1 DEVICE=cpu python -m unittest discover python/tests -v
             LOW_MEMORY=1 DEVICE=gpu python -m tests discover python/tests -v
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,9 @@ jobs:
       - run:
           name: Run style checks
           command: |
-            uvx pre-commit run --all
+            uv venv
+            uv pip install pre-commit
+            uv run --no-project pre-commit run --all
             if ! git diff --quiet; then echo 'Style checks failed, please install pre-commit and run pre-commit run --all and push the change'; exit 1; fi
       - run:
           name: Install dependencies
@@ -85,7 +87,6 @@ jobs:
       - run:
           name: Install Python package
           command: |
-            uv venv
             uv pip install cmake
             uv pip install -e ".[dev]"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,9 @@ jobs:
       resource_class: large
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - cpu-{{ arch }}-
       - run:
           name: Run style checks
           command: |
@@ -112,6 +115,10 @@ jobs:
       - run:
           name: Run CPP tests
           command: ./build/tests/tests
+      - save_cache:
+          key: cpu-{{ arch }}-{{ epoch }}
+          paths:
+            - /home/circleci/.cache/uv
 
   mac_build_and_test:
     parameters:
@@ -249,6 +256,7 @@ jobs:
           key: cuda-<< parameters.image_date >>-{{ arch }}-{{ epoch }}
           paths:
             - /home/circleci/.cache/ccache
+            - /home/circleci/.cache/uv
 
   build_release:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,6 @@ jobs:
             export DEBIAN_FRONTEND=noninteractive
             export NEEDRESTART_MODE=a
             sudo apt-get update
-            sudo apt-get upgrade -y
             pip install --upgrade cmake
             sudo apt-get install -y libblas-dev liblapack-dev liblapacke-dev
             sudo apt-get install openmpi-bin openmpi-common libopenmpi-dev
@@ -343,14 +342,10 @@ jobs:
             export DEBIAN_FRONTEND=noninteractive
             export NEEDRESTART_MODE=a
             sudo apt-get update
-            sudo apt-get upgrade -y
             TZ=Etc/UTC sudo apt-get -y install tzdata
-            sudo apt-get install -y apt-utils
-            sudo apt-get install -y software-properties-common
             sudo add-apt-repository -y ppa:deadsnakes/ppa
             sudo apt-get install -y $PYTHON $PYTHON-dev $PYTHON-full
             sudo apt-get install -y libblas-dev liblapack-dev liblapacke-dev
-            sudo apt-get install -y build-essential git
             $PYTHON -m venv env
             source env/bin/activate
             pip install --upgrade pip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,8 +75,8 @@ jobs:
       - run:
           name: Run style checks
           command: |
-            pip install pre-commit
-            pre-commit run --all
+            curl -LsSf https://astral.sh/uv/install.sh | sh
+            uvx pre-commit run --all
             if ! git diff --quiet; then echo 'Style checks failed, please install pre-commit and run pre-commit run --all and push the change'; exit 1; fi
       - run:
           name: Install dependencies
@@ -87,7 +87,6 @@ jobs:
             pip install --upgrade cmake
             sudo apt-get install -y libblas-dev liblapack-dev liblapacke-dev
             sudo apt-get install openmpi-bin openmpi-common libopenmpi-dev
-            curl -LsSf https://astral.sh/uv/install.sh | sh
       - run:
           name: Install Python package
           command: |
@@ -138,33 +137,30 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            brew install python@3.9
             brew install openmpi
-            python3.9 -m venv env
-            source env/bin/activate
-            pip install --upgrade pip
-            pip install --upgrade cmake
-            pip install nanobind==2.4.0
-            pip install numpy
-            pip install torch
-            pip install tensorflow
-            pip install unittest-xml-reporting
+            curl -LsSf https://astral.sh/uv/install.sh | sh
+            uv venv --python 3.9
+            uv pip install \
+              nanobind==2.4.0 \
+              cmake \
+              numpy \
+              torch \
+              tensorflow \
+              unittest-xml-reporting
       - run:
           name: Install Python package
           command: |
-            source env/bin/activate
             DEBUG=1 CMAKE_ARGS="-DCMAKE_COMPILE_WARNING_AS_ERROR=ON" \
-              pip install -e . -v
+              uv pip install -e .
       - run:
           name: Generate package stubs
           command: |
-            source env/bin/activate
-            pip install typing_extensions
-            python setup.py generate_stubs
+            uv pip install typing_extensions
+            uv run --no-project setup.py generate_stubs
       - run:
           name: Run Python tests
           command: |
-            source env/bin/activate
+            source .venv/bin/activate
             LOW_MEMORY=1 DEVICE=cpu python -m xmlrunner discover -v python/tests -o test-results/cpu
             LOW_MEMORY=1 DEVICE=gpu METAL_DEVICE_WRAPPER_TYPE=1 METAL_DEBUG_ERROR_MODE=0 python -m xmlrunner discover -v python/tests -o test-results/gpu
             mpirun --bind-to none -host localhost:8 -np 8 -x DYLD_LIBRARY_PATH=/opt/homebrew/lib/ python python/tests/mpi_test_distributed.py
@@ -173,16 +169,15 @@ jobs:
       - run:
           name: Build example extension
           command: |
-            source env/bin/activate
             cd examples/extensions
-            pip install -r requirements.txt
-            python setup.py build_ext -j8
+            uv pip install -r requirements.txt
+            uv run --no-project setup.py build_ext -j8
       - store_test_results:
           path: test-results
       - run:
           name: Build CPP only
           command: |
-            source env/bin/activate
+            source .venv/bin/activate
             mkdir -p build && cd build && cmake .. && make -j `sysctl -n hw.ncpu`
       - run:
           name: Run CPP tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,7 @@ jobs:
       - run:
           name: Run style checks
           command: |
+            curl -LsSf https://astral.sh/uv/install.sh | sh
             uv venv
             uv pip install pre-commit
             uv run --no-project pre-commit run --all
@@ -131,7 +132,8 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            HOMEBREW_NO_AUTO_UPDATE=1 brew install openmpi uv
+            HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 \
+              brew install openmpi uv
             uv venv --python 3.9
             uv pip install \
               nanobind==2.4.0 \
@@ -221,6 +223,7 @@ jobs:
             curl -sL https://github.com/ccache/ccache/releases/download/v4.11.3/ccache-4.11.3-linux-x86_64.tar.xz | tar xJf -
             sudo mv ccache-4.11.3-linux-x86_64/ccache /usr/bin/ccache
             rm -rf ccache-4.11.3-linux-x86_64
+            curl -LsSf https://astral.sh/uv/install.sh | sh
       - run:
           name: Install Python package
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,10 +72,8 @@ jobs:
       - run:
           name: Run style checks
           command: |
-            curl -LsSf https://astral.sh/uv/install.sh | sh
-            uv venv
-            uv pip install pre-commit
-            uv run --no-project pre-commit run --all
+            pip install pre-commit
+            pre-commit run --all
             if ! git diff --quiet; then echo 'Style checks failed, please install pre-commit and run pre-commit run --all and push the change'; exit 1; fi
       - run:
           name: Install dependencies
@@ -85,9 +83,11 @@ jobs:
             sudo apt-get update
             sudo apt-get install -y libblas-dev liblapack-dev liblapacke-dev
             sudo apt-get install openmpi-bin openmpi-common libopenmpi-dev
+            curl -LsSf https://astral.sh/uv/install.sh | sh
       - run:
           name: Install Python package
           command: |
+            uv venv
             uv pip install cmake
             uv pip install -e ".[dev]"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
           command: |
             uv venv
             uv pip install cmake
-            uv pip install -e ".[dev]"
+            uv pip install -e ".[dev]" -v
       - run:
           name: Generate package stubs
           command: |
@@ -146,7 +146,7 @@ jobs:
           name: Install Python package
           command: |
             DEBUG=1 CMAKE_ARGS="-DCMAKE_COMPILE_WARNING_AS_ERROR=ON" \
-              uv pip install -e .
+              uv pip install -e . -v
       - run:
           name: Generate package stubs
           command: |
@@ -229,7 +229,7 @@ jobs:
           command: |
             uv venv
             CMAKE_ARGS="-DMLX_BUILD_CUDA=ON -DCMAKE_CUDA_COMPILER=`which nvcc`" \
-              uv pip install -e ".[dev]"
+              uv pip install -e ".[dev]" -v
       - run:
           name: Run Python tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,19 +84,21 @@ jobs:
             pip install --upgrade cmake
             sudo apt-get install -y libblas-dev liblapack-dev liblapacke-dev
             sudo apt-get install openmpi-bin openmpi-common libopenmpi-dev
+            curl -LsSf https://astral.sh/uv/install.sh | sh
       - run:
           name: Install Python package
           command: |
-            pip install -e ".[dev]"
+            uv venv
+            uv pip install -e ".[dev]"
       - run:
           name: Generate package stubs
           command: |
-            echo "stubs"
-            pip install typing_extensions
-            python setup.py generate_stubs
+            uv pip install typing_extensions
+            uv run --no-project setup.py generate_stubs
       - run:
           name: Run Python tests
           command: |
+            source .venv/bin/activate
             python -m unittest discover python/tests -v
             mpirun --bind-to none -host localhost:8 -np 8 python python/tests/mpi_test_distributed.py
             mlx.launch --verbose -n 8 python/tests/ring_test_distributed.py -v 2> >(tee -a stderr.log >&2)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,6 @@ jobs:
       - run:
           name: Run style checks
           command: |
-            curl -LsSf https://astral.sh/uv/install.sh | sh
             uvx pre-commit run --all
             if ! git diff --quiet; then echo 'Style checks failed, please install pre-commit and run pre-commit run --all and push the change'; exit 1; fi
       - run:
@@ -84,13 +83,13 @@ jobs:
             export DEBIAN_FRONTEND=noninteractive
             export NEEDRESTART_MODE=a
             sudo apt-get update
-            pip install --upgrade cmake
             sudo apt-get install -y libblas-dev liblapack-dev liblapacke-dev
             sudo apt-get install openmpi-bin openmpi-common libopenmpi-dev
       - run:
           name: Install Python package
           command: |
             uv venv
+            uv pip install cmake
             uv pip install -e ".[dev]"
       - run:
           name: Generate package stubs
@@ -108,6 +107,7 @@ jobs:
       - run:
           name: Build CPP only
           command: |
+            source .venv/bin/activate
             mkdir -p build && cd build
             cmake .. -DMLX_BUILD_METAL=OFF -DCMAKE_BUILD_TYPE=DEBUG
             make -j `nproc`
@@ -137,8 +137,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            brew install openmpi
-            curl -LsSf https://astral.sh/uv/install.sh | sh
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install openmpi uv
             uv venv --python 3.9
             uv pip install \
               nanobind==2.4.0 \
@@ -186,7 +185,7 @@ jobs:
       - run:
           name: Build small binary
           command: |
-            source env/bin/activate
+            source .venv/bin/activate
             cd build/
             cmake .. -DCMAKE_BUILD_TYPE=MinSizeRel \
               -DBUILD_SHARED_LIBS=ON \
@@ -198,12 +197,13 @@ jobs:
       - run:
           name: Run Python tests with JIT
           command: |
-            source env/bin/activate
             CMAKE_ARGS="-DMLX_METAL_JIT=ON" \
-              pip install -e . -v
+              uv pip install -e .
             LOW_MEMORY=1 DEVICE=gpu METAL_DEVICE_WRAPPER_TYPE=1 \
               METAL_DEBUG_ERROR_MODE=0 \
-              python -m xmlrunner discover -v python/tests -o test-results/gpu_jit
+              uv run --no-project python -m xmlrunner discover \
+                -v python/tests \
+                -o test-results/gpu_jit
 
   cuda_build_and_test:
     parameters:
@@ -227,7 +227,6 @@ jobs:
             curl -sL https://github.com/ccache/ccache/releases/download/v4.11.3/ccache-4.11.3-linux-x86_64.tar.xz | tar xJf -
             sudo mv ccache-4.11.3-linux-x86_64/ccache /usr/bin/ccache
             rm -rf ccache-4.11.3-linux-x86_64
-            curl -LsSf https://astral.sh/uv/install.sh | sh
       - run:
           name: Install Python package
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,9 @@ jobs:
           command: |
             HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 \
               brew install openmpi uv
+      - run:
+          name: Install Python package
+          command: |
             uv venv --python 3.9
             uv pip install \
               nanobind==2.4.0 \
@@ -142,9 +145,6 @@ jobs:
               torch \
               tensorflow \
               unittest-xml-reporting
-      - run:
-          name: Install Python package
-          command: |
             DEBUG=1 CMAKE_ARGS="-DCMAKE_COMPILE_WARNING_AS_ERROR=ON" \
               uv pip install -e . -v
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,9 +69,6 @@ jobs:
       resource_class: large
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - cpu-{{ arch }}-
       - run:
           name: Run style checks
           command: |
@@ -114,10 +111,6 @@ jobs:
       - run:
           name: Run CPP tests
           command: ./build/tests/tests
-      - save_cache:
-          key: cpu-{{ arch }}-{{ epoch }}
-          paths:
-            - /home/circleci/.cache/uv
 
   mac_build_and_test:
     parameters:
@@ -250,7 +243,6 @@ jobs:
           key: cuda-<< parameters.image_date >>-{{ arch }}-{{ epoch }}
           paths:
             - /home/circleci/.cache/ccache
-            - /home/circleci/.cache/uv
 
   build_release:
     parameters:


### PR DESCRIPTION
Reduce the time spent on installing dependencies by:

* removing redundant `apt-install`s
* using uv to install python packages

Reduced time:

* `cuda_build_and_test`:
  * Install python package: 3m14s => 1m12s
* `linux_build_and_test`:
  * Install dependencies: 3m9s => 25s
  * Install python package: 4m17s => 3m26s
* `mac_build_and_test`:
  * Install dependencies: 1m19s => 22s
