### PR TITLE
fix release

### DIFF
--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -7,6 +7,12 @@ runs:
     - name: Setup machine
       uses: ./.github/actions/setup-macos
 
+    - name: Setup uv
+      uses: astral-sh/setup-uv@v6
+      with:
+          python-version: "3.10"
+          activate-environment: true
+
     - name: Install dependencies
       shell: sh
       run: |

--- a/.github/actions/build-macos-release/action.yml
+++ b/.github/actions/build-macos-release/action.yml
@@ -20,14 +20,17 @@ runs:
       env:
         MACOSX_DEPLOYMENT_TARGET: ${{ inputs.macos-target }}
       run: |
-        uv pip install build
-        uv run --no-project setup.py clean --all
-        MLX_BUILD_STAGE=1 uv run -m build -w
+        conda activate env
+        pip install build
+        python setup.py clean --all
+        MLX_BUILD_STAGE=1 python -m build -w
+
     - name: Build backend package
       if: ${{ inputs.build-backend }}
       shell: bash
       env:
         MACOSX_DEPLOYMENT_TARGET: ${{ inputs.macos-target }}
       run: |
-        uv run --no-project setup.py clean --all
-        MLX_BUILD_STAGE=2 uv run -m build -w
+        conda activate env
+        python setup.py clean --all
+        MLX_BUILD_STAGE=2 python -m build -w

--- a/.github/actions/build-macos/action.yml
+++ b/.github/actions/build-macos/action.yml
@@ -1,14 +1,31 @@
 name: 'Build and Test on macOS'
 description: 'Build and test MLX on macOS'
 
+inputs:
+  python-version:
+    description: 'Python version to use'
+    required: false
+    default: '3.10'
+  macos-target:
+    description: 'macOS target to build and test for'
+    required: false
+    default: '14.0'
+
 runs:
   using: "composite"
   steps:
+    - name: Setup uv
+      uses: astral-sh/setup-uv@v6
+      with:
+          python-version: ${{ inputs.python-version }}
+          activate-environment: true
+
     - name: Install dependencies
       shell: sh
       env:
         DEBUG: 1
         CMAKE_ARGS: "-DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
+        MACOSX_DEPLOYMENT_TARGET: ${{ inputs.macos-target }}
       run: |
         uv pip install --upgrade pip
         uv pip install cmake setuptools nanobind==2.4.0
@@ -29,6 +46,7 @@ runs:
       shell: bash
       env:
         LOW_MEMORY: 1
+        MACOSX_DEPLOYMENT_TARGET: ${{ inputs.macos-target }}
       run: |
         DEVICE=cpu uv run -m xmlrunner discover -v python/tests -o test-results/cpu
         DEVICE=gpu METAL_DEVICE_WRAPPER_TYPE=1 METAL_DEBUG_ERROR_MODE=0 uv run -m xmlrunner discover -v python/tests -o test-results/gpu
@@ -38,6 +56,8 @@ runs:
     
     - name: Build example extension
       shell: bash
+      env:
+        MACOSX_DEPLOYMENT_TARGET: ${{ inputs.macos-target }}
       run: |
         cd examples/extensions
         uv pip install -r requirements.txt
@@ -46,6 +66,8 @@ runs:
     
     - name: Build CPP only
       shell: bash
+      env:
+        MACOSX_DEPLOYMENT_TARGET: ${{ inputs.macos-target }}
       run: |
         mkdir -p build
         cd build
@@ -62,6 +84,8 @@ runs:
     
     - name: Build small binary with JIT
       shell: bash
+      env:
+        MACOSX_DEPLOYMENT_TARGET: ${{ inputs.macos-target }}
       run: |
         mkdir -p build
         cd build
@@ -80,6 +104,7 @@ runs:
         DEVICE: gpu
         METAL_DEVICE_WRAPPER_TYPE: 1
         METAL_DEBUG_ERROR_MODE: 0
+        MACOSX_DEPLOYMENT_TARGET: ${{ inputs.macos-target }}
       run: |
         CMAKE_ARGS="-DMLX_METAL_JIT=ON" \
           uv pip install -e . -v

--- a/.github/actions/setup-macos/action.yml
+++ b/.github/actions/setup-macos/action.yml
@@ -1,12 +1,6 @@
 name: 'Setup macOS Environment'
 description: 'Install dependencies for macOS builds'
 
-inputs:
-  python-version:
-    description: 'Python version to use'
-    required: false
-    default: '3.10'
-
 runs:
   using: "composite"
   steps:
@@ -17,9 +11,3 @@ runs:
     - name: Verify MetalToolchain installed
       shell: bash
       run: xcodebuild -showComponent MetalToolchain
-    
-    - name: Setup uv
-      uses: astral-sh/setup-uv@v6
-      with:
-          python-version: ${{ inputs.python-version }}
-          activate-environment: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -28,12 +28,17 @@ jobs:
 
   mac_build_and_test:
     if: github.repository == 'ml-explore/mlx'
+    strategy:
+      matrix:
+        macos-target: ["14.0", "15.0"]
     runs-on: [self-hosted, macos]
     needs: check_lint
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-macos
       - uses: ./.github/actions/build-macos
+        with:
+          macos-target: ${{ matrix.macos-target }}
 
   cuda_build_and_test:
     if: github.repository == 'ml-explore/mlx'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+    inputs:
+      dev_release:
+        description: "Do a dev release or regular release"
+        required: true
+        default: "false"
 
 permissions:
   contents: read
@@ -12,10 +17,6 @@ permissions:
 jobs:
   setup:
     runs-on: ubuntu-latest
-    outputs:
-      pypi_env: ${{ github.event_name == 'push' && 'pypi' || 'test-pypi' }}
-      pypi_url: ${{ github.event_name == 'push' && 'https://upload.pypi.org/legacy/' || 'https://test.pypi.org/legacy/' }}
-      skip_duplicates: ${{ github.event_name == 'push' && 'false' || 'true' }}
     steps:
       - name: Set publishing variables
         run: echo "Publishing setup complete"
@@ -54,6 +55,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     env:
       PYPI_RELEASE: 1
+      DEV_RELEASE: ${{ github.event.inputs.dev_release == 'true' && 1 || 0 }}
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-linux
@@ -83,22 +85,27 @@ jobs:
     runs-on: [self-hosted, macos]
     env:
       PYPI_RELEASE: 1
+      DEV_RELEASE: ${{ github.event.inputs.dev_release == 'true' && 1 || 0 }}
+
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-macos
+      - uses: conda-incubator/setup-miniconda@v3
         with:
+          miniconda-version: "latest"
           python-version: ${{ matrix.python-version }}
+
       - name: Install dependencies
         shell: sh
         run: |
-          uv pip install --upgrade pip
-          uv pip install cmake setuptools nanobind==2.4.0
-          uv pip install -e . -v
+          pip install --upgrade pip
+          pip install cmake setuptools nanobind==2.4.0
+          pip install -e . -v
       - name: Generate package stubs
         shell: bash
         run: |
-          uv pip install typing_extensions
-          uv run --no-project setup.py generate_stubs
+          pip install typing_extensions
+          python setup.py generate_stubs
       - name: Build macOS 14 package
         uses: ./.github/actions/build-macos-release
         with:
@@ -126,6 +133,7 @@ jobs:
     runs-on: ubuntu-22-large
     env:
       PYPI_RELEASE: 1
+      DEV_RELEASE: ${{ github.event.inputs.dev_release == 'true' && 1 || 0 }}
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-linux
@@ -148,7 +156,7 @@ jobs:
     permissions:
       id-token: write
     environment:
-      name: ${{ needs.setup.outputs.pypi_env }}
+      name: pypi
       url: https://pypi.org/p/mlx
     steps:
       - uses: actions/download-artifact@v6
@@ -166,9 +174,7 @@ jobs:
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository-url: ${{ needs.setup.outputs.pypi_url }}
-          skip-existing: ${{ needs.setup.outputs.skip_duplicates }}
-          print-hash: true
+          repository-url: https://upload.pypi.org/legacy/
   
   pypi-publish-cuda:
     name: Upload CUDA release to PyPI
@@ -177,7 +183,7 @@ jobs:
     permissions:
       id-token: write
     environment:
-      name: ${{ needs.setup.outputs.pypi_env }}
+      name: pypi
       url: https://pypi.org/p/mlx-cuda
     steps:
       - uses: actions/download-artifact@v6
@@ -189,9 +195,7 @@ jobs:
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository-url: ${{ needs.setup.outputs.pypi_url }}
-          skip-existing: ${{ needs.setup.outputs.skip_duplicates }}
-          print-hash: true
+          repository-url: https://upload.pypi.org/legacy/
 
   pypi-publish-cpu:
     name: Upload CPU release to PyPI
@@ -200,7 +204,7 @@ jobs:
     permissions:
       id-token: write
     environment:
-      name: ${{ needs.setup.outputs.pypi_env }}
+      name: pypi
       url: https://pypi.org/p/mlx-cpu
     steps:
       - uses: actions/download-artifact@v6
@@ -212,9 +216,7 @@ jobs:
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository-url: ${{ needs.setup.outputs.pypi_url }}
-          skip-existing: ${{ needs.setup.outputs.skip_duplicates }}
-          print-hash: true
+          repository-url: https://upload.pypi.org/legacy/
 
   pypi-publish-metal:
     name: Upload Metal release to PyPI
@@ -223,7 +225,7 @@ jobs:
     permissions:
       id-token: write
     environment:
-      name: ${{ needs.setup.outputs.pypi_env }}
+      name: pypi
       url: https://pypi.org/p/mlx-metal
     steps:
       - uses: actions/download-artifact@v6
@@ -235,6 +237,4 @@ jobs:
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository-url: ${{ needs.setup.outputs.pypi_url }}
-          skip-existing: ${{ needs.setup.outputs.skip_duplicates }}
-          print-hash: true
+          repository-url: https://upload.pypi.org/legacy/

--- a/setup.py
+++ b/setup.py
@@ -24,11 +24,11 @@ def get_version():
             if "#define MLX_VERSION_PATCH" in l:
                 patch = l.split()[-1]
     version = f"{major}.{minor}.{patch}"
-    if "PYPI_RELEASE" not in os.environ:
+    if os.environ.get("PYPI_RELEASE", False):
         today = datetime.date.today()
         version = f"{version}.dev{today.year}{today.month:02d}{today.day:02d}"
 
-        if "DEV_RELEASE" not in os.environ:
+        if os.environ.get("DEV_RELEASE", False):
             git_hash = (
                 run(
                     "git rev-parse --short HEAD".split(),


### PR DESCRIPTION
A few changes here:

- Use conda python for release builds so that we don't have the issue of the python binary being compiled on a later macos than the target for the build (as we had it in circle ci)
- Remove releases to test pypi as they are not useful
- Add support dev release as we had it in circle ci
-  Test on more than one macos version as we had it in circle ci (now test on 14 and 15)