### PR TITLE
Fix dequantize python sig

### DIFF
--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -4271,7 +4271,7 @@ void init_ops(nb::module_& m) {
       nb::kw_only(),
       "stream"_a = nb::none(),
       nb::sig(
-          "def dequantize(w: array, /, scales: array, biases: Optional[array] = = None, group_size: int = 64, bits: int = 4, mode: str = 'affine', *, stream: Union[None, Stream, Device] = None) -> array"),
+          "def dequantize(w: array, /, scales: array, biases: Optional[array] = None, group_size: int = 64, bits: int = 4, mode: str = 'affine', *, stream: Union[None, Stream, Device] = None) -> array"),
       R"pbdoc(
         Dequantize the matrix ``w`` using quantization parameters.
 


### PR DESCRIPTION
## Proposed changes

The `dequantize` op was [recently changed](https://github.com/ml-explore/mlx/commit/70560b6bd5324efbfd9f97c9076c884d21ffac34#diff-8a607e80673e9f8e9c1e73a5aba9d6f89ac56ad34765e4022d5130f890776cacR4167-R4274) to have a broken type signature, breaking mypy checks against it:

```
.venvs/default/lib/python3.13/site-packages/mlx/core/__init__.pyi:1653:71: error: Invalid syntax  [syntax]
    def dequantize(w: array, /, scales: array, biases: Optional[array] = = None, group_size: int = 64, bit...
```



## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
