### PR TITLE
optionally load metallib from framework

### DIFF
--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -78,7 +78,7 @@ MTL::Library* try_load_framework(
     NS::URL* url,
     const std::string& lib_name) {
   std::string resource_path = std::string(url->fileSystemRepresentation()) +
-      "/Resources/" + lib_name + ".metallib";
+      "/" + lib_name + ".metallib";
   auto [lib, error] = load_library_from_path(device, resource_path.c_str());
   if (lib) {
     return lib;


### PR DESCRIPTION
## Proposed changes

Support for https://github.com/ml-explore/mlx-swift/pull/289 -- this will also allow `SWIFTPM_BUNDLE` to name a framework identifier.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
