### PR TITLE
Fix python package install path in stubgen

### DIFF
--- a/python/src/CMakeLists.txt
+++ b/python/src/CMakeLists.txt
@@ -37,6 +37,7 @@ if(MLX_BUILD_PYTHON_STUBS)
     MODULE
     "mlx.core"
     PYTHON_PATH
+    "$<TARGET_FILE_DIR:core>/.."
     "${CMAKE_CURRENT_SOURCE_DIR}/.."
     PATTERN_FILE
     "${CMAKE_CURRENT_SOURCE_DIR}/../mlx/_stub_patterns.txt"


### PR DESCRIPTION
We need to pass the path where the mlx package is installed to `stubgen`, previously it was hard coded to `~/mlx/python` but would fail for some cases like https://github.com/ml-explore/mlx/pull/3003#discussion_r2701997478. This PR fixes it by also searching the actual path of extension with the ` $<TARGET_FILE_DIR>` expression.