### PR TITLE
Fix stubgen

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -181,7 +181,7 @@ class GenerateStubs(Command):
         pass
 
     def run(self) -> None:
-        out_path = "python/mlx/core"
+        out_path = "python/mlx"
         stub_cmd = [
             "python",
             "-m",
@@ -192,9 +192,6 @@ class GenerateStubs(Command):
             "python/mlx/_stub_patterns.txt",
         ]
         subprocess.run(stub_cmd + ["-r", "-O", out_path])
-        # Run again without recursive to specify output file name
-        subprocess.run(["rm", f"{out_path}/mlx.pyi"])
-        subprocess.run(stub_cmd + ["-o", f"{out_path}/__init__.pyi"])
 
 
 class MLXBdistWheel(bdist_wheel):


### PR DESCRIPTION
After bumping version of nanobind with https://github.com/ml-explore/mlx/pull/2896 the structure of type stubs have changed.

Before:

```
python/mlx/core
├── __init__.pyi
├── cuda
│   └── __init__.pyi
├── distributed
│   └── __init__.pyi
├── fast
│   └── __init__.pyi
├── fft
│   └── __init__.pyi
├── linalg
│   └── __init__.pyi
├── metal
│   └── __init__.pyi
└── random
    └── __init__.pyi
```

After:

```
python/mlx/core
├── __init__.pyi
└── core
    ├── __init__.pyi
    ├── cuda.pyi
    ├── distributed.pyi
    ├── fast.pyi
    ├── fft.pyi
    ├── linalg.pyi
    ├── metal.pyi
    └── random.pyi
```

Which was caused by https://github.com/wjakob/nanobind/pull/892. With this PR the structure will become:

```
python/mlx/core
├── __init__.pyi
├── cuda.pyi
├── distributed.pyi
├── fast.pyi
├── fft.pyi
├── linalg.pyi
├── metal.pyi
└── random.pyi
```