### PR TITLE
Use CMake <4.1 to avoid the nvpl error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,6 @@
 requires = [
   "setuptools>=80",
   "nanobind==2.4.0",
-  "cmake>=3.25",
+  "cmake>=3.25,<4.1",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
For now use CMake versions <4.1 to avoid the NVPL error so that CI works again.