### PR TITLE
Implement probability distribution support via mlx.distributions

### DIFF
--- a/docs/src/python/distributions/composition.rst
+++ b/docs/src/python/distributions/composition.rst
@@ -1,0 +1,16 @@
+.. _distributions_composition:
+
+.. currentmodule:: mlx.distributions
+
+Composition Utilities
+---------------------
+
+These are higher-order functions that create new distributions by composing or
+modifying existing ones.
+
+.. autosummary::
+   :toctree: _autosummary_composition
+   :template: nn-module-template.rst
+
+   Independent
+   TransformedDistribution

--- a/docs/src/python/distributions/distributions.rst
+++ b/docs/src/python/distributions/distributions.rst
@@ -1,0 +1,17 @@
+.. _distributions_modules:
+
+.. currentmodule:: mlx.distributions
+
+Distributions
+-------------
+
+These modules contain the core functions (``sample``, ``log_prob``, ``entropy``, etc.)
+for specific probability distributions.
+
+.. autosummary::
+   :toctree: _autosummary_distributions
+   :template: nn-module-template.rst
+
+   normal
+   
+..

--- a/docs/src/python/distributions/index.rst
+++ b/docs/src/python/distributions/index.rst
@@ -1,0 +1,24 @@
+.. _distributions:
+
+=================================
+Distributions (`mlx.distributions`)
+=================================
+
+The ``mlx.distributions`` package contains parameterizable probability
+distributions and sampling functions.
+
+The design is inspired by ``torch.distributions`` but is adapted for the
+functional and JIT-first nature of MLX. Key features include:
+
+- **Differentiable Sampling**: Distributions that support it use the
+  reparameterization trick, making sampling a differentiable operation.
+- **Composability**: Complex distributions can be built from simpler ones
+  using transforms and other utilities.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Distributions:
+
+   distributions
+   transforms
+   composition

--- a/docs/src/python/distributions/transforms.rst
+++ b/docs/src/python/distributions/transforms.rst
@@ -1,0 +1,16 @@
+.. _distributions_transforms:
+
+.. currentmodule:: mlx.distributions.transforms
+
+Transforms
+----------
+
+Transforms are invertible, differentiable functions that can be used with
+``TransformedDistribution`` to create new distributions from existing ones.
+
+.. autosummary::
+   :toctree: _autosummary_transforms
+   :template: nn-module-template.rst
+
+   Transform
+   ExpTransform

--- a/python/mlx/distributions/__init__.py
+++ b/python/mlx/distributions/__init__.py
@@ -1,0 +1,4 @@
+from mlx.distributions.independent import *
+from mlx.distributions.normal import *
+from mlx.distributions.transformed_distribution import *
+from mlx.distributions.transforms import *

--- a/python/mlx/distributions/independent.py
+++ b/python/mlx/distributions/independent.py
@@ -1,0 +1,68 @@
+from types import SimpleNamespace
+
+import mlx.core as mx
+import mlx.distributions.normal as normal  # Used for the example
+
+
+def Independent(base_distribution, reinterpreted_batch_ndims: int) -> SimpleNamespace:
+    r"""Reinterprets batch dimensions of a distribution as event dimensions.
+
+    This function is a factory that creates a new distribution from a base
+    distribution with a batch shape. It treats the last
+    ``reinterpreted_batch_ndims`` of the batch dimensions as a single event.
+
+    The primary use of this is to compute the joint log probability of a set of
+    independent random variables. For example, if a base distribution has a
+    batch shape of ``[B]`` and an event shape of ``[E]``, ``Independent`` can
+    create a new distribution with a batch shape of ``[]`` and an event shape
+    of ``[B, E]``. The ``log_prob`` method of this new distribution will then
+    return a single scalar value representing the sum of the log probabilities
+    of the independent events.
+
+    Args:
+        base_distribution (module): The base distribution module (e.g.,
+          ``mlx.distributions.normal``).
+        reinterpreted_batch_ndims (int): The number of trailing batch dimensions
+          to treat as event dimensions.
+
+    Returns:
+        SimpleNamespace: A new distribution-like module with ``sample`` and
+        ``log_prob`` methods.
+
+    Example:
+        >>> import mlx.core as mx
+        >>> import mlx.distributions.normal as normal
+        >>>
+        >>> # A batch of 3 independent Normal distributions
+        >>> loc = mx.array([0.0, 1.0, 2.0])
+        >>> scale = mx.array([1.0, 1.0, 1.0])
+        >>>
+        >>> # Without Independent, log_prob is element-wise
+        >>> base_log_probs = normal.log_prob(loc, loc, scale)
+        >>> base_log_probs
+        array([-0.918939, -0.918939, -0.918939], dtype=float32)
+        >>>
+        >>> # Use Independent to treat the batch of 3 as a single 3D event
+        >>> from mlx.distributions import Independent
+        >>> independent_normal = Independent(normal, reinterpreted_batch_ndims=1)
+        >>>
+        >>> # The new log_prob returns a single scalar value (the sum)
+        >>> joint_log_prob = independent_normal.log_prob(loc, loc, scale)
+        >>> joint_log_prob
+        array(-2.75682, dtype=float32)
+    """
+
+    def sample(key: mx.array, **kwargs) -> mx.array:
+        return base_distribution.sample(key=key, **kwargs)
+
+    def log_prob(*args, **kwargs) -> mx.array:
+        base_log_prob = base_distribution.log_prob(*args, **kwargs)
+
+        # Sum over the dimensions that are being reinterpreted as part of the event.
+        # These are the trailing `reinterpreted_batch_ndims` dimensions.
+        if reinterpreted_batch_ndims > 0:
+            axes_to_sum = tuple(range(-reinterpreted_batch_ndims, 0))
+            return mx.sum(base_log_prob, axis=axes_to_sum)
+        return base_log_prob
+
+    return SimpleNamespace(sample=sample, log_prob=log_prob)

--- a/python/mlx/distributions/normal.py
+++ b/python/mlx/distributions/normal.py
@@ -1,0 +1,88 @@
+import math
+
+import mlx.core as mx
+
+# Pre-computed constant for performance
+LOG_SQRT_2PI = 0.5 * math.log(2 * math.pi)
+
+
+def sample(loc: mx.array, scale: mx.array, key: mx.array) -> mx.array:
+    r"""Samples from a Normal distribution.
+
+    This function uses the reparameterization trick, making it differentiable
+    with respect to ``loc`` and ``scale``.
+
+    Args:
+        loc (mx.array): The mean of the distribution(s).
+        scale (mx.array): The standard deviation of the distribution(s).
+        key (mx.array): The PRNG key for random number generation.
+
+    Returns:
+        mx.array: An array of samples from the Normal distribution(s).
+
+    Example:
+        >>> import mlx.core as mx
+        >>> import mlx.distributions.normal as normal
+        >>>
+        >>> key = mx.random.key(0)
+        >>> loc = mx.array([0.0, 10.0])
+        >>> scale = mx.array([1.0, 2.0])
+        >>> normal.sample(loc, scale, key)
+        array([-0.784766, 11.7129], dtype=float32)
+    """
+    return loc + scale * mx.random.normal(loc.shape, key=key)
+
+
+def log_prob(value: mx.array, loc: mx.array, scale: mx.array) -> mx.array:
+    r"""Computes the log probability of a value given a Normal distribution.
+
+    Args:
+        value (mx.array): The value(s) at which to evaluate the log probability.
+        loc (mx.array): The mean of the distribution(s).
+        scale (mx.array): The standard deviation of the distribution(s).
+
+    Returns:
+        mx.array: The log probability of the given values.
+
+    Example:
+        >>> import mlx.core as mx
+        >>> import mlx.distributions.normal as normal
+        >>>
+        >>> # Evaluate the log probability at the mean for two distributions
+        >>> loc = mx.array([0.0, 10.0])
+        >>> scale = mx.array([1.0, 2.0])
+        >>> value = mx.array([0.0, 10.0])
+        >>> normal.log_prob(value, loc, scale)
+        array([-0.918939, -1.61209], dtype=float32)
+    """
+    var = scale**2
+    log_scale = mx.log(scale)
+    return -((value - loc) ** 2) / (2 * var) - log_scale - LOG_SQRT_2PI
+
+
+def entropy(scale: mx.array) -> mx.array:
+    r"""Computes the entropy of the Normal distribution.
+
+    Args:
+        scale (mx.array): The standard deviation of the distribution(s).
+
+    Returns:
+        mx.array: The entropy of the distribution(s).
+
+    Example:
+        >>> import mlx.core as mx
+        >>> import mlx.distributions.normal as normal
+        >>>
+        >>> scale = mx.array([1.0, 2.0])
+        >>> normal.entropy(scale)
+        array([1.41894, 2.11209], dtype=float32)
+    """
+    return 0.5 + mx.log(scale) + LOG_SQRT_2PI
+
+
+def mean(loc: mx.array) -> mx.array:
+    return loc
+
+
+def variance(scale: mx.array) -> mx.array:
+    return scale**2

--- a/python/mlx/distributions/transformed_distribution.py
+++ b/python/mlx/distributions/transformed_distribution.py
@@ -1,0 +1,71 @@
+from types import SimpleNamespace
+
+import mlx.core as mx
+
+from .transforms import Transform
+
+
+def TransformedDistribution(base_distribution, transform: Transform) -> SimpleNamespace:
+    r"""Creates a new distribution by applying a transform to a base distribution.
+
+    This function is a factory that generates a new distribution module by
+    composing a base distribution with an invertible transformation. The
+    probability density of the new distribution is calculated using the
+    change of variables formula.
+
+    The returned object is a ``SimpleNamespace`` containing ``sample`` and
+    ``log_prob`` functions that can be used like any other distribution module
+    in this library.
+
+    Args:
+        base_distribution (module): The base distribution module (e.g.,
+          ``mlx.distributions.normal``).
+        transform (Transform): An instance of a ``Transform`` subclass (e.g.,
+          ``ExpTransform()``).
+
+    Returns:
+        SimpleNamespace: A new distribution-like module with ``sample`` and
+        ``log_prob`` methods.
+
+    Example:
+        >>> from mlx.distributions.transformed_distribution import TransformedDistribution
+        >>> # Create a LogNormal distribution from a Normal distribution
+        >>> log_normal = TransformedDistribution(normal, ExpTransform())
+        >>>
+        >>> # Sample from the new distribution
+        >>> key = mx.random.key(0)
+        >>> loc = mx.array([0.0])
+        >>> scale = mx.array([1.0])
+        >>> samples = log_normal.sample(loc=loc, scale=scale, key=key)
+        >>> samples
+        array([0.813962], dtype=float32)
+        >>>
+        >>> # Calculate the log probability of a value
+        >>> # This is equivalent to stats.lognorm.logpdf(1.0, s=1.0, scale=1.0)
+        >>> log_prob_val = log_normal.log_prob(value=1.0, loc=0.0, scale=1.0)
+        >>> log_prob_val
+        array(-0.918939, dtype=float32)
+    """
+
+    def sample(key: mx.array, **kwargs) -> mx.array:
+        base_sample = base_distribution.sample(key=key, **kwargs)
+        return transform.forward(base_sample)
+
+    def log_prob(value: mx.array, **kwargs) -> mx.array:
+        # This is the change of variables formula for probabilities:
+        # log p_Y(y) = log p_X(x) - log|det(J)|
+        # where y = f(x) and J is the Jacobian of f.
+
+        # Computing x = f^{-1}(y)
+        x = transform.inverse(value)
+
+        # Computing the log prob of the origin value x
+        base_log_prob = base_distribution.log_prob(value=x, **kwargs)
+
+        # Computing the log determinant of the Jacobian
+        log_det = transform.log_abs_det_jacobian(x, value)
+
+        return base_log_prob - log_det
+
+    # Return as new module
+    return SimpleNamespace(sample=sample, log_prob=log_prob)

--- a/python/mlx/distributions/transforms.py
+++ b/python/mlx/distributions/transforms.py
@@ -1,0 +1,87 @@
+from abc import ABC, abstractmethod
+
+import mlx.core as mx
+
+
+class Transform(ABC):
+    """Abstract base class for invertible, differentiable transformations.
+
+    A ``Transform`` represents a differentiable, invertible mapping, to create
+    complex distributions via the ``TransformedDistribution`` factory.
+    """
+
+    @abstractmethod
+    def forward(self, x: mx.array) -> mx.array:
+        """Computes the forward transformation ``y = f(x)``.
+
+        Args:
+            x (mx.array): The input array to the transformation.
+
+        Returns:
+            mx.array: The transformed output array.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def inverse(self, y: mx.array) -> mx.array:
+        """Computes the inverse transformation ``x = f^-1(y)``.
+
+        Args:
+            y (mx.array): The output array from the forward transformation.
+
+        Returns:
+            mx.array: The reconstructed input array.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def log_abs_det_jacobian(self, x: mx.array, y: mx.array) -> mx.array:
+        """Computes the log of the absolute value of the determinant of the Jacobian.
+
+        This is a key component of the change of variables formula used to compute
+        the log probability of a ``TransformedDistribution``. For a 1-D
+        transformation, this simplifies to ``log|dy/dx|``.
+
+        Args:
+            x (mx.array): The input array to the forward transformation.
+            y (mx.array): The output array from the forward transformation.
+
+        Returns:
+            mx.array: The log absolute determinant of the Jacobian.
+        """
+        raise NotImplementedError
+
+
+class ExpTransform(Transform):
+    r"""A transformation applying the exponential function ``y = exp(x)``.
+
+    This is commonly used to transform a distribution defined on the real line
+    (like the Normal distribution) to one defined on the positive real line
+    (like the LogNormal distribution).
+
+    Example:
+        >>> import mlx.core as mx
+        >>> from mlx.distributions.transforms import ExpTransform
+        >>>
+        >>> transform = ExpTransform()
+        >>> x = mx.array([0.0, 1.0, -1.0])
+        >>> y = transform.forward(x)
+        >>> y
+        array([1, 2.71828, 0.367879], dtype=float32)
+        >>>
+        >>> # Check the inverse operation
+        >>> transform.inverse(y)
+        array([0, 1, -1], dtype=float32)
+    """
+
+    def forward(self, x: mx.array) -> mx.array:
+        return mx.exp(x)
+
+    def inverse(self, y: mx.array) -> mx.array:
+        return mx.log(y)
+
+    def log_abs_det_jacobian(self, x, y) -> mx.array:
+        # The derivative of exp(x) is exp(x).
+        # The log of the absolute value of the derivative is log(exp(x))
+        # We use x directly as it's often more numerically stable than log(y).
+        return x

--- a/python/tests/test_distribution_normal.py
+++ b/python/tests/test_distribution_normal.py
@@ -1,0 +1,121 @@
+import mlx.core as mx
+import mlx.distributions.normal as normal
+import mlx_tests
+from mlx.distributions.independent import Independent
+from mlx.distributions.transformed_distribution import TransformedDistribution
+from mlx.distributions.transforms import ExpTransform
+
+GOLDEN_VALUES = {
+    "normal_log_prob_scalar": -1.7370857156692723,
+    "normal_log_prob_batched": [-1.4189385332046727, -1.7370857156692723],
+    "normal_entropy_scalar": 2.1120858192443848,
+    "exp_transform_forward": [1.0, 2.7182817459106445, 0.1353352814912796],
+    "log_normal_log_prob": -1.4180873656830202,
+    "independent_normal_joint_log_prob": -3.8725460335371453,
+}
+
+
+class TestDistributions(mlx_tests.MLXTestCase):
+    def assert_all_close(self, a, b, atol=1e-6, rtol=1e-5):
+        self.assertTrue(
+            mx.allclose(a, b, atol=atol, rtol=rtol),
+            f"Arrays are not close: \na = {a}\n, b = {b}",
+        )
+
+    def test_sample_reproducibility(self):
+        key = mx.random.key(42)
+        loc, scale = mx.array(10.0), mx.array(0.1)
+        sample1 = normal.sample(loc, scale, key=key)
+        sample2 = normal.sample(loc, scale, key=key)
+        self.assertTrue(mx.all(sample1 == sample2))
+
+        key2 = mx.random.key(43)
+        sample3 = normal.sample(loc, scale, key=key2)
+        self.assertFalse(mx.all(sample1 == sample3))
+
+    def test_log_prob_golden_scalar(self):
+        expected = mx.array(GOLDEN_VALUES["normal_log_prob_scalar"])
+        actual = normal.log_prob(
+            value=mx.array(1.5), loc=mx.array(0.5), scale=mx.array(2.0)
+        )
+        self.assert_all_close(actual, expected)
+
+    def test_log_prob_golden_batched(self):
+        expected = mx.array(GOLDEN_VALUES["normal_log_prob_batched"])
+        actual = normal.log_prob(
+            value=mx.array([-1.0, 6.0]),
+            loc=mx.array([0.0, 5.0]),
+            scale=mx.array([1.0, 2.0]),
+        )
+        self.assert_all_close(actual, expected)
+
+    def test_entropy_golden_scalar(self):
+        expected = mx.array(GOLDEN_VALUES["normal_entropy_scalar"])
+        actual = normal.entropy(scale=mx.array(2.0))
+        self.assert_all_close(actual, expected)
+
+    def test_mean_and_variance_golden(self):
+        self.assert_all_close(normal.mean(mx.array(1.23)), mx.array(1.23))
+        self.assert_all_close(normal.variance(mx.array(2.0)), mx.array(4.0))
+
+    def test_gradient_wrt_loc_golden(self):
+        loc, scale, value = mx.array(0.5), mx.array(2.0), mx.array(1.5)
+        loss_fn = lambda p: normal.log_prob(value, loc=p, scale=scale)
+        grad_mlx = mx.grad(loss_fn)(loc)
+
+        # Analytical gradient: (value - loc) / scale**2
+        grad_analytical = (value - loc) / scale**2
+        self.assert_all_close(grad_mlx, grad_analytical)
+
+    def test_gradient_wrt_scale_golden(self):
+        loc, scale, value = mx.array(0.5), mx.array(2.0), mx.array(1.5)
+        loss_fn = lambda p: normal.log_prob(value, loc=loc, scale=p)
+        grad_mlx = mx.grad(loss_fn)(scale)
+
+        # Analytical gradient: ((value - loc)**2 / scale**3) - (1 / scale)
+        grad_analytical = ((value - loc) ** 2 / scale**3) - (1 / scale)
+        self.assert_all_close(grad_mlx, grad_analytical)
+
+    def test_normal_symmetry_property_manual(self):
+        scale, value = mx.array(1.5), mx.array(0.7)
+        log_prob1 = normal.log_prob(value, loc=mx.array(0.0), scale=scale)
+        log_prob2 = normal.log_prob(-value, loc=mx.array(0.0), scale=scale)
+        self.assert_all_close(log_prob1, log_prob2)
+
+    def test_log_prob_peak_at_mean_property_manual(self):
+        loc, scale, delta = mx.array(0.5), mx.array(2.0), 1e-3
+        log_prob_at_mean = normal.log_prob(loc, loc=loc, scale=scale)
+        log_prob_off_mean = normal.log_prob(loc + delta, loc=loc, scale=scale)
+        self.assertGreaterEqual(log_prob_at_mean.item(), log_prob_off_mean.item())
+
+    def test_transformed_distribution_log_prob_golden(self):
+        log_normal_factory = TransformedDistribution(normal, ExpTransform())
+        expected = mx.array(GOLDEN_VALUES["log_normal_log_prob"])
+        actual = log_normal_factory.log_prob(
+            value=mx.array(2.0), loc=mx.array(0.5), scale=mx.array(0.8)
+        )
+        self.assert_all_close(actual, expected)
+
+    def test_independent_log_prob_golden(self):
+        independent_normal = Independent(normal, reinterpreted_batch_ndims=1)
+        expected = mx.array(GOLDEN_VALUES["independent_normal_joint_log_prob"])
+        actual = independent_normal.log_prob(
+            value=mx.array([1.0, 2.0]),
+            loc=mx.array([0.0, 0.5]),
+            scale=mx.array([1.0, 0.8]),
+        )
+        self.assert_all_close(actual, expected)
+
+    def test_exp_transform_golden(self):
+        transform = ExpTransform()
+        x = mx.array([0.0, 1.0, -2.0])
+        y_expected = mx.array(GOLDEN_VALUES["exp_transform_forward"])
+        y_actual = transform.forward(x)
+        self.assert_all_close(y_actual, y_expected)
+
+        x_reconstructed = transform.inverse(y_actual)
+        self.assert_all_close(x_reconstructed, x)
+
+
+if __name__ == "__main__":
+    mlx_tests.MLXTestRunner()


### PR DESCRIPTION
## Proposed changes

This PR includes the beginning components to support probability distributions within MLX via python.mlx.distributions. Inspired by Jax and PyTorch the component implements key probability distribution methods namely:

- sample()
- log_prob()
- entropy()
- mean()
- variance()

for the normal distribution. It also includes composition utilities like Independent and TransformedDistribution methods. It does so while following MLX's functional paradigm and JIT-first approach. I've also included several tests and pieces of documentation in line with the nn module as much as possible. 

This PR, more than anything, is to validate upon review this approach to an MLX probability distribution component. Before then adding additional distributions, more complex composition patterns and additional utilities. 

## Checklist

Put an `x` in the boxes that apply.

- [ x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x ] I have added tests that prove my fix is effective or that my feature works
- [ x] I have updated the necessary documentation (if needed)
