### PR TITLE
Make cpu binary_op easily accessible

### DIFF
--- a/mlx/backend/cpu/binary.cpp
+++ b/mlx/backend/cpu/binary.cpp
@@ -179,7 +179,7 @@ void LogAddExp::eval_cpu(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 2);
   auto& a = inputs[0];
   auto& b = inputs[1];
-  binary_float_cpu(a, b, out, detail::LogAddExp(), stream());
+  binary_float_op_cpu(a, b, out, detail::LogAddExp(), stream());
 }
 
 void LogicalAnd::eval_cpu(const std::vector<array>& inputs, array& out) {
@@ -242,19 +242,19 @@ void BitwiseBinary::eval_cpu(const std::vector<array>& inputs, array& out) {
   auto& b = inputs[1];
   switch (op_) {
     case BitwiseBinary::And:
-      binary_int_cpu(a, b, out, detail::BitwiseAnd(), stream());
+      binary_int_op_cpu(a, b, out, detail::BitwiseAnd(), stream());
       break;
     case BitwiseBinary::Or:
-      binary_int_cpu(a, b, out, detail::BitwiseOr(), stream());
+      binary_int_op_cpu(a, b, out, detail::BitwiseOr(), stream());
       break;
     case BitwiseBinary::Xor:
-      binary_int_cpu(a, b, out, detail::BitwiseXor(), stream());
+      binary_int_op_cpu(a, b, out, detail::BitwiseXor(), stream());
       break;
     case BitwiseBinary::LeftShift:
-      binary_int_cpu(a, b, out, detail::LeftShift(), stream());
+      binary_int_op_cpu(a, b, out, detail::LeftShift(), stream());
       break;
     case BitwiseBinary::RightShift:
-      binary_int_cpu(a, b, out, detail::RightShift(), stream());
+      binary_int_op_cpu(a, b, out, detail::RightShift(), stream());
       break;
   }
 }
@@ -263,7 +263,7 @@ void ArcTan2::eval_cpu(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 2);
   const auto& a = inputs[0];
   const auto& b = inputs[1];
-  binary_float_cpu(a, b, out, detail::ArcTan2(), stream());
+  binary_float_op_cpu(a, b, out, detail::ArcTan2(), stream());
 }
 
 } // namespace mlx::core

--- a/mlx/backend/cpu/binary.h
+++ b/mlx/backend/cpu/binary.h
@@ -422,7 +422,7 @@ void comparison_op_cpu(
 }
 
 template <typename Op>
-void binary_float_cpu(
+void binary_float_op_cpu(
     const array& a,
     const array& b,
     array& out,
@@ -463,7 +463,7 @@ void binary_float_cpu(
 }
 
 template <typename Op>
-void binary_int_cpu(
+void binary_int_op_cpu(
     const array& a,
     const array& b,
     array& out,

--- a/mlx/backend/cpu/matmul.cpp
+++ b/mlx/backend/cpu/matmul.cpp
@@ -148,7 +148,7 @@ void AddMM::eval_cpu(const std::vector<array>& inputs, array& out) {
     } else {
       array beta_scalar = array(beta_, c.dtype());
       auto& encoder = cpu::get_command_encoder(stream());
-      binary_float_cpu(c, beta_scalar, out, detail::Multiply(), stream());
+      binary_float_op_cpu(c, beta_scalar, out, detail::Multiply(), stream());
       encoder.add_temporary(std::move(beta_scalar));
     }
     return;


### PR DESCRIPTION
Similar to the GPU side of things this moves the high level `binary(...)` into `mlx::core` renamed as `binary_op_cpu` and `comparison_op_cpu` etc.

The point is to simplify things like the one in `matmul.cpp`. Not many around so maybe we don't want to merge if we thing this pollutes the namespace (but we have all the lower-level stuff in `mlx::core` 🤷‍♂️ )