### PR TITLE
chore: Update Docs With Slice Copy Example

### DIFF
--- a/docs/src/usage/indexing.rst
+++ b/docs/src/usage/indexing.rst
@@ -107,8 +107,19 @@ same array:
   >>> a
   array([1, 2, 0], dtype=int32)
 
+Note that unlike NumPy, mutating a variable bound to a slice creates a copy and does not mutate the original array:
 
-Note, unlike NumPy, updates to the same location are nondeterministic:
+.. code-block:: shell
+
+  >>> a = mx.array([1, 2, 3])
+  >>> b = a[:]
+  >>> b[2] = 0
+  >>> b
+  array([1, 2, 0], dtype=int32)
+  >>> a
+  array([1, 2, 3], dtype=int32)
+
+Also unlike NumPy, updates to the same location are nondeterministic:
 
 .. code-block:: shell
 

--- a/docs/src/usage/indexing.rst
+++ b/docs/src/usage/indexing.rst
@@ -107,7 +107,8 @@ same array:
   >>> a
   array([1, 2, 0], dtype=int32)
 
-Note that unlike NumPy, mutating a variable bound to a slice creates a copy and does not mutate the original array:
+Note that unlike NumPy, slicing an array creates a copy, not a view. So
+mutating it does not mutate the original array:
 
 .. code-block:: shell
 


### PR DESCRIPTION
## Proposed changes

Issue #2208 points out that unlike NumPy, modifying a slice does not modify the original array. This update to the documentation in `Indexing Arrays > In Place Updates` clearly describes this behaviour so that people coming from NumPy are aware of the difference


<img width="1702" height="528" alt="image" src="https://github.com/user-attachments/assets/0a0ca8d9-2dc4-4d4b-84ea-7b6bf7c83c16" />


## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
