### PR TITLE
[CUDA] Check CUDA error in synchronize

### DIFF
--- a/mlx/backend/cuda/device.cpp
+++ b/mlx/backend/cuda/device.cpp
@@ -368,7 +368,7 @@ void CommandEncoder::commit() {
 }
 
 void CommandEncoder::synchronize() {
-  cudaStreamSynchronize(stream_);
+  CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
   auto p = std::make_shared<std::promise<void>>();
   std::future<void> f = p->get_future();
   add_completed_handler([p = std::move(p)]() { p->set_value(); });

--- a/mlx/backend/cuda/worker.cpp
+++ b/mlx/backend/cuda/worker.cpp
@@ -44,7 +44,7 @@ void Worker::commit(cudaStream_t stream) {
   }
   signal_event_.record(stream);
   signal_event_.wait(signal_stream_);
-  cudaLaunchHostFunc(signal_stream_, signal, this);
+  CHECK_CUDA_ERROR(cudaLaunchHostFunc(signal_stream_, signal, this));
 }
 
 void Worker::thread_fn() {


### PR DESCRIPTION
When there was fatal error running CUDA kernel, further CUDA calls would fail and `synchronize()` would get stuck because it would be waiting for a callback failed to be registered.