### PR TITLE
Fix docs omission

### DIFF
--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -70,6 +70,7 @@ are the CPU and GPU.
    python/fft
    python/linalg
    python/metal
+   python/cuda
    python/memory_management
    python/nn
    python/optimizers


### PR DESCRIPTION
Forgot to add the `cuda` page to a toctree.