### PR TITLE
Do not run CPU tests in CUDA builds

### DIFF
--- a/.github/actions/test-linux/action.yml
+++ b/.github/actions/test-linux/action.yml
@@ -30,6 +30,7 @@ runs:
         echo "::endgroup::"
 
     - name: Run Python tests - CPU
+      if: ${{ inputs.cpu-only == 'true' }}
       shell: bash
       env:
         DEVICE: cpu


### PR DESCRIPTION
Out of the 26 minutes running tests in the CUDA builds, CPU tests took about 15 minutes:

```
  Ran 642 tests in 888.583s
```

Which is too much time and we don't gain much benefits.