### PR TITLE
Add asarray to __array_namespace__

### DIFF
--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -1670,13 +1670,13 @@ void init_ops(nb::module_& m) {
       )pbdoc");
   m.def(
       "asarray",
-      [](const ScalarOrArray& a, std::optional<mx::Dtype> dtype) {
-        return to_array(a, dtype);
+      [](const ArrayInitType& a, std::optional<mx::Dtype> dtype) {
+        return create_array(a, dtype);
       },
       nb::arg(),
       "dtype"_a = nb::none(),
-      nb::sig("def asarray(a: Union[scalar, array], dtype: Optional[Dtype] = "
-              "None) -> array"),
+      nb::sig("def asarray(a: Union[scalar, array, Sequence], dtype: "
+              "Optional[Dtype] = None) -> array"),
       R"pbdoc(
         Convert the input to an array.
 

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -1987,6 +1987,44 @@ class TestArray(mlx_tests.MLXTestCase):
         arr_pass = xp.asarray(existing)
         self.assertEqual(arr_pass.tolist(), [4, 5, 6])
 
+    def test_asarray(self):
+        # List inputs
+        self.assertEqual(mx.asarray([1, 2, 3]).tolist(), [1, 2, 3])
+        self.assertEqual(mx.asarray([[1, 2], [3, 4]]).tolist(), [[1, 2], [3, 4]])
+
+        # Tuple inputs
+        self.assertEqual(mx.asarray((1, 2, 3)).tolist(), [1, 2, 3])
+        self.assertEqual(mx.asarray(((1, 2), (3, 4))).tolist(), [[1, 2], [3, 4]])
+
+        # Mixed nesting
+        self.assertEqual(mx.asarray([(1, 2), (3, 4)]).tolist(), [[1, 2], [3, 4]])
+        self.assertEqual(mx.asarray(([1, 2], [3, 4])).tolist(), [[1, 2], [3, 4]])
+
+        # Scalar inputs
+        self.assertEqual(mx.asarray(42).item(), 42)
+        self.assertEqual(mx.asarray(3.14).item(), 3.140000104904175)
+        self.assertEqual(mx.asarray(True).item(), True)
+        self.assertEqual(mx.asarray(1 + 2j).item(), (1 + 2j))
+
+        # MLX array inputs
+        arr = mx.array([1, 2, 3])
+        self.assertEqual(mx.asarray(arr).tolist(), [1, 2, 3])
+
+        arr_int = mx.array([1, 2, 3], dtype=mx.int32)
+        arr_float = mx.asarray(arr_int, dtype=mx.float32)
+        self.assertEqual(arr_float.dtype, mx.float32)
+        self.assertEqual(arr_float.tolist(), [1.0, 2.0, 3.0])
+
+        # NumPy array inputs
+        np_arr = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        mx_arr = mx.asarray(np_arr)
+        self.assertEqual(mx_arr.tolist(), [1.0, 2.0, 3.0])
+        self.assertEqual(mx_arr.dtype, mx.float32)
+
+        # dtype parameter
+        self.assertEqual(mx.asarray([1, 2, 3], dtype=mx.float32).dtype, mx.float32)
+        self.assertEqual(mx.asarray(42, dtype=mx.float16).dtype, mx.float16)
+
     def test_to_scalar(self):
         a = mx.array(1)
         self.assertEqual(int(a), 1)


### PR DESCRIPTION
## Summary
- Add `asarray` function to `mlx.core` module
- Makes `xp.asarray()` available via the Array API namespace

## Test plan
- [x] Added `test_array_namespace_asarray` test

Fixes #2945