### PR TITLE
Set ccache size before building

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,6 +231,9 @@ jobs:
             rm -rf ccache-4.11.3-linux-x86_64
             curl -LsSf https://astral.sh/uv/install.sh | sh
       - run:
+          name: Set CCache size
+          command: ccache --max-size 1G
+      - run:
           name: Install Python package
           command: |
             uv venv
@@ -260,7 +263,6 @@ jobs:
           command: |
             ccache --show-stats
             ccache --zero-stats
-            ccache --max-size 400MB
             ccache --cleanup
       - save_cache:
           key: cuda-<< parameters.image_date >>-{{ arch }}-{{ epoch }}


### PR DESCRIPTION
The cache miss is very high in CUDA build recently:

```
Cacheable calls:    415 / 415 (100.0%)
  Hits:             180 / 415 (43.37%)
    Direct:         176 / 180 (97.78%)
    Preprocessed:     4 / 180 ( 2.22%)
  Misses:           235 / 415 (56.63%)
Local storage:
  Cache size (GiB): 0.6 / 5.0 (11.22%)
  Cleanups:         124
  Hits:             180 / 415 (43.37%)
  Misses:           235 / 415 (56.63%)
Statistics zeroed
Set cache size limit to 400.0 MB
Cleaning... 100.0%
```

It seems that ccache removed recent caches when doing cleaning, setting cache size being building should be able to make things work better, also increase the cache size a bit.