### PR TITLE
Better support consumer CUDA GPUs

### DIFF
--- a/mlx/backend/cuda/device.cpp
+++ b/mlx/backend/cuda/device.cpp
@@ -209,6 +209,10 @@ std::pair<int, int> get_graph_limits(Device& d) {
       ops = 50;
       mb = 500;
       break;
+    case 1200: // Consumer Blackwell
+      ops = 100;
+      mb = 1000;
+      break;
     case 1210: // DGX Spark
       ops = 20;
       mb = 25;

--- a/mlx/backend/cuda/device.h
+++ b/mlx/backend/cuda/device.h
@@ -119,7 +119,7 @@ class CommandEncoder {
   CudaStream stream_;
   CudaGraph graph_;
   Worker worker_;
-  char node_count_{0};
+  int node_count_{0};
   bool in_concurrent_{false};
   std::vector<cudaGraphNode_t> from_nodes_;
   std::vector<cudaGraphNode_t> to_nodes_;

--- a/mlx/backend/cuda/jit_module.cpp
+++ b/mlx/backend/cuda/jit_module.cpp
@@ -272,7 +272,7 @@ void compile(
   std::vector<const char*> args;
   bool use_sass = compiler_supports_device_sass(device);
   auto cc = device.compute_capability_major();
-  std::string arch_tag = (cc == 90 || cc == 100 || cc == 121) ? "a" : "";
+  std::string arch_tag = (cc >= 9) ? "a" : "";
   std::string compute = fmt::format(
       "--gpu-architecture={}_{}{}{}",
       use_sass ? "sm" : "compute",


### PR DESCRIPTION
## Proposed changes

Currently there are a few places where parameters are set based on checking for particular (primarily data center) GPUs. This extends some checks for consumer GPUs, generalizing where possible to avoid needing to maintain lists. Consumer GPUs tend to have more SKUs and variations, including within the same generation.

There are two places where this is an issue:
 - CUDA graph limits, which are based on hand-tuned values. The default limits aren't able to saturate Blackwell GPUs, such as the RTX 6000 Pro and 5090. Older GPUs seem fine with the existing default limits.
 - JIT use of non-forward compatible architectural features. There is an existing bug which prevents this from ever triggering since it is comparing major version to major and minor. This fixes the issue and broadens the check to all GPUs that support non-forward compatible features.

## Benchmarks

I tried to find a generic calculation for tuning the CUDA graph limits, primarily focusing on memory bandwidth. In the end, I couldn’t convince myself that it was a reliable calculation across GPUs and models. As a result, I just extended the existing limits for consumer Blackwell devices, which is where the real performance differences were. Ideally, I would still like to generalize this better in the future.

Performance gains are most significant (42%) with larger models:
RTX Pro 6000 Blackwell
`mlx_lm.benchmark --model Qwen/Qwen3-30B-A3B-Thinking-2507 --prompt-tokens 1024 -g 128 -b 1 -n 4`
| | Generation TPS | Peak Memory |
| ------------- | ------------- |------------- |
| Before | 88.192  | 61.768  |
| After  | 125.281  | 64.475  |

Smaller improvement but still decent (6%) on with a smaller model (Qwen/Qwen3-4B-Thinking-2507) on the same machine:
| | Generation TPS | Peak Memory |
| ------------- | ------------- |------------- |
| Before | 155.513  | 8.898  |
| After  | 164.661  | 11.192  |

## Checklist

Put an `x` in the boxes that apply.

- [X] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [X] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
