### PR TITLE
[CUDA] Fix NCCL stub for release build

### DIFF
--- a/mlx/distributed/nccl/nccl_stub/CMakeLists.txt
+++ b/mlx/distributed/nccl/nccl_stub/CMakeLists.txt
@@ -8,6 +8,7 @@ file(
   "${CMAKE_CURRENT_BINARY_DIR}/nccl.h")
 
 add_library(nccl SHARED nccl_stubs.cpp)
+set_target_properties(nccl PROPERTIES SOVERSION 2)
 find_package(CUDAToolkit REQUIRED)
 target_include_directories(nccl PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
 target_include_directories(nccl PRIVATE ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
Set the version for the `so` so it find the right library.