### PR TITLE
Handle data smaller than BUFFER_SIZE in jaccl recv

### DIFF
--- a/mlx/distributed/jaccl/jaccl.cpp
+++ b/mlx/distributed/jaccl/jaccl.cpp
@@ -965,7 +965,7 @@ class IBVGroup : public GroupImpl {
 
       // Prefill the pipeline
       int buff = 0;
-      while (write_offset < n_bytes && buff < PIPELINE) {
+      while (N * buff < n_bytes && buff < PIPELINE) {
         cm_.recv_from(src, buff);
 
         in_flight++;


### PR DESCRIPTION
## Proposed changes

**Motivation**
Fix recv pipeline prefill loop posting too many receives when n_bytes < BUFFER_SIZE.                                                                                                                           
                                                                                                                                                                                                                 The prefill loop condition checked write_offset < n_bytes, which was a redundant check as write_offset = 0 for the duration of that loop. 

This caused it to always post 2 receives regardless of data size (as PIPELINE = 2). So for data <= 4096 bytes, the receiver would wait for at least 2 incoming messages when the sender only sent 1.                                                                                                                          
                                                                                                                                                                                                                 
**Proposed solution**
Use N * buff < n_bytes instead. N = BUFFER_SIZE and buff is incremented every step of the loop, so the loop would exit for small data after the first iteration.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
