### PR TITLE
Add missing algorithm header to jit_compiler.cpp for Linux builds

### DIFF
--- a/mlx/backend/cpu/jit_compiler.cpp
+++ b/mlx/backend/cpu/jit_compiler.cpp
@@ -2,6 +2,7 @@
 
 #include "mlx/backend/cpu/jit_compiler.h"
 
+#include <algorithm>
 #include <sstream>
 #include <vector>
 


### PR DESCRIPTION
## Summary

This PR fixes issue #2459 by adding the missing algorithm header to mlx/backend/cpu/jit_compiler.cpp.

## Problem

The file uses std::find_if on line 121 but wasn't including the algorithm header that defines it. While this might work on some platforms where algorithm is transitively included through other headers, it's not guaranteed by the C++ standard. On Linux with GCC/Clang, the transitive inclusion doesn't happen, causing build failures.

## Solution

Added include algorithm to the includes section of jit_compiler.cpp to explicitly include the header that defines std::find_if.

## Testing

- Built successfully on macOS with Clang  
- All existing tests pass (225 test cases, 3290 assertions)
- The change is minimal and safe - only adds a required header

## Related Issues

Fixes #2459