### PR TITLE
feat: add rANS entropy-coded quantization

### DIFF
--- a/mlx/backend/cpu/quantized.cpp
+++ b/mlx/backend/cpu/quantized.cpp
@@ -969,6 +969,30 @@ void QuantizedMatmul::eval_cpu(const std::vector<array>& inputs, array& out) {
   }
 }
 
+void EntropyCodedMatmul::eval_cpu(
+    const std::vector<array>& inputs,
+    array& out) {
+  throw std::runtime_error(
+      "[EntropyCodedMatmul::eval_cpu] Not implemented. "
+      "Entropy-coded matmul requires GPU.");
+}
+
+void EntropyCodedMatmulV2::eval_cpu(
+    const std::vector<array>& inputs,
+    array& out) {
+  throw std::runtime_error(
+      "[EntropyCodedMatmulV2::eval_cpu] Not implemented. "
+      "Entropy-coded matmul requires GPU.");
+}
+
+void EntropyDecodeAsync::eval_cpu(
+    const std::vector<array>& inputs,
+    array& out) {
+  throw std::runtime_error(
+      "[EntropyDecodeAsync::eval_cpu] Not implemented. "
+      "Entropy decode requires GPU.");
+}
+
 void GatherQMM::eval_cpu(const std::vector<array>& inputs, array& out) {
   auto& x_pre = inputs[0];
   auto& w_pre = inputs[1];

--- a/mlx/backend/metal/kernels/CMakeLists.txt
+++ b/mlx/backend/metal/kernels/CMakeLists.txt
@@ -135,6 +135,7 @@ if(NOT MLX_METAL_JIT)
   build_kernel(quantized quantized.h quantized_utils.h ${STEEL_HEADERS})
   build_kernel(fp_quantized fp4.h fp8.h fp_quantized.h quantized_utils.h
                ${STEEL_HEADERS})
+  build_kernel(entropy_coded entropy_coded.h)
   build_kernel(scan scan.h)
   build_kernel(softmax softmax.h)
   build_kernel(logsumexp logsumexp.h)

--- a/mlx/backend/metal/kernels/entropy_coded.h
+++ b/mlx/backend/metal/kernels/entropy_coded.h
@@ -1,0 +1,392 @@
+// Copyright © 2024 Apple Inc.
+// Entropy-Coded Quantization: rANS decode + dequantize for 2x compression
+
+#pragma once
+
+#include <metal_stdlib>
+#include <metal_simdgroup>
+
+using namespace metal;
+
+// rANS constants
+constant uint PROB_BITS = 14;
+constant uint PROB_SCALE = 1 << PROB_BITS;  // 16384
+constant uint RANS_L = 1 << 23;
+
+// Tile header for compressed weights
+struct EntropyTileHeader {
+    uint n_streams;
+    uint n_symbols;
+    uint max_stream_len;
+};
+
+// ============================================================================
+// rANS Decode + Dequantize + GEMV Kernel (Optimized)
+// 
+// Optimizations applied:
+// 1. Physical interleaving for coalesced memory access
+// 2. Register-cached frequency tables (eliminates ~600 cycles/symbol)
+// 3. Threadgroup-cached symbol table (eliminates ~300 cycles/lookup)
+// 4. SIMD reduction for dot product
+// 5. 256 parallel rANS streams
+//
+// NOTE: This kernel expects the ENTIRE weight matrix to be encoded as a
+// single flat array. Each output row shares the same compressed data but
+// uses different scale/bias for that row.
+// ============================================================================
+
+template <typename T>
+[[kernel]] void entropy_coded_qmv(
+    device const uint8_t* compressed [[buffer(0)]],
+    device const uint* stream_lengths [[buffer(1)]],
+    device const uint16_t* freq [[buffer(2)]],
+    device const uint16_t* cumfreq [[buffer(3)]],
+    device const uint8_t* sym_table [[buffer(4)]],
+    device const T* input [[buffer(5)]],
+    device T* output [[buffer(6)]],
+    device const T* scales [[buffer(7)]],
+    device const T* biases [[buffer(8)]],
+    constant uint& n_streams [[buffer(9)]],
+    constant uint& n_symbols [[buffer(10)]],
+    constant uint& max_stream_len [[buffer(11)]],
+    constant uint& out_vec_size [[buffer(12)]],
+    constant uint& in_vec_size [[buffer(13)]],
+    uint3 tid [[thread_position_in_grid]],
+    uint3 tgid [[threadgroup_position_in_grid]],
+    uint simd_lane [[thread_index_in_simdgroup]],
+    uint simd_group [[simdgroup_index_in_threadgroup]],
+    uint thread_idx [[thread_index_in_threadgroup]]
+) {
+    // Each threadgroup handles one output row
+    uint row = tgid.x;
+    if (row >= out_vec_size) return;
+    
+    // ========================================================================
+    // OPTIMIZATION 1: Register-cached frequency tables (32 bytes total)
+    // Eliminates ~600 cycles/symbol of VRAM latency
+    // ========================================================================
+    uint16_t local_freq[16];
+    uint16_t local_cumfreq[16];
+    for (int i = 0; i < 16; i++) {
+        local_freq[i] = freq[i];
+        local_cumfreq[i] = cumfreq[i];
+    }
+    
+    // ========================================================================
+    // OPTIMIZATION 2: Threadgroup-cached symbol lookup table
+    // 16KB table cached in fast threadgroup memory (~10 cycles vs ~300 device)
+    // Each thread loads 64 entries (256 threads * 64 = 16384 = PROB_SCALE)
+    // ========================================================================
+    threadgroup uint8_t shared_sym_table[PROB_SCALE];
+    
+    // Cooperative load: each thread loads 64 consecutive entries
+    uint load_start = thread_idx * 64;
+    if (load_start < PROB_SCALE) {
+        for (uint i = 0; i < 64 && (load_start + i) < PROB_SCALE; i++) {
+            shared_sym_table[load_start + i] = sym_table[load_start + i];
+        }
+    }
+    
+    // Ensure all threads have loaded before proceeding
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    
+    // Shared memory for SIMD reduction
+    threadgroup float partial_sums[32];
+    
+    uint stream_idx = simd_lane + simd_group * 32;
+    float acc = 0.0f;
+    
+    // Row-specific scale and bias
+    T scale = scales[row];
+    T bias = biases[row];
+    
+    // Calculate offsets for this row's weights in the flat encoding
+    // Weights are stored row-major: [row0_col0, row0_col1, ..., row0_colN, row1_col0, ...]
+    uint row_start_symbol = row * in_vec_size;
+    
+    if (stream_idx < n_streams) {
+        uint stream_len = stream_lengths[stream_idx];
+        
+        if (stream_len >= 4) {
+            // ================================================================
+            // OPTIMIZATION 3: Coalesced state initialization
+            // Physical interleaving ensures adjacent threads read adjacent bytes
+            // ================================================================
+            uint b0 = compressed[stream_idx + 0 * n_streams];
+            uint b1 = compressed[stream_idx + 1 * n_streams];
+            uint b2 = compressed[stream_idx + 2 * n_streams];
+            uint b3 = compressed[stream_idx + 3 * n_streams];
+            uint state = (b0 << 24) | (b1 << 16) | (b2 << 8) | b3;
+            uint ptr = 4;
+            
+            // Calculate how many symbols this stream handles for the entire matrix
+            uint total_symbols_in_stream = (n_symbols - stream_idx + n_streams - 1) / n_streams;
+            
+            // Decode all symbols in this stream, but only accumulate those for our row
+            for (uint i = 0; i < total_symbols_in_stream; i++) {
+                uint global_sym_idx = stream_idx + i * n_streams;
+                if (global_sym_idx >= n_symbols) break;
+                
+                // Decode symbol using threadgroup-cached table (fast!)
+                uint slot = state & (PROB_SCALE - 1);
+                uint8_t s = shared_sym_table[slot];
+                
+                // State update with register-cached tables (no memory access)
+                uint freq_s = local_freq[s];
+                uint start_s = local_cumfreq[s];
+                state = freq_s * (state >> PROB_BITS) + slot - start_s;
+                
+                // ============================================================
+                // OPTIMIZATION 4: Coalesced renormalization reads
+                // Adjacent threads read adjacent bytes during renormalization
+                // ============================================================
+                while (state < RANS_L && ptr < stream_len) {
+                    uint8_t b = compressed[stream_idx + ptr * n_streams];
+                    state = (state << 8) | b;
+                    ptr++;
+                }
+                
+                // Check if this symbol belongs to our row
+                if (global_sym_idx >= row_start_symbol && 
+                    global_sym_idx < row_start_symbol + in_vec_size) {
+                    uint col = global_sym_idx - row_start_symbol;
+                    
+                    // Dequantize + MAC (fused, no intermediate storage)
+                    T weight = T(s) * scale + bias;
+                    acc += float(weight * input[col]);
+                }
+            }
+        }
+    }
+    
+    // ========================================================================
+    // OPTIMIZATION 5: SIMD reduction (hardware-accelerated)
+    // ========================================================================
+    acc = simd_sum(acc);
+    
+    if (simd_lane == 0) {
+        partial_sums[simd_group] = acc;
+    }
+    
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    
+    // Final reduction across SIMD groups
+    if (simd_group == 0) {
+        float final_sum = 0.0f;
+        uint n_simd_groups = (min(uint(256), n_streams) + 31) / 32;
+        if (simd_lane < n_simd_groups) {
+            final_sum = partial_sums[simd_lane];
+        }
+        final_sum = simd_sum(final_sum);
+        
+        if (simd_lane == 0) {
+            output[row] = T(final_sum);
+        }
+    }
+}
+
+// ============================================================================
+// Per-Row Encoded rANS Decode + Dequantize + GEMV Kernel
+// 
+// This variant expects each row to be independently encoded, which allows:
+// 1. Parallel decode of all rows simultaneously
+// 2. Better compression (per-row frequency tables)
+// 3. Simpler memory access pattern
+// ============================================================================
+
+template <typename T>
+[[kernel]] void entropy_coded_qmv_per_row(
+    device const uint8_t* compressed [[buffer(0)]],      // All rows concatenated
+    device const uint* row_offsets [[buffer(1)]],        // Offset to each row's data
+    device const uint* stream_lengths [[buffer(2)]],     // Per-stream lengths (global)
+    device const uint16_t* freq [[buffer(3)]],           // Single freq table
+    device const uint16_t* cumfreq [[buffer(4)]],
+    device const uint8_t* sym_table [[buffer(5)]],
+    device const T* input [[buffer(6)]],
+    device T* output [[buffer(7)]],
+    device const T* scales [[buffer(8)]],
+    device const T* biases [[buffer(9)]],
+    constant uint& n_streams [[buffer(10)]],
+    constant uint& in_vec_size [[buffer(11)]],
+    constant uint& max_stream_len [[buffer(12)]],
+    uint3 tgid [[threadgroup_position_in_grid]],
+    uint simd_lane [[thread_index_in_simdgroup]],
+    uint simd_group [[simdgroup_index_in_threadgroup]],
+    uint thread_idx [[thread_index_in_threadgroup]]
+) {
+    uint row = tgid.x;
+    
+    // Register-cached frequency tables
+    uint16_t local_freq[16];
+    uint16_t local_cumfreq[16];
+    for (int i = 0; i < 16; i++) {
+        local_freq[i] = freq[i];
+        local_cumfreq[i] = cumfreq[i];
+    }
+    
+    // Threadgroup-cached symbol table
+    threadgroup uint8_t shared_sym_table[PROB_SCALE];
+    uint load_start = thread_idx * 64;
+    if (load_start < PROB_SCALE) {
+        for (uint i = 0; i < 64 && (load_start + i) < PROB_SCALE; i++) {
+            shared_sym_table[load_start + i] = sym_table[load_start + i];
+        }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    
+    threadgroup float partial_sums[32];
+    
+    uint stream_idx = simd_lane + simd_group * 32;
+    float acc = 0.0f;
+    
+    T scale = scales[row];
+    T bias = biases[row];
+    
+    // Get this row's compressed data
+    device const uint8_t* row_data = compressed + row_offsets[row];
+    
+    if (stream_idx < n_streams) {
+        uint stream_len = stream_lengths[stream_idx];
+        
+        if (stream_len >= 4) {
+            // Coalesced state init from this row's data
+            uint b0 = row_data[stream_idx + 0 * n_streams];
+            uint b1 = row_data[stream_idx + 1 * n_streams];
+            uint b2 = row_data[stream_idx + 2 * n_streams];
+            uint b3 = row_data[stream_idx + 3 * n_streams];
+            uint state = (b0 << 24) | (b1 << 16) | (b2 << 8) | b3;
+            uint ptr = 4;
+            
+            uint symbols_per_stream = (in_vec_size - stream_idx + n_streams - 1) / n_streams;
+            
+            for (uint i = 0; i < symbols_per_stream; i++) {
+                uint col = stream_idx + i * n_streams;
+                if (col >= in_vec_size) break;
+                
+                uint slot = state & (PROB_SCALE - 1);
+                uint8_t s = shared_sym_table[slot];
+                
+                uint freq_s = local_freq[s];
+                uint start_s = local_cumfreq[s];
+                state = freq_s * (state >> PROB_BITS) + slot - start_s;
+                
+                while (state < RANS_L && ptr < stream_len) {
+                    uint8_t b = row_data[stream_idx + ptr * n_streams];
+                    state = (state << 8) | b;
+                    ptr++;
+                }
+                
+                // Dequantize + MAC
+                T weight = T(s) * scale + bias;
+                acc += float(weight * input[col]);
+            }
+        }
+    }
+    
+    // SIMD reduction
+    acc = simd_sum(acc);
+    if (simd_lane == 0) {
+        partial_sums[simd_group] = acc;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    
+    if (simd_group == 0) {
+        float final_sum = 0.0f;
+        uint n_simd_groups = (min(uint(256), n_streams) + 31) / 32;
+        if (simd_lane < n_simd_groups) {
+            final_sum = partial_sums[simd_lane];
+        }
+        final_sum = simd_sum(final_sum);
+        if (simd_lane == 0) {
+            output[row] = T(final_sum);
+        }
+    }
+}
+
+// ============================================================================
+// Standalone rANS Decode Kernel (for GPU_ASYNC strategy)
+// Decodes to indices without fusing with GEMV
+// ============================================================================
+
+[[kernel]] void entropy_decode_only(
+    device const uint8_t* compressed [[buffer(0)]],
+    device const uint* stream_lengths [[buffer(1)]],
+    device const uint16_t* freq [[buffer(2)]],
+    device const uint16_t* cumfreq [[buffer(3)]],
+    device const uint8_t* sym_table [[buffer(4)]],
+    device uint8_t* output [[buffer(5)]],
+    constant uint& n_streams [[buffer(6)]],
+    constant uint& n_symbols [[buffer(7)]],
+    constant uint& max_stream_len [[buffer(8)]],
+    uint tid [[thread_position_in_grid]],
+    uint thread_idx [[thread_index_in_threadgroup]]
+) {
+    uint stream_idx = tid;
+    if (stream_idx >= n_streams) return;
+    
+    // Register-cached tables
+    uint16_t local_freq[16];
+    uint16_t local_cumfreq[16];
+    for (int i = 0; i < 16; i++) {
+        local_freq[i] = freq[i];
+        local_cumfreq[i] = cumfreq[i];
+    }
+    
+    // Note: For standalone decode, we use device memory for sym_table
+    // (threadgroup caching less beneficial for 1D dispatch)
+    
+    uint stream_len = stream_lengths[stream_idx];
+    if (stream_len < 4) return;
+    
+    // Coalesced state init
+    uint b0 = compressed[stream_idx + 0 * n_streams];
+    uint b1 = compressed[stream_idx + 1 * n_streams];
+    uint b2 = compressed[stream_idx + 2 * n_streams];
+    uint b3 = compressed[stream_idx + 3 * n_streams];
+    uint state = (b0 << 24) | (b1 << 16) | (b2 << 8) | b3;
+    uint ptr = 4;
+    
+    uint symbols_in_stream = (n_symbols - stream_idx + n_streams - 1) / n_streams;
+    
+    for (uint i = 0; i < symbols_in_stream; i++) {
+        uint output_idx = stream_idx + i * n_streams;
+        if (output_idx >= n_symbols) break;
+        
+        uint slot = state & (PROB_SCALE - 1);
+        uint8_t s = sym_table[slot];
+        output[output_idx] = s;
+        
+        uint freq_s = local_freq[s];
+        uint start_s = local_cumfreq[s];
+        state = freq_s * (state >> PROB_BITS) + slot - start_s;
+        
+        while (state < RANS_L && ptr < stream_len) {
+            uint8_t b = compressed[stream_idx + ptr * n_streams];
+            state = (state << 8) | b;
+            ptr++;
+        }
+    }
+}
+
+// ============================================================================
+// Dequantize kernel (for pre-decoded weights)
+// ============================================================================
+
+template <typename T>
+[[kernel]] void dequantize_4bit(
+    device const uint8_t* indices [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    device const T* scales [[buffer(2)]],
+    device const T* biases [[buffer(3)]],
+    constant uint& n_elements [[buffer(4)]],
+    constant uint& group_size [[buffer(5)]],
+    uint tid [[thread_position_in_grid]]
+) {
+    if (tid >= n_elements) return;
+    
+    uint group_id = tid / group_size;
+    T scale = scales[group_id];
+    T bias = biases[group_id];
+    
+    output[tid] = T(indices[tid]) * scale + bias;
+}

--- a/mlx/backend/metal/kernels/entropy_coded.metal
+++ b/mlx/backend/metal/kernels/entropy_coded.metal
@@ -1,0 +1,153 @@
+// Copyright © 2024 Apple Inc.
+// Entropy-Coded Quantization Metal Kernels
+
+#include "entropy_coded.h"
+#include "entropy_coded_v2.h"
+#include "entropy_decode_async.h"
+
+// Instantiate for float and bfloat16
+template [[host_name("entropy_coded_qmv_float")]] [[kernel]] void
+entropy_coded_qmv<float>(
+    device const uint8_t* compressed [[buffer(0)]],
+    device const uint* stream_lengths [[buffer(1)]],
+    device const uint16_t* freq [[buffer(2)]],
+    device const uint16_t* cumfreq [[buffer(3)]],
+    device const uint8_t* sym_table [[buffer(4)]],
+    device const float* input [[buffer(5)]],
+    device float* output [[buffer(6)]],
+    device const float* scales [[buffer(7)]],
+    device const float* biases [[buffer(8)]],
+    constant uint& n_streams [[buffer(9)]],
+    constant uint& n_symbols [[buffer(10)]],
+    constant uint& max_stream_len [[buffer(11)]],
+    constant uint& out_vec_size [[buffer(12)]],
+    constant uint& in_vec_size [[buffer(13)]],
+    uint3 tid [[thread_position_in_grid]],
+    uint3 tgid [[threadgroup_position_in_grid]],
+    uint simd_lane [[thread_index_in_simdgroup]],
+    uint simd_group [[simdgroup_index_in_threadgroup]],
+    uint thread_idx [[thread_index_in_threadgroup]]);
+
+template [[host_name("entropy_coded_qmv_bfloat16")]] [[kernel]] void
+entropy_coded_qmv<bfloat>(
+    device const uint8_t* compressed [[buffer(0)]],
+    device const uint* stream_lengths [[buffer(1)]],
+    device const uint16_t* freq [[buffer(2)]],
+    device const uint16_t* cumfreq [[buffer(3)]],
+    device const uint8_t* sym_table [[buffer(4)]],
+    device const bfloat* input [[buffer(5)]],
+    device bfloat* output [[buffer(6)]],
+    device const bfloat* scales [[buffer(7)]],
+    device const bfloat* biases [[buffer(8)]],
+    constant uint& n_streams [[buffer(9)]],
+    constant uint& n_symbols [[buffer(10)]],
+    constant uint& max_stream_len [[buffer(11)]],
+    constant uint& out_vec_size [[buffer(12)]],
+    constant uint& in_vec_size [[buffer(13)]],
+    uint3 tid [[thread_position_in_grid]],
+    uint3 tgid [[threadgroup_position_in_grid]],
+    uint simd_lane [[thread_index_in_simdgroup]],
+    uint simd_group [[simdgroup_index_in_threadgroup]],
+    uint thread_idx [[thread_index_in_threadgroup]]);
+
+template [[host_name("dequantize_4bit_float")]] [[kernel]] void
+dequantize_4bit<float>(
+    device const uint8_t* indices [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    device const float* scales [[buffer(2)]],
+    device const float* biases [[buffer(3)]],
+    constant uint& n_elements [[buffer(4)]],
+    constant uint& group_size [[buffer(5)]],
+    uint tid [[thread_position_in_grid]]);
+
+template [[host_name("dequantize_4bit_bfloat16")]] [[kernel]] void
+dequantize_4bit<bfloat>(
+    device const uint8_t* indices [[buffer(0)]],
+    device bfloat* output [[buffer(1)]],
+    device const bfloat* scales [[buffer(2)]],
+    device const bfloat* biases [[buffer(3)]],
+    constant uint& n_elements [[buffer(4)]],
+    constant uint& group_size [[buffer(5)]],
+    uint tid [[thread_position_in_grid]]);
+
+// Per-row encoded kernel instantiations
+template [[host_name("entropy_coded_qmv_per_row_float")]] [[kernel]] void
+entropy_coded_qmv_per_row<float>(
+    device const uint8_t* compressed [[buffer(0)]],
+    device const uint* row_offsets [[buffer(1)]],
+    device const uint* stream_lengths [[buffer(2)]],
+    device const uint16_t* freq [[buffer(3)]],
+    device const uint16_t* cumfreq [[buffer(4)]],
+    device const uint8_t* sym_table [[buffer(5)]],
+    device const float* input [[buffer(6)]],
+    device float* output [[buffer(7)]],
+    device const float* scales [[buffer(8)]],
+    device const float* biases [[buffer(9)]],
+    constant uint& n_streams [[buffer(10)]],
+    constant uint& in_vec_size [[buffer(11)]],
+    constant uint& max_stream_len [[buffer(12)]],
+    uint3 tgid [[threadgroup_position_in_grid]],
+    uint simd_lane [[thread_index_in_simdgroup]],
+    uint simd_group [[simdgroup_index_in_threadgroup]],
+    uint thread_idx [[thread_index_in_threadgroup]]);
+
+template [[host_name("entropy_coded_qmv_per_row_bfloat16")]] [[kernel]] void
+entropy_coded_qmv_per_row<bfloat>(
+    device const uint8_t* compressed [[buffer(0)]],
+    device const uint* row_offsets [[buffer(1)]],
+    device const uint* stream_lengths [[buffer(2)]],
+    device const uint16_t* freq [[buffer(3)]],
+    device const uint16_t* cumfreq [[buffer(4)]],
+    device const uint8_t* sym_table [[buffer(5)]],
+    device const bfloat* input [[buffer(6)]],
+    device bfloat* output [[buffer(7)]],
+    device const bfloat* scales [[buffer(8)]],
+    device const bfloat* biases [[buffer(9)]],
+    constant uint& n_streams [[buffer(10)]],
+    constant uint& in_vec_size [[buffer(11)]],
+    constant uint& max_stream_len [[buffer(12)]],
+    uint3 tgid [[threadgroup_position_in_grid]],
+    uint simd_lane [[thread_index_in_simdgroup]],
+    uint simd_group [[simdgroup_index_in_threadgroup]],
+    uint thread_idx [[thread_index_in_threadgroup]]);
+
+// V2 Per-Row Kernels with proper buffer layout
+template [[host_name("entropy_coded_qmv_v2_float")]] [[kernel]] void
+entropy_coded_qmv_v2<float>(
+    device const uint8_t* compressed [[buffer(0)]],
+    device const uint* row_offsets [[buffer(1)]],
+    device const uint* row_stream_lens [[buffer(2)]],
+    device const uint16_t* freq [[buffer(3)]],
+    device const uint16_t* cumfreq [[buffer(4)]],
+    device const uint8_t* sym_table [[buffer(5)]],
+    device const float* input [[buffer(6)]],
+    device float* output [[buffer(7)]],
+    device const float* scales [[buffer(8)]],
+    device const float* biases [[buffer(9)]],
+    constant uint& n_streams [[buffer(10)]],
+    constant uint& in_vec_size [[buffer(11)]],
+    constant uint& out_vec_size [[buffer(12)]],
+    uint3 tgid [[threadgroup_position_in_grid]],
+    uint simd_lane [[thread_index_in_simdgroup]],
+    uint simd_group [[simdgroup_index_in_threadgroup]],
+    uint thread_idx [[thread_index_in_threadgroup]]);
+
+template [[host_name("entropy_coded_qmv_v2_bfloat16")]] [[kernel]] void
+entropy_coded_qmv_v2<bfloat>(
+    device const uint8_t* compressed [[buffer(0)]],
+    device const uint* row_offsets [[buffer(1)]],
+    device const uint* row_stream_lens [[buffer(2)]],
+    device const uint16_t* freq [[buffer(3)]],
+    device const uint16_t* cumfreq [[buffer(4)]],
+    device const uint8_t* sym_table [[buffer(5)]],
+    device const bfloat* input [[buffer(6)]],
+    device bfloat* output [[buffer(7)]],
+    device const bfloat* scales [[buffer(8)]],
+    device const bfloat* biases [[buffer(9)]],
+    constant uint& n_streams [[buffer(10)]],
+    constant uint& in_vec_size [[buffer(11)]],
+    constant uint& out_vec_size [[buffer(12)]],
+    uint3 tgid [[threadgroup_position_in_grid]],
+    uint simd_lane [[thread_index_in_simdgroup]],
+    uint simd_group [[simdgroup_index_in_threadgroup]],
+    uint thread_idx [[thread_index_in_threadgroup]]);

--- a/mlx/backend/metal/kernels/entropy_coded_v2.h
+++ b/mlx/backend/metal/kernels/entropy_coded_v2.h
@@ -1,0 +1,256 @@
+// Copyright © 2024 Apple Inc.
+// Entropy-Coded Quantization V2: Per-Row Encoding for O(n) decode
+//
+// Key optimization: Each row is encoded independently, so each threadgroup
+// only decodes in_vec_size symbols instead of out_vec_size * in_vec_size.
+// This reduces decode work from O(rows * total) to O(total).
+
+#pragma once
+
+#include <metal_stdlib>
+#include <metal_simdgroup>
+
+using namespace metal;
+
+// rANS constants
+constant uint PROB_BITS_V2 = 14;
+constant uint PROB_SCALE_V2 = 1 << PROB_BITS_V2;  // 16384
+constant uint RANS_L_V2 = 1 << 23;
+
+// ============================================================================
+// Per-Row Fused Decode + Dequantize + GEMV Kernel
+//
+// Each row is independently encoded, so each threadgroup decodes exactly
+// in_vec_size symbols - no wasted work!
+//
+// Data layout:
+//   compressed: [row0_data | row1_data | ... | rowN_data]
+//   row_offsets: [offset_to_row0, offset_to_row1, ...]
+//   Each row's data is physically interleaved across n_streams
+// ============================================================================
+
+template <typename T>
+[[kernel]] void entropy_coded_qmv_v2(
+    device const uint8_t* compressed [[buffer(0)]],      // All rows concatenated
+    device const uint* row_offsets [[buffer(1)]],        // Byte offset to each row
+    device const uint* row_stream_lens [[buffer(2)]],    // Per-row stream lengths [n_rows * n_streams]
+    device const uint16_t* freq [[buffer(3)]],           // Frequency table (16 entries)
+    device const uint16_t* cumfreq [[buffer(4)]],        // Cumulative freq (16 entries)
+    device const uint8_t* sym_table [[buffer(5)]],       // Symbol lookup (16384 entries)
+    device const T* input [[buffer(6)]],                 // Input vector
+    device T* output [[buffer(7)]],                      // Output vector
+    device const T* scales [[buffer(8)]],                // Per-row scales
+    device const T* biases [[buffer(9)]],                // Per-row biases
+    constant uint& n_streams [[buffer(10)]],             // Parallel streams per row
+    constant uint& in_vec_size [[buffer(11)]],           // Columns per row
+    constant uint& out_vec_size [[buffer(12)]],          // Number of rows
+    uint3 tgid [[threadgroup_position_in_grid]],
+    uint simd_lane [[thread_index_in_simdgroup]],
+    uint simd_group [[simdgroup_index_in_threadgroup]],
+    uint thread_idx [[thread_index_in_threadgroup]]
+) {
+    uint row = tgid.x;
+    if (row >= out_vec_size) return;
+    
+    // ========================================================================
+    // OPTIMIZATION 1: Register-cached frequency tables
+    // ========================================================================
+    uint16_t local_freq[16];
+    uint16_t local_cumfreq[16];
+    for (int i = 0; i < 16; i++) {
+        local_freq[i] = freq[i];
+        local_cumfreq[i] = cumfreq[i];
+    }
+    
+    // ========================================================================
+    // OPTIMIZATION 2: Threadgroup-cached symbol table
+    // ========================================================================
+    threadgroup uint8_t shared_sym_table[PROB_SCALE_V2];
+    uint load_start = thread_idx * 64;
+    if (load_start < PROB_SCALE_V2) {
+        for (uint i = 0; i < 64 && (load_start + i) < PROB_SCALE_V2; i++) {
+            shared_sym_table[load_start + i] = sym_table[load_start + i];
+        }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    
+    threadgroup float partial_sums[32];
+    
+    uint stream_idx = simd_lane + simd_group * 32;
+    float acc = 0.0f;
+    
+    T scale = scales[row];
+    T bias = biases[row];
+    
+    // ========================================================================
+    // KEY OPTIMIZATION: Only decode THIS ROW's data
+    // ========================================================================
+    device const uint8_t* row_data = compressed + row_offsets[row];
+    device const uint* row_lens = row_stream_lens + row * n_streams;
+    
+    if (stream_idx < n_streams) {
+        uint stream_len = row_lens[stream_idx];
+        
+        if (stream_len >= 4) {
+            // Coalesced state init from this row's interleaved data
+            uint b0 = row_data[stream_idx + 0 * n_streams];
+            uint b1 = row_data[stream_idx + 1 * n_streams];
+            uint b2 = row_data[stream_idx + 2 * n_streams];
+            uint b3 = row_data[stream_idx + 3 * n_streams];
+            uint state = (b0 << 24) | (b1 << 16) | (b2 << 8) | b3;
+            uint ptr = 4;
+            
+            // Only decode symbols for THIS row (in_vec_size total)
+            uint symbols_per_stream = (in_vec_size - stream_idx + n_streams - 1) / n_streams;
+            
+            for (uint i = 0; i < symbols_per_stream; i++) {
+                uint col = stream_idx + i * n_streams;
+                if (col >= in_vec_size) break;
+                
+                // Decode from threadgroup cache
+                uint slot = state & (PROB_SCALE_V2 - 1);
+                uint8_t s = shared_sym_table[slot];
+                
+                // State update from register cache
+                uint freq_s = local_freq[s];
+                uint start_s = local_cumfreq[s];
+                state = freq_s * (state >> PROB_BITS_V2) + slot - start_s;
+                
+                // Coalesced renormalization
+                while (state < RANS_L_V2 && ptr < stream_len) {
+                    uint8_t b = row_data[stream_idx + ptr * n_streams];
+                    state = (state << 8) | b;
+                    ptr++;
+                }
+                
+                // Fused dequantize + MAC
+                T weight = T(s) * scale + bias;
+                acc += float(weight * input[col]);
+            }
+        }
+    }
+    
+    // SIMD reduction
+    acc = simd_sum(acc);
+    if (simd_lane == 0) {
+        partial_sums[simd_group] = acc;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    
+    // Final reduction
+    if (simd_group == 0) {
+        float final_sum = 0.0f;
+        uint n_simd_groups = (min(uint(256), n_streams) + 31) / 32;
+        if (simd_lane < n_simd_groups) {
+            final_sum = partial_sums[simd_lane];
+        }
+        final_sum = simd_sum(final_sum);
+        if (simd_lane == 0) {
+            output[row] = T(final_sum);
+        }
+    }
+}
+
+// ============================================================================
+// Shared frequency table variant - when all rows use same distribution
+// ============================================================================
+
+template <typename T>
+[[kernel]] void entropy_coded_qmv_v2_shared_freq(
+    device const uint8_t* compressed [[buffer(0)]],
+    device const uint* row_offsets [[buffer(1)]],
+    device const uint* max_stream_len_per_row [[buffer(2)]],  // Single value per row
+    device const uint16_t* freq [[buffer(3)]],
+    device const uint16_t* cumfreq [[buffer(4)]],
+    device const uint8_t* sym_table [[buffer(5)]],
+    device const T* input [[buffer(6)]],
+    device T* output [[buffer(7)]],
+    device const T* scales [[buffer(8)]],
+    device const T* biases [[buffer(9)]],
+    constant uint& n_streams [[buffer(10)]],
+    constant uint& in_vec_size [[buffer(11)]],
+    constant uint& out_vec_size [[buffer(12)]],
+    uint3 tgid [[threadgroup_position_in_grid]],
+    uint simd_lane [[thread_index_in_simdgroup]],
+    uint simd_group [[simdgroup_index_in_threadgroup]],
+    uint thread_idx [[thread_index_in_threadgroup]]
+) {
+    uint row = tgid.x;
+    if (row >= out_vec_size) return;
+    
+    // Register-cached tables
+    uint16_t local_freq[16];
+    uint16_t local_cumfreq[16];
+    for (int i = 0; i < 16; i++) {
+        local_freq[i] = freq[i];
+        local_cumfreq[i] = cumfreq[i];
+    }
+    
+    // Threadgroup-cached symbol table
+    threadgroup uint8_t shared_sym_table[PROB_SCALE_V2];
+    uint load_start = thread_idx * 64;
+    if (load_start < PROB_SCALE_V2) {
+        for (uint i = 0; i < 64 && (load_start + i) < PROB_SCALE_V2; i++) {
+            shared_sym_table[load_start + i] = sym_table[load_start + i];
+        }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    
+    threadgroup float partial_sums[32];
+    
+    uint stream_idx = simd_lane + simd_group * 32;
+    float acc = 0.0f;
+    
+    T scale = scales[row];
+    T bias = biases[row];
+    
+    // This row's compressed data
+    device const uint8_t* row_data = compressed + row_offsets[row];
+    uint max_len = max_stream_len_per_row[row];
+    
+    if (stream_idx < n_streams && max_len >= 4) {
+        // All streams in this row have same max length (padded)
+        uint b0 = row_data[stream_idx + 0 * n_streams];
+        uint b1 = row_data[stream_idx + 1 * n_streams];
+        uint b2 = row_data[stream_idx + 2 * n_streams];
+        uint b3 = row_data[stream_idx + 3 * n_streams];
+        uint state = (b0 << 24) | (b1 << 16) | (b2 << 8) | b3;
+        uint ptr = 4;
+        
+        uint symbols_per_stream = (in_vec_size - stream_idx + n_streams - 1) / n_streams;
+        
+        for (uint i = 0; i < symbols_per_stream; i++) {
+            uint col = stream_idx + i * n_streams;
+            if (col >= in_vec_size) break;
+            
+            uint slot = state & (PROB_SCALE_V2 - 1);
+            uint8_t s = shared_sym_table[slot];
+            
+            uint freq_s = local_freq[s];
+            uint start_s = local_cumfreq[s];
+            state = freq_s * (state >> PROB_BITS_V2) + slot - start_s;
+            
+            while (state < RANS_L_V2 && ptr < max_len) {
+                uint8_t b = row_data[stream_idx + ptr * n_streams];
+                state = (state << 8) | b;
+                ptr++;
+            }
+            
+            T weight = T(s) * scale + bias;
+            acc += float(weight * input[col]);
+        }
+    }
+    
+    // Reduction
+    acc = simd_sum(acc);
+    if (simd_lane == 0) partial_sums[simd_group] = acc;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    
+    if (simd_group == 0) {
+        float final_sum = 0.0f;
+        uint n_simd_groups = (min(uint(256), n_streams) + 31) / 32;
+        if (simd_lane < n_simd_groups) final_sum = partial_sums[simd_lane];
+        final_sum = simd_sum(final_sum);
+        if (simd_lane == 0) output[row] = T(final_sum);
+    }
+}

--- a/mlx/backend/metal/kernels/entropy_decode_async.h
+++ b/mlx/backend/metal/kernels/entropy_decode_async.h
@@ -1,0 +1,250 @@
+// Copyright © 2024 Apple Inc.
+// Entropy Decode Kernel for GPU_ASYNC Mode
+//
+// This kernel decodes compressed weights to 4-bit indices without doing the
+// matmul. Used for async prefetching: decode layer N+1 while computing layer N.
+//
+// Timeline:
+//   GPU Queue 1: [Compute L0] [Compute L1] [Compute L2] ...
+//   GPU Queue 2: [Decode L1]  [Decode L2]  [Decode L3]  ...
+//                     ↓           ↓           ↓
+//                Ready before GPU needs it!
+
+#pragma once
+
+#include <metal_stdlib>
+#include <metal_simdgroup>
+
+using namespace metal;
+
+// rANS constants
+constant uint PROB_BITS_ASYNC = 14;
+constant uint PROB_SCALE_ASYNC = 1 << PROB_BITS_ASYNC;  // 16384
+constant uint RANS_L_ASYNC = 1 << 23;
+
+// ============================================================================
+// Decode-Only Kernel (V1: Flat Encoding)
+//
+// Decodes interleaved rANS streams to output buffer.
+// Each thread handles one stream.
+// ============================================================================
+
+template <typename T>
+[[kernel]] void entropy_decode_flat(
+    device const uint8_t* compressed [[buffer(0)]],
+    device const uint* stream_lengths [[buffer(1)]],
+    device const uint16_t* freq [[buffer(2)]],
+    device const uint16_t* cumfreq [[buffer(3)]],
+    device const uint8_t* sym_table [[buffer(4)]],
+    device uint8_t* output [[buffer(5)]],           // Decoded 4-bit indices
+    device const T* scales [[buffer(6)]],           // For dequantization
+    device const T* biases [[buffer(7)]],
+    device T* dequantized [[buffer(8)]],            // Dequantized weights (optional)
+    constant uint& n_streams [[buffer(9)]],
+    constant uint& n_symbols [[buffer(10)]],
+    constant uint& max_stream_len [[buffer(11)]],
+    constant uint& out_vec_size [[buffer(12)]],
+    constant uint& in_vec_size [[buffer(13)]],
+    constant uint& group_size [[buffer(14)]],
+    constant bool& do_dequantize [[buffer(15)]],    // Whether to also dequantize
+    uint tid [[thread_position_in_grid]],
+    uint thread_idx [[thread_index_in_threadgroup]]
+) {
+    uint stream_idx = tid;
+    if (stream_idx >= n_streams) return;
+    
+    // Cache frequency tables in registers
+    uint16_t local_freq[16];
+    uint16_t local_cumfreq[16];
+    for (int i = 0; i < 16; i++) {
+        local_freq[i] = freq[i];
+        local_cumfreq[i] = cumfreq[i];
+    }
+    
+    // Threadgroup-cached symbol table
+    threadgroup uint8_t shared_sym_table[PROB_SCALE_ASYNC];
+    uint load_start = thread_idx * 64;
+    if (load_start < PROB_SCALE_ASYNC) {
+        for (uint i = 0; i < 64 && (load_start + i) < PROB_SCALE_ASYNC; i++) {
+            shared_sym_table[load_start + i] = sym_table[load_start + i];
+        }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    
+    uint stream_len = stream_lengths[stream_idx];
+    if (stream_len < 4) return;
+    
+    // Initialize state from physically interleaved data
+    uint b0 = compressed[stream_idx + 0 * n_streams];
+    uint b1 = compressed[stream_idx + 1 * n_streams];
+    uint b2 = compressed[stream_idx + 2 * n_streams];
+    uint b3 = compressed[stream_idx + 3 * n_streams];
+    uint state = (b0 << 24) | (b1 << 16) | (b2 << 8) | b3;
+    uint ptr = 4;
+    
+    // Calculate symbols this stream handles
+    uint symbols_per_stream = (n_symbols - stream_idx + n_streams - 1) / n_streams;
+    
+    for (uint i = 0; i < symbols_per_stream; i++) {
+        uint output_idx = stream_idx + i * n_streams;
+        if (output_idx >= n_symbols) break;
+        
+        // Decode symbol
+        uint slot = state & (PROB_SCALE_ASYNC - 1);
+        uint8_t s = shared_sym_table[slot];
+        
+        // Write decoded symbol
+        output[output_idx] = s;
+        
+        // Optionally dequantize
+        if (do_dequantize && dequantized != nullptr) {
+            uint row = output_idx / in_vec_size;
+            uint col = output_idx % in_vec_size;
+            uint group = col / group_size;
+            uint scale_idx = row * ((in_vec_size + group_size - 1) / group_size) + group;
+            T weight = T(s) * scales[scale_idx] + biases[scale_idx];
+            dequantized[output_idx] = weight;
+        }
+        
+        // Update state
+        uint freq_s = local_freq[s];
+        uint start_s = local_cumfreq[s];
+        state = freq_s * (state >> PROB_BITS_ASYNC) + slot - start_s;
+        
+        // Renormalize
+        while (state < RANS_L_ASYNC && ptr < stream_len) {
+            uint8_t b = compressed[stream_idx + ptr * n_streams];
+            state = (state << 8) | b;
+            ptr++;
+        }
+    }
+}
+
+// ============================================================================
+// Decode-Only Kernel (V2: Per-Row Encoding)
+//
+// Each threadgroup decodes one row independently.
+// Much faster for async decode since O(n) work.
+// ============================================================================
+
+template <typename T>
+[[kernel]] void entropy_decode_per_row(
+    device const uint8_t* compressed [[buffer(0)]],
+    device const uint* row_offsets [[buffer(1)]],
+    device const uint* row_stream_lens [[buffer(2)]],
+    device const uint16_t* freq [[buffer(3)]],
+    device const uint16_t* cumfreq [[buffer(4)]],
+    device const uint8_t* sym_table [[buffer(5)]],
+    device uint8_t* output [[buffer(6)]],           // Decoded indices [out_vec_size, in_vec_size]
+    device const T* scales [[buffer(7)]],
+    device const T* biases [[buffer(8)]],
+    device T* dequantized [[buffer(9)]],            // Dequantized weights (optional)
+    constant uint& n_streams [[buffer(10)]],
+    constant uint& in_vec_size [[buffer(11)]],
+    constant uint& out_vec_size [[buffer(12)]],
+    constant bool& do_dequantize [[buffer(13)]],
+    uint3 tgid [[threadgroup_position_in_grid]],
+    uint simd_lane [[thread_index_in_simdgroup]],
+    uint simd_group [[simdgroup_index_in_threadgroup]],
+    uint thread_idx [[thread_index_in_threadgroup]]
+) {
+    uint row = tgid.x;
+    if (row >= out_vec_size) return;
+    
+    // Register-cached frequency tables
+    uint16_t local_freq[16];
+    uint16_t local_cumfreq[16];
+    for (int i = 0; i < 16; i++) {
+        local_freq[i] = freq[i];
+        local_cumfreq[i] = cumfreq[i];
+    }
+    
+    // Threadgroup-cached symbol table
+    threadgroup uint8_t shared_sym_table[PROB_SCALE_ASYNC];
+    uint load_start = thread_idx * 64;
+    if (load_start < PROB_SCALE_ASYNC) {
+        for (uint i = 0; i < 64 && (load_start + i) < PROB_SCALE_ASYNC; i++) {
+            shared_sym_table[load_start + i] = sym_table[load_start + i];
+        }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    
+    uint stream_idx = simd_lane + simd_group * 32;
+    
+    T scale = scales[row];
+    T bias = biases[row];
+    
+    // This row's compressed data
+    device const uint8_t* row_data = compressed + row_offsets[row];
+    device const uint* row_lens = row_stream_lens + row * n_streams;
+    
+    if (stream_idx < n_streams) {
+        uint stream_len = row_lens[stream_idx];
+        
+        if (stream_len >= 4) {
+            // Initialize state
+            uint b0 = row_data[stream_idx + 0 * n_streams];
+            uint b1 = row_data[stream_idx + 1 * n_streams];
+            uint b2 = row_data[stream_idx + 2 * n_streams];
+            uint b3 = row_data[stream_idx + 3 * n_streams];
+            uint state = (b0 << 24) | (b1 << 16) | (b2 << 8) | b3;
+            uint ptr = 4;
+            
+            uint symbols_per_stream = (in_vec_size - stream_idx + n_streams - 1) / n_streams;
+            
+            for (uint i = 0; i < symbols_per_stream; i++) {
+                uint col = stream_idx + i * n_streams;
+                if (col >= in_vec_size) break;
+                
+                // Decode symbol
+                uint slot = state & (PROB_SCALE_ASYNC - 1);
+                uint8_t s = shared_sym_table[slot];
+                
+                // Write to output
+                uint output_idx = row * in_vec_size + col;
+                output[output_idx] = s;
+                
+                // Optionally dequantize
+                if (do_dequantize && dequantized != nullptr) {
+                    T weight = T(s) * scale + bias;
+                    dequantized[output_idx] = weight;
+                }
+                
+                // Update state
+                uint freq_s = local_freq[s];
+                uint start_s = local_cumfreq[s];
+                state = freq_s * (state >> PROB_BITS_ASYNC) + slot - start_s;
+                
+                // Renormalize
+                while (state < RANS_L_ASYNC && ptr < stream_len) {
+                    uint8_t b = row_data[stream_idx + ptr * n_streams];
+                    state = (state << 8) | b;
+                    ptr++;
+                }
+            }
+        }
+    }
+}
+
+// Kernel instantiations
+#define INSTANTIATE_DECODE_KERNELS(T)                              \
+    template [[host_name("entropy_decode_flat_" #T)]]              \
+    [[kernel]] void entropy_decode_flat<T>(                        \
+        device const uint8_t*, device const uint*,                 \
+        device const uint16_t*, device const uint16_t*,            \
+        device const uint8_t*, device uint8_t*,                    \
+        device const T*, device const T*, device T*,               \
+        constant uint&, constant uint&, constant uint&,            \
+        constant uint&, constant uint&, constant uint&,            \
+        constant bool&, uint, uint);                               \
+    template [[host_name("entropy_decode_per_row_" #T)]]           \
+    [[kernel]] void entropy_decode_per_row<T>(                     \
+        device const uint8_t*, device const uint*, device const uint*, \
+        device const uint16_t*, device const uint16_t*,            \
+        device const uint8_t*, device uint8_t*,                    \
+        device const T*, device const T*, device T*,               \
+        constant uint&, constant uint&, constant uint&,            \
+        constant bool&, uint3, uint, uint, uint);
+
+INSTANTIATE_DECODE_KERNELS(float)
+INSTANTIATE_DECODE_KERNELS(half)

--- a/mlx/ops.h
+++ b/mlx/ops.h
@@ -1451,6 +1451,56 @@ array gather_qmm(
     bool sorted_indices = false,
     StreamOrDevice s = {});
 
+/** Entropy-coded quantized matmul with fused rANS decode + dequant + GEMV */
+array entropy_coded_matmul(
+    const array& compressed,
+    const array& stream_lengths,
+    const array& freq,
+    const array& cumfreq,
+    const array& sym_table,
+    const array& x,
+    const array& scales,
+    const array& biases,
+    int n_streams,
+    int n_symbols,
+    int max_stream_len,
+    int out_vec_size,
+    int in_vec_size,
+    int group_size = 64,
+    StreamOrDevice s = {});
+
+/** Per-row entropy-coded matmul (V2) - O(n) decode work */
+array entropy_coded_matmul_v2(
+    const array& compressed,
+    const array& row_offsets,
+    const array& row_stream_lens,
+    const array& freq,
+    const array& cumfreq,
+    const array& sym_table,
+    const array& x,
+    const array& scales,
+    const array& biases,
+    int n_streams,
+    int in_vec_size,
+    int out_vec_size,
+    StreamOrDevice s = {});
+
+/** Async entropy decode - decode weights without matmul for prefetching */
+array entropy_decode_async(
+    const array& compressed,
+    const array& row_offsets,
+    const array& row_stream_lens,
+    const array& freq,
+    const array& cumfreq,
+    const array& sym_table,
+    const array& scales,
+    const array& biases,
+    int n_streams,
+    int in_vec_size,
+    int out_vec_size,
+    bool dequantize = true,
+    StreamOrDevice s = {});
+
 /** Returns a contraction of a and b over multiple dimensions. */
 array tensordot(
     const array& a,

--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -3470,6 +3470,49 @@ std::vector<Shape> QuantizedMatmul::output_shapes(
   return {std::move(out_shape)};
 }
 
+bool EntropyCodedMatmul::is_equivalent(const Primitive& other) const {
+  const EntropyCodedMatmul& ecm_other =
+      static_cast<const EntropyCodedMatmul&>(other);
+  return n_streams_ == ecm_other.n_streams_ &&
+      n_symbols_ == ecm_other.n_symbols_ &&
+      max_stream_len_ == ecm_other.max_stream_len_ &&
+      out_vec_size_ == ecm_other.out_vec_size_ &&
+      in_vec_size_ == ecm_other.in_vec_size_ &&
+      group_size_ == ecm_other.group_size_;
+}
+
+std::vector<Shape> EntropyCodedMatmul::output_shapes(
+    const std::vector<array>& inputs) {
+  return {{out_vec_size_}};
+}
+
+bool EntropyCodedMatmulV2::is_equivalent(const Primitive& other) const {
+  const EntropyCodedMatmulV2& ecm_other =
+      static_cast<const EntropyCodedMatmulV2&>(other);
+  return n_streams_ == ecm_other.n_streams_ &&
+      in_vec_size_ == ecm_other.in_vec_size_ &&
+      out_vec_size_ == ecm_other.out_vec_size_;
+}
+
+std::vector<Shape> EntropyCodedMatmulV2::output_shapes(
+    const std::vector<array>& inputs) {
+  return {{out_vec_size_}};
+}
+
+bool EntropyDecodeAsync::is_equivalent(const Primitive& other) const {
+  const EntropyDecodeAsync& eda_other =
+      static_cast<const EntropyDecodeAsync&>(other);
+  return n_streams_ == eda_other.n_streams_ &&
+      in_vec_size_ == eda_other.in_vec_size_ &&
+      out_vec_size_ == eda_other.out_vec_size_ &&
+      dequantize_ == eda_other.dequantize_;
+}
+
+std::vector<Shape> EntropyDecodeAsync::output_shapes(
+    const std::vector<array>& inputs) {
+  return {{out_vec_size_, in_vec_size_}};
+}
+
 bool QQMatmul::is_equivalent(const Primitive& other) const {
   const QQMatmul& qm_other = static_cast<const QQMatmul&>(other);
   return group_size_ == qm_other.group_size_ && bits_ == qm_other.bits_ &&

--- a/mlx/primitives.h
+++ b/mlx/primitives.h
@@ -1711,6 +1711,108 @@ class GatherQMM : public UnaryPrimitive {
   bool right_sorted_;
 };
 
+class EntropyCodedMatmul : public UnaryPrimitive {
+ public:
+  explicit EntropyCodedMatmul(
+      Stream stream,
+      int n_streams,
+      int n_symbols,
+      int max_stream_len,
+      int out_vec_size,
+      int in_vec_size,
+      int group_size)
+      : UnaryPrimitive(stream),
+        n_streams_(n_streams),
+        n_symbols_(n_symbols),
+        max_stream_len_(max_stream_len),
+        out_vec_size_(out_vec_size),
+        in_vec_size_(in_vec_size),
+        group_size_(group_size) {}
+
+  void eval_cpu(const std::vector<array>& inputs, array& out) override;
+  void eval_gpu(const std::vector<array>& inputs, array& out) override;
+
+  DEFINE_NAME(EntropyCodedMatmul)
+  bool is_equivalent(const Primitive& other) const override;
+  std::vector<Shape> output_shapes(const std::vector<array>& inputs) override;
+  auto state() const {
+    return std::make_tuple(
+        n_streams_,
+        n_symbols_,
+        max_stream_len_,
+        out_vec_size_,
+        in_vec_size_,
+        group_size_);
+  }
+
+ private:
+  int n_streams_;
+  int n_symbols_;
+  int max_stream_len_;
+  int out_vec_size_;
+  int in_vec_size_;
+  int group_size_;
+};
+
+class EntropyCodedMatmulV2 : public UnaryPrimitive {
+ public:
+  explicit EntropyCodedMatmulV2(
+      Stream stream,
+      int n_streams,
+      int in_vec_size,
+      int out_vec_size)
+      : UnaryPrimitive(stream),
+        n_streams_(n_streams),
+        in_vec_size_(in_vec_size),
+        out_vec_size_(out_vec_size) {}
+
+  void eval_cpu(const std::vector<array>& inputs, array& out) override;
+  void eval_gpu(const std::vector<array>& inputs, array& out) override;
+
+  DEFINE_NAME(EntropyCodedMatmulV2)
+  bool is_equivalent(const Primitive& other) const override;
+  std::vector<Shape> output_shapes(const std::vector<array>& inputs) override;
+  auto state() const {
+    return std::make_tuple(n_streams_, in_vec_size_, out_vec_size_);
+  }
+
+ private:
+  int n_streams_;
+  int in_vec_size_;
+  int out_vec_size_;
+};
+
+class EntropyDecodeAsync : public UnaryPrimitive {
+ public:
+  explicit EntropyDecodeAsync(
+      Stream stream,
+      int n_streams,
+      int in_vec_size,
+      int out_vec_size,
+      bool dequantize)
+      : UnaryPrimitive(stream),
+        n_streams_(n_streams),
+        in_vec_size_(in_vec_size),
+        out_vec_size_(out_vec_size),
+        dequantize_(dequantize) {}
+
+  void eval_cpu(const std::vector<array>& inputs, array& out) override;
+  void eval_gpu(const std::vector<array>& inputs, array& out) override;
+
+  DEFINE_NAME(EntropyDecodeAsync)
+  bool is_equivalent(const Primitive& other) const override;
+  std::vector<Shape> output_shapes(const std::vector<array>& inputs) override;
+  auto state() const {
+    return std::make_tuple(n_streams_, in_vec_size_, out_vec_size_, dequantize_);
+  }
+
+ private:
+  int n_streams_;
+  int in_vec_size_;
+  int out_vec_size_;
+  bool dequantize_;
+};
+
 class RandomBits : public UnaryPrimitive {
  public:
   explicit RandomBits(Stream stream, const Shape& shape, int width)

--- a/python/mlx/nn/layers/__init__.py
+++ b/python/mlx/nn/layers/__init__.py
@@ -93,6 +93,11 @@ from mlx.nn.layers.quantized import (
     QuantizedLinear,
     quantize,
 )
+from mlx.nn.layers.entropy_coded import (
+    EntropyCodedLinear,
+    entropy_quantize,
+    DecodeMode,
+)
 from mlx.nn.layers.recurrent import GRU, LSTM, RNN
 from mlx.nn.layers.transformer import (
     MultiHeadAttention,

--- a/python/mlx/nn/layers/entropy_coded.py
+++ b/python/mlx/nn/layers/entropy_coded.py
@@ -1,0 +1,762 @@
+# Copyright © 2024 Apple Inc.
+# Entropy-Coded Quantization for MLX
+#
+# Achieves 1.84x additional compression over 4-bit quantization using rANS
+# entropy coding. Provides multiple decode strategies for memory/speed tradeoff.
+
+import math
+from typing import Optional, Tuple, List
+from enum import Enum
+
+import mlx.core as mx
+import numpy as np
+from mlx.nn.layers.base import Module
+
+
+# rANS Constants
+PROB_BITS = 14
+PROB_SCALE = 1 << PROB_BITS  # 16384
+RANS_BYTE_L = 1 << 23
+
+
+class DecodeMode(Enum):
+    """Decode strategy selection."""
+    FUSED = "fused"          # V1: Decode in GEMV kernel (smallest memory)
+    FUSED_V2 = "fused_v2"    # V2: Per-row decode (O(n) vs O(rows*n))
+    CACHED = "cached"        # Decode at load, keep in RAM (fastest inference)
+    GPU_ASYNC = "gpu_async"  # Metal async decode queue
+
+
+class AsyncDecodePrefetcher:
+    """
+    GPU Async Prefetcher for entropy-coded layers.
+    
+    While GPU computes layer N, we decode layer N+1 in parallel using
+    a separate stream. Uses double-buffering to avoid synchronization.
+    
+    Timeline:
+      GPU Stream 1: [Compute L0] [Compute L1] [Compute L2] ...
+      GPU Stream 2: [Decode L1]  [Decode L2]  [Decode L3]  ...
+                         ↓           ↓           ↓
+                    Ready before GPU needs it!
+    """
+    
+    def __init__(self):
+        # Double buffer: stores pre-decoded weights
+        self._decode_buffers = [None, None]
+        self._current_buffer = 0
+        self._pending_decode = None
+        self._decode_stream = mx.new_stream(mx.gpu)  # Separate stream for decode
+    
+    def start_prefetch(self, layer: 'EntropyCodedLinear'):
+        """Start async decode of a layer's weights on separate stream."""
+        if layer._compressed_data_v2 is None:
+            return
+        
+        # Prepare MLX arrays if not done
+        if not hasattr(layer, '_mx_compressed_v2'):
+            layer._mx_compressed_v2 = mx.array(
+                np.frombuffer(layer._compressed_data_v2, dtype=np.uint8))
+            layer._mx_row_offsets = mx.array(layer._row_offsets)
+            layer._mx_row_stream_lens = mx.array(layer._row_stream_lens)
+            layer._mx_freq = mx.array(layer._freq.astype(np.uint16))
+            layer._mx_cumfreq = mx.array(layer._cumfreq.astype(np.uint16))
+            layer._mx_sym_table = mx.array(layer._sym_table.astype(np.uint8))
+        
+        # Start decode on separate stream
+        with mx.stream(self._decode_stream):
+            decoded = mx.entropy_decode_async(
+                layer._mx_compressed_v2,
+                layer._mx_row_offsets,
+                layer._mx_row_stream_lens,
+                layer._mx_freq,
+                layer._mx_cumfreq,
+                layer._mx_sym_table,
+                layer.scales.flatten(),
+                layer.biases_quant.flatten(),
+                layer.n_streams,
+                layer.input_dims,
+                layer.output_dims,
+                dequantize=True
+            )
+            # Store in next buffer slot
+            next_buffer = 1 - self._current_buffer
+            self._decode_buffers[next_buffer] = decoded
+            self._pending_decode = decoded
+    
+    def get_decoded_weights(self) -> Optional[mx.array]:
+        """Get pre-decoded weights from current buffer."""
+        if self._pending_decode is not None:
+            # Wait for decode to complete
+            mx.eval(self._pending_decode)
+            self._pending_decode = None
+        
+        # Swap buffers
+        weights = self._decode_buffers[self._current_buffer]
+        self._current_buffer = 1 - self._current_buffer
+        return weights
+    
+    def has_prefetched(self) -> bool:
+        """Check if we have prefetched weights available."""
+        return self._decode_buffers[self._current_buffer] is not None
+
+
+# Global prefetcher instance for GPU_ASYNC mode
+_global_prefetcher: Optional[AsyncDecodePrefetcher] = None
+
+
+def get_prefetcher() -> AsyncDecodePrefetcher:
+    """Get or create global prefetcher."""
+    global _global_prefetcher
+    if _global_prefetcher is None:
+        _global_prefetcher = AsyncDecodePrefetcher()
+    return _global_prefetcher
+
+
+class RANSTable:
+    """rANS frequency table for 4-bit symbols."""
+    
+    def __init__(self, freq: np.ndarray, cumfreq: np.ndarray, sym_table: np.ndarray):
+        self.freq = freq
+        self.cumfreq = cumfreq
+        self.sym_table = sym_table
+    
+    @classmethod
+    def from_counts(cls, counts: np.ndarray, n_symbols: int = 16) -> 'RANSTable':
+        """Build frequency table from symbol counts."""
+        counts = np.maximum(counts, 1).astype(np.float64)
+        total = counts.sum()
+        
+        # Scale to PROB_SCALE
+        scaled = (counts / total * PROB_SCALE).astype(np.int64)
+        
+        # Ensure sum equals PROB_SCALE
+        diff = PROB_SCALE - scaled.sum()
+        scaled[np.argmax(counts)] += diff
+        
+        freq = scaled.astype(np.uint16)
+        cumfreq = np.zeros(n_symbols + 1, dtype=np.uint16)
+        cumfreq[1:] = np.cumsum(freq)
+        
+        # Build symbol lookup table
+        sym_table = np.zeros(PROB_SCALE, dtype=np.uint8)
+        for s in range(n_symbols):
+            start = cumfreq[s]
+            end = cumfreq[s + 1]
+            sym_table[start:end] = s
+        
+        return cls(freq, cumfreq[:n_symbols], sym_table)
+
+
+def entropy_encode(indices: np.ndarray, table: RANSTable, n_streams: int = 256) -> Tuple[bytes, List[int], int]:
+    """
+    Encode 4-bit indices using interleaved rANS (V1: flat encoding).
+    
+    Returns:
+        data: Physically interleaved compressed bytes
+        stream_lengths: Length of each stream
+        max_stream_len: Maximum stream length (for padding)
+    """
+    indices = indices.flatten().astype(np.uint32)
+    n = len(indices)
+    
+    # Split into interleaved streams
+    stream_symbols = [indices[i::n_streams] for i in range(n_streams)]
+    
+    stream_bytes_list = []
+    stream_lengths = []
+    
+    for stream_idx in range(n_streams):
+        syms = stream_symbols[stream_idx]
+        if len(syms) == 0:
+            stream_bytes_list.append(b'')
+            stream_lengths.append(0)
+            continue
+        
+        out_bytes = []
+        state = RANS_BYTE_L
+        
+        # Encode in reverse
+        for i in range(len(syms) - 1, -1, -1):
+            s = syms[i]
+            freq_s = int(table.freq[s])
+            start_s = int(table.cumfreq[s])
+            
+            x_max = ((RANS_BYTE_L >> PROB_BITS) << 8) * freq_s
+            while state >= x_max:
+                out_bytes.append(state & 0xFF)
+                state >>= 8
+            
+            state = ((state // freq_s) << PROB_BITS) + (state % freq_s) + start_s
+        
+        # Flush state
+        out_bytes.extend([
+            (state >> 0) & 0xFF,
+            (state >> 8) & 0xFF,
+            (state >> 16) & 0xFF,
+            (state >> 24) & 0xFF
+        ])
+        
+        encoded = bytes(reversed(out_bytes))
+        stream_bytes_list.append(encoded)
+        stream_lengths.append(len(encoded))
+    
+    # Physical interleaving for coalesced GPU access
+    max_stream_len = max(stream_lengths) if stream_lengths else 0
+    
+    stream_matrix = np.zeros((n_streams, max_stream_len), dtype=np.uint8)
+    for i, stream_data in enumerate(stream_bytes_list):
+        if len(stream_data) > 0:
+            stream_matrix[i, :len(stream_data)] = np.frombuffer(stream_data, dtype=np.uint8)
+    
+    interleaved_data = stream_matrix.T.flatten().tobytes()
+    
+    return interleaved_data, stream_lengths, max_stream_len
+
+
+def entropy_encode_v2(indices_2d: np.ndarray, table: RANSTable, n_streams: int = 256) -> Tuple[bytes, np.ndarray, np.ndarray]:
+    """
+    Encode 4-bit indices using per-row interleaved rANS (V2: O(n) decode).
+    
+    Args:
+        indices_2d: 2D array of indices [out_dim, in_dim]
+        table: RANSTable with frequency data
+        n_streams: Number of parallel streams per row
+        
+    Returns:
+        compressed_data: All rows concatenated (physically interleaved per row)
+        row_offsets: Byte offset to each row's data
+        row_stream_lens: Per-stream lengths for each row [out_dim * n_streams]
+    """
+    out_dim, in_dim = indices_2d.shape
+    
+    all_row_data = []
+    row_offsets = []
+    row_stream_lens = []
+    current_offset = 0
+    
+    for row_idx in range(out_dim):
+        row_indices = indices_2d[row_idx].astype(np.uint32)
+        
+        # Split row into interleaved streams
+        stream_symbols = [row_indices[i::n_streams] for i in range(n_streams)]
+        
+        stream_bytes_list = []
+        stream_lengths = []
+        
+        for stream_idx in range(n_streams):
+            syms = stream_symbols[stream_idx]
+            if len(syms) == 0:
+                stream_bytes_list.append(b'')
+                stream_lengths.append(0)
+                continue
+            
+            out_bytes = []
+            state = RANS_BYTE_L
+            
+            # Encode in reverse
+            for i in range(len(syms) - 1, -1, -1):
+                s = syms[i]
+                freq_s = int(table.freq[s])
+                start_s = int(table.cumfreq[s])
+                
+                x_max = ((RANS_BYTE_L >> PROB_BITS) << 8) * freq_s
+                while state >= x_max:
+                    out_bytes.append(state & 0xFF)
+                    state >>= 8
+                
+                state = ((state // freq_s) << PROB_BITS) + (state % freq_s) + start_s
+            
+            # Flush state
+            out_bytes.extend([
+                (state >> 0) & 0xFF,
+                (state >> 8) & 0xFF,
+                (state >> 16) & 0xFF,
+                (state >> 24) & 0xFF
+            ])
+            
+            encoded = bytes(reversed(out_bytes))
+            stream_bytes_list.append(encoded)
+            stream_lengths.append(len(encoded))
+        
+        # Physical interleaving for this row
+        max_stream_len = max(stream_lengths) if stream_lengths else 0
+        
+        stream_matrix = np.zeros((n_streams, max_stream_len), dtype=np.uint8)
+        for i, stream_data in enumerate(stream_bytes_list):
+            if len(stream_data) > 0:
+                stream_matrix[i, :len(stream_data)] = np.frombuffer(stream_data, dtype=np.uint8)
+        
+        interleaved_row = stream_matrix.T.flatten().tobytes()
+        
+        row_offsets.append(current_offset)
+        current_offset += len(interleaved_row)
+        all_row_data.append(interleaved_row)
+        row_stream_lens.extend(stream_lengths)
+    
+    compressed_data = b''.join(all_row_data)
+    row_offsets = np.array(row_offsets, dtype=np.uint32)
+    row_stream_lens = np.array(row_stream_lens, dtype=np.uint32)
+    
+    return compressed_data, row_offsets, row_stream_lens
+
+
+class EntropyCodedLinear(Module):
+    """
+    Linear layer with entropy-coded quantized weights.
+    
+    Achieves 1.84x additional compression over 4-bit quantization using
+    rANS entropy coding. The decode overhead is hidden using GPU async
+    decode or eliminated by decoding at load time.
+    
+    Args:
+        input_dims (int): Input dimension
+        output_dims (int): Output dimension  
+        bias (bool): Whether to include bias
+        n_streams (int): Number of parallel rANS streams (default: 256)
+        decode_mode (str): One of 'fused', 'cached', 'gpu_async'
+        group_size (int): Quantization group size (default: 64)
+    """
+    
+    def __init__(
+        self,
+        input_dims: int,
+        output_dims: int,
+        bias: bool = True,
+        n_streams: int = 256,
+        decode_mode: str = "fused_v2",
+        group_size: int = 64,
+    ):
+        super().__init__()
+        
+        self.input_dims = input_dims
+        self.output_dims = output_dims
+        self.n_streams = n_streams
+        self.decode_mode = DecodeMode(decode_mode)
+        self.group_size = group_size
+        
+        # Placeholders - will be set by from_linear or load
+        self._compressed_data = None
+        self._stream_lengths = None
+        self._max_stream_len = None
+        self._freq = None
+        self._cumfreq = None
+        self._sym_table = None
+        self._decoded_indices = None  # For CACHED mode
+        
+        # Quantization parameters
+        self.scales = None
+        self.biases_quant = None
+        
+        if bias:
+            self.bias = mx.zeros((output_dims,))
+        else:
+            self.bias = None
+    
+    @classmethod
+    def from_linear(
+        cls,
+        linear_layer,
+        n_streams: int = 256,
+        decode_mode: str = "cached",
+        group_size: int = 64,
+    ) -> 'EntropyCodedLinear':
+        """
+        Convert a Linear layer to EntropyCodedLinear.
+        
+        Args:
+            linear_layer: Source Linear or QuantizedLinear layer
+            n_streams: Number of parallel rANS streams
+            decode_mode: Decode strategy ('fused', 'cached', 'gpu_async')
+            group_size: Quantization group size
+            
+        Returns:
+            EntropyCodedLinear layer with compressed weights
+        """
+        # Get weight matrix
+        if hasattr(linear_layer, 'weight'):
+            weight = np.array(linear_layer.weight)
+        else:
+            raise ValueError("Layer must have 'weight' attribute")
+        
+        output_dims, input_dims = weight.shape
+        has_bias = hasattr(linear_layer, 'bias') and linear_layer.bias is not None
+        
+        # Create layer
+        layer = cls(
+            input_dims=input_dims,
+            output_dims=output_dims,
+            bias=has_bias,
+            n_streams=n_streams,
+            decode_mode=decode_mode,
+            group_size=group_size,
+        )
+        
+        # Quantize to 4-bit
+        # For best compression, use per-tensor quantization (single scale/bias)
+        # For best accuracy, use per-group quantization
+        if group_size >= input_dims:
+            # Per-tensor quantization (best compression)
+            w_min = weight.min()
+            w_max = weight.max()
+            scale = (w_max - w_min) / 15 if w_max != w_min else 1e-8
+            
+            indices = np.clip(np.round((weight - w_min) / scale), 0, 15).astype(np.uint8)
+            scales = np.array([[scale]], dtype=np.float32)
+            biases_quant = np.array([[w_min]], dtype=np.float32)
+            layer.group_size = input_dims  # Mark as per-tensor
+        else:
+            # Per-group quantization (better accuracy)
+            n_groups = (input_dims + group_size - 1) // group_size
+            scales = np.zeros((output_dims, n_groups), dtype=np.float32)
+            biases_quant = np.zeros((output_dims, n_groups), dtype=np.float32)
+            indices = np.zeros((output_dims, input_dims), dtype=np.uint8)
+            
+            for row in range(output_dims):
+                for g in range(n_groups):
+                    start = g * group_size
+                    end = min(start + group_size, input_dims)
+                    group_weights = weight[row, start:end]
+                    
+                    w_min = group_weights.min()
+                    w_max = group_weights.max()
+                    scale = (w_max - w_min) / 15 if w_max != w_min else 1e-8
+                    
+                    scales[row, g] = scale
+                    biases_quant[row, g] = w_min
+                    
+                    q = np.clip(np.round((group_weights - w_min) / scale), 0, 15).astype(np.uint8)
+                    indices[row, start:end] = q
+        
+        # Entropy encode
+        counts = np.bincount(indices.flatten(), minlength=16)
+        table = RANSTable.from_counts(counts)
+        
+        # V2 and GPU_ASYNC use per-row encoding for O(n) decode
+        if layer.decode_mode in (DecodeMode.FUSED_V2, DecodeMode.GPU_ASYNC):
+            compressed_data_v2, row_offsets, row_stream_lens = entropy_encode_v2(
+                indices, table, n_streams
+            )
+            layer._compressed_data_v2 = compressed_data_v2
+            layer._row_offsets = row_offsets
+            layer._row_stream_lens = row_stream_lens
+            compressed_bytes = len(compressed_data_v2)
+        else:
+            compressed_data, stream_lengths, max_stream_len = entropy_encode(
+                indices.flatten(), table, n_streams
+            )
+            layer._compressed_data = compressed_data
+            layer._stream_lengths = stream_lengths
+            layer._max_stream_len = max_stream_len
+            compressed_bytes = len(compressed_data)
+        
+        # Store frequency tables
+        layer._freq = table.freq
+        layer._cumfreq = table.cumfreq
+        layer._sym_table = table.sym_table
+        
+        # Store quantization params as MLX arrays
+        layer.scales = mx.array(scales)
+        layer.biases_quant = mx.array(biases_quant)
+        
+        # Copy bias if present
+        if has_bias:
+            layer.bias = mx.array(np.array(linear_layer.bias))
+        
+        # For CACHED mode, decode immediately
+        if layer.decode_mode == DecodeMode.CACHED:
+            layer._decode_weights()
+        
+        # Calculate compression stats
+        original_bytes = output_dims * input_dims * 0.5  # 4-bit
+        layer._compression_ratio = original_bytes / compressed_bytes
+        
+        return layer
+    
+    def _decode_weights(self):
+        """Decode compressed weights to 4-bit indices (for CACHED mode)."""
+        # This would use the GPU kernel in production
+        # For now, use Python decode
+        data = np.frombuffer(self._compressed_data, dtype=np.uint8)
+        n_streams = self.n_streams
+        n_symbols = self.output_dims * self.input_dims
+        max_stream_len = self._max_stream_len
+        stream_lengths = self._stream_lengths
+        
+        output = np.zeros(n_symbols, dtype=np.uint8)
+        
+        for stream_idx in range(n_streams):
+            stream_len = stream_lengths[stream_idx]
+            if stream_len < 4:
+                continue
+            
+            def read_byte(ptr: int) -> int:
+                return int(data[stream_idx + ptr * n_streams])
+            
+            ptr = 0
+            state = (read_byte(0) << 24) | (read_byte(1) << 16) | \
+                    (read_byte(2) << 8) | read_byte(3)
+            ptr = 4
+            
+            n_syms = len(range(stream_idx, n_symbols, n_streams))
+            
+            for i in range(n_syms):
+                output_idx = stream_idx + i * n_streams
+                if output_idx >= n_symbols:
+                    break
+                
+                slot = state & (PROB_SCALE - 1)
+                s = int(self._sym_table[slot])
+                output[output_idx] = s
+                
+                freq_s = int(self._freq[s])
+                start_s = int(self._cumfreq[s])
+                state = freq_s * (state >> PROB_BITS) + slot - start_s
+                
+                while state < RANS_BYTE_L and ptr < stream_len:
+                    state = (state << 8) | read_byte(ptr)
+                    ptr += 1
+        
+        self._decoded_indices = mx.array(output.reshape(self.output_dims, self.input_dims))
+    
+    def __call__(self, x: mx.array) -> mx.array:
+        """Forward pass with entropy-coded weights."""
+        
+        # GPU_ASYNC mode: use prefetched weights if available
+        if self.decode_mode == DecodeMode.GPU_ASYNC and self._compressed_data_v2 is not None:
+            return self._forward_gpu_async(x)
+        
+        # Use fused GPU kernel V2 if available
+        if self.decode_mode == DecodeMode.FUSED_V2 and self._compressed_data_v2 is not None:
+            return self._forward_fused_v2(x)
+        
+        # Use fused GPU kernel V1 if available
+        if self.decode_mode == DecodeMode.FUSED and self._compressed_data is not None:
+            return self._forward_fused(x)
+        
+        # Fallback: decode weights if not already done, then use standard matmul
+        if self._decoded_indices is None:
+            self._decode_weights()
+        
+        # Dequantize: weight = index * scale + bias
+        indices = self._decoded_indices.astype(mx.float32)
+        
+        # Check if per-tensor quantization (single scale/bias)
+        if self.scales.shape == (1, 1):
+            # Per-tensor: simple broadcast
+            weights = indices * self.scales[0, 0] + self.biases_quant[0, 0]
+        else:
+            # Per-group: process each group
+            n_groups = self.scales.shape[1]
+            weight_groups = []
+            for g in range(n_groups):
+                start = g * self.group_size
+                end = min(start + self.group_size, self.input_dims)
+                group_indices = indices[:, start:end]
+                group_scale = self.scales[:, g:g+1]  # (output_dims, 1)
+                group_bias = self.biases_quant[:, g:g+1]  # (output_dims, 1)
+                dequantized = group_indices * group_scale + group_bias
+                weight_groups.append(dequantized)
+            
+            weights = mx.concatenate(weight_groups, axis=1)
+        
+        # Matrix multiply
+        y = x @ weights.T
+        
+        if self.bias is not None:
+            y = y + self.bias
+        
+        return y
+    
+    def _forward_fused(self, x: mx.array) -> mx.array:
+        """Fused GPU kernel path: decode + dequant + GEMV in one kernel."""
+        # Convert data to MLX arrays if needed
+        if not hasattr(self, '_mx_compressed'):
+            self._mx_compressed = mx.array(
+                np.frombuffer(self._compressed_data, dtype=np.uint8))
+            self._mx_stream_lengths = mx.array(
+                np.array(self._stream_lengths, dtype=np.uint32))
+            self._mx_freq = mx.array(self._freq.astype(np.uint16))
+            self._mx_cumfreq = mx.array(self._cumfreq.astype(np.uint16))
+            self._mx_sym_table = mx.array(self._sym_table.astype(np.uint8))
+        
+        # Handle batched input: process each vector separately
+        # (kernel currently supports 1D input only)
+        orig_shape = x.shape
+        if x.ndim > 1:
+            batch_size = x.shape[0]
+            outputs = []
+            for i in range(batch_size):
+                y_i = mx.entropy_coded_matmul(
+                    self._mx_compressed,
+                    self._mx_stream_lengths,
+                    self._mx_freq,
+                    self._mx_cumfreq,
+                    self._mx_sym_table,
+                    x[i],
+                    self.scales.flatten(),
+                    self.biases_quant.flatten(),
+                    self.n_streams,
+                    self.output_dims * self.input_dims,
+                    self._max_stream_len,
+                    self.output_dims,
+                    self.input_dims,
+                    self.group_size
+                )
+                outputs.append(y_i)
+            y = mx.stack(outputs, axis=0)
+        else:
+            y = mx.entropy_coded_matmul(
+                self._mx_compressed,
+                self._mx_stream_lengths,
+                self._mx_freq,
+                self._mx_cumfreq,
+                self._mx_sym_table,
+                x,
+                self.scales.flatten(),
+                self.biases_quant.flatten(),
+                self.n_streams,
+                self.output_dims * self.input_dims,
+                self._max_stream_len,
+                self.output_dims,
+                self.input_dims,
+                self.group_size
+            )
+        
+        if self.bias is not None:
+            y = y + self.bias
+        
+        return y
+    
+    def _forward_fused_v2(self, x: mx.array) -> mx.array:
+        """Fused GPU kernel V2 path: per-row decode + dequant + GEMV."""
+        # Convert data to MLX arrays if needed
+        if not hasattr(self, '_mx_compressed_v2'):
+            self._mx_compressed_v2 = mx.array(
+                np.frombuffer(self._compressed_data_v2, dtype=np.uint8))
+            self._mx_row_offsets = mx.array(self._row_offsets)
+            self._mx_row_stream_lens = mx.array(self._row_stream_lens)
+            self._mx_freq = mx.array(self._freq.astype(np.uint16))
+            self._mx_cumfreq = mx.array(self._cumfreq.astype(np.uint16))
+            self._mx_sym_table = mx.array(self._sym_table.astype(np.uint8))
+        
+        # Handle batched input: process each vector separately
+        orig_shape = x.shape
+        if x.ndim > 1:
+            batch_size = x.shape[0]
+            outputs = []
+            for i in range(batch_size):
+                y_i = mx.entropy_coded_matmul_v2(
+                    self._mx_compressed_v2,
+                    self._mx_row_offsets,
+                    self._mx_row_stream_lens,
+                    self._mx_freq,
+                    self._mx_cumfreq,
+                    self._mx_sym_table,
+                    x[i],
+                    self.scales.flatten(),
+                    self.biases_quant.flatten(),
+                    self.n_streams,
+                    self.input_dims,
+                    self.output_dims
+                )
+                outputs.append(y_i)
+            y = mx.stack(outputs, axis=0)
+        else:
+            y = mx.entropy_coded_matmul_v2(
+                self._mx_compressed_v2,
+                self._mx_row_offsets,
+                self._mx_row_stream_lens,
+                self._mx_freq,
+                self._mx_cumfreq,
+                self._mx_sym_table,
+                x,
+                self.scales.flatten(),
+                self.biases_quant.flatten(),
+                self.n_streams,
+                self.input_dims,
+                self.output_dims
+            )
+        
+        if self.bias is not None:
+            y = y + self.bias
+        
+        return y
+    
+    def _forward_gpu_async(self, x: mx.array) -> mx.array:
+        """
+        GPU Async path: use prefetched weights or decode inline.
+        
+        This mode uses a separate GPU stream to decode the next layer
+        while the current layer is computing. On first call, it decodes
+        inline (like FUSED_V2). On subsequent calls, it uses pre-decoded
+        weights from the prefetch buffer.
+        """
+        prefetcher = get_prefetcher()
+        
+        # Check if we have prefetched weights
+        if prefetcher.has_prefetched():
+            weights = prefetcher.get_decoded_weights()
+            if weights is not None:
+                # Use pre-decoded weights with standard matmul
+                if x.ndim > 1:
+                    y = x @ weights.T
+                else:
+                    y = x @ weights.T
+                
+                if self.bias is not None:
+                    y = y + self.bias
+                return y
+        
+        # No prefetched weights - decode now using V2 kernel
+        # This happens on first call before prefetching starts
+        return self._forward_fused_v2(x)
+    
+    def prefetch_weights(self):
+        """Start async prefetch of this layer's weights."""
+        if self.decode_mode == DecodeMode.GPU_ASYNC and self._compressed_data_v2 is not None:
+            prefetcher = get_prefetcher()
+            prefetcher.start_prefetch(self)
+    
+    @property
+    def compression_ratio(self) -> float:
+        """Compression ratio over 4-bit quantization."""
+        return getattr(self, '_compression_ratio', 1.0)
+    
+    @property
+    def bits_per_weight(self) -> float:
+        """Effective bits per weight."""
+        return 4.0 / self.compression_ratio
+
+
+def entropy_quantize(
+    model: Module,
+    n_streams: int = 256,
+    decode_mode: str = "fused_v2",
+    group_size: int = 64,
+) -> None:
+    """
+    Convert all Linear layers in a model to EntropyCodedLinear.
+    
+    Args:
+        model: The model to quantize
+        n_streams: Number of parallel rANS streams
+        decode_mode: Decode strategy ('fused', 'cached', 'gpu_async')
+        group_size: Quantization group size
+    """
+    from mlx.nn.layers.linear import Linear
+    from mlx.utils import tree_map_with_path
+    
+    def _maybe_convert(path, m):
+        if isinstance(m, Linear):
+            return EntropyCodedLinear.from_linear(
+                m,
+                n_streams=n_streams,
+                decode_mode=decode_mode,
+                group_size=group_size,
+            )
+        return m
+    
+    leaves = model.leaf_modules()
+    leaves = tree_map_with_path(_maybe_convert, leaves, is_leaf=Module.is_module)
+    model.update_modules(leaves)


### PR DESCRIPTION
## Summary

Add rANS entropy coding on top of quantized weights for **1.3-2x additional lossless compression**.


## Motivation

Quantized LLM weights have entropy significantly below their bit-width:
- 4-bit weights: ~2.17 bits entropy → 1.84x compression potential
- 8-bit weights: ~4-5 bits entropy → 1.6-2x compression potential

This PR closes that gap with lossless entropy coding, reducing memory bandwidth during inference.

## Implementation

### New Primitives
- `EntropyCodedMatmul` - V1 fused decode+GEMV
- `EntropyCodedMatmulV2` - V2 per-row decode (recommended)
- `EntropyDecodeAsync` - Async GPU decode for prefetching

### Metal Kernels
- `entropy_coded.h` - V1 kernel
- `entropy_coded_v2.h` - V2 per-row kernel (O(N) vs O(rows×N))
- `entropy_decode_async.h` - Async decode kernel

### Python API
```python
from mlx.nn.layers import EntropyCodedLinear

# Convert quantized layer
ec_layer = EntropyCodedLinear.from_linear(linear, decode_mode="fused_v2")
```

## Decode Modes

| Mode | Memory | Speed | Use Case |
|------|--------|-------|----------|
| `fused_v2` | 1.3-2x smaller | 1.1-1.5x overhead | Memory-constrained |
| `cached` | Same as quantized | 1.0x | Speed-critical |
| `gpu_async` | 1.3-2x smaller | ~1.0x | Deep models |

## Testing

- Build passes (cmake + make)
- All 235 existing tests pass
- Benchmarked on M3 Pro with synthetic and real model weights
