### PR TITLE
refactor: use time.perf_counter for consistent and accurate benchmarking

### DIFF
--- a/benchmarks/python/comparative/bench_mlx.py
+++ b/benchmarks/python/comparative/bench_mlx.py
@@ -38,10 +38,10 @@ def bench(f, *args):
     for i in range(10):
         f(*args)
 
-    s = time.time()
+    s = time.perf_counter()
     for i in range(100):
         f(*args)
-    e = time.time()
+    e = time.perf_counter()
     return e - s
 
 

--- a/benchmarks/python/comparative/bench_torch.py
+++ b/benchmarks/python/comparative/bench_torch.py
@@ -37,10 +37,10 @@ def bench(f, *args):
     for i in range(10):
         f(*args)
 
-    s = time.time()
+    s = time.perf_counter()
     for i in range(100):
         f(*args)
-    e = time.time()
+    e = time.perf_counter()
     return e - s
 
 

--- a/benchmarks/python/time_utils.py
+++ b/benchmarks/python/time_utils.py
@@ -31,8 +31,8 @@ def measure_runtime(fn, **kwargs):
     for _ in range(5):
         fn(**kwargs)
 
-    tic = time.time()
+    tic = time.perf_counter()
     iters = 100
     for _ in range(iters):
         fn(**kwargs)
-    return (time.time() - tic) * 1000 / iters
+    return (time.perf_counter() - tic) * 1000 / iters

--- a/docs/src/dev/extensions.rst
+++ b/docs/src/dev/extensions.rst
@@ -777,11 +777,11 @@ with the naive :meth:`simple_axpby` we first defined.
             mx.eval(z)
 
         # Timed run
-        s = time.time()
+        s = time.perf_counter()
         for i in range(100):
             z = f(x, y, alpha, beta)
             mx.eval(z)
-        e = time.time()
+        e = time.perf_counter()
         return 1000 * (e - s) / 100
 
     simple_time = bench(simple_axpby)

--- a/examples/python/linear_regression.py
+++ b/examples/python/linear_regression.py
@@ -29,12 +29,12 @@ def loss_fn(w):
 
 grad_fn = mx.grad(loss_fn)
 
-tic = time.time()
+tic = time.perf_counter()
 for _ in range(num_iters):
     grad = grad_fn(w)
     w = w - lr * grad
     mx.eval(w)
-toc = time.time()
+toc = time.perf_counter()
 
 loss = loss_fn(w)
 error_norm = mx.sum(mx.square(w - w_star)).item() ** 0.5


### PR DESCRIPTION
**Proposed Changes:**
This PR updates the timing logic in several benchmark scripts to use `time.perf_counter()` instead of `time.time()`.

**Files modified:**

* `benchmarks/python/comparative/bench_mlx.py` 
* `benchmarks/python/comparative/bench_torch.py` 
*  `benchmarks/python/time_utils.py`
* `docs/src/dev/extensions.rst`
* `examples/python/linear_regression.py`

**Why this is necessary:**

1. **Monotonicity:** `time.time()` can be affected by system clock updates (NTP sync), whereas `time.perf_counter()` is a monotonic clock that never goes backward.
2. **Precision:** High-performance kernels (like those in MLX and Torch) require the highest resolution possible to calculate accurate "msec" per iteration.
3. **Consistency:** This aligns the benchmarking utility functions with the style already adopted in the rest of the MLX examples.

---

### Checklist

* [x] I have read the [[CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md)](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
* [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] I have updated the necessary documentation (if needed)
