### PR TITLE
Add CyclicLR scheduler

### DIFF
--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -20,6 +20,7 @@ MLX was developed with contributions from the following individuals:
 - Paul Paczuski: Improved stability of BCE loss calculation
 - Max-Heinrich Laves: Added `conv_transpose1d`, `conv_transpose2d`, and `conv_transpose3d` ops.
 - Gökdeniz Gülmez: Added the `Muon (MomentUm Orthogonalized by Newton-schulz)` optimizer.
+- Vincent Amato: Added `cyclic_lr` scheduler.
 
 <a href="https://github.com/ml-explore/mlx/graphs/contributors">
   <img class="dark-light" src="https://contrib.rocks/image?repo=ml-explore/mlx&anon=0&columns=20&max=100&r=true" />

--- a/docs/src/python/optimizers/schedulers.rst
+++ b/docs/src/python/optimizers/schedulers.rst
@@ -8,8 +8,9 @@ Schedulers
 .. autosummary::
    :toctree: _autosummary
 
-   cosine_decay    
-   exponential_decay    
+   cosine_decay
+   cyclic_lr
+   exponential_decay
    join_schedules
    linear_schedule
    step_decay    

--- a/python/tests/test_optimizers.py
+++ b/python/tests/test_optimizers.py
@@ -446,6 +446,23 @@ class TestSchedulers(mlx_tests.MLXTestCase):
         lr = lr_schedule(20)
         self.assertEqual(lr, expected_end_lr)
 
+    def test_cyclic_lr(self):
+        lr_schedule = opt.cyclic_lr(0.001, 0.1, step_size_up=10)
+
+        lr = lr_schedule(0)
+        self.assertAlmostEqual(lr, 0.001, delta=1e-7)
+
+        lr = lr_schedule(10)
+        self.assertAlmostEqual(lr, 0.1, delta=1e-7)
+
+        lr = lr_schedule(20)
+        self.assertAlmostEqual(lr, 0.001, delta=1e-7)
+
+        lr_schedule = opt.cyclic_lr(0.001, 0.1, step_size_up=5, mode="triangular2")
+        lr = lr_schedule(15)
+        expected_lr = 0.001 + (0.1 - 0.001) * 0.5
+        self.assertAlmostEqual(lr, expected_lr, delta=1e-6)
+
     def test_schedule_joiner(self):
         boundaries = [2, 3, 4]
         schedules = [lambda _: 3, lambda _: 4, lambda _: 5]


### PR DESCRIPTION
## Proposed changes

- Implements cyclical learning rate with triangular wave patterns (CLR)
- Supports three scaling modes (`triangular`, `triangular2`, `exp_range`) and asymmetric cycles
- Includes comprehensive tests and documentation

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
