### PR TITLE
PR 3007 Fix Seg Fault

### DIFF
--- a/mlx/distributed/utils.cpp
+++ b/mlx/distributed/utils.cpp
@@ -184,7 +184,9 @@ TCPSocket TCPSocket::connect(
       break;
     }
 
-    cb(attempt, wait);
+    if (cb != nullptr) {
+      cb(attempt, wait);
+    }
     if (wait > 0) {
       std::this_thread::sleep_for(std::chrono::milliseconds(wait));
     }

--- a/mlx/distributed/utils.h
+++ b/mlx/distributed/utils.h
@@ -56,8 +56,7 @@ class TCPSocket {
       const address_t& addr,
       int num_retries = 1,
       int wait = 0,
-      // adding in fix as per PR 3007
-      std::function<void(int, int)> cb = [](int, int) {});
+      std::function<void(int, int)> cb = nullptr);
 
  private:
   TCPSocket(int sock);


### PR DESCRIPTION
## Proposed changes

Fixes a potential seg fault wherein utils.h defaults to a nullptr but utils.cpp doesn't check to see if it's actually passed a nullptr issue #3007 .



## Checklist

Put an `x` in the boxes that apply.

- [ X] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ X] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [X ] I have added tests that prove my fix is effective or that my feature works
- [ X] I have updated the necessary documentation (if needed)
