### PR TITLE
Fix Stream Creation Races (Scheduler + Metal)

### DIFF
--- a/mlx/scheduler.cpp
+++ b/mlx/scheduler.cpp
@@ -55,6 +55,11 @@ void synchronize() {
 
 namespace scheduler {
 
+std::mutex& stream_creation_mutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+
 /** A singleton scheduler to manage devices, streams, and task execution. */
 Scheduler& scheduler() {
   // Leak the scheduler on Windows to avoid joining threads on exit, can be


### PR DESCRIPTION
Proposed changes
- Guard scheduler stream/thread vectors with a creation mutex to keep stream IDs unique under concurrency.
- Protect Metal stream_map_ with shared/unique locking and stable pointers to prevent races/rehash invalidation; centralize command buffer creation.
- Add a regression test for concurrent CPU stream creation.

Checklist
- [x]  I have read the CONTRIBUTING document
- [x] I have run pre-commit run --all-files to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x]  I have updated the necessary documentation (if needed) 
