### PR TITLE
Fix a few ccache cache miss

### DIFF
--- a/mlx/version.cpp
+++ b/mlx/version.cpp
@@ -1,10 +1,8 @@
 // Copyright © 2025 Apple Inc.
 
-#include <string>
-
 namespace mlx::core {
 
-std::string version() {
+const char* version() {
   return MLX_VERSION;
 }
 

--- a/mlx/version.h
+++ b/mlx/version.h
@@ -15,6 +15,6 @@ namespace mlx::core {
  *
  * For dev builds, the version will include the suffix ".devYYYYMMDD+hash"
  */
-std::string version();
+const char* version();
 
 } // namespace mlx::core

--- a/python/src/CMakeLists.txt
+++ b/python/src/CMakeLists.txt
@@ -52,7 +52,6 @@ set_target_properties(
              ${MLX_PYTHON_BINDINGS_OUTPUT_DIRECTORY})
 
 target_link_libraries(core PRIVATE mlx)
-target_compile_definitions(core PRIVATE _VERSION_=${MLX_VERSION})
 
 if(BUILD_SHARED_LIBS)
   if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/python/src/mlx.cpp
+++ b/python/src/mlx.cpp
@@ -2,9 +2,9 @@
 
 #include <nanobind/nanobind.h>
 
-#define STRINGIFY(x) #x
-#define TOSTRING(x) STRINGIFY(x)
+#include "mlx/version.h"
 
+namespace mx = mlx::core;
 namespace nb = nanobind;
 
 void init_mlx_func(nb::module_&);
@@ -48,5 +48,5 @@ NB_MODULE(core, m) {
   init_distributed(m);
   init_export(m);
 
-  m.attr("__version__") = TOSTRING(_VERSION_);
+  m.attr("__version__") = mx::version();
 }

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,8 @@ class CMakeBuild(build_ext):
             build_args += [f"-j{os.cpu_count()}"]
 
         # Avoid cache miss when building from temporary dirs.
-        os.environ["CCACHE_BASEDIR"] = os.path.abspath(self.build_temp)
+        os.environ["CCACHE_BASEDIR"] = os.path.realpath(self.build_temp)
+        os.environ["CCACHE_NOHASHDIR"] = "true"
 
         subprocess.run(
             ["cmake", ext.sourcedir, *cmake_args], cwd=build_temp, check=True


### PR DESCRIPTION
Fix ccache cache misses caused by building in temporary directories, also remove the `_VERSION_` define in python binding code which causes a lot of unnecessary re-compilations.