### PR TITLE
Fix docs: replace nonexistent mx.random.randn with mx.random.normal

### DIFF
--- a/docs/src/usage/indexing.rst
+++ b/docs/src/usage/indexing.rst
@@ -186,7 +186,7 @@ Boolean masks follow NumPy semantics:
 .. code-block:: shell
 
    >>> a = mx.arange(1000).reshape(10, 10, 10)
-   >>> a[mx.random.randn(10, 10) > 0.0] = 0  # valid: mask covers axes 0 and 1
+   >>> a[mx.random.normal((10, 10)) > 0.0] = 0  # valid: mask covers axes 0 and 1
 
 The mask of shape ``(10, 10)`` applies to the first two axes, so ``a[mask]``
 selects the 1-D slices ``a[i, j, :]`` where ``mask[i, j]`` is ``True``.


### PR DESCRIPTION
## Proposed changes

The documentation under "Boolean masks follow NumPy semantics" uses the example:

    a[mx.random.randn(10, 10) > 0.0] = 0

However, MLX does not implement `mx.random.randn`. Running this code produces:

    AttributeError: module 'mlx.core.random' has no attribute 'randn'

This PR replaces the invalid call with the correct MLX API:

    mx.random.normal((10, 10))

This makes the documentation runnable and consistent with the current MLX API.


## Checklist

Put an `x` in the boxes that apply.

- [ x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x] I have updated the necessary documentation (if needed)
