### PR TITLE
Fix cumulative operations when axis=None

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -3468,6 +3468,14 @@ array cumsum(
       {a});
 }
 
+array cumsum(
+    const array& a,
+    bool reverse /* = false*/,
+    bool inclusive /* = true*/,
+    StreamOrDevice s /* = {}*/) {
+  return cumsum(flatten(a, to_stream(s)), 0, reverse, inclusive, to_stream(s));
+}
+
 array cumprod(
     const array& a,
     int axis,
@@ -3488,6 +3496,14 @@ array cumprod(
       std::make_shared<Scan>(
           to_stream(s), Scan::ReduceType::Prod, axis, reverse, inclusive),
       {a});
+}
+
+array cumprod(
+    const array& a,
+    bool reverse /* = false*/,
+    bool inclusive /* = true*/,
+    StreamOrDevice s /* = {}*/) {
+  return cumprod(flatten(a, s), 0, reverse, inclusive, s);
 }
 
 array cummax(
@@ -3512,6 +3528,14 @@ array cummax(
       {a});
 }
 
+array cummax(
+    const array& a,
+    bool reverse /* = false*/,
+    bool inclusive /* = true*/,
+    StreamOrDevice s /* = {}*/) {
+  return cummax(flatten(a, s), 0, reverse, inclusive, s);
+}
+
 array cummin(
     const array& a,
     int axis,
@@ -3534,6 +3558,14 @@ array cummin(
       {a});
 }
 
+array cummin(
+    const array& a,
+    bool reverse /* = false*/,
+    bool inclusive /* = true*/,
+    StreamOrDevice s /* = {}*/) {
+  return cummin(flatten(a, s), 0, reverse, inclusive, s);
+}
+
 array logcumsumexp(
     const array& a,
     int axis,
@@ -3554,6 +3586,15 @@ array logcumsumexp(
       std::make_shared<Scan>(
           to_stream(s), Scan::ReduceType::LogAddExp, axis, reverse, inclusive),
       {a});
+}
+
+array logcumsumexp(
+    const array& a,
+    bool reverse /* = false*/,
+    bool inclusive /* = true*/,
+    StreamOrDevice s /* = {}*/) {
+  return logcumsumexp(
+      flatten(a, to_stream(s)), 0, reverse, inclusive, to_stream(s));
 }
 
 /** Convolution operations */

--- a/mlx/ops.h
+++ b/mlx/ops.h
@@ -718,6 +718,13 @@ array topk(const array& a, int k, int axis, StreamOrDevice s = {});
 /** Cumulative logsumexp of an array. */
 array logcumsumexp(
     const array& a,
+    bool reverse = false,
+    bool inclusive = true,
+    StreamOrDevice s = {});
+
+/** Cumulative logsumexp of an array along the given axis. */
+array logcumsumexp(
+    const array& a,
     int axis,
     bool reverse = false,
     bool inclusive = true,
@@ -1188,12 +1195,26 @@ array power(const array& a, const array& b, StreamOrDevice s = {});
 /** Cumulative sum of an array. */
 array cumsum(
     const array& a,
+    bool reverse = false,
+    bool inclusive = true,
+    StreamOrDevice s = {});
+
+/** Cumulative sum of an array along the given axis. */
+array cumsum(
+    const array& a,
     int axis,
     bool reverse = false,
     bool inclusive = true,
     StreamOrDevice s = {});
 
 /** Cumulative product of an array. */
+array cumprod(
+    const array& a,
+    bool reverse = false,
+    bool inclusive = true,
+    StreamOrDevice s = {});
+
+/** Cumulative product of an array along the given axis. */
 array cumprod(
     const array& a,
     int axis,
@@ -1204,12 +1225,26 @@ array cumprod(
 /** Cumulative max of an array. */
 array cummax(
     const array& a,
+    bool reverse = false,
+    bool inclusive = true,
+    StreamOrDevice s = {});
+
+/** Cumulative max of an array along the given axis. */
+array cummax(
+    const array& a,
     int axis,
     bool reverse = false,
     bool inclusive = true,
     StreamOrDevice s = {});
 
 /** Cumulative min of an array. */
+array cummin(
+    const array& a,
+    bool reverse = false,
+    bool inclusive = true,
+    StreamOrDevice s = {});
+
+/** Cumulative min of an array along the given axis. */
 array cummin(
     const array& a,
     int axis,

--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -1275,10 +1275,7 @@ void init_array(nb::module_& m) {
             if (axis) {
               return mx::logcumsumexp(a, *axis, reverse, inclusive, s);
             } else {
-              // TODO: Implement that in the C++ API as well. See concatenate
-              // above.
-              return mx::logcumsumexp(
-                  mx::reshape(a, {-1}, s), 0, reverse, inclusive, s);
+              return mx::logcumsumexp(a, reverse, inclusive, s);
             }
           },
           "axis"_a = nb::none(),
@@ -1408,9 +1405,7 @@ void init_array(nb::module_& m) {
             if (axis) {
               return mx::cumsum(a, *axis, reverse, inclusive, s);
             } else {
-              // TODO: Implement that in the C++ API as well. See concatenate
-              // above.
-              return mx::cumsum(reshape(a, {-1}, s), 0, reverse, inclusive, s);
+              return mx::cumsum(a, reverse, inclusive, s);
             }
           },
           "axis"_a = nb::none(),
@@ -1429,10 +1424,7 @@ void init_array(nb::module_& m) {
             if (axis) {
               return mx::cumprod(a, *axis, reverse, inclusive, s);
             } else {
-              // TODO: Implement that in the C++ API as well. See concatenate
-              // above.
-              return mx::cumprod(
-                  mx::reshape(a, {-1}, s), 0, reverse, inclusive, s);
+              return mx::cumprod(a, reverse, inclusive, s);
             }
           },
           "axis"_a = nb::none(),
@@ -1451,10 +1443,7 @@ void init_array(nb::module_& m) {
             if (axis) {
               return mx::cummax(a, *axis, reverse, inclusive, s);
             } else {
-              // TODO: Implement that in the C++ API as well. See concatenate
-              // above.
-              return mx::cummax(
-                  mx::reshape(a, {-1}, s), 0, reverse, inclusive, s);
+              return mx::cummax(a, reverse, inclusive, s);
             }
           },
           "axis"_a = nb::none(),
@@ -1473,10 +1462,7 @@ void init_array(nb::module_& m) {
             if (axis) {
               return mx::cummin(a, *axis, reverse, inclusive, s);
             } else {
-              // TODO: Implement that in the C++ API as well. See concatenate
-              // above.
-              return mx::cummin(
-                  mx::reshape(a, {-1}, s), 0, reverse, inclusive, s);
+              return mx::cummin(a, reverse, inclusive, s);
             }
           },
           "axis"_a = nb::none(),


### PR DESCRIPTION
## Proposed changes

Previously, the Python bindings used workarounds by flattening arrays and operating along axis 0. Now these operations have proper C++ overloads without axis parameters that automatically flatten the arrays, following the same pattern as concatenate.
## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
