### PR TITLE
[CUDA] Wait for tasks in cuda

### DIFF
--- a/mlx/backend/cuda/allocator.cpp
+++ b/mlx/backend/cuda/allocator.cpp
@@ -86,7 +86,7 @@ CudaAllocator::CudaAllocator()
   // TODO: Set memory limit for multi-device.
   size_t free, total;
   CHECK_CUDA_ERROR(cudaMemGetInfo(&free, &total));
-  memory_limit_ = total * 0.8;
+  memory_limit_ = total * 0.95;
   max_pool_size_ = memory_limit_;
 }
 

--- a/mlx/backend/cuda/device.h
+++ b/mlx/backend/cuda/device.h
@@ -83,7 +83,7 @@ class CommandEncoder {
   }
 
   void add_completed_handler(std::function<void()> task);
-  void maybe_commit();
+  int get_num_ops();
   void commit();
 
   Device& device() {


### PR DESCRIPTION
This helps keep the work submission from running to far ahead of complete work for the CUDA back-end. I'ts virtually identical to what we do for Metal.

Some benchmarks:

Model | Pre It/sec | Post it/sec | Pre Peak Mem GB | Post Peak Mem GB |
----- | ---- | ---- | ---- | ----
0.6 B  | 6.45 | 6.44 | 54.3 | 28.9
0.86 B  | 3.59 | 5.82 | 64.79 | 36.47

Generation speed is unaffected.