### PR TITLE
refactor: Expose Metal device buffer limits

### DIFF
--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -326,28 +326,28 @@ Device::Device() {
   auto arch = arch_.back();
   switch (arch) {
     case 'p': // phone
-      max_ops_per_buffer_ = 20;
-      max_mb_per_buffer_ = 40;
+      max_ops_per_buffer = 20;
+      max_mb_per_buffer = 40;
       break;
     case 'g': // base, pro
-      max_ops_per_buffer_ = 40;
-      max_mb_per_buffer_ = 40;
+      max_ops_per_buffer = 40;
+      max_mb_per_buffer = 40;
       break;
     case 's': // max
-      max_ops_per_buffer_ = 50;
-      max_mb_per_buffer_ = 50;
+      max_ops_per_buffer = 50;
+      max_mb_per_buffer = 50;
       break;
     case 'd': // ultra
-      max_ops_per_buffer_ = 50;
-      max_mb_per_buffer_ = 50;
+      max_ops_per_buffer = 50;
+      max_mb_per_buffer = 50;
       break;
     default: // default to medium
-      max_ops_per_buffer_ = 40;
-      max_mb_per_buffer_ = 40;
+      max_ops_per_buffer = 40;
+      max_mb_per_buffer = 40;
       break;
   }
-  max_ops_per_buffer_ = env::max_ops_per_buffer(max_ops_per_buffer_);
-  max_mb_per_buffer_ = env::max_mb_per_buffer(max_mb_per_buffer_);
+  max_ops_per_buffer = env::max_ops_per_buffer(max_ops_per_buffer);
+  max_mb_per_buffer = env::max_mb_per_buffer(max_mb_per_buffer);
 }
 
 Device::~Device() {
@@ -382,8 +382,8 @@ MTL::CommandQueue* Device::get_queue(Stream stream) {
 
 bool Device::command_buffer_needs_commit(int index) {
   auto& stream = get_stream_(index);
-  return (stream.buffer_ops > max_ops_per_buffer_) ||
-      ((stream.buffer_sizes >> 20) > max_mb_per_buffer_);
+  return (stream.buffer_ops > max_ops_per_buffer) ||
+      ((stream.buffer_sizes >> 20) > max_mb_per_buffer);
 }
 
 MTL::CommandBuffer* Device::get_command_buffer(int index) {

--- a/mlx/backend/metal/device.h
+++ b/mlx/backend/metal/device.h
@@ -171,6 +171,8 @@ class Device {
 
   MTL::CommandBuffer* get_command_buffer(int index);
   bool command_buffer_needs_commit(int index);
+  int max_ops_per_buffer;
+  int max_mb_per_buffer;
   void commit_command_buffer(int index);
   CommandEncoder& get_command_encoder(int index);
   void end_encoding(int index);
@@ -257,8 +259,6 @@ class Device {
   const MTL::ResidencySet* residency_set_{nullptr};
   std::string arch_;
   int arch_gen_;
-  int max_ops_per_buffer_;
-  int max_mb_per_buffer_;
 };
 
 Device& device(mlx::core::Device);


### PR DESCRIPTION
Makes `max_ops_per_buffer` and `max_mb_per_buffer` public members of the Metal `Device` class. This allows direct access to these command buffer configuration parameters.

## Proposed changes

Please include a description of the problem or feature this PR is addressing. If there is a corresponding issue, include the issue #.

## Checklist

Put an `x` in the boxes that apply.

- [ ] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
