### PR TITLE
[CUDA] Make CudaEvent work with multi-device

### DIFF
--- a/mlx/backend/cuda/device.cpp
+++ b/mlx/backend/cuda/device.cpp
@@ -68,8 +68,8 @@ Device::~Device() {
 
 void Device::make_current() {
   // We need to set/get current CUDA device very frequently, cache it to reduce
-  // actual calls of CUDA APIs. This function assumes single-thread in host.
-  static int current = 0;
+  // actual calls of CUDA APIs.
+  static thread_local int current = 0;
   if (current != device_) {
     CHECK_CUDA_ERROR(cudaSetDevice(device_));
     current = device_;

--- a/mlx/backend/cuda/device.cpp
+++ b/mlx/backend/cuda/device.cpp
@@ -196,6 +196,7 @@ CommandEncoder::CommandEncoder(Device& d)
     : device_(d),
       stream_(d),
       graph_(d),
+      worker_(d),
       graph_cache_("MLX_CUDA_GRAPH_CACHE_SIZE", /* default_capacity */ 400) {}
 
 void CommandEncoder::add_completed_handler(std::function<void()> task) {

--- a/mlx/backend/cuda/device.h
+++ b/mlx/backend/cuda/device.h
@@ -140,7 +140,7 @@ class Device {
   Device(const Device&) = delete;
   Device& operator=(const Device&) = delete;
 
-  // Make this device the current cuda device, required by some cuda calls.
+  // Make this device the current cuda device, this method is thread-safe.
   void make_current();
 
   CommandEncoder& get_command_encoder(Stream s);

--- a/mlx/backend/cuda/eval.cpp
+++ b/mlx/backend/cuda/eval.cpp
@@ -15,11 +15,12 @@ bool is_available() {
 }
 
 void new_stream(Stream s) {
-  // Force initalization of CUDA by creating an event, so the CUDA runtime and
-  // our CUDA event pool get destroyed last.
-  cu::CudaEvent(cudaEventDefault);
+  // Initialize CUDA runtime and device before everythig else.
+  auto& d = cu::device(s.device);
+  // Create an event so our CUDA event pool get destroyed last.
+  cu::CudaEvent(d, cudaEventDefault);
   // Ensure the static stream objects get created.
-  cu::get_command_encoder(s);
+  d.get_command_encoder(s);
 }
 
 void eval(array& arr) {

--- a/mlx/backend/cuda/eval.cpp
+++ b/mlx/backend/cuda/eval.cpp
@@ -15,12 +15,12 @@ bool is_available() {
 }
 
 void new_stream(Stream s) {
-  // Initialize CUDA runtime and device before everythig else.
-  auto& d = cu::device(s.device);
-  // Create an event so our CUDA event pool get destroyed last.
-  cu::CudaEvent(d, cudaEventDefault);
+  // Force initalization of CUDA, so CUDA runtime get destroyed at last.
+  cudaFree(nullptr);
+  // Make sure CUDA event pool get destroyed after device and stream.
+  cu::CudaEvent::init_pool();
   // Ensure the static stream objects get created.
-  d.get_command_encoder(s);
+  cu::get_command_encoder(s);
 }
 
 void eval(array& arr) {

--- a/mlx/backend/cuda/event.h
+++ b/mlx/backend/cuda/event.h
@@ -13,9 +13,12 @@
 
 namespace mlx::core::cu {
 
+class Device;
+
 // RAII-managed move-only wrapper of cudaEvent_t.
 struct CudaEventHandle : public CudaHandle<cudaEvent_t, cudaEventDestroy> {
-  CudaEventHandle(int flags);
+  CudaEventHandle(Device& d, int flags);
+  int device;
   int flags;
 };
 
@@ -23,7 +26,7 @@ struct CudaEventHandle : public CudaHandle<cudaEvent_t, cudaEventDestroy> {
 // on GPU stream in CPU stream, but can not wait on CPU stream.
 class CudaEvent {
  public:
-  explicit CudaEvent(int flags);
+  CudaEvent(Device& d, int flags);
   ~CudaEvent();
 
   CudaEvent(CudaEvent&&) = default;

--- a/mlx/backend/cuda/event.h
+++ b/mlx/backend/cuda/event.h
@@ -18,7 +18,7 @@ class Device;
 // RAII-managed move-only wrapper of cudaEvent_t.
 struct CudaEventHandle : public CudaHandle<cudaEvent_t, cudaEventDestroy> {
   CudaEventHandle(Device& d, int flags);
-  int device;
+  Device& device;
   int flags;
 };
 
@@ -42,6 +42,9 @@ class CudaEvent {
   // Return whether the recorded kernels have completed. Note that this method
   // returns true if record() has not been called.
   bool completed() const;
+
+  // Internal: make sure event pool is initialized.
+  static void init_pool();
 
  private:
   CudaEventHandle event_;

--- a/mlx/backend/cuda/worker.cpp
+++ b/mlx/backend/cuda/worker.cpp
@@ -5,9 +5,9 @@
 
 namespace mlx::core::cu {
 
-Worker::Worker()
-    : signal_stream_(device(mlx::core::Device::gpu)),
-      signal_event_(cudaEventDisableTiming | cudaEventBlockingSync),
+Worker::Worker(Device& d)
+    : signal_stream_(d),
+      signal_event_(d, cudaEventDisableTiming | cudaEventBlockingSync),
       worker_(&Worker::thread_fn, this) {}
 
 Worker::~Worker() {

--- a/mlx/backend/cuda/worker.h
+++ b/mlx/backend/cuda/worker.h
@@ -15,7 +15,7 @@ namespace mlx::core::cu {
 // Run tasks in worker thread, synchronized with cuda stream.
 class Worker {
  public:
-  Worker();
+  explicit Worker(Device& d);
   ~Worker();
 
   Worker(const Worker&) = delete;


### PR DESCRIPTION
Most APIs of CUDA event have requirements on being used on the same device with the device that the event was created on, this PR makes sure the `CudaEvent` class set current device before invoking the APIs.

There is also an issue that the `CudaEvent` could be destroyed in worker thread when used for waiting on a GPU work in CPU stream, which would cause race conditions when accessing event cache, this PR uses a simple strategy by skipping the cache when event is created or destroyed on worker threads, so we don't have to add thread-safety overhead for those rare cases.

Note that this PR does not guarantee multi-thread or multi-device safety, this is mostly a defensive change.