### PR TITLE
Use CUDA runtime headers from local python package

### DIFF
--- a/mlx/backend/cuda/CMakeLists.txt
+++ b/mlx/backend/cuda/CMakeLists.txt
@@ -74,8 +74,6 @@ else()
     mlx PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/gemms/cublas_gemm_batched_12_0.cpp)
 endif()
 
-target_compile_definitions(mlx PRIVATE MLX_USE_CUDA)
-
 # Embed kernel sources in binary for JIT compilation.
 file(
   GLOB MLX_JIT_SOURCES
@@ -93,6 +91,10 @@ add_custom_command(
 add_custom_target(cuda_jit_sources DEPENDS gen/cuda_jit_sources.h)
 add_dependencies(mlx cuda_jit_sources)
 target_include_directories(mlx PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/gen")
+
+# ------------------------ Compilation configs ------------------------
+
+target_compile_definitions(mlx PRIVATE MLX_USE_CUDA)
 
 # Enable defining device lambda functions.
 target_compile_options(mlx
@@ -115,6 +117,10 @@ endif()
 # Suppress warning when building for compute capability 7 used by V100.
 target_compile_options(
   mlx PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:--Wno-deprecated-gpu-targets>")
+
+# Suppress nvcc warnings on MLX headers.
+target_compile_options(mlx PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe
+                                   --diag_suppress=997>)
 
 # Use stronger binaries compression. This feature was introduced in CUDA 12.8
 # and requires drivers released after CUDA 12.4.
@@ -143,13 +149,27 @@ message(STATUS "CUDA architectures: ${MLX_CUDA_ARCHITECTURES}")
 set_target_properties(mlx PROPERTIES CUDA_ARCHITECTURES
                                      "${MLX_CUDA_ARCHITECTURES}")
 
+# ------------------------ Dependencies ------------------------
+
 # Use fixed version of CCCL.
 FetchContent_Declare(
   cccl
   URL "https://github.com/NVIDIA/cccl/releases/download/v2.8.1/cccl-v2.8.1.zip")
 FetchContent_MakeAvailable(cccl)
 target_include_directories(mlx BEFORE PRIVATE "${cccl_SOURCE_DIR}/include")
-set_target_properties(mlx PROPERTIES CCCL_DIR "${cccl_SOURCE_DIR}/include")
+
+# Install CCCL headers for JIT.
+install(DIRECTORY ${cccl_SOURCE_DIR}/include/cuda
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cccl)
+install(DIRECTORY ${cccl_SOURCE_DIR}/include/nv
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cccl)
+
+# The binary of C++ tests will not be installed so it can not find the CCCL
+# headers, and we have to hard-code the path.
+if(MLX_BUILD_TESTS)
+  target_compile_definitions(mlx
+                             PRIVATE MLX_CCCL_DIR="${cccl_SOURCE_DIR}/include")
+endif()
 
 # Use fixed version of NVTX.
 FetchContent_Declare(
@@ -187,10 +207,3 @@ target_link_libraries(mlx PRIVATE cudnn_frontend)
 # Link with the actual cuDNN libraries.
 include(${cudnn_frontend_SOURCE_DIR}/cmake/cuDNN.cmake)
 target_link_libraries(mlx PRIVATE CUDNN::cudnn_all)
-
-# Suppress nvcc warnings on MLX headers.
-target_compile_options(mlx PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe
-                                   --diag_suppress=997>)
-# Install CCCL headers for JIT.
-install(DIRECTORY ${cccl_SOURCE_DIR}/include/cuda
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cccl)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,14 +36,6 @@ target_sources(
           linalg_tests.cpp
           ${METAL_TEST_SOURCES})
 
-if(MLX_BUILD_CUDA)
-  # C++ tests are always built from source, so we have to specify where to find
-  # CCCL headers for JIT as they are not installed in system.
-  get_target_property(MLX_CCCL_DIR mlx CCCL_DIR)
-  target_compile_definitions(mlx PRIVATE MLX_CCCL_DIR="${MLX_CCCL_DIR}")
-  message(STATUS MLX_CCCL_DIR="${MLX_CCCL_DIR}")
-endif()
-
 target_link_libraries(tests PRIVATE mlx doctest)
 doctest_discover_tests(tests)
 add_test(NAME tests COMMAND tests)


### PR DESCRIPTION
Close https://github.com/ml-explore/mlx/issues/2842.

Search `../../nvidia/cuda_runtime/include` for CUDA runtime headers, which is available when the `cuda-toolkit` python package is installed together with `mlx`. This follows the behavior of where CUDA libraries are searched:

https://github.com/ml-explore/mlx/blob/bedefed784115eb233a22c0e192b957de92b2a85/python/scripts/repair_cuda.sh#L20-L22

Also slightly reorganizes the cmake file — especially put the CCCL related configurations together.