### PR TITLE
Add missing <algorithm> include to buffer_cache.h

### DIFF
--- a/mlx/backend/common/buffer_cache.h
+++ b/mlx/backend/common/buffer_cache.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cassert>
 #include <functional>
 #include <map>


### PR DESCRIPTION
## Proposed changes

Fixes #3051.

`buffer_cache.h` uses `std::find_if` but doesn't include `<algorithm>`. This works with Clang (which transitively includes it through `<functional>` or `<map>`), but fails with GCC 15+.

@awni would something like https://github.com/include-what-you-use/include-what-you-use be useful to catch these? Or is it too noisy for this codebase?

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)