### PR TITLE
Compiled should not end in broadcast

### DIFF
--- a/mlx/compile.cpp
+++ b/mlx/compile.cpp
@@ -727,7 +727,7 @@ void compile_fuse(
       }
     };
 
-    if (arr.has_primitive()) {
+    if (arr.has_primitive() && !is_broadcast(arr.primitive())) {
       Stream s = arr.primitive().stream();
       recurse(arr, 0, s, arr.shape());
     }


### PR DESCRIPTION
Very good point in #2585 and very easy fix.

We go from

<img width="462" height="443" alt="cgraph-old" src="https://github.com/user-attachments/assets/27d2b7ae-b811-43e5-b6b6-e9302a8c79b7" />

to 

<img width="390" height="635" alt="cgraph" src="https://github.com/user-attachments/assets/6cef74cf-cb0b-45e2-b96e-b19075dee098" />

for

<img width="224" height="1595" alt="graph" src="https://github.com/user-attachments/assets/13caced7-4566-4482-b0f0-eb0cba39b016" />
