### PR TITLE
Use faster dequant for fp4

### DIFF
--- a/mlx/backend/metal/kernels/fp4.h
+++ b/mlx/backend/metal/kernels/fp4.h
@@ -49,7 +49,10 @@ struct fp4_e2m1 {
   }
 
   operator float() {
-    return FP4_LUT[bits];
+    half converted = as_type<half>(ushort((bits & 7) << 9));
+    converted *= 16384.0;
+    converted = bits & 8 ? -converted : converted;
+    return converted;
   }
 
   uint8_t bits;


### PR DESCRIPTION
Uses a faster + simpler dequant (instead of the LUT for FP4). Speeds up generation a little but also simplifies the code.

Pre: eneration_tps=121.29
Post: generation_tps=124.01

For QMMs I didn't change it because it's slower. The extra ops are worse than using the LUT.