### PR TITLE
Use C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ project(
 
 # ----------------------------- Setup -----------------------------
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_INSTALL_MESSAGE NEVER)

--- a/docs/src/dev/mlx_in_cpp.rst
+++ b/docs/src/dev/mlx_in_cpp.rst
@@ -45,7 +45,7 @@ The next step is to setup a CMake file in ``CMakeLists.txt``:
 
   project(example LANGUAGES CXX)
 
-  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD 20)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 

--- a/docs/src/install.rst
+++ b/docs/src/install.rst
@@ -83,7 +83,7 @@ Build from source
 Build Requirements
 ^^^^^^^^^^^^^^^^^^
 
-- A C++ compiler with C++17 support (e.g. Clang >= 5.0)
+- A C++ compiler with C++20 support (e.g. Clang >= 15.0)
 - `cmake <https://cmake.org/>`_ -- version 3.25 or later, and ``make``
 - Xcode >= 15.0 and macOS SDK >= 14.0
 

--- a/mlx/backend/cpu/simd/base_simd.h
+++ b/mlx/backend/cpu/simd/base_simd.h
@@ -1,8 +1,11 @@
 #pragma once
 
+// Required for using M_LN2 in MSVC.
+#define _USE_MATH_DEFINES
+
+#include <math.h>
 #include <stdint.h>
 #include <algorithm>
-#include <cmath>
 #include <complex>
 #include <functional>
 

--- a/mlx/backend/cuda/CMakeLists.txt
+++ b/mlx/backend/cuda/CMakeLists.txt
@@ -126,9 +126,9 @@ endif()
 target_compile_options(
   mlx PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:--Wno-deprecated-gpu-targets>")
 
-# Suppress nvcc warnings on MLX headers.
-target_compile_options(mlx PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe
-                                   --diag_suppress=997>)
+# Suppress nvcc warnings on C++ headers.
+target_compile_options(
+  mlx PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe="--diag_suppress=997,20208">)
 
 # Use stronger binaries compression. This feature was introduced in CUDA 12.8
 # and requires drivers released after CUDA 12.4.

--- a/mlx/backend/metal/indexing.cpp
+++ b/mlx/backend/metal/indexing.cpp
@@ -697,8 +697,8 @@ void MaskedScatter::eval_gpu(const std::vector<array>& inputs, array& out) {
   auto lib = d.get_library(kernel_name, [&]() {
     std::string source = metal::utils();
     source += metal::masked_scatter();
-    source += fmt::format(
-        std::string(masked_assign_kernel), kernel_name, value_type, contiguous);
+    source +=
+        fmt::format(masked_assign_kernel, kernel_name, value_type, contiguous);
     return source;
   });
   auto kernel = d.get_kernel(kernel_name, lib);

--- a/tests/einsum_tests.cpp
+++ b/tests/einsum_tests.cpp
@@ -5,6 +5,15 @@
 
 using namespace mlx::core;
 
+namespace std {
+
+// Required to make doctest compile.
+ostream& operator<<(ostream& os, const vector<vector<int>>&) {
+  return os;
+}
+
+} // namespace std
+
 TEST_CASE("test einsum path") {
   std::vector<std::vector<int>> expected = {{1, 2}, {0, 1}};
   auto path =


### PR DESCRIPTION
We only used C++17 features but to make some code (mainly `dispatch_xxx` utils) compile with MSVC we have to enable C++20.