### PR TITLE
[CUDA] Faster general copy

### DIFF
--- a/mlx/backend/gpu/copy.cpp
+++ b/mlx/backend/gpu/copy.cpp
@@ -7,8 +7,6 @@
 
 namespace mlx::core {
 
-void copy_gpu(const array& in, array& out, CopyType ctype, const Stream& s);
-
 void copy_gpu(const array& in, array& out, CopyType ctype) {
   copy_gpu(in, out, ctype, out.primitive().stream());
 }


### PR DESCRIPTION
Use a larger work per thread for general to contiguous copies when possible.

On B200:

Type | Pre ms | Post ms
--- | --- | ----
bf16 | 140.536 | 94.853 |
fp32 | 135.735 | 77.529 |

Pretraining 4B model:

Pre: 26580.4548 tok/s
Post: 27443.1227 tok/s

Microbench script:

```python
import mlx.core as mx
import time

B = 8
T = 2048
H = 32
D = 128

for t in [mx.float32, mx.bfloat16]:
    x = mx.random.normal(shape=(B, T, H, D)).astype(t)

    def fun(x):
        for _ in range(50):
            x = mx.contiguous(x.swapaxes(1, 2))
        return x

    for _ in range(20):
        mx.eval(fun(x))

    tic = time.time()
    for _ in range(20):
        mx.eval(fun(x))
    toc = time.time()

    s = toc - tic
    gb = x.nbytes * 2 * 50 * 20 / 1e9
    gbps = gb / s
    ms = s * 1e3
    print(f"{gbps=:.3f}, {ms=:.3f}")
    ```