### PR TITLE
replace MLX_IBV_COORDINATOR with MLX_JACCL_COORDINATOR

### DIFF
--- a/docs/src/usage/distributed.rst
+++ b/docs/src/usage/distributed.rst
@@ -584,7 +584,7 @@ the process.
 **MLX_JACCL_COORDINATOR** should contain the IP and port that rank 0 can listen
 to all the other ranks connect to in order to establish the RDMA connections.
 
-**MLX_IBV_DEVICES** should contain the path to a json file that contains the
+**MLX_JACCL_DEVICES** should contain the path to a json file that contains the
 ibverbs device names that connect each node to each other node, something like
 the following:
 

--- a/mlx/distributed/jaccl/jaccl.cpp
+++ b/mlx/distributed/jaccl/jaccl.cpp
@@ -1159,7 +1159,7 @@ bool is_available() {
 }
 
 std::shared_ptr<GroupImpl> init(bool strict /* = false */) {
-  const char* dev_file = std::getenv("MLX_IBV_DEVICES");
+  const char* dev_file = std::getenv("MLX_JACCL_DEVICES");
   const char* coordinator = std::getenv("MLX_JACCL_COORDINATOR");
   const char* rank_str = std::getenv("MLX_RANK");
 
@@ -1167,9 +1167,9 @@ std::shared_ptr<GroupImpl> init(bool strict /* = false */) {
     if (strict) {
       std::ostringstream msg;
       msg << "[jaccl] You need to provide via environment variables a rank (MLX_RANK), "
-          << "a device file (MLX_IBV_DEVICES) and a coordinator ip/port (MLX_JACCL_COORDINATOR) "
+          << "a device file (MLX_JACCL_DEVICES) and a coordinator ip/port (MLX_JACCL_COORDINATOR) "
           << "but provided MLX_RANK=\"" << ((rank_str) ? rank_str : "")
-          << "\", MLX_IBV_DEVICES=\"" << ((dev_file) ? dev_file : "")
+          << "\", MLX_JACCL_DEVICES=\"" << ((dev_file) ? dev_file : "")
           << "\" and MLX_JACCL_COORDINATOR=\""
           << ((coordinator) ? coordinator : "");
       throw std::runtime_error(msg.str());

--- a/python/mlx/_distributed_utils/launch.py
+++ b/python/mlx/_distributed_utils/launch.py
@@ -376,7 +376,7 @@ def launch_jaccl(parser, hosts, args, command):
     env = args.env
     cwd = args.cwd
     env.append(f"MLX_JACCL_COORDINATOR={coordinator}:{args.starting_port}")
-    files = {"MLX_IBV_DEVICES": json.dumps([h.rdma for h in hosts])}
+    files = {"MLX_JACCL_DEVICES": json.dumps([h.rdma for h in hosts])}
 
     log(args.verbose, "Running", shlex.join(command))
 


### PR DESCRIPTION
## Proposed changes

Expect MLX_JACCL_DEVICES instead of MLX_IBV_DEVICES in the JACCL distributed backend, consistent with the JACCL coordinator env var.

Please close if this was intended - but I couldn't find any discussion explicitly intending this behaviour.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] (N/A) I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
