### PR TITLE
Allow take on empty array when it makes sense

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -3162,9 +3162,9 @@ array take(
   }
 
   // Check for valid take
-  if (a.size() == 0 && indices.size() != 0) {
+  if (a.shape(axis) == 0 && indices.size() != 0) {
     throw std::invalid_argument(
-        "[take] Cannot do a non-empty take from an array with zero elements.");
+        "[take] Cannot do a non-empty take from an empty axis.");
   }
 
   // Handle negative axis

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -1242,6 +1242,14 @@ class TestOps(mlx_tests.MLXTestCase):
         out = mx.take(a, mx.array([[1]]), axis=0)
         self.assertEqual(out.shape, (1, 1, 4))
 
+        # Take from empty array works in some cases
+        a = mx.zeros((4, 0))
+        out = mx.take(a, mx.array([1, 2]), axis=0)
+        self.assertEqual(out.shape, (2, 0))
+        self.assertEqual(out.dtype, a.dtype)
+        with self.assertRaises(ValueError):
+            mx.take(a, mx.array([[1]]), axis=1)
+
     def test_take_along_axis(self):
         a_np = np.arange(8).reshape(2, 2, 2)
         a_mlx = mx.array(a_np)


### PR DESCRIPTION
This also matches the behavior in numpy and closes https://github.com/ml-explore/mlx-lm/issues/798