### PR TITLE
Fix some NVCC warnings when building CUDA backend with MSVC

### DIFF
--- a/mlx/CMakeLists.txt
+++ b/mlx/CMakeLists.txt
@@ -22,13 +22,7 @@ target_sources(
 # Define MLX_VERSION only in the version.cpp file.
 add_library(mlx_version OBJECT ${CMAKE_CURRENT_SOURCE_DIR}/version.cpp)
 target_compile_definitions(mlx_version PRIVATE MLX_VERSION="${MLX_VERSION}")
-# mlx_version needs access to api.h for MLX_API export macro
 target_include_directories(mlx_version PRIVATE ${PROJECT_SOURCE_DIR})
-# On Windows shared lib builds, mlx_version also needs MLX_EXPORT for proper DLL
-# linkage
-if(WIN32 AND BUILD_SHARED_LIBS)
-  target_compile_definitions(mlx_version PRIVATE MLX_EXPORT)
-endif()
 target_link_libraries(mlx PRIVATE $<BUILD_INTERFACE:mlx_version>)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
@@ -39,21 +33,40 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 endif()
 
 if(MSVC)
-  # Disable some MSVC warnings to speed up compilation.
-  target_compile_options(mlx PUBLIC /wd4068 /wd4244 /wd4267 /wd4804)
-  # Enable /bigobj for heavily templated code (e.g., binary.cpp) that exceeds
-  # the default 65,535 section limit in COFF object files. Use generator
-  # expression to only apply to C/CXX, not CUDA (NVCC doesn't understand /bigobj
-  # directly).
-  target_compile_options(mlx PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/bigobj>)
   # Windows DLLs have a 65535 symbol export limit. We use explicit exports via
   # MLX_API macro (__declspec(dllexport)) on public API functions only. This
   # avoids exporting internal template instantiations.
   if(BUILD_SHARED_LIBS)
     target_compile_definitions(mlx PRIVATE MLX_EXPORT)
+    target_compile_definitions(mlx_version PRIVATE MLX_EXPORT)
   else()
     target_compile_definitions(mlx PUBLIC MLX_STATIC)
+    target_compile_definitions(mlx_version PRIVATE MLX_STATIC)
   endif()
+  # Some of CUDA's headers include windows.h, which defines min/max macros.
+  target_compile_definitions(mlx PRIVATE NOMINMAX)
+  # Disable some MSVC warnings to speed up compilation.
+  target_compile_options(
+    mlx
+    PUBLIC $<$<COMPILE_LANGUAGE:CXX>:/wd4068
+           /wd4244
+           /wd4267
+           /wd4700
+           /wd4804>
+           $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=/wd4068
+           -Xcompiler=/wd4244
+           -Xcompiler=/wd4267
+           -Xcompiler=/wd4700
+           -Xcompiler=/wd4804>)
+  # Enable /bigobj for heavily templated code (e.g., binary.cpp) that exceeds
+  # the default 65,535 section limit in COFF object files.
+  target_compile_options(
+    mlx PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/bigobj>
+                $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=/bigobj>)
+  # Use modern preprocessor, otherwise CCCL would complain.
+  target_compile_options(
+    mlx PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/Zc:preprocessor>
+                $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=/Zc:preprocessor>)
 endif()
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/backend/common)

--- a/mlx/backend/cuda/CMakeLists.txt
+++ b/mlx/backend/cuda/CMakeLists.txt
@@ -113,22 +113,16 @@ target_compile_options(mlx
 target_compile_options(
   mlx PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr>")
 
-# CUDA 12.8 emits warning #20280-D for copy kernels which is a false positive.
-# Explicitly pass this flag to suppress the warning, it is safe to set it to
-# true but the warning wouldn't be suppressed.
-if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.8.0)
-  target_compile_options(
-    mlx
-    PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:--static-global-template-stub=false>")
-endif()
-
-# Suppress warning when building for compute capability 7 used by V100.
-target_compile_options(
-  mlx PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:--Wno-deprecated-gpu-targets>")
-
 # Suppress nvcc warnings on C++ headers.
 target_compile_options(
-  mlx PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe="--diag_suppress=997,20208">)
+  mlx
+  PRIVATE
+    $<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe="--diag_suppress=27,997,1394,20011,20208">
+)
+
+# Ignore some valid nvcc warnings, we might want to fix them in future.
+target_compile_options(
+  mlx PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe="--diag_suppress=177,550">)
 
 # Use stronger binaries compression. This feature was introduced in CUDA 12.8
 # and requires drivers released after CUDA 12.4.

--- a/mlx/io/load.cpp
+++ b/mlx/io/load.cpp
@@ -7,7 +7,6 @@
 
 // Used by pread implementation.
 #ifdef _WIN32
-#define NOMINMAX
 #include <windows.h>
 #endif // _WIN32
 


### PR DESCRIPTION
Also remove options used for suppressing some warnings before but no longer relevant.