### PR TITLE
skip self-hosted runners on forks

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,6 +50,7 @@ jobs:
       - uses: ./.github/actions/build-linux
 
   build_mac_release:
+    if: github.repository == 'ml-explore/mlx'
     strategy:
       matrix:
         python-version: ["3.10", "3.13"]
@@ -65,6 +66,7 @@ jobs:
       - uses: ./.github/actions/build-macos
 
   build_cuda_with_tests:
+    if: github.repository == 'ml-explore/mlx'
     runs-on: gpu-t4-4-core
     steps:
       - uses: actions/checkout@v5
@@ -74,6 +76,7 @@ jobs:
       - uses: ./.github/actions/build-cuda
 
   build_cuda_release:
+    if: github.repository == 'ml-explore/mlx'
     runs-on: ubuntu-22-large
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: ./.github/actions/build-linux
 
   mac_build_and_test:
+    if: github.repository == 'ml-explore/mlx'
     runs-on: [self-hosted, macos]
     needs: check_lint
     steps:
@@ -29,6 +30,7 @@ jobs:
       - uses: ./.github/actions/build-macos
 
   cuda_build_and_test:
+    if: github.repository == 'ml-explore/mlx'
     runs-on: gpu-t4-4-core
     needs: check_lint
     steps:
@@ -39,6 +41,7 @@ jobs:
       - uses: ./.github/actions/build-cuda
 
   build_documentation:
+    if: github.repository == 'ml-explore/mlx'
     runs-on: [self-hosted, macos]
     needs: check_lint
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
         run: echo "Publishing setup complete"
 
   build_documentation:
+    if: github.repository == 'ml-explore/mlx'
     runs-on: [self-hosted, macos]
     steps:
       - uses: actions/checkout@v5
@@ -40,6 +41,7 @@ jobs:
         uses: actions/deploy-pages@v4
 
   build_linux_release:
+    if: github.repository == 'ml-explore/mlx'
     strategy:
       matrix:
         python_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
@@ -68,6 +70,7 @@ jobs:
           path: wheelhouse/mlx_cpu-*.whl
   
   build_mac_release:
+    if: github.repository == 'ml-explore/mlx'
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
@@ -96,6 +99,7 @@ jobs:
           path: dist/mlx_metal-*.whl
 
   build_cuda_release:
+    if: github.repository == 'ml-explore/mlx'
     runs-on: ubuntu-22-large
     env:
       PYPI_RELEASE: 1


### PR DESCRIPTION
## Proposed changes

When somebody forks this repo, they will not have all of the same self-hosted or larger runners available so we should skip them. Otherwise they will have workflows queued up that never launch.
