### PR TITLE
Fix KeyError for missing domain_uuid_key in Thunderbolt setup

### DIFF
--- a/python/mlx/distributed_run.py
+++ b/python/mlx/distributed_run.py
@@ -567,13 +567,16 @@ def prepare_tb_ring(args, hosts):
         name = ""
         ports = []
         for t in c["SPThunderboltDataType"]:
+            uuid = t.get("domain_uuid_key")
+            if uuid is None:
+                continue
             name = t["device_name_key"]
-            uuid = t["domain_uuid_key"]
             tag = t["receptacle_1_tag"]["receptacle_id_key"]
-            if items := t.get("_items", []):
-                connected_to = items[0]["domain_uuid_key"]
-            else:
-                connected_to = None
+            items = t.get("_items", [])
+            connected_items = [item for item in items if "domain_uuid_key" in item]
+            connected_to = (
+                connected_items[0]["domain_uuid_key"] if connected_items else None
+            )
             iface = iface_map[f"Thunderbolt {tag}"]
             ports.append(ThunderboltPort(iface, uuid, connected_to))
         tb_hosts.append(ThunderboltHost(name, sorted(ports, key=lambda x: x.iface)))


### PR DESCRIPTION
- Check for None before accessing domain_uuid_key and skip invalid entries
- Filter items to only those with domain_uuid_key before extracting connection
- Prevents KeyError when thunderbolt topology data is incomplete

## Proposed changes

Fixes a `KeyError` in `mlx.distributed` when setting up Thunderbolt ring topology.

The error occurred when `domain_uuid_key` was missing from Thunderbolt topology data, which happens when certain devices (such as external monitors) are connected to the Mac. The code attempted to access this key without first checking for its presence.

This PR adds validation to check for `domain_uuid_key` before accessing it and filters topology items to only those with valid keys, preventing the crash when the topology data is incomplete.

## Checklist

Put an `x` in the boxes that apply.

- [X] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [X] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes