### PR TITLE
do not use simd neon intrinsics on x86

### DIFF
--- a/mlx/backend/cpu/simd/type.h
+++ b/mlx/backend/cpu/simd/type.h
@@ -3,5 +3,9 @@
 #include "mlx/backend/cpu/simd/base_simd.h"
 
 #ifdef MLX_USE_ACCELERATE
+#if defined(__x86_64__)
+// the accelerate_simd implementation require neon -- use base implementation
+#else
 #include "mlx/backend/cpu/simd/accelerate_simd.h"
+#endif
 #endif


### PR DESCRIPTION
- see https://github.com/ml-explore/mlx-swift/issues/309
- when MLX_USE_ACCELERATE and building for an x86_64 target do not try to use the accelerate_simd header which requires neon
- this is true for Release builds (Xcode) for mlx-swift

## Proposed changes

Conditional include of `accelerate_simd.h` on `x86_64`, especially for Release builds (Xcode) of mlx-swift.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
