### PR TITLE
Fix warnings with cmake 4.1

### DIFF
--- a/cmake/Findnvpl.cmake
+++ b/cmake/Findnvpl.cmake
@@ -1,0 +1,3 @@
+# This file does nothing but to suppress the cmake warning: "By not providing
+# Findnvpl.cmake in CMAKE_MODULE_PATH...", which is caused by the
+# find_package(nvpl) from cmake's builtin FindLAPACK.cmake module.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,6 @@
 requires = [
   "setuptools>=80",
   "nanobind==2.4.0",
-  "cmake>=3.25,<4.1",
+  "cmake>=3.25",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Fix the annoying cmake warning (for some versions it is an error):

```
  CMake Warning at .venv/lib/python3.10/site-packages/cmake/data/share/cmake-4.1/Modules/FindLAPACK.cmake:740 (find_package):
    By not providing "Findnvpl.cmake" in CMAKE_MODULE_PATH this project has
    asked CMake to find a package configuration file provided by "nvpl", but
    CMake did not find one.

    Could not find a package configuration file provided by "nvpl" with any of
    the following names:

      nvplConfig.cmake
      nvpl-config.cmake

    Add the installation prefix of "nvpl" to CMAKE_PREFIX_PATH or set
    "nvpl_DIR" to a directory containing one of the above files.  If "nvpl"
    provides a separate development package or SDK, be sure it has been
    installed.
  Call Stack (most recent call first):
    CMakeLists.txt:216 (find_package)
```

Also remove the cmake version limit from https://github.com/ml-explore/mlx/pull/2489.