### PR TITLE
Allocator fix

### DIFF
--- a/mlx/backend/cuda/allocator.cpp
+++ b/mlx/backend/cuda/allocator.cpp
@@ -94,7 +94,6 @@ Buffer CudaAllocator::malloc(size_t size) {
   // Find available buffer from cache.
   auto orig_size = size;
   std::unique_lock lock(mutex_);
-
   if (size <= small_block_size) {
     size = small_block_size;
   } else if (size < page_size) {
@@ -132,7 +131,6 @@ Buffer CudaAllocator::malloc(size_t size) {
       lock.lock();
     }
   }
-
   active_memory_ += size;
   peak_memory_ = std::max(active_memory_, peak_memory_);
 


### PR DESCRIPTION
Currently, in the allocator, when `CudaAllocator::free(buf)` is called, buffers with `buf->size <= small_pool_size` are still recycled into the main `buffer_cache_`. As a result, scalar allocations end up in `buffer_cache_` (if I’m reading the logic correctly). Later, when we call `CudaBuffer* buf = buffer_cache_.reuse_from_cache(size)` in `malloc`, these cached scalars may be returned from the main cache. I wasn’t sure if this is the intended behavior, so this change is a quick fix (based on my current understanding). 
