### PR TITLE
Only clear disk when building for release

### DIFF
--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -4,20 +4,25 @@ description: 'Install dependencies for Linux builds'
 inputs:
   toolkit:
     description: 'Which toolkit to install'
-    required: false
     default: 'cpu'
   python-version:
     description: 'Version of python to set up'
-    required: false
     default: '3.14'
+  clear-disk:
+    description: 'Remove unused software to free some disk space'
+    default: 'false'
   use-ccache:
     description: 'Whether to enable ccache'
-    required: false
     default: 'true'
 
 runs:
   using: "composite"
   steps:
+    - name: Clear disk
+      if: ${{ inputs.clear-disk == 'true' }}
+      shell: bash
+      run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+
     - name: Install common dependencies
       shell: bash
       run: |
@@ -27,7 +32,6 @@ runs:
             zip \
             libblas-dev liblapack-dev liblapacke-dev \
             openmpi-bin openmpi-common libopenmpi-dev
-        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc || true
         echo "::endgroup::"
 
     - name: Use ccache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,7 @@ jobs:
       - uses: ./.github/actions/setup-linux
         with:
           python-version: ${{ matrix.python_version }}
+          clear-disk: true
           use-ccache: false
       - uses: ./.github/actions/build-linux-release
         with:
@@ -141,6 +142,7 @@ jobs:
       - uses: ./.github/actions/setup-linux
         with:
           toolkit: ${{ matrix.toolkit }}
+          clear-disk: true
           use-ccache: false
       - name: Build Python package
         uses: ./.github/actions/build-cuda-release


### PR DESCRIPTION
IO is very slow in CI so removing lots of files would add 1~2 minutes to run time. Only do it for release build.

Also removes `required: false` from the inputs, it literally does nothing and adds cognitive costs when reading code.