### PR TITLE
test(gguf): Add bfloat16 support to GGUF loading tests

### DIFF
--- a/python/tests/test_load.py
+++ b/python/tests/test_load.py
@@ -22,6 +22,7 @@ class TestLoad(mlx_tests.MLXTestCase):
         "int64",
         "float32",
         "float16",
+        "bfloat16",
         "complex64",
     ]
 
@@ -116,7 +117,7 @@ class TestLoad(mlx_tests.MLXTestCase):
             os.mkdir(self.test_dir)
 
         # TODO: Add support for other dtypes (self.dtypes + ["bfloat16"])
-        supported_dtypes = ["float16", "float32", "int8", "int16", "int32"]
+        supported_dtypes = ["float16", "float32", "int8", "int16", "int32", "bfloat16"]
         for dt in supported_dtypes:
             with self.subTest(dtype=dt):
                 for i, shape in enumerate([(1,), (23,), (1024, 1024), (4, 6, 3, 1, 2)]):


### PR DESCRIPTION
## Proposed changes

 This PR extends the GGUF loading tests to support bfloat16 data types. Previously, bfloat16 was missing from the supported_dtypes list in tests/test_load.py, leaving a gap in test coverage for models utilizing this precision format. This change ensures that GGUF save and load operations are correctly validated for bfloat16.

## Checklist

Put an `x` in the boxes that apply.

- [ x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] I have updated the necessary documentation (if needed)
