### PR TITLE
Einsum error msg improvement

### DIFF
--- a/mlx/einsum.cpp
+++ b/mlx/einsum.cpp
@@ -724,23 +724,6 @@ std::pair<std::vector<PathNode>, PathInfo> einsum_path_helper(
         ellipsis_length = max_ellipsis_length;
       }
 
-      if (ellipsis_length < 0) {
-        std::ostringstream msg;
-        msg << "[" << fn_name
-            << "] Ellipsis expansion resulted in negative length ("
-            << ellipsis_length << ") for subscript '" << subscript << "'.";
-        throw std::invalid_argument(msg.str());
-      }
-
-      if (ellipsis_length > remaining_chars.size()) {
-        std::ostringstream msg;
-        msg << "[" << fn_name
-            << "] Not enough characters available for ellipsis expansion. "
-            << "Required " << ellipsis_length << " characters but only "
-            << remaining_chars.size() << " available.";
-        throw std::invalid_argument(msg.str());
-      }
-
       subscript.replace(
           subscript.begin() + cnt_before,
           subscript.begin() + cnt_before + 3,


### PR DESCRIPTION
## Proposed changes

Modified the error message logic of `einsum()` mentioned on #2677 to clearly identify which operand is problematic, show its shape and the specific subscript pattern that's causing the issue.

``` python
import mlx.core as mx
y = mx.ones((6, 10))
x = mx.ones((6,))
mx.einsum("...i,ij->...j", x[0], y)
```

New Error Message
```
Traceback (most recent call last):
  File "/Users/mv/repos/mlx/einsum_test.py", line 4, in <module>
    mx.einsum("...i,ij->...j", x[0], y)
ValueError: [einsum] Operand 0 with shape {} has insufficient dimensions for subscript '...i'.
The ellipsis requires at least 1 dimensions but the operand has 0 dimensions.
```

Example on the same error in PyTorch:
`einsum(): the number of subscripts in the equation (1) is more than the number of dimensions (0) for operand 0`

## Checklist

Put an `x` in the boxes that apply.

- [X] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [X] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works **-> Not necessary**
- [ ] I have updated the necessary documentation (if needed) **-> Not necessary**
