### PR TITLE
Optimize erf function with expm1f in Metal backend

### DIFF
--- a/mlx/backend/metal/kernels/erf.h
+++ b/mlx/backend/metal/kernels/erf.h
@@ -2,6 +2,7 @@
 
 #pragma once
 #include <metal_math>
+#include "mlx/backend/metal/kernels/expm1f.h"
 
 /*
  * Approximation to the error function.
@@ -23,8 +24,7 @@ float erf(float a) {
     r = metal::fma(r, t, -6.34846687e-1f); // -0x1.450aa0p-1
     r = metal::fma(r, t, -1.28717512e-1f); // -0x1.079d0cp-3
     r = metal::fma(r, t, -t);
-    // TODO, replace with expm1 when implemented
-    r = 1.0f - metal::exp(r);
+    r = -expm1f(r);
     r = metal::copysign(r, a);
   } else {
     // maximum error 0.98929 ulp


### PR DESCRIPTION
## Proposed changes
Replaces `1.0f - metal::exp(r)` with `-expm1f(r)` in the Metal [erf] kernel for better numerical accuracy. This addresses the TODO comment on line 26 of [mlx/backend/metal/kernels/erf.h].
Both expressions are mathematically equivalent, but [expm1f] provides superior precision for values near zero.

Please include a description of the problem or feature this PR is addressing. If there is a corresponding issue, include the issue #.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
