### PR TITLE
fix: library loading for swift dynamic frameworks

### DIFF
--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -127,12 +127,18 @@ MTL::Library* load_default_library(MTL::Device* device) {
     return lib;
   }
 
+  // Try lo load resources from Framework resources if SwiftPM wrapped as a dynamic framework.
+  std::tie(lib, error[3]) = load_colocated_library(device, "Resources/default");
+  if (lib) {
+    return lib;
+  }
+
   // Finally try default_mtllib_path
-  std::tie(lib, error[3]) = load_library_from_path(device, default_mtllib_path);
+  std::tie(lib, error[4]) = load_library_from_path(device, default_mtllib_path);
   if (!lib) {
     std::ostringstream msg;
     msg << "Failed to load the default metallib. ";
-    for (int i = 0; i < 4; i++) {
+    for (int i = 0; i < 5; i++) {
       if (error[i] != nullptr) {
         msg << error[i]->localizedDescription()->utf8String() << " ";
       }

--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -108,7 +108,7 @@ std::pair<MTL::Library*, NS::Error*> load_swiftpm_library(
 }
 
 MTL::Library* load_default_library(MTL::Device* device) {
-  NS::Error* error[4];
+  NS::Error* error[5];
   MTL::Library* lib;
   // First try the colocated mlx.metallib
   std::tie(lib, error[0]) = load_colocated_library(device, "mlx");
@@ -127,7 +127,8 @@ MTL::Library* load_default_library(MTL::Device* device) {
     return lib;
   }
 
-  // Try lo load resources from Framework resources if SwiftPM wrapped as a dynamic framework.
+  // Try lo load resources from Framework resources if SwiftPM wrapped as a
+  // dynamic framework.
   std::tie(lib, error[3]) = load_colocated_library(device, "Resources/default");
   if (lib) {
     return lib;


### PR DESCRIPTION
## Proposed changes


By default, Dynamic Framework doesn't create a resources bundle and packs all resources inside its own `Resources` folder. 

To fix the issue related to SwiftPM, add try loading metal library from `Framework/../Resources/default.metallib` when `mlx` codebase is built as a dynamic framework.


## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
