### PR TITLE
Fix dequantize python sig (dtype default)

### DIFF
--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -4335,7 +4335,7 @@ void init_ops(nb::module_& m) {
       nb::kw_only(),
       "stream"_a = nb::none(),
       nb::sig(
-          "def dequantize(w: array, /, scales: array, biases: Optional[array] = None, group_size: Optional[int] = None, bits: Optional[int] = None, mode: str = 'affine', dtype: Optional[Dtype], *, stream: Union[None, Stream, Device] = None) -> array"),
+          "def dequantize(w: array, /, scales: array, biases: Optional[array] = None, group_size: Optional[int] = None, bits: Optional[int] = None, mode: str = 'affine', dtype: Optional[Dtype] = None, *, stream: Union[None, Stream, Device] = None) -> array"),
       R"pbdoc(
         Dequantize the matrix ``w`` using quantization parameters.
 


### PR DESCRIPTION
## Proposed changes

The `dtype` param is missing its `None` default in its signature, breaking mypy checks against it (as it follows other non-default positionals).

```
.venvs/default/lib/python3.13/site-packages/mlx/core/__init__.pyi:1674:161: error: Parameter without a default
follows parameter with a default  [syntax]
    ...p_size: Optional[int] = None, bits: Optional[int] = None, mode: str = 'affine', dtype: Optional[Dtype]...
                                                                                        ^
Found 1 error in 1 file (errors prevented further checking)
```

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
