### PR TITLE
Fix wrong strides when inserting a dim with expand_dims

### DIFF
--- a/mlx/backend/common/common.cpp
+++ b/mlx/backend/common/common.cpp
@@ -78,9 +78,17 @@ void Depends::eval(
 void ExpandDims::eval(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 1);
   const auto& in = inputs[0];
+  auto shape = in.shape();
   auto strides = in.strides();
-  for (auto ax : axes_) {
-    strides.insert(strides.begin() + ax, 1);
+  for (int ax : axes_) {
+    int64_t stride;
+    if (ax >= strides.size()) {
+      stride = strides.empty() ? 1 : strides.back();
+    } else {
+      stride = shape[ax] * strides[ax];
+    }
+    shape.insert(shape.begin() + ax, 1);
+    strides.insert(strides.begin() + ax, stride);
   }
   out.copy_shared_buffer(in, strides, in.flags(), in.data_size());
 }

--- a/python/tests/cuda_skip.py
+++ b/python/tests/cuda_skip.py
@@ -14,7 +14,6 @@ cuda_skip = {
     "TestOps.test_hadamard",
     "TestOps.test_hadamard_grad_vmap",
     # Convolutions NYI
-    "TestConv.test_1d_conv_with_2d",
     "TestConv.test_conv_1d_groups_flipped",
     "TestConv.test_conv_general_flip_grad",
     "TestConv.test_torch_conv_2D",

--- a/tests/ops_tests.cpp
+++ b/tests/ops_tests.cpp
@@ -206,6 +206,24 @@ TEST_CASE("test squeeze and expand") {
   CHECK_THROWS(expand_dims(x, -4));
   CHECK_THROWS(expand_dims(x, {0, 1, 0}));
   CHECK_THROWS(expand_dims(x, {0, 1, -4}));
+
+  x = zeros({2, 2, 2});
+  array y = expand_dims(x, 0);
+  CHECK_EQ(y.shape(), Shape{1, 2, 2, 2});
+  y.eval();
+  CHECK_EQ(y.strides(), Strides{8, 4, 2, 1});
+  y = expand_dims(x, -1);
+  CHECK_EQ(y.shape(), Shape{2, 2, 2, 1});
+  y.eval();
+  CHECK_EQ(y.strides(), Strides{4, 2, 1, 1});
+  y = expand_dims(x, 1);
+  CHECK_EQ(y.shape(), Shape{2, 1, 2, 2});
+  y.eval();
+  CHECK_EQ(y.strides(), Strides{4, 4, 2, 1});
+  y = expand_dims(x, {0, 1, 2, 3});
+  CHECK_EQ(y.shape(), Shape{1, 1, 1, 1, 2, 2, 2});
+  y.eval();
+  CHECK_EQ(y.strides(), Strides{8, 8, 8, 8, 4, 2, 1});
 }
 
 TEST_CASE("test slice") {


### PR DESCRIPTION
Normally the stride of a dim with size-one does not matter, but when passing the strides to cuDNN it would lead to wrong results.