### PR TITLE
bump python

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,9 +26,9 @@ jobs:
           name: Install
           command: |
             xcodebuild -downloadComponent MetalToolchain
-            brew install python@3.9
+            brew install python@3.10
             brew install doxygen
-            python3.9 -m venv env
+            python3.10 -m venv env
             source env/bin/activate
             pip install --upgrade pip
             pip install --upgrade cmake
@@ -140,7 +140,7 @@ jobs:
       - run:
           name: Install Python package
           command: |
-            uv venv --python 3.9
+            uv venv --python 3.10
             uv pip install \
               nanobind==2.4.0 \
               cmake \
@@ -273,7 +273,7 @@ jobs:
     parameters:
       python_version:
         type: string
-        default: "3.9"
+        default: "3.10"
       xcode_version:
         type: string
         default: "26.0.0"
@@ -328,7 +328,7 @@ jobs:
             << parameters.build_env >> MLX_BUILD_STAGE=1 python -m build -w
       - when:
           condition:
-            equal: ["3.9", << parameters.python_version >>]
+            equal: ["3.10", << parameters.python_version >>]
           steps:
             - run:
                 name: Build common package
@@ -351,7 +351,7 @@ jobs:
     parameters:
       python_version:
         type: string
-        default: "3.9"
+        default: "3.10"
       build_env:
         type: string
         default: ""
@@ -387,7 +387,7 @@ jobs:
             bash python/scripts/repair_linux.sh
       - when:
           condition:
-            equal: ["3.9", << parameters.python_version >>]
+            equal: ["3.10", << parameters.python_version >>]
           steps:
             - run:
                 name: Build common package
@@ -484,7 +484,7 @@ workflows:
               ignore: /.*/
           matrix:
             parameters:
-              python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+              python_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
               macosx_deployment_target: ["13.5", "14.0", "15.0"]
               build_env: ["PYPI_RELEASE=1"]
               xcode_version: ["26.0.0"]
@@ -503,7 +503,7 @@ workflows:
               ignore: /.*/
           matrix:
             parameters:
-              python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+              python_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
               build_env: ["PYPI_RELEASE=1"]
       - build_cuda_release:
           filters:
@@ -546,13 +546,13 @@ workflows:
       - build_release:
           matrix:
             parameters:
-              python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+              python_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
               macosx_deployment_target: ["13.5", "14.0", "15.0"]
               xcode_version: ["26.0.0"]
       - build_linux_release:
           matrix:
             parameters:
-              python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+              python_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       - build_cuda_release
 
   build_dev_release:
@@ -564,14 +564,14 @@ workflows:
       - build_release:
           matrix:
             parameters:
-              python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+              python_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
               macosx_deployment_target: ["13.5", "14.0", "15.0"]
               build_env: ["DEV_RELEASE=1"]
               xcode_version: ["26.0.0"]
       - build_linux_release:
           matrix:
             parameters:
-              python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+              python_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
               build_env: ["DEV_RELEASE=1"]
       - build_cuda_release:
           matrix:

--- a/docs/src/install.rst
+++ b/docs/src/install.rst
@@ -16,7 +16,7 @@ silicon computer is
 To install from PyPI your system must meet the following requirements:
 
 - Using an M series chip (Apple silicon)
-- Using a native Python >= 3.9
+- Using a native Python >= 3.10
 - macOS >= 13.5
 
 .. note::
@@ -39,7 +39,7 @@ requirements:
 - Nvidia driver >= 550.54.14
 - CUDA toolkit >= 12.0
 - Linux distribution with glibc >= 2.35
-- Python >= 3.9
+- Python >= 3.10
 
 
 CPU-only (Linux)
@@ -55,7 +55,7 @@ To install the CPU-only package from PyPi your system must meet the following
 requirements:
 
 - Linux distribution with glibc >= 2.35
-- Python >= 3.9
+- Python >= 3.10
 
 
 Troubleshooting

--- a/setup.py
+++ b/setup.py
@@ -224,7 +224,7 @@ if __name__ == "__main__":
         include_package_data=True,
         package_dir=package_dir,
         zip_safe=False,
-        python_requires=">=3.9",
+        python_requires=">=3.10",
         ext_modules=[CMakeExtension("mlx.core")],
         cmdclass={
             "build_ext": CMakeBuild,


### PR DESCRIPTION
Python 3.9 entered end of life a couple weeks ago and Python 3.14 entered stable.

I think a reasonable policy for MLX Python support is to follow the [official Python versions](https://devguide.python.org/versions/).