### PR TITLE
Do not give workflow boolean inputs default values

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,18 +4,18 @@ on:
   push:
     tags:
       - 'v*'
+    branches:
+      - 'test-publish/*'
   workflow_dispatch:
     inputs:
-      publish:
-        description: 'Publish to PyPI (uncheck for dry run)'
+      dry_run:
+        description: 'Dry run (do not publish to PyPi)'
         required: false
         type: boolean
-        default: true
       dev_release:
         description: 'Development release (DEV_RELEASE=1)'
         required: false
         type: boolean
-        default: false
 
 permissions:
   contents: read
@@ -29,7 +29,7 @@ jobs:
       - uses: ./.github/actions/build-docs
 
   deploy_documentation:
-    if: ${{ github.event_name == 'push' || inputs.publish }}
+    if: ${{ !inputs.dry_run }}
     needs: build_documentation
     permissions:
       pages: write
@@ -161,7 +161,7 @@ jobs:
     permissions:
       id-token: write
     environment:
-      name: pypi
+      name: ${{ inputs.dry_run && 'dry-run' || 'pypi' }}
       url: https://pypi.org/p/mlx
     steps:
       - uses: actions/download-artifact@v7
@@ -177,7 +177,7 @@ jobs:
       - name: Display structure of downloaded files
         run: du -ah dist
       - name: Publish package distributions to PyPI
-        if: ${{ github.event_name == 'push' || inputs.publish }}
+        if: ${{ !inputs.dry_run }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://upload.pypi.org/legacy/
@@ -189,7 +189,7 @@ jobs:
     permissions:
       id-token: write
     environment:
-      name: pypi
+      name: ${{ inputs.dry_run && 'dry-run' || 'pypi' }}
       url: https://pypi.org/p/mlx-cuda
     steps:
       - uses: actions/download-artifact@v7
@@ -200,7 +200,7 @@ jobs:
       - name: Display structure of downloaded files
         run: du -ah dist
       - name: Publish package distributions to PyPI
-        if: ${{ github.event_name == 'push' || inputs.publish }}
+        if: ${{ !inputs.dry_run }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://upload.pypi.org/legacy/
@@ -212,7 +212,7 @@ jobs:
     permissions:
       id-token: write
     environment:
-      name: pypi
+      name: ${{ inputs.dry_run && 'dry-run' || 'pypi' }}
       url: https://pypi.org/p/mlx-cpu
     steps:
       - uses: actions/download-artifact@v7
@@ -223,7 +223,7 @@ jobs:
       - name: Display structure of downloaded files
         run: du -ah dist
       - name: Publish package distributions to PyPI
-        if: ${{ github.event_name == 'push' || inputs.publish }}
+        if: ${{ !inputs.dry_run }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://upload.pypi.org/legacy/
@@ -235,7 +235,7 @@ jobs:
     permissions:
       id-token: write
     environment:
-      name: pypi
+      name: ${{ inputs.dry_run && 'dry-run' || 'pypi' }}
       url: https://pypi.org/p/mlx-metal
     steps:
       - uses: actions/download-artifact@v7
@@ -245,7 +245,7 @@ jobs:
       - name: Display structure of downloaded files
         run: du -ah dist
       - name: Publish package distributions to PyPI
-        if: ${{ github.event_name == 'push' || inputs.publish }} 
+        if: ${{ !inputs.dry_run }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://upload.pypi.org/legacy/


### PR DESCRIPTION
There is a pitfall in GitHub Actions that the default value of workflow_dispatch inputs can only be string, so when setting `default: true` we might get a string "true" or a boolean false as default value (it seems that we ran into the latter case).

This PR just removes the default values so inputs would all default to boolean `false` for pushes.

Also note that I'm using a non-exist env in `name: ${{ inputs.dry_run && 'dry-run' || 'pypi' }}` because `inputs.dry_run && '' || 'pypi'` would always evaluate to `pypi` regardless of the input value, which is another pitfall.

Checked a few cases and they all seem to work as expected:
* ✅ [Manually triggered dry run](https://github.com/ml-explore/mlx/actions/runs/21111585367)
* ❌ [Manually triggered publish](https://github.com/ml-explore/mlx/actions/runs/21111587901)
* ❌ [Push triggered publish](https://github.com/ml-explore/mlx/actions/runs/21111546178)
