### PR TITLE
feat(fft): Implement scaled FFT primitive to optimize VJP

### DIFF
--- a/mlx/backend/cpu/fft.cpp
+++ b/mlx/backend/cpu/fft.cpp
@@ -31,7 +31,7 @@ void FFT::eval_cpu(const std::vector<array>& inputs, array& out) {
     shape.insert(shape.end(), in.shape().begin(), in.shape().end());
   }
 
-  float scale = 1.0f;
+  float scale = scale_;
   if (inverse_) {
     size_t nelem = std::accumulate(
         axes_.begin(), axes_.end(), 1, [&shape](auto x, auto y) {

--- a/mlx/primitives.h
+++ b/mlx/primitives.h
@@ -1075,8 +1075,13 @@ class FFT : public UnaryPrimitive {
       Stream stream,
       const std::vector<size_t>& axes,
       bool inverse,
-      bool real)
-      : UnaryPrimitive(stream), axes_(axes), inverse_(inverse), real_(real) {}
+      bool real,
+      float scale = 1.0f)
+      : UnaryPrimitive(stream),
+        axes_(axes),
+        inverse_(inverse),
+        real_(real),
+        scale_(scale) {}
 
   void eval_cpu(const std::vector<array>& inputs, array& out) override;
   void eval_gpu(const std::vector<array>& inputs, array& out) override;
@@ -1087,13 +1092,14 @@ class FFT : public UnaryPrimitive {
 
   bool is_equivalent(const Primitive& other) const override;
   auto state() const {
-    return std::make_tuple(axes_, inverse_, real_);
+    return std::make_tuple(axes_, inverse_, real_, scale_);
   }
 
  private:
   std::vector<size_t> axes_;
   bool inverse_;
   bool real_;
+  float scale_;
 };
 
 class Flatten : public UnaryPrimitive {


### PR DESCRIPTION
## Proposed changes

This PR implements a scale parameter for the FFT primitive and updates the FFT::vjp (Vector Jacobian Product) to utilize this parameter. Previously, the VJP for FFT involved explicit Multiply nodes to handle 1/N scaling and symmetry masks. By integrating the scaling factor directly into the FFT primitive:
The computation graph is simplified (fewer nodes).
Performance is potentially improved by fusing the scaling operation into the FFT kernel execution on both CPU and Metal backends.
The FFT primitive constructor and is_equivalent checks have been updated to support the new member variable.

## Checklist

Put an `x` in the boxes that apply.

- [x ] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x ] I have added tests that prove my fix is effective or that my feature works
- [ x] I have updated the necessary documentation (if needed)
