### PR TITLE
use thread local cpature mode

### DIFF
--- a/mlx/backend/cuda/device.cpp
+++ b/mlx/backend/cuda/device.cpp
@@ -96,7 +96,7 @@ CommandEncoder::CaptureContext::CaptureContext(CommandEncoder& enc) : enc(enc) {
     return;
   }
   CHECK_CUDA_ERROR(
-      cudaStreamBeginCapture(enc.stream(), cudaStreamCaptureModeGlobal));
+      cudaStreamBeginCapture(enc.stream(), cudaStreamCaptureModeThreadLocal));
 }
 
 CommandEncoder::CaptureContext::~CaptureContext() {


### PR DESCRIPTION
This avoids potential race with `cudaFreeAsync` which can result in the following crash:

```
  what():  cudaFreeAsync(buf->data, free_streams_[buf->device]) failed: operation not permitted when stream is capturing
```