### PR TITLE
Add AdaptiveMaxPool1d, AdaptiveMaxPool2d, and AdaptiveMaxPool3d layers

### DIFF
--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -20,6 +20,7 @@ MLX was developed with contributions from the following individuals:
 - Paul Paczuski: Improved stability of BCE loss calculation
 - Max-Heinrich Laves: Added `conv_transpose1d`, `conv_transpose2d`, and `conv_transpose3d` ops.
 - Gökdeniz Gülmez: Added the `Muon (MomentUm Orthogonalized by Newton-schulz)` optimizer.
+- Vincent Amato: Added adaptive max pooling layers: `AdaptiveMaxPool1d`, `AdaptiveMaxPool2d`, and `AdaptiveMaxPool3d`.
 
 <a href="https://github.com/ml-explore/mlx/graphs/contributors">
   <img class="dark-light" src="https://contrib.rocks/image?repo=ml-explore/mlx&anon=0&columns=20&max=100&r=true" />

--- a/docs/src/python/nn/layers.rst
+++ b/docs/src/python/nn/layers.rst
@@ -9,6 +9,9 @@ Layers
    :toctree: _autosummary
    :template: nn-module-template.rst
 
+   AdaptiveMaxPool1d
+   AdaptiveMaxPool2d
+   AdaptiveMaxPool3d
    ALiBi
    AvgPool1d
    AvgPool2d

--- a/python/mlx/nn/layers/__init__.py
+++ b/python/mlx/nn/layers/__init__.py
@@ -77,6 +77,9 @@ from mlx.nn.layers.normalization import (
     RMSNorm,
 )
 from mlx.nn.layers.pooling import (
+    AdaptiveMaxPool1d,
+    AdaptiveMaxPool2d,
+    AdaptiveMaxPool3d,
     AvgPool1d,
     AvgPool2d,
     AvgPool3d,


### PR DESCRIPTION
## Proposed changes

- Added `AdaptiveMaxPool1d`, `AdaptiveMaxPool2d`, and `AdaptiveMaxPool3d` layers
- Handles all edge cases including larger output than input and None dimensions
- Complete integration with documentation, exports, and proper error handling
- Comprehensive test coverage ensuring correctness

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
