### PR TITLE
[CUDA] Use ConcurrentContext in concatenate_gpu

### DIFF
--- a/mlx/backend/cuda/slicing.cpp
+++ b/mlx/backend/cuda/slicing.cpp
@@ -30,8 +30,7 @@ void concatenate_gpu(
   flags.row_contiguous = false;
   flags.col_contiguous = false;
   flags.contiguous = false;
-  // TODO: Handle concurrent outputs:
-  // https://github.com/ml-explore/mlx/pull/2145#discussion_r2070753816
+  auto concurrent = cu::get_command_encoder(s).concurrent_context();
   for (int i = 0; i < inputs.size(); i++) {
     array out_slice(inputs[i].shape(), out.dtype(), nullptr, {});
     size_t data_offset = strides[axis] * sizes[i];


### PR DESCRIPTION
Re-land https://github.com/ml-explore/mlx/pull/2531.

After more testings we believe there is no negative affects on performance for inference or trainings, and for simple test (https://github.com/ml-explore/mlx/pull/2531#issuecomment-3216218740) this made it 10% faster.