### PR TITLE
Fix flaky addmm tests

### DIFF
--- a/python/tests/test_blas.py
+++ b/python/tests/test_blas.py
@@ -702,7 +702,7 @@ class TestBlas(mlx_tests.MLXTestCase):
             b = mx.ones((5, 5))
             out = mx.addmm(a, b, a, beta=beta, alpha=alpha)
             expected = beta * a + alpha * (b @ a)
-            self.assertTrue(mx.allclose(expected, out))
+            self.assertTrue(mx.allclose(expected, out, atol=1e-5))
 
             # Broadcast c
             a = mx.ones((5, 5))
@@ -710,7 +710,7 @@ class TestBlas(mlx_tests.MLXTestCase):
             c = mx.ones((1, 5))
             out = mx.addmm(c, a, b, beta=beta, alpha=alpha)
             expected = beta * c + alpha * (a @ b)
-            self.assertTrue(mx.allclose(expected, out))
+            self.assertTrue(mx.allclose(expected, out, atol=1e-5))
 
     def test_addmm_grad(self):
         def make_ref_addmm(alpha, beta):


### PR DESCRIPTION
It seems that the test is a bit flaky:

```
======================================================================
FAIL: test_addmm (test_blas.TestBlas.test_addmm)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/circleci/project/python/tests/test_blas.py", line 713, in test_addmm
    self.assertTrue(mx.allclose(expected, out))
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: array(False, dtype=bool) is not true

----------------------------------------------------------------------
```

This PR adds `atol=1e-5` which all other `addmm` tests already did.