### PR TITLE
Use std::optional for mask_arr arg

### DIFF
--- a/mlx/fast.h
+++ b/mlx/fast.h
@@ -49,7 +49,7 @@ array scaled_dot_product_attention(
     const array& values,
     const float scale,
     const std::string& mask_mode = "",
-    const std::vector<array>& mask_arrs = {},
+    std::optional<array> mask_arr = {},
     const std::optional<array>& sinks = {},
     StreamOrDevice s = {});
 

--- a/python/src/fast.cpp
+++ b/python/src/fast.cpp
@@ -213,11 +213,11 @@ void init_fast(nb::module_& parent_module) {
               throw std::invalid_argument(msg.str());
             }
             return mx::fast::scaled_dot_product_attention(
-                queries, keys, values, scale, mask_str, {}, sinks, s);
+                queries, keys, values, scale, mask_str, std::nullopt, sinks, s);
           } else {
             auto mask_arr = std::get<mx::array>(mask);
             return mx::fast::scaled_dot_product_attention(
-                queries, keys, values, scale, "", {mask_arr}, sinks, s);
+                queries, keys, values, scale, "", mask_arr, sinks, s);
           }
 
         } else {


### PR DESCRIPTION
Both the API and kernel only support one mask so there is no need to store masks in a std::vector.