### PR TITLE
Fix nightly build

### DIFF
--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -35,7 +35,7 @@ runs:
       run: |
         python -m venv .venv
         source .venv/bin/activate
-        pip install cmake nanobind==2.4.0
+        pip install setuptools cmake nanobind==2.4.0
         echo PATH=$PATH >> $GITHUB_ENV
         # Make cmake search .venv for nanobind
         echo PYTHONPATH=`python -c 'import sys; print(sys.path[-1])'` >> $GITHUB_ENV


### PR DESCRIPTION
Nightly build was [failing](https://github.com/ml-explore/mlx/actions/runs/19420886107/job/55557831555) with:

```
  File "/home/runner/work/mlx/mlx/.venv/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_impl.py", line 402, in _call_hook
    raise BackendUnavailable(
pip._vendor.pyproject_hooks._impl.BackendUnavailable: Cannot import 'setuptools.build_meta'
```

Fixed nightly build for this branch:
https://github.com/ml-explore/mlx/actions/runs/19427287120
