### PR TITLE
Fix overflow in large filter small channels

### DIFF
--- a/mlx/backend/metal/kernels/steel/conv/loaders/loader_channel_n.h
+++ b/mlx/backend/metal/kernels/steel/conv/loaders/loader_channel_n.h
@@ -83,7 +83,7 @@ struct Conv2DInputBlockLoaderSmallChannels {
   const constant MLXConvParams<2>* params;
   const constant ImplicitGemmConv2DParams* gemm_params;
 
-  short weight_hw;
+  int weight_hw;
 
   const device T* src[n_rows];
 

--- a/python/tests/test_conv.py
+++ b/python/tests/test_conv.py
@@ -1186,6 +1186,13 @@ class TestConv(mlx_tests.MLXTestCase):
         y_hat = mx.conv2d(x, w)
         self.assertTrue(mx.allclose(y, y_hat))
 
+    def test_conv2d_large_filter_small_channels(self):
+        x = mx.random.normal(shape=(1, 181, 181, 1))
+        w = mx.random.normal(shape=(1, 182, 182, 1))
+        y = mx.conv2d(x, w, (1, 1), (1, 1), stream=mx.cpu)
+        y_hat = mx.conv2d(x, w, (1, 1), (1, 1))
+        self.assertTrue(mx.allclose(y, y_hat, rtol=1e-3, atol=1e-3))
+
 
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner()


### PR DESCRIPTION
Fixes #2504. 

No perf regression on the following benchmark.

```python
import time
import mlx.core as mx


def bench(x, w):
    start = time.time()
    for i in range(10):
        outs = [mx.conv2d(x, w, (1, 1), (1, 1)) for i in range(10)]
        mx.eval(outs)
    end = time.time()
    return end-start

x = mx.random.normal((16, 224, 224, 3))
w = mx.random.normal((32, 4, 4, 3))
mx.eval(x, w)

print(bench(x, w))
print(bench(x, w))
```

In case it isn't clear where the overflow is, it happens on line 191 and it affects us on line 135 where instead of zeroing out the oob part of the tile we keep reading cause `weight_hw` has become negative :-) . Doing `ushort` would be correct for filters up to 255x255 but I think using `int` is fine.