### PR TITLE
Add gated rms norm

### DIFF
--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -19,7 +19,7 @@ MLX was developed with contributions from the following individuals:
 - Gleb Pobudzey: Added the `where` primitive, and groups in 1D and 2D convolutions.
 - Paul Paczuski: Improved stability of BCE loss calculation
 - Max-Heinrich Laves: Added `conv_transpose1d`, `conv_transpose2d`, and `conv_transpose3d` ops.
-- Gökdeniz Gülmez: Added the `Muon (MomentUm Orthogonalized by Newton-schulz)` optimizer, and the `ReLU²` activation function.
+- - Gökdeniz Gülmez: Added the `Muon (MomentUm Orthogonalized by Newton-schulz)` optimizer, the `ReLU²` activation function, and the `Gated Root Mean Square Layer Normalisation` layer.
 
 <a href="https://github.com/ml-explore/mlx/graphs/contributors">
   <img class="dark-light" src="https://contrib.rocks/image?repo=ml-explore/mlx&anon=0&columns=20&max=100&r=true" />

--- a/docs/src/python/nn/layers.rst
+++ b/docs/src/python/nn/layers.rst
@@ -49,6 +49,7 @@ Layers
    QuantizedEmbedding
    QuantizedLinear
    RMSNorm
+   GatedRMSNorm
    ReLU
    ReLU2
    ReLU6

--- a/python/mlx/nn/layers/__init__.py
+++ b/python/mlx/nn/layers/__init__.py
@@ -77,7 +77,7 @@ from mlx.nn.layers.normalization import (
     InstanceNorm,
     LayerNorm,
     RMSNorm,
-    GatedRMSNorm
+    GatedRMSNorm,
 )
 from mlx.nn.layers.pooling import (
     AvgPool1d,

--- a/python/mlx/nn/layers/__init__.py
+++ b/python/mlx/nn/layers/__init__.py
@@ -77,6 +77,7 @@ from mlx.nn.layers.normalization import (
     InstanceNorm,
     LayerNorm,
     RMSNorm,
+    GatedRMSNorm
 )
 from mlx.nn.layers.pooling import (
     AvgPool1d,

--- a/python/mlx/nn/layers/__init__.py
+++ b/python/mlx/nn/layers/__init__.py
@@ -73,11 +73,11 @@ from mlx.nn.layers.embedding import Embedding
 from mlx.nn.layers.linear import Bilinear, Identity, Linear
 from mlx.nn.layers.normalization import (
     BatchNorm,
+    GatedRMSNorm,
     GroupNorm,
     InstanceNorm,
     LayerNorm,
     RMSNorm,
-    GatedRMSNorm,
 )
 from mlx.nn.layers.pooling import (
     AvgPool1d,

--- a/python/mlx/nn/layers/normalization.py
+++ b/python/mlx/nn/layers/normalization.py
@@ -3,8 +3,9 @@
 from typing import Tuple
 
 import mlx.core as mx
-from mlx import nn
 from mlx.nn.layers.base import Module
+
+from mlx import nn
 
 
 class InstanceNorm(Module):
@@ -185,9 +186,7 @@ class GatedRMSNorm(Module):
         self.gate_before_norm = gate_before_norm
 
     def _extra_repr(self):
-        return (
-            f"{self.weight.shape[0]}, eps={self.eps}, gate_before_norm={self.gate_before_norm}"
-        )
+        return f"{self.weight.shape[0]}, eps={self.eps}, gate_before_norm={self.gate_before_norm}"
 
     def __call__(self, x):
         gate = nn.silu(self["gate"])


### PR DESCRIPTION
## Proposed changes

added this for Mamba2, NemotronH and Qwen3Next, using the gate_before_norm True for mamba2 and also for qwen3next.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
