### PR TITLE
[CUDA] Fix stride of singleton dims before passing to cuDNN

### DIFF
--- a/python/tests/cuda_skip.py
+++ b/python/tests/cuda_skip.py
@@ -13,8 +13,6 @@ cuda_skip = {
     # Hadamard NYI
     "TestOps.test_hadamard",
     "TestOps.test_hadamard_grad_vmap",
-    # Convolutions NYI
-    "TestConv.test_1d_conv_with_2d",
     # FFTs NYI
     "TestFFT.test_fft",
     "TestFFT.test_fft_big_powers_of_two",


### PR DESCRIPTION
This fixes the last failed conv test, the reason behind the change can be found in the code comment.