### PR TITLE
fix array allocator with user buffer and deleter

### DIFF
--- a/mlx/array.cpp
+++ b/mlx/array.cpp
@@ -96,7 +96,7 @@ array::array(
     deleter(data);
   } else {
     auto wrapped_deleter = [deleter](allocator::Buffer buffer) {
-      auto ptr = buffer.ptr();
+      auto ptr = buffer.raw_ptr();
       allocator::release(buffer);
       return deleter(ptr);
     };

--- a/tests/array_tests.cpp
+++ b/tests/array_tests.cpp
@@ -613,7 +613,12 @@ TEST_CASE("test make array from user buffer") {
   std::vector<int> buffer(size, 0);
 
   int count = 0;
-  auto deleter = [&count](void*) { count++; };
+  auto deleter = [&count, data = buffer.data()](void* ptr) {
+    // make sure pointer is correct
+    if (ptr == data) {
+      count++;
+    }
+  };
 
   {
     auto a = array(buffer.data(), Shape{size}, int32, deleter);


### PR DESCRIPTION
## Proposed changes

The array allocator with a custom user buffer and deleter is inaccurately providing the Buffer pointer to the user deleter, instead of the original user pointer.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
