### PR TITLE
Use nccl header only when nccl is not present

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -394,7 +394,7 @@ jobs:
         default: ""
     machine:
       image: ubuntu-2204:current
-      resource_class: large
+      resource_class: xlarge
     steps:
       - checkout
       - run:

--- a/mlx/distributed/nccl/CMakeLists.txt
+++ b/mlx/distributed/nccl/CMakeLists.txt
@@ -1,8 +1,20 @@
 if(MLX_BUILD_CUDA)
   target_sources(mlx PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/nccl.cpp)
-  find_package(NCCL REQUIRED)
-  target_link_libraries(mlx PRIVATE ${NCCL_LIBRARIES})
-  target_include_directories(mlx PRIVATE ${NCCL_INCLUDE_DIRS})
+  find_package(NCCL)
+  if(NCCL_FOUND)
+    target_link_libraries(mlx PRIVATE ${NCCL_LIBRARIES})
+    target_include_directories(mlx PRIVATE ${NCCL_INCLUDE_DIRS})
+  else()
+    message(
+      STATUS
+        "NCCL not found, using stubs. To run distributed with NCCL backend, install NCCL."
+    )
+    file(
+      DOWNLOAD
+      "https://raw.githubusercontent.com/NVIDIA/nccl/refs/tags/v2.27.5-1/src/nccl.h.in"
+      "${CMAKE_CURRENT_BINARY_DIR}/nccl.h")
+    target_include_directories(mlx PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
+  endif()
 else()
   target_sources(mlx PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/no_nccl.cpp)
 endif()


### PR DESCRIPTION
This downlaods nccl.h if NCCL is not installed. It's really intended for building the MLX CUDA back-end on a CPU-only machine (where it won't be run)so we can do the PyPi release.

It may be an issue if someone build from source without NCCL since I think it will be a link error rather than run without NCCL. So it might be good to require NCCL unless a specific flag is passed.. 