### PR TITLE
Fix irregular_strides benchmark shape type

### DIFF
--- a/benchmarks/cpp/irregular_strides.cpp
+++ b/benchmarks/cpp/irregular_strides.cpp
@@ -75,7 +75,7 @@ void time_irregular_binary_ops_3D() {
 
 void time_irregular_binary_ops_4D() {
   auto device = mx::default_device();
-  std::vector<int> shape = {8, 8, 512, 512};
+  mx::Shape shape = {8, 8, 512, 512};
   auto a = mx::random::uniform(shape);
   auto b = mx::random::uniform(shape);
 
@@ -115,7 +115,7 @@ void time_irregular_binary_ops_4D() {
 
 void time_irregular_reshape() {
   auto device = mx::default_device();
-  std::vector<int> shape;
+  mx::Shape shape;
   auto reshape_fn = [&shape, device](const mx::array& a) {
     return mx::reshape(a, shape, device);
   };
@@ -170,7 +170,7 @@ void time_irregular_astype_1D() {
 void time_irregular_astype_2D() {
   auto device = mx::default_device();
   int size = 2048;
-  std::vector<int> shape = {size, size};
+  mx::Shape shape = {size, size};
 
   auto a = mx::random::uniform(shape);
   TIMEM("2D regular", mx::astype, a, mx::int32, device);


### PR DESCRIPTION
## Proposed changes

#2454 changed shapes to `SmallVector` which broke this benchmark:

```
/Users/spinlock/src/ml-explore/mlx/benchmarks/cpp/irregular_strides.cpp:79:12: error: no matching function for call to 'uniform'
   79 |   auto a = mx::random::uniform(shape);
      |            ^~~~~~~~~~~~~~~~~~~
/Users/spinlock/src/ml-explore/mlx/mlx/random.h:88:14: note: candidate function not viable: no known conversion from 'std::vector<int>' to 'const Shape' (aka 'const SmallVector<int>') for 1st argument
   88 | inline array uniform(
      |              ^
   89 |     const Shape& shape,
      |     ~~~~~~~~~~~~~~~~~~
```

I saw #2493 added some `std::vector` interop but it also says shapes are always `SmallVector`s.

Would `auto shape = mx::Shape{...};` be preferred?

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
