### PR TITLE
add null check -- the bundleIdentifier is optional

### DIFF
--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -122,7 +122,7 @@ std::pair<MTL::Library*, NS::Error*> load_swiftpm_library(
     const auto bundle = reinterpret_cast<NS::Bundle*>(frameworks->object(i));
     const auto identifier = bundle->bundleIdentifier();
     if (identifier != nullptr &&
-        !strcmp(bundle->bundleIdentifier()->utf8String(), SWIFTPM_BUNDLE)) {
+        !strcmp(identifier->utf8String(), SWIFTPM_BUNDLE)) {
       library = try_load_framework(device, bundle->resourceURL(), lib_name);
       if (library != nullptr) {
         return {library, nullptr};


### PR DESCRIPTION
## Proposed changes

Add null check as function can return null (observed by person testing swift xcodeproj).  See also #2702

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
