### PR TITLE
Avoid producing NaN in attention

### DIFF
--- a/mlx/fast.cpp
+++ b/mlx/fast.cpp
@@ -732,10 +732,7 @@ array scaled_dot_product_attention(
       }
       if (mask.dtype() == bool_) {
         scores = where(
-            mask,
-            scores,
-            array(-std::numeric_limits<float>::infinity(), scores.dtype()),
-            s);
+            mask, scores, array(finfo(scores.dtype()).min, scores.dtype()), s);
       } else {
         scores = add(scores, mask, s);
       }


### PR DESCRIPTION
As it turns out.. producing NaNs in the attention when an entire row of keys is masked is quite inconvenient for batching. In that case the NaNs can propagate which breaks everything.

The simplest fix is to avoid producing NaNs when an entire row is masked. This changes the behavior from before.

It also aligns prompt processing for the fallback fast SDPA with the fused SDPA (which already did not produce NaNs).