### PR TITLE
bump minimum required Python version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,7 +273,7 @@ target_link_libraries(mlx PRIVATE $<BUILD_INTERFACE:fmt::fmt-header-only>)
 if(MLX_BUILD_PYTHON_BINDINGS)
   message(STATUS "Building Python bindings.")
   find_package(
-    Python 3.8
+    Python 3.10
     COMPONENTS Interpreter Development.Module
     REQUIRED)
   execute_process(


### PR DESCRIPTION
## Proposed changes

This fixes build issues I see trying to use a Python coming from Pyenv on my personal development environment. For whatever reason, cmake finds the Python3.9 coming from Xcode and uses that to build, despite me having a suitable Python in my PATH. 

```
  -- Building Python bindings.
  -- Found Python: /Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.9/bin/python3 (found suitable version "3.9.6", minimum required is "3.8") found components: Interpreter Development.Module
```

See [this old github thread](https://github.com/AcademySoftwareFoundation/openexr/issues/684) with people having a similar problem.

Both Python 3.8 and 3.9 are EOL. The last release of mlx included wheels for 3.10 and newer. IMO the most straightforward fix is to specify that we need 3.10 or newer which avoids using the xcode Python, at least until Apple updates it.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
