### PR TITLE
Faster two pass sdpa

### DIFF
--- a/mlx/backend/metal/scaled_dot_product_attention.cpp
+++ b/mlx/backend/metal/scaled_dot_product_attention.cpp
@@ -468,8 +468,11 @@ void sdpa_vector_2pass(
       }
     }
   } else {
-    // TODO tune this for other chip sizes
-    blocks = 64;
+    if (n_simds >= 4) {
+      blocks = 64;
+    } else {
+      blocks = 32;
+    }
   }
   size_t k_head_stride = k.shape(1) == 1 ? k.strides(0) : k.strides(1);
   size_t k_seq_stride = k.strides()[2];


### PR DESCRIPTION
This PR does two things:
- Adds an option to use more than 32 blocks in the 2pass vector SDPA (it is set via function constant)
- Changes the work distribution so that one thread group is responsible for all the queries for a given key to maximize locality 

I tuned the block sizes on m3u, m4m and m5