### PR TITLE
refactor: use perf_counter for accurate benchmarking

### DIFF
--- a/examples/python/logistic_regression.py
+++ b/examples/python/logistic_regression.py
@@ -1,6 +1,6 @@
 # Copyright © 2023 Apple Inc.
 
-from time import perf_counter
+import time
 
 import mlx.core as mx
 
@@ -30,13 +30,13 @@ def loss_fn(w):
 
 grad_fn = mx.grad(loss_fn)
 
-tic = perf_counter()
+tic = time.perf_counter()
 for _ in range(num_iters):
     grad = grad_fn(w)
     w = w - lr * grad
     mx.eval(w)
 
-toc = perf_counter()
+toc = time.perf_counter()
 
 loss = loss_fn(w)
 final_preds = (X @ w) > 0


### PR DESCRIPTION
## Proposed changes

This PR replaces `time.time()` with `time.perf_counter()` in the logistic regression example. 

**Problem:** `time.time()` is non-monotonic and susceptible to system clock adjustments, which can lead to inaccurate throughput (it/s) measurements.
**Solution:** `time.perf_counter()` provides a high-resolution, monotonic clock ideal for benchmarking.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)