### PR TITLE
fix: linux-{fedora}x86_64-build

### DIFF
--- a/mlx/event.h
+++ b/mlx/event.h
@@ -1,6 +1,7 @@
 // Copyright © 2024 Apple Inc.
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <stdexcept>
 


### PR DESCRIPTION
## Proposed changes

This fixes build errors on a Fedora x86_64 machine (`6.17.4-200.fc42.x86_64`), see below

```
In file included from /mlx/mlx/backend/no_gpu/event.cpp:3:
/mlx/mlx/event.h:33:3: error: ‘uint64_t’ does not name a type
   33 |   uint64_t value() const {
      |   ^~~~~~~~
/mlx/mlx/event.h:8:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
    7 | #include "mlx/stream.h"
  +++ |+#include <cstdint>
    8 | 
/mlx/mlx/event.h:37:18: error: ‘uint64_t’ has not been declared
   37 |   void set_value(uint64_t v) {
```

Note that I did not observe this error on `aarch64`.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
