### PR TITLE
Make CommandEncoder.add_temporary return reference

### DIFF
--- a/mlx/backend/cpu/encoder.h
+++ b/mlx/backend/cpu/encoder.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <deque>
 #include <unordered_map>
 
 #include "mlx/array.h"
@@ -25,8 +26,9 @@ struct CommandEncoder {
 
   // Hold onto a temporary until any already scheduled tasks which use it as
   // an input are complete.
-  void add_temporary(array arr) {
+  array& add_temporary(array arr) {
     temporaries_.push_back(std::move(arr));
+    return temporaries_.back();
   }
 
   void add_temporaries(std::vector<array> arrays) {
@@ -36,7 +38,7 @@ struct CommandEncoder {
         std::make_move_iterator(arrays.end()));
   }
 
-  std::vector<array>& temporaries() {
+  std::deque<array>& temporaries() {
     return temporaries_;
   }
 
@@ -58,7 +60,7 @@ struct CommandEncoder {
 
  private:
   Stream stream_;
-  std::vector<array> temporaries_;
+  std::deque<array> temporaries_;
   int num_ops_{0};
 };
 

--- a/mlx/backend/cpu/logsumexp.cpp
+++ b/mlx/backend/cpu/logsumexp.cpp
@@ -83,17 +83,15 @@ void LogSumExp::eval_cpu(const std::vector<array>& inputs, array& out) {
   // Make sure that the last dimension is contiguous
   auto s = stream();
   auto& encoder = cpu::get_command_encoder(s);
-  auto ensure_contiguous = [&s, &encoder](const array& x) {
+  auto ensure_contiguous = [&s, &encoder](const array& x) -> const array& {
     if (x.flags().contiguous && x.strides()[x.ndim() - 1] == 1) {
       return x;
     } else {
-      array x_copy = contiguous_copy_cpu(x, s);
-      encoder.add_temporary(x_copy);
-      return x_copy;
+      return encoder.add_temporary(contiguous_copy_cpu(x, s));
     }
   };
 
-  auto in = ensure_contiguous(inputs[0]);
+  const array& in = ensure_contiguous(inputs[0]);
   if (in.flags().row_contiguous) {
     out.set_data(allocator::malloc(out.nbytes()));
   } else {

--- a/mlx/backend/cuda/device.h
+++ b/mlx/backend/cuda/device.h
@@ -13,6 +13,7 @@
 #include <cudnn.h>
 #include <thrust/execution_policy.h>
 
+#include <deque>
 #include <unordered_map>
 
 namespace mlx::core::cu {
@@ -79,8 +80,9 @@ class CommandEncoder {
 
   void add_graph_node(cudaGraph_t child);
 
-  void add_temporary(const array& arr) {
-    temporaries_.push_back(arr.data_shared_ptr());
+  array& add_temporary(array arr) {
+    temporaries_.push_back(std::move(arr));
+    return temporaries_.back();
   }
 
   void add_completed_handler(std::function<void()> task);
@@ -126,7 +128,7 @@ class CommandEncoder {
   std::string graph_nodes_key_;
   std::string graph_deps_key_;
   std::vector<GraphNode> concurrent_nodes_;
-  std::vector<std::shared_ptr<array::Data>> temporaries_;
+  std::deque<array> temporaries_;
   LRUCache<std::string, CudaGraphExec> graph_cache_;
   std::vector<std::uintptr_t> active_deps_;
   std::vector<std::uintptr_t> active_outputs_;

--- a/mlx/backend/cuda/distributed.cu
+++ b/mlx/backend/cuda/distributed.cu
@@ -63,17 +63,15 @@ void AllGather::eval_gpu(
   auto& s = stream();
   auto& encoder = cu::get_command_encoder(s);
 
-  auto ensure_contiguous = [&s, &encoder](const array& x) {
+  auto ensure_contiguous = [&s, &encoder](const array& x) -> const array& {
     if (x.flags().row_contiguous) {
       return x;
     } else {
-      array x_copy = contiguous_copy_gpu(x, s);
-      encoder.add_temporary(x_copy);
-      return x_copy;
+      return encoder.add_temporary(contiguous_copy_gpu(x, s));
     }
   };
 
-  auto input = ensure_contiguous(inputs[0]);
+  const array& input = ensure_contiguous(inputs[0]);
   outputs[0].set_data(cu::malloc_async(outputs[0].nbytes(), encoder));
 
   encoder.set_input_array(input);
@@ -92,17 +90,15 @@ void ReduceScatter::eval_gpu(
   auto& s = stream();
   auto& encoder = cu::get_command_encoder(s);
 
-  auto ensure_contiguous = [&s, &encoder](const array& x) {
+  auto ensure_contiguous = [&s, &encoder](const array& x) -> const array& {
     if (x.flags().row_contiguous) {
       return x;
     } else {
-      array x_copy = contiguous_copy_gpu(x, s);
-      encoder.add_temporary(x_copy);
-      return x_copy;
+      return encoder.add_temporary(contiguous_copy_gpu(x, s));
     }
   };
 
-  auto input = ensure_contiguous(inputs[0]);
+  const array& input = ensure_contiguous(inputs[0]);
   outputs[0].set_data(cu::malloc_async(outputs[0].nbytes(), encoder));
 
   encoder.set_input_array(input);

--- a/mlx/backend/cuda/logsumexp.cu
+++ b/mlx/backend/cuda/logsumexp.cu
@@ -103,17 +103,15 @@ void LogSumExp::eval_gpu(const std::vector<array>& inputs, array& out) {
   auto& encoder = cu::get_command_encoder(s);
 
   // Make sure that the last dimension is contiguous.
-  auto ensure_contiguous = [&s, &encoder](const array& x) {
+  auto ensure_contiguous = [&s, &encoder](const array& x) -> const array& {
     if (x.flags().contiguous && x.strides()[x.ndim() - 1] == 1) {
       return x;
     } else {
-      array x_copy = contiguous_copy_gpu(x, s);
-      encoder.add_temporary(x_copy);
-      return x_copy;
+      return encoder.add_temporary(contiguous_copy_gpu(x, s));
     }
   };
 
-  auto in = ensure_contiguous(inputs[0]);
+  const array& in = ensure_contiguous(inputs[0]);
   if (in.flags().row_contiguous) {
     out.set_data(cu::malloc_async(out.nbytes(), encoder));
   } else {

--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -409,8 +409,10 @@ void Device::commit_command_buffer(int index) {
   stream.buffer_sizes = 0;
 }
 
-void Device::add_temporary(array arr, int index) {
-  get_stream_(index).temporaries.push_back(std::move(arr));
+array& Device::add_temporary(array arr, int index) {
+  auto& temporaries = get_stream_(index).temporaries;
+  temporaries.push_back(std::move(arr));
+  return temporaries.back();
 }
 
 void Device::add_temporaries(std::vector<array> arrays, int index) {

--- a/mlx/backend/metal/device.h
+++ b/mlx/backend/metal/device.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <Metal/Metal.hpp>
+#include <deque>
 #include <functional>
 #include <mutex>
 #include <shared_mutex>
@@ -143,7 +144,7 @@ struct DeviceStream {
   // encoders
   std::unique_ptr<CommandEncoder> encoder{nullptr};
   std::shared_ptr<Fence> fence;
-  std::vector<array> temporaries;
+  std::deque<array> temporaries;
 };
 
 class Device {
@@ -202,7 +203,7 @@ class Device {
       const std::vector<MTL::ArgumentDescriptor*>& arg_descs) const;
 
   // Record temporary arrays for the given stream index
-  void add_temporary(array arr, int index);
+  array& add_temporary(array arr, int index);
   void add_temporaries(std::vector<array> arrays, int index);
 
   void set_residency_set(const MTL::ResidencySet* residency_set);

--- a/mlx/backend/metal/logsumexp.cpp
+++ b/mlx/backend/metal/logsumexp.cpp
@@ -21,17 +21,15 @@ void LogSumExp::eval_gpu(const std::vector<array>& inputs, array& out) {
   auto& d = metal::device(s.device);
 
   // Make sure that the last dimension is contiguous
-  auto ensure_contiguous = [&s, &d](const array& x) {
+  auto ensure_contiguous = [&s, &d](const array& x) -> const array& {
     if (x.flags().contiguous && x.strides()[x.ndim() - 1] == 1) {
       return x;
     } else {
-      array x_copy = contiguous_copy_gpu(x, s);
-      d.add_temporary(x_copy, s.index);
-      return x_copy;
+      return d.add_temporary(contiguous_copy_gpu(x, s), s.index);
     }
   };
 
-  auto in = ensure_contiguous(inputs[0]);
+  const array& in = ensure_contiguous(inputs[0]);
   if (in.flags().row_contiguous) {
     out.set_data(allocator::malloc(out.nbytes()));
   } else {

--- a/mlx/backend/metal/matmul.cpp
+++ b/mlx/backend/metal/matmul.cpp
@@ -40,12 +40,10 @@ std::tuple<bool, int64_t, array> check_transpose(
   }
 };
 
-inline array
+inline const array&
 ensure_row_contiguous(const array& x, metal::Device& d, const Stream& s) {
   if (!x.flags().row_contiguous) {
-    array x_copy = contiguous_copy_gpu(x, s);
-    d.add_temporary(x_copy, s.index);
-    return x_copy;
+    return d.add_temporary(contiguous_copy_gpu(x, s), s.index);
   } else {
     return x;
   }
@@ -1630,7 +1628,7 @@ void gather_mm_rhs(
     array& out,
     metal::Device& d,
     const Stream& s) {
-  array indices = ensure_row_contiguous(indices_, d, s);
+  const array& indices = ensure_row_contiguous(indices_, d, s);
   auto [transpose_b, ldb, b] = ensure_batch_contiguous(b_, d, s);
 
   // Broadcast a with indices. If we are here that means lhs_indices were not
@@ -1649,7 +1647,7 @@ void gather_mm_rhs(
     broadcast(x, new_x);
     return ensure_row_contiguous(new_x, d, s);
   };
-  array a = broadcast_with_indices(a_);
+  const array& a = broadcast_with_indices(a_);
 
   // Extract the matmul shapes
   int K = a.shape(-1);
@@ -1763,7 +1761,7 @@ void gather_mm_rhs_nax(
     array& out,
     metal::Device& d,
     const Stream& s) {
-  array indices = ensure_row_contiguous(indices_, d, s);
+  const array& indices = ensure_row_contiguous(indices_, d, s);
   auto [transpose_b, ldb, b] = ensure_batch_contiguous(b_, d, s);
 
   // Broadcast a with indices. If we are here that means lhs_indices were not
@@ -1782,7 +1780,7 @@ void gather_mm_rhs_nax(
     broadcast(x, new_x);
     return ensure_row_contiguous(new_x, d, s);
   };
-  array a = broadcast_with_indices(a_);
+  const array& a = broadcast_with_indices(a_);
 
   // Extract the matmul shapes
   int K = a.shape(-1);


### PR DESCRIPTION
This PR tweaks on how we create temporary arrays.

Before:

```c++
array x = x_pre;
if (needs_copy) {
  x = copy(x);
  encoder.add_temporary(x);
}
```

After:

```c++
const array& x = needs_copy ? encoder.add_temporary(copy(x)) : x_pre;
```

Benefits are:

* 1~2 less copies of `array` per each input.
* Simplified code for lots of cases.