### PR TITLE
DOC : Add compile state example

### DIFF
--- a/docs/src/usage/compile.rst
+++ b/docs/src/usage/compile.rst
@@ -258,18 +258,23 @@ constants. For example:
 In order to have the change of state reflected in the outputs of ``fun`` you
 again have two options. The first option is to simply pass ``state`` as input
 to the function.
+
 .. code-block:: python
+
   state = [mx.array(1.0)]
 
   @mx.compile
   def fun(x, state):
-      return x+ state[0]
+      return x + state[0]
 
-  print(fun(mx.array(2.0), state))
+  # Prints array(2, dtype=float32)
+  print(fun(mx.array(1.0), state))
 
-  state[0] = mx.array(3.0)
-  print(fun(mx.array(2.0), state))
+  # Update state
+  state[0] = mx.array(5.0)
 
+  # Prints array(6, dtype=float32)
+  print(fun(mx.array(1.0), state))
 
 In some cases this can be pretty inconvenient. Hence,
 :func:`compile` also has a parameter to capture implicit inputs:


### PR DESCRIPTION
## Proposed changes

This PR addresses an inconsistency in the "Pure Functions" subsection of the `mlx.compile` documentation.

The guide currently mentions two methods for capturing mutable external state, but only provides a code example for the second method.

**Problem:** The text states, "The first option is to simply pass `state` as input to the function," but this method was not demonstrated with code.

**Solution:** This change inserts the missing code block, which explicitly shows the technique of passing `state` as an argument. This provides a clear contrast between the two options and improves the overall clarity and completeness of the documentation section.


## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)