### PR TITLE
Add float64 Eig and complex64 SVD/Eig support (Fixes #2708)

### DIFF
--- a/mlx/backend/cpu/eig.cpp
+++ b/mlx/backend/cpu/eig.cpp
@@ -12,30 +12,183 @@ namespace mlx::core {
 
 namespace {
 
-// Wrapper for cgeev
-inline void cgeev_wrapper(
-    const char* jobvl,
-    const char* jobvr,
-    const int* n,
-    std::complex<float>* a,
-    const int* lda,
-    std::complex<float>* w,
-    std::complex<float>* vl,
-    const int* ldvl,
-    std::complex<float>* vr,
-    const int* ldvr,
-    std::complex<float>* work,
-    const int* lwork,
-    float* rwork,
-    int* info) {
-#ifdef MLX_USE_ACCELERATE
-  cgeev_(
-      jobvl, jobvr, n, a, lda, w, vl, ldvl, vr, ldvr, work, lwork, rwork, info);
-#else
-  MLX_LAPACK_FUNC(cgeev)(
-      jobvl, jobvr, n, a, lda, w, vl, ldvl, vr, ldvr, work, lwork, rwork, info);
-#endif
+template <typename T>
+struct EigOutputType {
+  using type = std::complex<T>;
+};
+
+template <>
+struct EigOutputType<double> {
+  using type = complex64_t;
+};
+
+template <typename From, typename To>
+inline To convert_complex(const From& val) {
+  if constexpr (std::is_same_v<From, To>) {
+    return val;
+  } else {
+    return To(static_cast<float>(val.real()), static_cast<float>(val.imag()));
+  }
 }
+
+template <typename T, class Enable = void>
+struct EigWork {};
+
+template <typename T>
+struct EigWork<
+    T,
+    typename std::enable_if<std::is_floating_point<T>::value>::type> {
+  using R = std::complex<T>;
+  using O = typename EigOutputType<T>::type;
+
+  char jobl;
+  char jobr;
+  int N;
+  int lwork;
+  int info;
+  std::vector<array::Data> buffers;
+
+  EigWork(char jobl_, char jobr_, int N_, bool compute_eigenvectors)
+      : jobl(jobl_), jobr(jobr_), N(N_), lwork(-1) {
+    T work;
+    int n_vecs_l = compute_eigenvectors ? N_ : 1;
+    int n_vecs_r = 1;
+    geev<T>(
+        &jobl,
+        &jobr,
+        &N,
+        nullptr,
+        &N,
+        nullptr,
+        nullptr,
+        nullptr,
+        &n_vecs_l,
+        nullptr,
+        &n_vecs_r,
+        &work,
+        &lwork,
+        &info);
+    lwork = static_cast<int>(work);
+
+    buffers.emplace_back(allocator::malloc(sizeof(T) * N * 2));
+    if (compute_eigenvectors) {
+      buffers.emplace_back(allocator::malloc(sizeof(T) * N * N * 2));
+    }
+    buffers.emplace_back(allocator::malloc(sizeof(T) * lwork));
+  }
+
+  void run(T* a, O* values, O* vectors) {
+    auto eig_tmp = static_cast<T*>(buffers[0].buffer.raw_ptr());
+    T* vec_tmp = nullptr;
+    if (vectors) {
+      vec_tmp = static_cast<T*>(buffers[1].buffer.raw_ptr());
+    }
+    auto work = static_cast<T*>(buffers[vectors ? 2 : 1].buffer.raw_ptr());
+
+    int n_vecs_l = vectors ? N : 1;
+    int n_vecs_r = 1;
+    geev<T>(
+        &jobl,
+        &jobr,
+        &N,
+        a,
+        &N,
+        eig_tmp,
+        eig_tmp + N,
+        vectors ? vec_tmp : nullptr,
+        &n_vecs_l,
+        nullptr,
+        &n_vecs_r,
+        work,
+        &lwork,
+        &info);
+
+    for (int i = 0; i < N; ++i) {
+      R val = {eig_tmp[i], eig_tmp[N + i]};
+      values[i] = convert_complex<R, O>(val);
+    }
+
+    if (vectors) {
+      for (int i = 0; i < N; ++i) {
+        if (values[i].imag() != 0) {
+          for (int j = 0; j < N; ++j) {
+            R v1 = {vec_tmp[i * N + j], -vec_tmp[(i + 1) * N + j]};
+            R v2 = {vec_tmp[i * N + j], vec_tmp[(i + 1) * N + j]};
+            vectors[i * N + j] = convert_complex<R, O>(v1);
+            vectors[(i + 1) * N + j] = convert_complex<R, O>(v2);
+          }
+          i += 1;
+        } else {
+          for (int j = 0; j < N; ++j) {
+            R v = {vec_tmp[i * N + j], 0};
+            vectors[i * N + j] = convert_complex<R, O>(v);
+          }
+        }
+      }
+    }
+  }
+};
+
+template <>
+struct EigWork<std::complex<float>> {
+  using T = std::complex<float>;
+  using R = float;
+  using O = T;
+
+  char jobl;
+  char jobr;
+  int N;
+  int lwork;
+  int lrwork;
+  int info;
+  std::vector<array::Data> buffers;
+
+  EigWork(char jobl_, char jobr_, int N_, bool compute_eigenvectors)
+      : jobl(jobl_), jobr(jobr_), N(N_), lwork(-1), lrwork(2 * N_) {
+    T work;
+    R rwork;
+    int n_vecs_l = compute_eigenvectors ? N_ : 1;
+    int n_vecs_r = 1;
+    cgeev_wrapper(
+        &jobl,
+        &jobr,
+        &N,
+        nullptr,
+        &N,
+        nullptr,
+        nullptr,
+        &n_vecs_l,
+        nullptr,
+        &n_vecs_r,
+        &work,
+        &lwork,
+        &rwork,
+        &info);
+    lwork = static_cast<int>(work.real());
+    buffers.emplace_back(allocator::malloc(sizeof(T) * lwork));
+    buffers.emplace_back(allocator::malloc(sizeof(R) * lrwork));
+  }
+
+  void run(T* a, T* values, T* vectors) {
+    int n_vecs_l = vectors ? N : 1;
+    int n_vecs_r = 1;
+    cgeev_wrapper(
+        &jobl,
+        &jobr,
+        &N,
+        a,
+        &N,
+        values,
+        vectors,
+        &n_vecs_l,
+        nullptr,
+        &n_vecs_r,
+        static_cast<T*>(buffers[0].buffer.raw_ptr()),
+        &lwork,
+        static_cast<R*>(buffers[1].buffer.raw_ptr()),
+        &info);
+  }
+};
 
 template <typename T>
 void eig_impl(
@@ -44,304 +197,41 @@ void eig_impl(
     array& values,
     bool compute_eigenvectors,
     Stream stream) {
-  using OT = std::complex<T>;
+  using O = typename EigWork<T>::O;
+
   auto a_ptr = a.data<T>();
-  auto eig_ptr = values.data<OT>();
+  auto val_ptr = values.data<O>();
 
   auto& encoder = cpu::get_command_encoder(stream);
   encoder.set_input_array(a);
   encoder.set_output_array(values);
-  OT* vec_ptr = nullptr;
+  O* vec_ptr = nullptr;
   if (compute_eigenvectors) {
     encoder.set_output_array(vectors);
-    vec_ptr = vectors.data<OT>();
+    vec_ptr = vectors.data<O>();
   }
   encoder.dispatch([a_ptr,
+                    val_ptr,
                     vec_ptr,
-                    eig_ptr,
                     compute_eigenvectors,
                     N = vectors.shape(-1),
                     size = vectors.size()]() mutable {
-    // Work query
     char jobr = 'N';
     char jobl = compute_eigenvectors ? 'V' : 'N';
-    int n_vecs_r = 1;
-    int n_vecs_l = compute_eigenvectors ? N : 1;
-    int lwork = -1;
-    int info;
-    {
-      T work;
-      geev<T>(
-          &jobl,
-          &jobr,
-          &N,
-          nullptr,
-          &N,
-          nullptr,
-          nullptr,
-          nullptr,
-          &n_vecs_l,
-          nullptr,
-          &n_vecs_r,
-          &work,
-          &lwork,
-          &info);
-      lwork = static_cast<int>(work);
-    }
 
-    auto eig_tmp_data = array::Data{allocator::malloc(sizeof(T) * N * 2)};
-    auto vec_tmp_data =
-        array::Data{allocator::malloc(vec_ptr ? sizeof(T) * N * N * 2 : 0)};
-    auto eig_tmp = static_cast<T*>(eig_tmp_data.buffer.raw_ptr());
-    auto vec_tmp = static_cast<T*>(vec_tmp_data.buffer.raw_ptr());
-    auto work_buf = array::Data{allocator::malloc(sizeof(T) * lwork)};
+    EigWork<T> work(jobl, jobr, N, compute_eigenvectors);
+
     for (size_t i = 0; i < size / (N * N); ++i) {
-      geev<T>(
-          &jobl,
-          &jobr,
-          &N,
-          a_ptr,
-          &N,
-          eig_tmp,
-          eig_tmp + N,
-          vec_tmp,
-          &n_vecs_l,
-          nullptr,
-          &n_vecs_r,
-          static_cast<T*>(work_buf.buffer.raw_ptr()),
-          &lwork,
-          &info);
-      for (int i = 0; i < N; ++i) {
-        eig_ptr[i] = {eig_tmp[i], eig_tmp[N + i]};
-      }
-      if (vec_ptr) {
-        for (int i = 0; i < N; ++i) {
-          if (eig_ptr[i].imag() != 0) {
-            // This vector and the next are a pair
-            for (int j = 0; j < N; ++j) {
-              vec_ptr[i * N + j] = {
-                  vec_tmp[i * N + j], -vec_tmp[(i + 1) * N + j]};
-              vec_ptr[(i + 1) * N + j] = {
-                  vec_tmp[i * N + j], vec_tmp[(i + 1) * N + j]};
-            }
-            i += 1;
-          } else {
-            for (int j = 0; j < N; ++j) {
-              vec_ptr[i * N + j] = {vec_tmp[i * N + j], 0};
-            }
-          }
-        }
-        vec_ptr += N * N;
-      }
+      work.run(a_ptr, val_ptr, vec_ptr);
       a_ptr += N * N;
-      eig_ptr += N;
-      if (info != 0) {
-        std::stringstream msg;
-        msg << "[Eig::eval_cpu] Eigenvalue decomposition failed with error code "
-            << info;
-        throw std::runtime_error(msg.str());
-      }
-    }
-  });
-  encoder.add_temporary(a);
-}
-
-template <>
-void eig_impl<double>(
-    array& a,
-    array& vectors,
-    array& values,
-    bool compute_eigenvectors,
-    Stream stream) {
-  using OT = std::complex<double>;
-  auto a_ptr = a.data<double>();
-  auto eig_ptr_out = values.data<complex64_t>();
-
-  auto& encoder = cpu::get_command_encoder(stream);
-  encoder.set_input_array(a);
-  encoder.set_output_array(values);
-  complex64_t* vec_ptr_out = nullptr;
-  if (compute_eigenvectors) {
-    encoder.set_output_array(vectors);
-    vec_ptr_out = vectors.data<complex64_t>();
-  }
-  encoder.dispatch([a_ptr,
-                    vec_ptr_out,
-                    eig_ptr_out,
-                    compute_eigenvectors,
-                    N = vectors.shape(-1),
-                    size = vectors.size()]() mutable {
-    char jobr = 'N';
-    char jobl = compute_eigenvectors ? 'V' : 'N';
-    int n_vecs_r = 1;
-    int n_vecs_l = compute_eigenvectors ? N : 1;
-    int lwork = -1;
-    int info;
-    {
-      double work;
-      geev<double>(
-          &jobl,
-          &jobr,
-          &N,
-          nullptr,
-          &N,
-          nullptr,
-          nullptr,
-          nullptr,
-          &n_vecs_l,
-          nullptr,
-          &n_vecs_r,
-          &work,
-          &lwork,
-          &info);
-      lwork = static_cast<int>(work);
-    }
-
-    auto eig_tmp_data = array::Data{allocator::malloc(sizeof(double) * N * 2)};
-    auto vec_tmp_data = array::Data{
-        allocator::malloc(vec_ptr_out ? sizeof(double) * N * N * 2 : 0)};
-    auto eig_tmp = static_cast<double*>(eig_tmp_data.buffer.raw_ptr());
-    auto vec_tmp = static_cast<double*>(vec_tmp_data.buffer.raw_ptr());
-    auto work_buf = array::Data{allocator::malloc(sizeof(double) * lwork)};
-    for (size_t i = 0; i < size / (N * N); ++i) {
-      geev<double>(
-          &jobl,
-          &jobr,
-          &N,
-          a_ptr,
-          &N,
-          eig_tmp,
-          eig_tmp + N,
-          vec_tmp,
-          &n_vecs_l,
-          nullptr,
-          &n_vecs_r,
-          static_cast<double*>(work_buf.buffer.raw_ptr()),
-          &lwork,
-          &info);
-      for (int i = 0; i < N; ++i) {
-        eig_ptr_out[i] = complex64_t(
-            static_cast<float>(eig_tmp[i]), static_cast<float>(eig_tmp[N + i]));
-      }
-      if (vec_ptr_out) {
-        for (int i = 0; i < N; ++i) {
-          if (eig_ptr_out[i].imag() != 0) {
-            for (int j = 0; j < N; ++j) {
-              vec_ptr_out[i * N + j] = complex64_t(
-                  static_cast<float>(vec_tmp[i * N + j]),
-                  static_cast<float>(-vec_tmp[(i + 1) * N + j]));
-              vec_ptr_out[(i + 1) * N + j] = complex64_t(
-                  static_cast<float>(vec_tmp[i * N + j]),
-                  static_cast<float>(vec_tmp[(i + 1) * N + j]));
-            }
-            i += 1;
-          } else {
-            for (int j = 0; j < N; ++j) {
-              vec_ptr_out[i * N + j] =
-                  complex64_t(static_cast<float>(vec_tmp[i * N + j]), 0.0f);
-            }
-          }
-        }
-        vec_ptr_out += N * N;
-      }
-      a_ptr += N * N;
-      eig_ptr_out += N;
-      if (info != 0) {
-        std::stringstream msg;
-        msg << "[Eig::eval_cpu] Eigenvalue decomposition failed with error code "
-            << info;
-        throw std::runtime_error(msg.str());
-      }
-    }
-  });
-  encoder.add_temporary(a);
-}
-
-template <>
-void eig_impl<std::complex<float>>(
-    array& a,
-    array& vectors,
-    array& values,
-    bool compute_eigenvectors,
-    Stream stream) {
-  using CT = std::complex<float>;
-  auto a_ptr = a.data<complex64_t>();
-  auto eig_ptr = values.data<complex64_t>();
-
-  auto& encoder = cpu::get_command_encoder(stream);
-  encoder.set_input_array(a);
-  encoder.set_output_array(values);
-  complex64_t* vec_ptr = nullptr;
-  if (compute_eigenvectors) {
-    encoder.set_output_array(vectors);
-    vec_ptr = vectors.data<complex64_t>();
-  }
-  encoder.dispatch([a_ptr,
-                    vec_ptr,
-                    eig_ptr,
-                    compute_eigenvectors,
-                    N = vectors.shape(-1),
-                    size = vectors.size()]() mutable {
-    char jobr = 'N';
-    char jobl = compute_eigenvectors ? 'V' : 'N';
-    int n_vecs_r = 1;
-    int n_vecs_l = compute_eigenvectors ? N : 1;
-    int lwork = -1;
-    int info;
-
-    const int lrwork = 2 * N;
-    auto rwork = array::Data{allocator::malloc(sizeof(float) * lrwork)};
-
-    {
-      std::complex<float> work_query;
-      cgeev_wrapper(
-          &jobl,
-          &jobr,
-          &N,
-          nullptr,
-          &N,
-          nullptr,
-          nullptr,
-          &n_vecs_l,
-          nullptr,
-          &n_vecs_r,
-          &work_query,
-          &lwork,
-          static_cast<float*>(rwork.buffer.raw_ptr()),
-          &info);
-      lwork = static_cast<int>(work_query.real());
-    }
-
-    auto work_buf =
-        array::Data{allocator::malloc(sizeof(std::complex<float>) * lwork)};
-
-    for (size_t i = 0; i < size / (N * N); ++i) {
-      cgeev_wrapper(
-          &jobl,
-          &jobr,
-          &N,
-          reinterpret_cast<std::complex<float>*>(a_ptr) + N * N * i,
-          &N,
-          reinterpret_cast<std::complex<float>*>(eig_ptr) + N * i,
-          vec_ptr ? reinterpret_cast<std::complex<float>*>(vec_ptr) + N * N * i
-                  : nullptr,
-          &n_vecs_l,
-          nullptr,
-          &n_vecs_r,
-          reinterpret_cast<std::complex<float>*>(work_buf.buffer.raw_ptr()),
-          &lwork,
-          static_cast<float*>(rwork.buffer.raw_ptr()),
-          &info);
-
+      val_ptr += N;
       if (vec_ptr) {
         vec_ptr += N * N;
       }
-      a_ptr += N * N;
-      eig_ptr += N;
-      if (info != 0) {
+      if (work.info != 0) {
         std::stringstream msg;
         msg << "[Eig::eval_cpu] Eigenvalue decomposition failed with error code "
-            << info;
+            << work.info;
         throw std::runtime_error(msg.str());
       }
     }

--- a/mlx/backend/cpu/eig.cpp
+++ b/mlx/backend/cpu/eig.cpp
@@ -12,6 +12,31 @@ namespace mlx::core {
 
 namespace {
 
+// Wrapper for cgeev
+inline void cgeev_wrapper(
+    const char* jobvl,
+    const char* jobvr,
+    const int* n,
+    std::complex<float>* a,
+    const int* lda,
+    std::complex<float>* w,
+    std::complex<float>* vl,
+    const int* ldvl,
+    std::complex<float>* vr,
+    const int* ldvr,
+    std::complex<float>* work,
+    const int* lwork,
+    float* rwork,
+    int* info) {
+#ifdef MLX_USE_ACCELERATE
+  cgeev_(
+      jobvl, jobvr, n, a, lda, w, vl, ldvl, vr, ldvr, work, lwork, rwork, info);
+#else
+  MLX_LAPACK_FUNC(cgeev)(
+      jobvl, jobvr, n, a, lda, w, vl, ldvl, vr, ldvr, work, lwork, rwork, info);
+#endif
+}
+
 template <typename T>
 void eig_impl(
     array& a,
@@ -121,6 +146,209 @@ void eig_impl(
   encoder.add_temporary(a);
 }
 
+template <>
+void eig_impl<double>(
+    array& a,
+    array& vectors,
+    array& values,
+    bool compute_eigenvectors,
+    Stream stream) {
+  using OT = std::complex<double>;
+  auto a_ptr = a.data<double>();
+  auto eig_ptr_out = values.data<complex64_t>();
+
+  auto& encoder = cpu::get_command_encoder(stream);
+  encoder.set_input_array(a);
+  encoder.set_output_array(values);
+  complex64_t* vec_ptr_out = nullptr;
+  if (compute_eigenvectors) {
+    encoder.set_output_array(vectors);
+    vec_ptr_out = vectors.data<complex64_t>();
+  }
+  encoder.dispatch([a_ptr,
+                    vec_ptr_out,
+                    eig_ptr_out,
+                    compute_eigenvectors,
+                    N = vectors.shape(-1),
+                    size = vectors.size()]() mutable {
+    char jobr = 'N';
+    char jobl = compute_eigenvectors ? 'V' : 'N';
+    int n_vecs_r = 1;
+    int n_vecs_l = compute_eigenvectors ? N : 1;
+    int lwork = -1;
+    int info;
+    {
+      double work;
+      geev<double>(
+          &jobl,
+          &jobr,
+          &N,
+          nullptr,
+          &N,
+          nullptr,
+          nullptr,
+          nullptr,
+          &n_vecs_l,
+          nullptr,
+          &n_vecs_r,
+          &work,
+          &lwork,
+          &info);
+      lwork = static_cast<int>(work);
+    }
+
+    auto eig_tmp_data = array::Data{allocator::malloc(sizeof(double) * N * 2)};
+    auto vec_tmp_data = array::Data{
+        allocator::malloc(vec_ptr_out ? sizeof(double) * N * N * 2 : 0)};
+    auto eig_tmp = static_cast<double*>(eig_tmp_data.buffer.raw_ptr());
+    auto vec_tmp = static_cast<double*>(vec_tmp_data.buffer.raw_ptr());
+    auto work_buf = array::Data{allocator::malloc(sizeof(double) * lwork)};
+    for (size_t i = 0; i < size / (N * N); ++i) {
+      geev<double>(
+          &jobl,
+          &jobr,
+          &N,
+          a_ptr,
+          &N,
+          eig_tmp,
+          eig_tmp + N,
+          vec_tmp,
+          &n_vecs_l,
+          nullptr,
+          &n_vecs_r,
+          static_cast<double*>(work_buf.buffer.raw_ptr()),
+          &lwork,
+          &info);
+      for (int i = 0; i < N; ++i) {
+        eig_ptr_out[i] = complex64_t(
+            static_cast<float>(eig_tmp[i]), static_cast<float>(eig_tmp[N + i]));
+      }
+      if (vec_ptr_out) {
+        for (int i = 0; i < N; ++i) {
+          if (eig_ptr_out[i].imag() != 0) {
+            for (int j = 0; j < N; ++j) {
+              vec_ptr_out[i * N + j] = complex64_t(
+                  static_cast<float>(vec_tmp[i * N + j]),
+                  static_cast<float>(-vec_tmp[(i + 1) * N + j]));
+              vec_ptr_out[(i + 1) * N + j] = complex64_t(
+                  static_cast<float>(vec_tmp[i * N + j]),
+                  static_cast<float>(vec_tmp[(i + 1) * N + j]));
+            }
+            i += 1;
+          } else {
+            for (int j = 0; j < N; ++j) {
+              vec_ptr_out[i * N + j] =
+                  complex64_t(static_cast<float>(vec_tmp[i * N + j]), 0.0f);
+            }
+          }
+        }
+        vec_ptr_out += N * N;
+      }
+      a_ptr += N * N;
+      eig_ptr_out += N;
+      if (info != 0) {
+        std::stringstream msg;
+        msg << "[Eig::eval_cpu] Eigenvalue decomposition failed with error code "
+            << info;
+        throw std::runtime_error(msg.str());
+      }
+    }
+  });
+  encoder.add_temporary(a);
+}
+
+template <>
+void eig_impl<std::complex<float>>(
+    array& a,
+    array& vectors,
+    array& values,
+    bool compute_eigenvectors,
+    Stream stream) {
+  using CT = std::complex<float>;
+  auto a_ptr = a.data<complex64_t>();
+  auto eig_ptr = values.data<complex64_t>();
+
+  auto& encoder = cpu::get_command_encoder(stream);
+  encoder.set_input_array(a);
+  encoder.set_output_array(values);
+  complex64_t* vec_ptr = nullptr;
+  if (compute_eigenvectors) {
+    encoder.set_output_array(vectors);
+    vec_ptr = vectors.data<complex64_t>();
+  }
+  encoder.dispatch([a_ptr,
+                    vec_ptr,
+                    eig_ptr,
+                    compute_eigenvectors,
+                    N = vectors.shape(-1),
+                    size = vectors.size()]() mutable {
+    char jobr = 'N';
+    char jobl = compute_eigenvectors ? 'V' : 'N';
+    int n_vecs_r = 1;
+    int n_vecs_l = compute_eigenvectors ? N : 1;
+    int lwork = -1;
+    int info;
+
+    const int lrwork = 2 * N;
+    auto rwork = array::Data{allocator::malloc(sizeof(float) * lrwork)};
+
+    {
+      std::complex<float> work_query;
+      cgeev_wrapper(
+          &jobl,
+          &jobr,
+          &N,
+          nullptr,
+          &N,
+          nullptr,
+          nullptr,
+          &n_vecs_l,
+          nullptr,
+          &n_vecs_r,
+          &work_query,
+          &lwork,
+          static_cast<float*>(rwork.buffer.raw_ptr()),
+          &info);
+      lwork = static_cast<int>(work_query.real());
+    }
+
+    auto work_buf =
+        array::Data{allocator::malloc(sizeof(std::complex<float>) * lwork)};
+
+    for (size_t i = 0; i < size / (N * N); ++i) {
+      cgeev_wrapper(
+          &jobl,
+          &jobr,
+          &N,
+          reinterpret_cast<std::complex<float>*>(a_ptr) + N * N * i,
+          &N,
+          reinterpret_cast<std::complex<float>*>(eig_ptr) + N * i,
+          vec_ptr ? reinterpret_cast<std::complex<float>*>(vec_ptr) + N * N * i
+                  : nullptr,
+          &n_vecs_l,
+          nullptr,
+          &n_vecs_r,
+          reinterpret_cast<std::complex<float>*>(work_buf.buffer.raw_ptr()),
+          &lwork,
+          static_cast<float*>(rwork.buffer.raw_ptr()),
+          &info);
+
+      if (vec_ptr) {
+        vec_ptr += N * N;
+      }
+      a_ptr += N * N;
+      eig_ptr += N;
+      if (info != 0) {
+        std::stringstream msg;
+        msg << "[Eig::eval_cpu] Eigenvalue decomposition failed with error code "
+            << info;
+        throw std::runtime_error(msg.str());
+      }
+    }
+  });
+  encoder.add_temporary(a);
+}
+
 } // namespace
 
 void Eig::eval_cpu(
@@ -165,8 +393,17 @@ void Eig::eval_cpu(
     case float32:
       eig_impl<float>(a_copy, vectors, values, compute_eigenvectors_, stream());
       break;
+    case float64:
+      eig_impl<double>(
+          a_copy, vectors, values, compute_eigenvectors_, stream());
+      break;
+    case complex64:
+      eig_impl<std::complex<float>>(
+          a_copy, vectors, values, compute_eigenvectors_, stream());
+      break;
     default:
-      throw std::runtime_error("[Eig::eval_cpu] only supports float32.");
+      throw std::runtime_error(
+          "[Eig::eval_cpu] only supports float32, float64, or complex64.");
   }
 }
 

--- a/mlx/backend/cpu/lapack.h
+++ b/mlx/backend/cpu/lapack.h
@@ -63,3 +63,54 @@ INSTANTIATE_LAPACK_REAL(trtri)
   }
 
 INSTANTIATE_LAPACK_COMPLEX(heevd)
+
+// Wrapper for complex geev (needs rwork parameter)
+inline void cgeev_wrapper(
+    const char* jobvl,
+    const char* jobvr,
+    const int* n,
+    std::complex<float>* a,
+    const int* lda,
+    std::complex<float>* w,
+    std::complex<float>* vl,
+    const int* ldvl,
+    std::complex<float>* vr,
+    const int* ldvr,
+    std::complex<float>* work,
+    const int* lwork,
+    float* rwork,
+    int* info) {
+#ifdef MLX_USE_ACCELERATE
+  cgeev_(
+      jobvl, jobvr, n, a, lda, w, vl, ldvl, vr, ldvr, work, lwork, rwork, info);
+#else
+  MLX_LAPACK_FUNC(cgeev)(
+      jobvl, jobvr, n, a, lda, w, vl, ldvl, vr, ldvr, work, lwork, rwork, info);
+#endif
+}
+
+// Wrapper for complex gesdd (needs rwork parameter)
+inline void cgesdd_wrapper(
+    const char* jobz,
+    const int* m,
+    const int* n,
+    std::complex<float>* a,
+    const int* lda,
+    float* s,
+    std::complex<float>* u,
+    const int* ldu,
+    std::complex<float>* vt,
+    const int* ldvt,
+    std::complex<float>* work,
+    const int* lwork,
+    float* rwork,
+    int* iwork,
+    int* info) {
+#ifdef MLX_USE_ACCELERATE
+  cgesdd_(
+      jobz, m, n, a, lda, s, u, ldu, vt, ldvt, work, lwork, rwork, iwork, info);
+#else
+  MLX_LAPACK_FUNC(cgesdd)(
+      jobz, m, n, a, lda, s, u, ldu, vt, ldvt, work, lwork, rwork, iwork, info);
+#endif
+}

--- a/mlx/backend/cpu/lapack.h
+++ b/mlx/backend/cpu/lapack.h
@@ -45,9 +45,7 @@
 INSTANTIATE_LAPACK_REAL(geqrf)
 INSTANTIATE_LAPACK_REAL(orgqr)
 INSTANTIATE_LAPACK_REAL(syevd)
-INSTANTIATE_LAPACK_REAL(geev)
 INSTANTIATE_LAPACK_REAL(potrf)
-INSTANTIATE_LAPACK_REAL(gesdd)
 INSTANTIATE_LAPACK_REAL(getrf)
 INSTANTIATE_LAPACK_REAL(getri)
 INSTANTIATE_LAPACK_REAL(trtri)
@@ -64,53 +62,19 @@ INSTANTIATE_LAPACK_REAL(trtri)
 
 INSTANTIATE_LAPACK_COMPLEX(heevd)
 
-// Wrapper for complex geev (needs rwork parameter)
-inline void cgeev_wrapper(
-    const char* jobvl,
-    const char* jobvr,
-    const int* n,
-    std::complex<float>* a,
-    const int* lda,
-    std::complex<float>* w,
-    std::complex<float>* vl,
-    const int* ldvl,
-    std::complex<float>* vr,
-    const int* ldvr,
-    std::complex<float>* work,
-    const int* lwork,
-    float* rwork,
-    int* info) {
-#ifdef MLX_USE_ACCELERATE
-  cgeev_(
-      jobvl, jobvr, n, a, lda, w, vl, ldvl, vr, ldvr, work, lwork, rwork, info);
-#else
-  MLX_LAPACK_FUNC(cgeev)(
-      jobvl, jobvr, n, a, lda, w, vl, ldvl, vr, ldvr, work, lwork, rwork, info);
-#endif
-}
+#define INSTANTIATE_LAPACK_ALL(FUNC)                                \
+  template <typename T, typename... Args>                           \
+  void FUNC(Args... args) {                                         \
+    if constexpr (std::is_same_v<T, float>) {                       \
+      MLX_LAPACK_FUNC(s##FUNC)(std::forward<Args>(args)...);        \
+    } else if constexpr (std::is_same_v<T, double>) {               \
+      MLX_LAPACK_FUNC(d##FUNC)(std::forward<Args>(args)...);        \
+    } else if constexpr (std::is_same_v<T, std::complex<float>>) {  \
+      MLX_LAPACK_FUNC(c##FUNC)(std::forward<Args>(args)...);        \
+    } else if constexpr (std::is_same_v<T, std::complex<double>>) { \
+      MLX_LAPACK_FUNC(z##FUNC)(std::forward<Args>(args)...);        \
+    }                                                               \
+  }
 
-// Wrapper for complex gesdd (needs rwork parameter)
-inline void cgesdd_wrapper(
-    const char* jobz,
-    const int* m,
-    const int* n,
-    std::complex<float>* a,
-    const int* lda,
-    float* s,
-    std::complex<float>* u,
-    const int* ldu,
-    std::complex<float>* vt,
-    const int* ldvt,
-    std::complex<float>* work,
-    const int* lwork,
-    float* rwork,
-    int* iwork,
-    int* info) {
-#ifdef MLX_USE_ACCELERATE
-  cgesdd_(
-      jobz, m, n, a, lda, s, u, ldu, vt, ldvt, work, lwork, rwork, iwork, info);
-#else
-  MLX_LAPACK_FUNC(cgesdd)(
-      jobz, m, n, a, lda, s, u, ldu, vt, ldvt, work, lwork, rwork, iwork, info);
-#endif
-}
+INSTANTIATE_LAPACK_ALL(geev)
+INSTANTIATE_LAPACK_ALL(gesdd)

--- a/mlx/backend/cpu/svd.cpp
+++ b/mlx/backend/cpu/svd.cpp
@@ -8,6 +8,32 @@
 
 namespace mlx::core {
 
+// Wrapper for cgesdd
+inline void cgesdd_wrapper(
+    const char* jobz,
+    const int* m,
+    const int* n,
+    std::complex<float>* a,
+    const int* lda,
+    float* s,
+    std::complex<float>* u,
+    const int* ldu,
+    std::complex<float>* vt,
+    const int* ldvt,
+    std::complex<float>* work,
+    const int* lwork,
+    float* rwork,
+    int* iwork,
+    int* info) {
+#ifdef MLX_USE_ACCELERATE
+  cgesdd_(
+      jobz, m, n, a, lda, s, u, ldu, vt, ldvt, work, lwork, rwork, iwork, info);
+#else
+  MLX_LAPACK_FUNC(cgesdd)(
+      jobz, m, n, a, lda, s, u, ldu, vt, ldvt, work, lwork, rwork, iwork, info);
+#endif
+}
+
 template <typename T>
 void svd_impl(
     const array& a,
@@ -158,6 +184,144 @@ void compute_svd(
     std::vector<array>& outputs,
     Stream stream) {}
 
+template <>
+void svd_impl<std::complex<float>>(
+    const array& a,
+    std::vector<array>& outputs,
+    bool compute_uv,
+    Stream stream) {
+  using CT = std::complex<float>;
+  using RT = float;
+
+  const int M = a.shape(-2);
+  const int N = a.shape(-1);
+  const int K = std::min(M, N);
+
+  size_t num_matrices = a.size() / (M * N);
+
+  array in(a.shape(), a.dtype(), nullptr, {});
+  copy_cpu(
+      a,
+      in,
+      a.flags().row_contiguous ? CopyType::Vector : CopyType::General,
+      stream);
+
+  auto& encoder = cpu::get_command_encoder(stream);
+  encoder.set_input_array(a);
+  auto in_ptr = in.data<complex64_t>();
+  complex64_t* u_ptr;
+  float* s_ptr;
+  complex64_t* vt_ptr;
+
+  if (compute_uv) {
+    array& u = outputs[0];
+    array& s = outputs[1];
+    array& vt = outputs[2];
+
+    u.set_data(allocator::malloc(u.nbytes()));
+    s.set_data(allocator::malloc(s.nbytes()));
+    vt.set_data(allocator::malloc(vt.nbytes()));
+
+    encoder.set_output_array(u);
+    encoder.set_output_array(s);
+    encoder.set_output_array(vt);
+
+    s_ptr = s.data<float>();
+    u_ptr = u.data<complex64_t>();
+    vt_ptr = vt.data<complex64_t>();
+  } else {
+    array& s = outputs[0];
+
+    s.set_data(allocator::malloc(s.nbytes()));
+
+    encoder.set_output_array(s);
+
+    s_ptr = s.data<float>();
+    u_ptr = nullptr;
+    vt_ptr = nullptr;
+  }
+
+  encoder.dispatch([in_ptr, u_ptr, s_ptr, vt_ptr, M, N, K, num_matrices]() {
+    const int lda = N;
+    const int ldu = N;
+    const int ldvt = M;
+
+    auto jobz = (u_ptr) ? "A" : "N";
+
+    std::complex<float> workspace_dimension = 0;
+
+    auto iwork = array::Data{allocator::malloc(sizeof(int) * 8 * K)};
+
+    static const int lwork_query = -1;
+
+    int info;
+
+    std::complex<float> work_query;
+    const int min_mn = std::min(M, N);
+    const int lrwork = (u_ptr) ? std::max(1, 5 * min_mn * min_mn + 5 * min_mn)
+                               : std::max(1, 7 * min_mn);
+    auto rwork = array::Data{allocator::malloc(sizeof(float) * lrwork)};
+
+    cgesdd_wrapper(
+        /* jobz = */ jobz,
+        // M and N are swapped since lapack expects column-major.
+        /* m = */ &N,
+        /* n = */ &M,
+        /* a = */ nullptr,
+        /* lda = */ &lda,
+        /* s = */ nullptr,
+        /* u = */ nullptr,
+        /* ldu = */ &ldu,
+        /* vt = */ nullptr,
+        /* ldvt = */ &ldvt,
+        /* work = */ &work_query,
+        /* lwork = */ &lwork_query,
+        /* rwork = */ static_cast<float*>(rwork.buffer.raw_ptr()),
+        /* iwork = */ static_cast<int*>(iwork.buffer.raw_ptr()),
+        /* info = */ &info);
+
+    if (info != 0) {
+      std::stringstream ss;
+      ss << "[SVD::eval_cpu] workspace calculation failed with code " << info;
+      throw std::runtime_error(ss.str());
+    }
+
+    const int lwork = static_cast<int>(work_query.real());
+    auto scratch =
+        array::Data{allocator::malloc(sizeof(std::complex<float>) * lwork)};
+
+    for (int i = 0; i < num_matrices; i++) {
+      cgesdd_wrapper(
+          /* jobz = */ jobz,
+          // M and N are swapped since lapack expects column-major.
+          /* m = */ &N,
+          /* n = */ &M,
+          /* a = */ reinterpret_cast<std::complex<float>*>(in_ptr) + M * N * i,
+          /* lda = */ &lda,
+          /* s = */ s_ptr + K * i,
+          // According to the identity above, lapack will write Vᵀᵀ as U.
+          /* u = */ reinterpret_cast<std::complex<float>*>(vt_ptr) + N * N * i,
+          /* ldu = */ &ldu,
+          // According to the identity above, lapack will write Uᵀ as Vᵀ.
+          /* vt = */ reinterpret_cast<std::complex<float>*>(u_ptr) + M * M * i,
+          /* ldvt = */ &ldvt,
+          /* work = */
+          reinterpret_cast<std::complex<float>*>(scratch.buffer.raw_ptr()),
+          /* lwork = */ &lwork,
+          /* rwork = */ static_cast<float*>(rwork.buffer.raw_ptr()),
+          /* iwork = */ static_cast<int*>(iwork.buffer.raw_ptr()),
+          /* info = */ &info);
+
+      if (info != 0) {
+        std::stringstream ss;
+        ss << "svd_impl: cgesdd failed with code " << info;
+        throw std::runtime_error(ss.str());
+      }
+    }
+  });
+  encoder.add_temporary(in);
+}
+
 void SVD::eval_cpu(
     const std::vector<array>& inputs,
     std::vector<array>& outputs) {
@@ -168,9 +332,12 @@ void SVD::eval_cpu(
     case float64:
       svd_impl<double>(inputs[0], outputs, compute_uv_, stream());
       break;
+    case complex64:
+      svd_impl<std::complex<float>>(inputs[0], outputs, compute_uv_, stream());
+      break;
     default:
       throw std::runtime_error(
-          "[SVD::eval_cpu] only supports float32 or float64.");
+          "[SVD::eval_cpu] only supports float32, float64, or complex64.");
   }
 }
 

--- a/mlx/backend/cpu/svd.cpp
+++ b/mlx/backend/cpu/svd.cpp
@@ -8,32 +8,6 @@
 
 namespace mlx::core {
 
-// Wrapper for cgesdd
-inline void cgesdd_wrapper(
-    const char* jobz,
-    const int* m,
-    const int* n,
-    std::complex<float>* a,
-    const int* lda,
-    float* s,
-    std::complex<float>* u,
-    const int* ldu,
-    std::complex<float>* vt,
-    const int* ldvt,
-    std::complex<float>* work,
-    const int* lwork,
-    float* rwork,
-    int* iwork,
-    int* info) {
-#ifdef MLX_USE_ACCELERATE
-  cgesdd_(
-      jobz, m, n, a, lda, s, u, ldu, vt, ldvt, work, lwork, rwork, iwork, info);
-#else
-  MLX_LAPACK_FUNC(cgesdd)(
-      jobz, m, n, a, lda, s, u, ldu, vt, ldvt, work, lwork, rwork, iwork, info);
-#endif
-}
-
 template <typename T>
 void svd_impl(
     const array& a,

--- a/mlx/linalg.cpp
+++ b/mlx/linalg.cpp
@@ -268,7 +268,6 @@ svd(const array& a, bool compute_uv, StreamOrDevice s /* = {} */) {
   s_shape.pop_back();
   s_shape[rank - 2] = std::min(m, n);
 
-  // For complex inputs, singular values are real
   auto s_dtype = a.dtype() == complex64 ? float32 : a.dtype();
 
   if (!compute_uv) {

--- a/mlx/linalg.cpp
+++ b/mlx/linalg.cpp
@@ -269,10 +269,7 @@ svd(const array& a, bool compute_uv, StreamOrDevice s /* = {} */) {
   s_shape[rank - 2] = std::min(m, n);
 
   // For complex inputs, singular values are real
-  Dtype s_dtype = a.dtype();
-  if (a.dtype() == complex64) {
-    s_dtype = float32;
-  }
+  auto s_dtype = a.dtype() == complex64 ? float32 : a.dtype();
 
   if (!compute_uv) {
     return {array(

--- a/mlx/linalg.cpp
+++ b/mlx/linalg.cpp
@@ -250,7 +250,7 @@ std::pair<array, array> qr(const array& a, StreamOrDevice s /* = {} */) {
 std::vector<array>
 svd(const array& a, bool compute_uv, StreamOrDevice s /* = {} */) {
   check_cpu_stream(s, "[linalg::svd]");
-  check_float(a.dtype(), "[linalg::svd]");
+  check_float_or_complex(a.dtype(), "[linalg::svd]");
 
   if (a.ndim() < 2) {
     std::ostringstream msg;
@@ -268,10 +268,16 @@ svd(const array& a, bool compute_uv, StreamOrDevice s /* = {} */) {
   s_shape.pop_back();
   s_shape[rank - 2] = std::min(m, n);
 
+  // For complex inputs, singular values are real
+  Dtype s_dtype = a.dtype();
+  if (a.dtype() == complex64) {
+    s_dtype = float32;
+  }
+
   if (!compute_uv) {
     return {array(
         std::move(s_shape),
-        a.dtype(),
+        s_dtype,
         std::make_shared<SVD>(to_stream(s), compute_uv),
         {a})};
   }
@@ -286,7 +292,7 @@ svd(const array& a, bool compute_uv, StreamOrDevice s /* = {} */) {
 
   return array::make_arrays(
       {u_shape, s_shape, vt_shape},
-      {a.dtype(), a.dtype(), a.dtype()},
+      {a.dtype(), s_dtype, a.dtype()},
       std::make_shared<SVD>(to_stream(s), compute_uv),
       {a});
 }

--- a/python/tests/test_linalg.py
+++ b/python/tests/test_linalg.py
@@ -168,6 +168,50 @@ class TestLinalg(mlx_tests.MLXTestCase):
                 )
             )
 
+        # Test float64 - set default device to CPU since float64 is not supported on GPU
+        old_device = mx.default_device()
+        mx.set_default_device(mx.cpu)
+        try:
+            A_f64 = mx.array(
+                [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]], dtype=mx.float64
+            )
+            U_f64, S_f64, Vt_f64 = mx.linalg.svd(A_f64, compute_uv=True, stream=mx.cpu)
+            mx.eval(U_f64, S_f64, Vt_f64)
+            self.assertTrue(
+                mx.allclose(
+                    U_f64[:, : len(S_f64)] @ mx.diag(S_f64) @ Vt_f64,
+                    A_f64,
+                    rtol=1e-5,
+                    atol=1e-7,
+                )
+            )
+            self.assertEqual(S_f64.dtype, mx.float64)
+        finally:
+            mx.set_default_device(old_device)
+
+        # Test complex64 - set default device to CPU since complex64 is not supported on GPU
+        old_device = mx.default_device()
+        mx.set_default_device(mx.cpu)
+        try:
+            A_c64 = mx.array(
+                [[1.0 + 1j, 2.0 + 2j], [3.0 + 3j, 4.0 + 4j]], dtype=mx.complex64
+            )
+            U_c64, S_c64, Vt_c64 = mx.linalg.svd(A_c64, compute_uv=True, stream=mx.cpu)
+            mx.eval(U_c64, S_c64, Vt_c64)
+            self.assertTrue(
+                mx.allclose(
+                    U_c64[:, : len(S_c64)] @ mx.diag(S_c64) @ Vt_c64,
+                    A_c64,
+                    rtol=1e-5,
+                    atol=1e-7,
+                )
+            )
+            self.assertEqual(S_c64.dtype, mx.float32)
+            self.assertEqual(U_c64.dtype, mx.complex64)
+            self.assertEqual(Vt_c64.dtype, mx.complex64)
+        finally:
+            mx.set_default_device(old_device)
+
     def test_inverse(self):
         A = mx.array([[1, 2, 3], [6, -5, 4], [-9, 8, 7]], dtype=mx.float32)
         A_inv = mx.linalg.inv(A, stream=mx.cpu)
@@ -341,6 +385,51 @@ class TestLinalg(mlx_tests.MLXTestCase):
         # Test with batched input
         A_np = np.random.randn(3, n, n).astype(np.float32)
         check_eigs_and_vecs(A_np)
+
+        # Test float64 - set default device to CPU since float64 is not supported on GPU
+        old_device = mx.default_device()
+        mx.set_default_device(mx.cpu)
+        try:
+            A_np_f64 = np.array([[1.0, 1.0], [3.0, 4.0]], dtype=np.float64)
+            A_f64 = mx.array(A_np_f64, dtype=mx.float64)
+            eig_vals_f64, eig_vecs_f64 = mx.linalg.eig(A_f64, stream=mx.cpu)
+            mx.eval(eig_vals_f64, eig_vecs_f64)
+            self.assertTrue(
+                mx.allclose(
+                    A_f64 @ eig_vecs_f64,
+                    eig_vals_f64[..., None, :] * eig_vecs_f64,
+                    rtol=1e-5,
+                    atol=1e-5,
+                )
+            )
+            # Eigenvalues should be complex64 (output dtype)
+            self.assertEqual(eig_vals_f64.dtype, mx.complex64)
+            self.assertEqual(eig_vecs_f64.dtype, mx.complex64)
+        finally:
+            mx.set_default_device(old_device)
+
+        # Test complex64 input - set default device to CPU since complex64 is not supported on GPU
+        old_device = mx.default_device()
+        mx.set_default_device(mx.cpu)
+        try:
+            A_np_c64 = np.array(
+                [[1.0 + 1j, 2.0 + 2j], [3.0 + 3j, 4.0 + 4j]], dtype=np.complex64
+            )
+            A_c64 = mx.array(A_np_c64, dtype=mx.complex64)
+            eig_vals_c64, eig_vecs_c64 = mx.linalg.eig(A_c64, stream=mx.cpu)
+            mx.eval(eig_vals_c64, eig_vecs_c64)
+            self.assertTrue(
+                mx.allclose(
+                    A_c64 @ eig_vecs_c64,
+                    eig_vals_c64[..., None, :] * eig_vecs_c64,
+                    rtol=1e-5,
+                    atol=1e-5,
+                )
+            )
+            self.assertEqual(eig_vals_c64.dtype, mx.complex64)
+            self.assertEqual(eig_vecs_c64.dtype, mx.complex64)
+        finally:
+            mx.set_default_device(old_device)
 
         # Test error cases
         with self.assertRaises(ValueError):

--- a/python/tests/test_linalg.py
+++ b/python/tests/test_linalg.py
@@ -168,14 +168,12 @@ class TestLinalg(mlx_tests.MLXTestCase):
                 )
             )
 
-        # Test float64 - set default device to CPU since float64 is not supported on GPU
-        old_device = mx.default_device()
-        mx.set_default_device(mx.cpu)
-        try:
+        # Test float64 - use CPU stream since float64 is not supported on GPU
+        with mx.stream(mx.cpu):
             A_f64 = mx.array(
                 [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]], dtype=mx.float64
             )
-            U_f64, S_f64, Vt_f64 = mx.linalg.svd(A_f64, compute_uv=True, stream=mx.cpu)
+            U_f64, S_f64, Vt_f64 = mx.linalg.svd(A_f64, compute_uv=True)
             mx.eval(U_f64, S_f64, Vt_f64)
             self.assertTrue(
                 mx.allclose(
@@ -186,17 +184,13 @@ class TestLinalg(mlx_tests.MLXTestCase):
                 )
             )
             self.assertEqual(S_f64.dtype, mx.float64)
-        finally:
-            mx.set_default_device(old_device)
 
-        # Test complex64 - set default device to CPU since complex64 is not supported on GPU
-        old_device = mx.default_device()
-        mx.set_default_device(mx.cpu)
-        try:
+        # Test complex64 - use CPU stream since complex64 is not supported on GPU
+        with mx.stream(mx.cpu):
             A_c64 = mx.array(
                 [[1.0 + 1j, 2.0 + 2j], [3.0 + 3j, 4.0 + 4j]], dtype=mx.complex64
             )
-            U_c64, S_c64, Vt_c64 = mx.linalg.svd(A_c64, compute_uv=True, stream=mx.cpu)
+            U_c64, S_c64, Vt_c64 = mx.linalg.svd(A_c64, compute_uv=True)
             mx.eval(U_c64, S_c64, Vt_c64)
             self.assertTrue(
                 mx.allclose(
@@ -209,8 +203,6 @@ class TestLinalg(mlx_tests.MLXTestCase):
             self.assertEqual(S_c64.dtype, mx.float32)
             self.assertEqual(U_c64.dtype, mx.complex64)
             self.assertEqual(Vt_c64.dtype, mx.complex64)
-        finally:
-            mx.set_default_device(old_device)
 
     def test_inverse(self):
         A = mx.array([[1, 2, 3], [6, -5, 4], [-9, 8, 7]], dtype=mx.float32)
@@ -386,13 +378,11 @@ class TestLinalg(mlx_tests.MLXTestCase):
         A_np = np.random.randn(3, n, n).astype(np.float32)
         check_eigs_and_vecs(A_np)
 
-        # Test float64 - set default device to CPU since float64 is not supported on GPU
-        old_device = mx.default_device()
-        mx.set_default_device(mx.cpu)
-        try:
+        # Test float64 - use CPU stream since float64 is not supported on GPU
+        with mx.stream(mx.cpu):
             A_np_f64 = np.array([[1.0, 1.0], [3.0, 4.0]], dtype=np.float64)
             A_f64 = mx.array(A_np_f64, dtype=mx.float64)
-            eig_vals_f64, eig_vecs_f64 = mx.linalg.eig(A_f64, stream=mx.cpu)
+            eig_vals_f64, eig_vecs_f64 = mx.linalg.eig(A_f64)
             mx.eval(eig_vals_f64, eig_vecs_f64)
             self.assertTrue(
                 mx.allclose(
@@ -405,18 +395,14 @@ class TestLinalg(mlx_tests.MLXTestCase):
             # Eigenvalues should be complex64 (output dtype)
             self.assertEqual(eig_vals_f64.dtype, mx.complex64)
             self.assertEqual(eig_vecs_f64.dtype, mx.complex64)
-        finally:
-            mx.set_default_device(old_device)
 
-        # Test complex64 input - set default device to CPU since complex64 is not supported on GPU
-        old_device = mx.default_device()
-        mx.set_default_device(mx.cpu)
-        try:
+        # Test complex64 input - use CPU stream since complex64 is not supported on GPU
+        with mx.stream(mx.cpu):
             A_np_c64 = np.array(
                 [[1.0 + 1j, 2.0 + 2j], [3.0 + 3j, 4.0 + 4j]], dtype=np.complex64
             )
             A_c64 = mx.array(A_np_c64, dtype=mx.complex64)
-            eig_vals_c64, eig_vecs_c64 = mx.linalg.eig(A_c64, stream=mx.cpu)
+            eig_vals_c64, eig_vecs_c64 = mx.linalg.eig(A_c64)
             mx.eval(eig_vals_c64, eig_vecs_c64)
             self.assertTrue(
                 mx.allclose(
@@ -428,8 +414,6 @@ class TestLinalg(mlx_tests.MLXTestCase):
             )
             self.assertEqual(eig_vals_c64.dtype, mx.complex64)
             self.assertEqual(eig_vecs_c64.dtype, mx.complex64)
-        finally:
-            mx.set_default_device(old_device)
 
         # Test error cases
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Proposed changes

Extended dtype support for `mlx.linalg.svd` and `mlx.linalg.eig` as requested in #2708.

**Changes:**
- Added `float64` support for `mlx.linalg.eig` (CPU)
- Added `complex64` support for `mlx.linalg.svd` (CPU)
- Added `complex64` support for `mlx.linalg.eig` (CPU)

**Implementation details:**
- Created LAPACK wrapper functions (`cgesdd_wrapper`, `cgeev_wrapper`) to handle complex LAPACK signatures with `rwork` parameters
- Added template specializations for `double` and `complex<float>` in `eig.cpp` and `svd.cpp`
- Extended unit tests in `test_linalg.py` to cover new dtypes

**Limitations:**
- GPU support not included (CPU only implementation)
- `complex128` not supported (MLX doesn't define this dtype)

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
