### PR TITLE
Type Enhancement for Func Transforms and Bug Fix

### DIFF
--- a/docs/src/python/transforms.rst
+++ b/docs/src/python/transforms.rst
@@ -11,6 +11,7 @@ Transforms
    eval
    async_eval
    compile
+   checkpoint
    custom_function
    disable_compile
    enable_compile

--- a/python/mlx/_stub_patterns.txt
+++ b/python/mlx/_stub_patterns.txt
@@ -1,10 +1,12 @@
 mlx.core.__prefix__:
-  from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+  from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union, ParamSpec, TypeVar
   import sys
   if sys.version_info >= (3, 10):
     from typing import TypeAlias
   else:
     from typing_extensions import TypeAlias
+  P = ParamSpec("P")
+  R = TypeVar("R")
 
 mlx.core.__suffix__:
   from typing import Union

--- a/python/src/transforms.cpp
+++ b/python/src/transforms.cpp
@@ -1333,7 +1333,7 @@ void init_transforms(nb::module_& m) {
       "argnums"_a = nb::none(),
       "argnames"_a = std::vector<std::string>{},
       nb::sig(
-          "def value_and_grad(fun: Callable, argnums: Optional[Union[int, Sequence[int]]] = None, argnames: Union[str, Sequence[str]] = []) -> Callable"),
+          "def value_and_grad(fun: Callable[P, R], argnums: Optional[Union[int, Sequence[int]]] = None, argnames: Union[str, Sequence[str]] = []) -> Callable[P, Tuple[R, Any]]"),
       R"pbdoc(
         Returns a function which computes the value and gradient of ``fun``.
 
@@ -1472,7 +1472,7 @@ void init_transforms(nb::module_& m) {
       "outputs"_a = nb::none(),
       "shapeless"_a = false,
       nb::sig(
-          "def compile(fun: Callable, inputs: Optional[object] = None, outputs: Optional[object] = None, shapeless: bool = False) -> Callable"),
+          "def compile(fun: Callable[P, R], inputs: Optional[object] = None, outputs: Optional[object] = None, shapeless: bool = False) -> Callable[P, R]"),
       R"pbdoc(
         Returns a compiled function which produces the same output as ``fun``.
 

--- a/python/src/transforms.cpp
+++ b/python/src/transforms.cpp
@@ -1402,7 +1402,7 @@ void init_transforms(nb::module_& m) {
       "argnums"_a = nb::none(),
       "argnames"_a = std::vector<std::string>{},
       nb::sig(
-          "def grad(fun: Callable, argnums: Optional[Union[int, Sequence[int]]] = None, argnames: Union[str, Sequence[str]] = []) -> Callable"),
+          "def grad(fun: Callable[P, R], argnums: Optional[Union[int, Sequence[int]]] = None, argnames: Union[str, Sequence[str]] = []) -> Callable[P, Any]"),
       R"pbdoc(
         Returns a function which computes the gradient of ``fun``.
 
@@ -1435,7 +1435,7 @@ void init_transforms(nb::module_& m) {
       "in_axes"_a = 0,
       "out_axes"_a = 0,
       nb::sig(
-          "def vmap(fun: Callable, in_axes: object = 0, out_axes: object = 0) -> Callable"),
+          "def vmap(fun: Callable[P, R], in_axes: object = 0, out_axes: object = 0) -> Callable[P, R]"),
       R"pbdoc(
         Returns a vectorized version of ``fun``.
 
@@ -1518,7 +1518,22 @@ void init_transforms(nb::module_& m) {
   m.def(
       "checkpoint",
       [](nb::callable fun) { return mlx_func(PyCheckpointedFun{fun}, fun); },
-      "fun"_a);
+      "fun"_a,
+      nb::sig("def checkpoint(fun: Callable[P, R]) -> Callable[P, R]"),
+      R"pbdoc(
+      Transform the passed callable to one that performs gradient
+      checkpointing with respect to the inputs of the callable.
+
+      Use this to reduce memory use for gradient computations at the expense of
+      increased computation.
+
+      Args:
+          fun (Callable): The function to checkpoint.
+
+      Returns:
+          A callable that recomputes intermediate states during gradient
+          computation.
+      )pbdoc");
 
   // Register static Python object cleanup before the interpreter exits
   auto atexit = nb::module_::import_("atexit");

--- a/setup.py
+++ b/setup.py
@@ -169,15 +169,10 @@ class CMakeBuild(build_ext):
             self.copy_tree(regular_dir, inplace_dir)
 
         # Build type stubs.
-        ext_fullpath = Path.cwd() / self.get_ext_fullpath(ext.name)  # type: ignore[no-untyped-call]
-        extdir = ext_fullpath.parent.parent.resolve()
         build_temp = Path(self.build_temp) / ext.name
-        env = os.environ.copy()
-        env["PYTHONPATH"] += f":{extdir}"
         subprocess.run(
             ["cmake", "--install", build_temp, "--component", "core_stub"],
             check=True,
-            env=env,
         )
 
 

--- a/setup.py
+++ b/setup.py
@@ -169,10 +169,15 @@ class CMakeBuild(build_ext):
             self.copy_tree(regular_dir, inplace_dir)
 
         # Build type stubs.
+        ext_fullpath = Path.cwd() / self.get_ext_fullpath(ext.name)  # type: ignore[no-untyped-call]
+        extdir = ext_fullpath.parent.parent.resolve()
         build_temp = Path(self.build_temp) / ext.name
+        env = os.environ.copy()
+        env["PYTHONPATH"] += f":{extdir}"
         subprocess.run(
             ["cmake", "--install", build_temp, "--component", "core_stub"],
             check=True,
+            env=env,
         )
 
 


### PR DESCRIPTION
## Proposed changes

1. Functions lose precise type hints after transformation. For example, mx.compile only annotates its input and output as Callable, so the original function signature and return types are not preserved in the type system.
2. Errors occur during the stub gen.

<img width="1701" height="423" alt="截屏2026-01-16 22 51 04" src="https://github.com/user-attachments/assets/9816a061-edca-4d1d-9fdb-c3b463d58b9c" />


Type Hints After This PR:

<img width="285" height="235" alt="截屏2026-01-16 20 23 34" src="https://github.com/user-attachments/assets/bfd98c67-a126-4182-b4b2-611eaefe95e9" />

<img width="343" height="243" alt="截屏2026-01-16 20 23 09" src="https://github.com/user-attachments/assets/67acead5-081c-4a0a-a0ea-ee24606bbe55" />

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
