### PR TITLE
Support pickling array for bfloat16

### DIFF
--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -466,7 +466,14 @@ void init_array(nb::module_& m) {
           })
       .def(
           "__iter__", [](const mx::array& a) { return ArrayPythonIterator(a); })
-      .def("__getstate__", &mlx_to_np_array)
+      .def(
+          "__getstate__",
+          [](const mx::array& arr) {
+            if (arr.dtype() == mx::bfloat16) {
+              return mlx_to_np_array(mx::astype(arr, mx::float32));
+            }
+            return mlx_to_np_array(arr);
+          })
       .def(
           "__setstate__",
           [](mx::array& arr,

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -532,7 +532,7 @@ class TestArray(mlx_tests.MLXTestCase):
         self.assertEqual(str(x), expected)
 
         x = mx.array([[1, 2], [1, 2], [1, 2]])
-        expected = "array([[1, 2],\n" "       [1, 2],\n" "       [1, 2]], dtype=int32)"
+        expected = "array([[1, 2],\n       [1, 2],\n       [1, 2]], dtype=int32)"
         self.assertEqual(str(x), expected)
 
         x = mx.array([[[1, 2], [1, 2]], [[1, 2], [1, 2]]])
@@ -886,6 +886,7 @@ class TestArray(mlx_tests.MLXTestCase):
             mx.uint64,
             mx.float16,
             mx.float32,
+            mx.bfloat16,
             mx.complex64,
         ]
 
@@ -893,12 +894,10 @@ class TestArray(mlx_tests.MLXTestCase):
             x = mx.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], dtype=dtype)
             state = pickle.dumps(x)
             y = pickle.loads(state)
-            self.assertEqualArray(y, x)
-
-        # check if it throws an error when dtype is not supported (bfloat16)
-        x = mx.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], dtype=mx.bfloat16)
-        with self.assertRaises(TypeError):
-            pickle.dumps(x)
+            if dtype == mx.bfloat16:
+                self.assertEqualArray(y.astype(mx.float32), x.astype(mx.float32))
+            else:
+                self.assertEqualArray(y, x)
 
     def test_array_copy(self):
         dtypes = [


### PR DESCRIPTION
## Proposed changes

Upcast to `float32` to preserve precision.

closes #795 

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
