### PR TITLE
Lower sorted QMM gather threshold

### DIFF
--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -948,8 +948,8 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
   // We are walking x in order and w is also in order so we can batch up the
   // matmuls and reuse reading x and w.
   //
-  // TODO: Tune 16 and 8 here a bit better.
-  if (M == 1 && B >= 16 && right_sorted_ == true && B / E >= 8) {
+  // TODO: Tune 16 and 4 here a bit better.
+  if (M == 1 && B >= 16 && right_sorted_ == true && B / E >= 4) {
     gather_qmm_rhs(
         x,
         w,


### PR DESCRIPTION
With GPT OSS for short prompts (256) it's much faster:

Pre: prompt_tps=480.979
Post: prompt_tps=974.984