### PR TITLE
Fix typo in metal command encoder

### DIFF
--- a/mlx/backend/metal/device.h
+++ b/mlx/backend/metal/device.h
@@ -104,7 +104,7 @@ struct CommandEncoder {
   };
 
   // Outputs of all kernels in the encoder including temporaries
-  std::unordered_set<const void*> outputs() {
+  std::unordered_set<const void*>& outputs() {
     return all_outputs_;
   };
 


### PR DESCRIPTION
Closes #2467 .

Thanks @ethereon for pointing it out!

The encoder is made anew when we commit it so we aren't really leaking anything but the intermediate optimization of removing temps and moving the outputs into the handler is indeed moot given it returns a copy.