### PR TITLE
Enable COMPILE_WARNING_AS_ERROR for linux builds in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,8 @@ jobs:
           command: |
             uv venv
             uv pip install cmake
-            uv pip install -e ".[dev]" -v
+            DEBUG=1 CMAKE_ARGS="-DCMAKE_COMPILE_WARNING_AS_ERROR=ON" \
+              uv pip install -e ".[dev]" -v
       - run:
           name: Generate package stubs
           command: |
@@ -231,7 +232,7 @@ jobs:
           name: Install Python package
           command: |
             uv venv
-            CMAKE_ARGS="-DMLX_BUILD_CUDA=ON -DCMAKE_CUDA_COMPILER=`which nvcc`" \
+            DEBUG=1 CMAKE_ARGS="-DMLX_BUILD_CUDA=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DCMAKE_CUDA_COMPILER=`which nvcc`" \
               uv pip install -e ".[dev]" -v
       - run:
           name: Run Python tests

--- a/mlx/io/CMakeLists.txt
+++ b/mlx/io/CMakeLists.txt
@@ -11,7 +11,7 @@ if(MLX_BUILD_GGUF)
   FetchContent_Declare(
     gguflib
     GIT_REPOSITORY https://github.com/antirez/gguf-tools/
-    GIT_TAG af7d88d808a7608a33723fba067036202910acb3)
+    GIT_TAG 8fa6eb65236618e28fd7710a0fba565f7faa1848)
   FetchContent_MakeAvailable(gguflib)
   target_include_directories(mlx
                              PRIVATE $<BUILD_INTERFACE:${gguflib_SOURCE_DIR}>)


### PR DESCRIPTION
Also update gguf-tools to fix compile warnings.