### PR TITLE
Fix MPI distributed tests with CUDA backend

### DIFF
--- a/.github/actions/test-linux/action.yml
+++ b/.github/actions/test-linux/action.yml
@@ -9,13 +9,18 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Run MPI tests
+      shell: bash
+      run: |
+        echo "::group::MPI tests"
+        mpirun --bind-to none --allow-run-as-root -host localhost:8 -np 8 python python/tests/mpi_test_distributed.py
+        echo "::endgroup::"
+
     - name: Run distributed tests
-      # FIXME: This test fails with CUDA build.
       if: ${{ inputs.cpu-only == 'true' }}
       shell: bash
       run: |
         echo "::group::Distributed tests"
-        mpirun --bind-to none --allow-run-as-root -host localhost:8 -np 8 python python/tests/mpi_test_distributed.py
         mlx.launch --verbose -n 8 python/tests/ring_test_distributed.py -v 2> >(tee -a stderr.log >&2)
         if grep -Fq '[WARN]' stderr.log ; then
           grep -F '[WARN]' stderr.log
@@ -34,7 +39,7 @@ runs:
         echo "::endgroup::"
 
     - name: Run Python tests - GPU
-      if: ${{ !inputs.cpu-only }}
+      if: ${{ inputs.cpu-only == 'false' }}
       shell: bash
       env:
         DEVICE: gpu
@@ -53,7 +58,7 @@ runs:
         echo "::endgroup::"
 
     - name: Run CPP tests - GPU
-      if: ${{ !inputs.cpu-only }}
+      if: ${{ inputs.cpu-only == 'false' }}
       shell: bash
       env:
         DEVICE: gpu

--- a/mlx/backend/cuda/utils.cpp
+++ b/mlx/backend/cuda/utils.cpp
@@ -60,7 +60,7 @@ const char* dtype_to_cuda_type(const Dtype& dtype) {
     case float64:
       return "double";
     case complex64:
-      return "complex64_t";
+      return "mlx::core::cu::complex64_t";
     default:
       return "unknown";
   }


### PR DESCRIPTION
Fix the error when running `mpi_test_distributed.py` with CUDA backend:

```
__nv_name_map(17): error: Error in parsing name expression for lowered name lookup. Input name expression was: " mlx :: core :: cu :: gather < complex64_t, uint32_t, 1, 6, int64_t >"
  #pragma nv_mangled_name mlx::core::cu::gather<complex64_t, uint32_t, 1, 6, int64_t>
```

Also fix the problem that GPU tests not actually running.