### PR TITLE
Remove pip cache in GitHub Actions

### DIFF
--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -33,11 +33,6 @@ runs:
     - uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
-        cache: 'pip'
-        cache-dependency-path: |
-          .github/actions/setup-linux/action.yml
-          pyproject.toml
-          setup.py
 
     - name: Setup Python venv
       shell: bash


### PR DESCRIPTION
I made some test runs to see how much time pip cache can save.

For normal linux build it saved 10s in build time (when most pip installs happen) but it is probably just noise.

For CUDA build, the build time reduced 40s but the setup time (when cache is uncompressed) increased 1m50s, it is likely because the cache size is too large (4GB). I also saw similar reports in https://github.com/actions/setup-python/issues/330.

So I think we should just remove the pip cache.