### PR TITLE
Improve batched gemm swizzle

### DIFF
--- a/mlx/backend/metal/matmul.cpp
+++ b/mlx/backend/metal/matmul.cpp
@@ -454,7 +454,8 @@ void steel_matmul_regular_axpby(
   int tm = (M + bm - 1) / bm;
 
   // TODO: Explore device-based tuning for swizzle
-  int swizzle_log = 0; // tm >= 6 ? 3 : (tm <= 3 ? 0 : 2);
+  // Use swizzle for batched operations with larger tile grids
+  int swizzle_log = (batch_size_out > 1 && tm >= 8 && tn >= 8) ? 1 : 0;
 
   // Prepare steel matmul params
   GEMMParams params{


### PR DESCRIPTION
## Proposed changes

Improve batched GEMM performance by enabling swizzle for operations with large tile grids.

Modified swizzle heuristic in `steel_matmul_regular_axpby` to use `swizzle_log=1` when:
- `batch_size_out > 1` (batched operations)
- `tm >= 8 && tn >= 8` (large tile grids, i.e., M >= 512 and N >= 512 with 64x64 blocks)

This improves cache efficiency for batched matrix multiplications commonly used in LLM training (attention projections, FFN layers).

### Benchmark Results

Tested on Apple Silicon M4 Max:

| Shape (B, M, N, K) | Before | After | Improvement |
|-------------------|--------|-------|-------------|
| (16, 1024, 1024, 1024) float32 | -7.6% vs PyTorch | -0.3% | **+7.3 pp** |
| (4, 1024, 1024, 4096) float32 | -17.6% | +8.1% | **+25.7 pp** |
| (4, 1024, 4096, 1024) float32 | -9.9% | +20.3% | **+30.2 pp** |

Non-batched operations (batch=1) are unchanged as they don't benefit from swizzle.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
