### PR TITLE
Fix float64 dtype loaded as complex64 from .npy files

### DIFF
--- a/mlx/io/load.cpp
+++ b/mlx/io/load.cpp
@@ -98,6 +98,8 @@ Dtype dtype_from_array_protocol(std::string_view t) {
           return float16;
         else if (size == 4)
           return float32;
+        else if (size == 8)
+          return float64;
       }
       case 'c': {
         return complex64;

--- a/python/tests/test_load.py
+++ b/python/tests/test_load.py
@@ -22,6 +22,7 @@ class TestLoad(mlx_tests.MLXTestCase):
         "int64",
         "float32",
         "float16",
+        "float64",
         "complex64",
     ]
 
@@ -418,6 +419,16 @@ class TestLoad(mlx_tests.MLXTestCase):
         load_with_binary = mx.get_peak_memory()
 
         self.assertEqual(load_only, load_with_binary)
+
+    def test_load_float64_dtype(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fpath = os.path.join(tmp, "float64_test.npy")
+            original = np.array([1.0, 2.0, 3.0], dtype=np.float64)
+            np.save(fpath, original)
+
+            loaded = mx.load(fpath)
+            self.assertEqual(loaded.dtype, mx.float64)
+            self.assertTrue(np.allclose(np.array(loaded), original))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Fix `dtype_from_array_protocol()` to handle float64 (size == 8)
- The 'f' case was missing the float64 handler, causing fall-through to 'c' case

## Test plan
- [x] Added `float64` to the dtypes test list in `test_load.py`
- [x] Added regression test `test_load_float64_dtype` for issue #2958

Fixes #2958