### PR TITLE
[CUDA] Add a small column specialization to reduce

### DIFF
--- a/mlx/backend/cuda/reduce/col_reduce.cu
+++ b/mlx/backend/cuda/reduce/col_reduce.cu
@@ -339,13 +339,12 @@ void col_reduce(
   // Small col reduce with a single or contiguous reduction axis
   if (args.non_col_reductions == 1 && args.reduction_size <= 32 &&
       args.reduction_stride % (16 / in.itemsize()) == 0) {
-    col_reduce_small(
-        encoder, in, out, reduce_type, axes, plan, std::move(args));
+    col_reduce_small(encoder, in, out, reduce_type, axes, plan, args);
     return;
   }
 
   // Fallback col reduce
-  col_reduce_looped(encoder, in, out, reduce_type, axes, plan, std::move(args));
+  col_reduce_looped(encoder, in, out, reduce_type, axes, plan, args);
 }
 
 } // namespace mlx::core

--- a/mlx/backend/cuda/reduce/col_reduce.cu
+++ b/mlx/backend/cuda/reduce/col_reduce.cu
@@ -181,6 +181,47 @@ col_reduce_looped(T* in, U* out, const __grid_constant__ ColReduceArgs args) {
   }
 }
 
+template <typename T, typename U, typename Op, int N_READS = 4>
+__global__ void col_reduce_small(
+    const T* in,
+    U* out,
+    const __grid_constant__ ColReduceArgs args,
+    size_t total) {
+  Op op;
+  auto grid = cg::this_grid();
+  auto block = cg::this_thread_block();
+
+  const auto idx = grid.thread_rank() * N_READS;
+  const auto before_axis = idx / args.reduction_stride;
+  const auto after_axis = idx % args.reduction_stride;
+  const auto offset =
+      before_axis * args.reduction_stride * args.reduction_size + after_axis;
+
+  if (idx >= total) {
+    return;
+  }
+
+  in += offset;
+  out += idx;
+
+  AlignedVector<U, N_READS> accumulator;
+  for (int i = 0; i < N_READS; i++) {
+    accumulator[i] = ReduceInit<Op, T>::value();
+  }
+
+  for (int i = 0; i < args.reduction_size; i++) {
+    auto values = load_vector<N_READS>(in, 0);
+
+    for (int j = 0; j < N_READS; j++) {
+      accumulator[j] = op(accumulator[j], cast_to<U>(values[j]));
+    }
+
+    in += args.reduction_stride;
+  }
+
+  store_vector(out, 0, accumulator);
+}
+
 } // namespace cu
 
 inline auto output_grid_for_col_reduce(
@@ -236,6 +277,43 @@ void col_reduce_looped(
   });
 }
 
+void col_reduce_small(
+    cu::CommandEncoder& encoder,
+    const array& in,
+    array& out,
+    Reduce::ReduceType reduce_type,
+    const std::vector<int>& axes,
+    const ReductionPlan& plan,
+    cu::ColReduceArgs args) {
+  // Allocate data for the output using in's layout to access them as
+  // contiguously as possible.
+  allocate_same_layout(out, in, axes);
+
+  encoder.set_input_array(in);
+  encoder.set_output_array(out);
+  dispatch_all_types(in.dtype(), [&](auto type_tag) {
+    dispatch_reduce_ops(reduce_type, [&](auto reduce_type_tag) {
+      using OP = MLX_GET_TYPE(reduce_type_tag);
+      using T = cuda_type_t<MLX_GET_TYPE(type_tag)>;
+      using U = typename cu::ReduceResult<OP, T>::type;
+
+      constexpr int N_READS = 16 / sizeof(T);
+      auto tmp_grid = get_2d_grid_dims(out.shape(), out.strides());
+      auto [grid, block] = get_grid_and_block(tmp_grid.x, tmp_grid.y, 1);
+      auto kernel = cu::col_reduce_small<T, U, OP, N_READS>;
+      encoder.add_kernel_node(
+          kernel,
+          grid,
+          block,
+          0,
+          in.data<T>(),
+          out.data<U>(),
+          args,
+          out.size());
+    });
+  });
+}
+
 void col_reduce(
     cu::CommandEncoder& encoder,
     const array& in,
@@ -258,8 +336,16 @@ void col_reduce(
   // Make the args struct to help route to the best kernel
   cu::ColReduceArgs args(in, plan, axes);
 
+  // Small col reduce with a single or contiguous reduction axis
+  if (args.non_col_reductions == 1 && args.reduction_size <= 32 &&
+      args.reduction_stride % 4 == 0) {
+    col_reduce_small(
+        encoder, in, out, reduce_type, axes, plan, std::move(args));
+    return;
+  }
+
   // Fallback col reduce
-  col_reduce_looped(encoder, in, out, reduce_type, axes, plan, args);
+  col_reduce_looped(encoder, in, out, reduce_type, axes, plan, std::move(args));
 }
 
 } // namespace mlx::core

--- a/mlx/backend/cuda/reduce/col_reduce.cu
+++ b/mlx/backend/cuda/reduce/col_reduce.cu
@@ -247,7 +247,7 @@ void col_reduce_looped(
     Reduce::ReduceType reduce_type,
     const std::vector<int>& axes,
     const ReductionPlan& plan,
-    cu::ColReduceArgs args) {
+    const cu::ColReduceArgs& args) {
   // Allocate data for the output using in's layout to access them as
   // contiguously as possible.
   allocate_same_layout(out, in, axes);
@@ -271,7 +271,13 @@ void col_reduce_looped(
         auto kernel =
             cu::col_reduce_looped<T, U, OP, reduce_ndim(), BM, BN, N_READS>;
         encoder.add_kernel_node(
-            kernel, grid, blocks, 0, indata, out.data<U>(), args);
+            kernel,
+            grid,
+            blocks,
+            0,
+            indata,
+            out.data<U>(),
+            static_cast<cu::ColReduceArgs>(args));
       });
     });
   });
@@ -284,7 +290,7 @@ void col_reduce_small(
     Reduce::ReduceType reduce_type,
     const std::vector<int>& axes,
     const ReductionPlan& plan,
-    cu::ColReduceArgs args) {
+    const cu::ColReduceArgs& args) {
   // Allocate data for the output using in's layout to access them as
   // contiguously as possible.
   allocate_same_layout(out, in, axes);
@@ -308,7 +314,7 @@ void col_reduce_small(
           0,
           in.data<T>(),
           out.data<U>(),
-          args,
+          static_cast<cu::ColReduceArgs>(args),
           out.size());
     });
   });

--- a/mlx/backend/cuda/reduce/col_reduce.cu
+++ b/mlx/backend/cuda/reduce/col_reduce.cu
@@ -338,7 +338,7 @@ void col_reduce(
 
   // Small col reduce with a single or contiguous reduction axis
   if (args.non_col_reductions == 1 && args.reduction_size <= 32 &&
-      args.reduction_stride % 4 == 0) {
+      args.reduction_stride % (16 / in.itemsize()) == 0) {
     col_reduce_small(
         encoder, in, out, reduce_type, axes, plan, std::move(args));
     return;


### PR DESCRIPTION
Dramatically improves performance for reductions of small columns such as `AxRxB` where `A` and `B` can be large but `R` is small. One can say the previous was broken basically. We still require more tuning across all reductions but this should at least fix the case for `R<=32`.

Before
```
sum_axis --size 128x4x128 --axis 1       0.08525443077087402
sum_axis --size 128x8x128 --axis 1       0.08588528633117676
sum_axis --size 128x16x128 --axis 1      0.08804011344909668
sum_axis --size 256x4x256 --axis 1       0.2319648265838623
sum_axis --size 256x8x256 --axis 1       0.24344205856323242
sum_axis --size 256x16x256 --axis 1      0.24147486686706543
sum_axis --size 512x4x512 --axis 1       0.815819501876831
sum_axis --size 512x8x512 --axis 1       0.8287558555603027
sum_axis --size 512x16x512 --axis 1      0.8524072170257568
sum_axis --size 1024x4x1024 --axis 1     3.193472385406494
sum_axis --size 1024x8x1024 --axis 1     3.3117425441741943
sum_axis --size 1024x16x1024 --axis 1    3.3808846473693848
sum_axis --size 2048x4x2048 --axis 1     13.04431700706482
sum_axis --size 2048x8x2048 --axis 1     13.143831968307495
sum_axis --size 2048x16x2048 --axis 1    13.350330829620361

```

After 
```
sum_axis --size 128x4x128 --axis 1       0.06705641746520996
sum_axis --size 128x8x128 --axis 1       0.07380414009094238
sum_axis --size 128x16x128 --axis 1      0.06083559989929199
sum_axis --size 256x4x256 --axis 1       0.06976032257080078
sum_axis --size 256x8x256 --axis 1       0.06670403480529785
sum_axis --size 256x16x256 --axis 1      0.07144594192504883
sum_axis --size 512x4x512 --axis 1       0.06734323501586914
sum_axis --size 512x8x512 --axis 1       0.07323694229125977
sum_axis --size 512x16x512 --axis 1      0.0779123306274414
sum_axis --size 1024x4x1024 --axis 1     0.12867093086242676
sum_axis --size 1024x8x1024 --axis 1     0.2707681655883789
sum_axis --size 1024x16x1024 --axis 1    0.4582681655883789
sum_axis --size 2048x4x2048 --axis 1     0.6412420272827148
sum_axis --size 2048x8x2048 --axis 1     1.0108389854431152
sum_axis --size 2048x16x2048 --axis 1    1.735480546951294
```
