### PR TITLE
Run CI for pushes

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,6 +1,6 @@
 name: Build and Test
 
-on: pull_request  
+on: [pull_request, push]
 
 permissions:
   contents: read


### PR DESCRIPTION
In Github Actions the cache created in pull requests are restricted in the pull request, to make cache work we have to run CI for pushes in the main branch to make cache available to all pull requests:
https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#restrictions-for-accessing-a-cache

It would also help to know a merged change did not cause CI to fail due to conflicts.