### PR TITLE
Improved mx.split() docs

### DIFF
--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -2577,12 +2577,23 @@ void init_ops(nb::module_& m) {
             a (array): Input array.
             indices_or_sections (int or list(int)): If ``indices_or_sections``
               is an integer the array is split into that many sections of equal
-              size. An error is raised if this is not possible. If ``indices_or_sections``
-              is a list, the list contains the indices which are the split points or boundaries where the array should be divided.
+              size. An error is raised if this is not possible. If
+              ``indices_or_sections`` is a list, then the indices are the split
+              points, and the array is divided into
+              ``len(indices_or_sections) + 1`` sub-arrays.
             axis (int, optional): Axis to split along, defaults to `0`.
 
         Returns:
             list(array): A list of split arrays.
+
+        Example:
+
+          >>> a = mx.array([1, 2, 3, 4], dtype=mx.int32)
+          >>> mx.split(a, 2)
+          [array([1, 2], dtype=int32), array([3, 4], dtype=int32)]
+          >>> mx.split(a, [1, 3])
+          [array([1], dtype=int32), array([2, 3], dtype=int32), array([4], dtype=int32)]
+
       )pbdoc");
   m.def(
       "argmin",


### PR DESCRIPTION
## Proposed changes

Changed the documentation of `mx.split()` based on the comments on #2675. Documentation change is regarding what a list passed as the second arg of the function is used for (a boundary that dictates all previous elements before the index will be split into a subarray).

**Before**: `the list contains the indices of the start of each subarray along the given axis.`
**After**: `the list contains the indices which are the split points or boundaries where the array should be divided.`

## Checklist

Put an `x` in the boxes that apply.

- [X] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [X] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works **-> Not necessary**
- [x] I have updated the necessary documentation (if needed)
