### PR TITLE
Fix double precision for exp, sin, cos, erf, erfinv on CPU

### DIFF
--- a/benchmarks/cpp/single_ops.cpp
+++ b/benchmarks/cpp/single_ops.cpp
@@ -57,6 +57,8 @@ void time_unary_ops() {
   int N = 500;
   auto device = mx::default_device();
 
+  // float32
+  std::cout << "  float32:" << std::endl;
   auto a = mx::random::normal({M, N});
   mx::eval(a);
   TIME(mlx::core::abs, a, device);
@@ -66,9 +68,30 @@ void time_unary_ops() {
   TIME(mlx::core::sqrt, a, device);
   TIME(mx::rsqrt, a, device);
   TIME(mlx::core::exp, a, device);
+  TIME(mlx::core::sin, a, device);
+  TIME(mlx::core::cos, a, device);
+  TIME(mx::erf, a, device);
+  TIME(mx::erfinv, a, device);
 
   a = mx::random::uniform({M, N});
+  mx::eval(a);
   TIME(mlx::core::log, a, device);
+
+  // float64 (CPU only)
+  if (device == mx::Device::cpu) {
+    std::cout << "  float64:" << std::endl;
+    auto a64 = mx::astype(mx::random::normal({M, N}), mx::float64);
+    mx::eval(a64);
+    TIME(mlx::core::exp, a64, device);
+    TIME(mlx::core::sin, a64, device);
+    TIME(mlx::core::cos, a64, device);
+    TIME(mx::erf, a64, device);
+    TIME(mx::erfinv, a64, device);
+
+    a64 = mx::astype(mx::random::uniform({M, N}), mx::float64);
+    mx::eval(a64);
+    TIME(mlx::core::log, a64, device);
+  }
 }
 
 void time_binary_ops() {
@@ -271,7 +294,16 @@ void time_divmod() {
   TIME(divmod_separate);
 }
 
-int main() {
+int main(int argc, char** argv) {
+  bool use_cpu = false;
+  for (int i = 1; i < argc; ++i) {
+    if (std::string(argv[i]) == "--cpu") {
+      use_cpu = true;
+    }
+  }
+  if (use_cpu) {
+    mx::set_default_device(mx::Device::cpu);
+  }
   std::cout << "Benchmarks for " << mx::default_device() << std::endl;
   time_creation_ops();
   time_type_conversions();

--- a/tests/ops_tests.cpp
+++ b/tests/ops_tests.cpp
@@ -1403,6 +1403,21 @@ TEST_CASE("test arithmetic unary ops") {
     CHECK_EQ(exp(x).item<complex64_t>(), complex64_t{0, 0});
   }
 
+  // float64 exp
+  if (default_device() == Device::cpu) {
+    array x(0.0, float64);
+    auto out = exp(x);
+    CHECK_EQ(out.dtype(), float64);
+    CHECK_EQ(out.item<double>(), 1.0);
+
+    x = array(2.0, float64);
+    CHECK_EQ(exp(x).item<double>(), doctest::Approx(std::exp(2.0)));
+
+    x = array(1.2345678901234567, float64);
+    CHECK_EQ(
+        exp(x).item<double>(), doctest::Approx(std::exp(1.2345678901234567)));
+  }
+
   // Test expm1
   {
     array x(-1.0f);
@@ -1441,6 +1456,21 @@ TEST_CASE("test arithmetic unary ops") {
     CHECK(allclose(sin(x), expected).item<bool>());
   }
 
+  // float64 sin
+  if (default_device() == Device::cpu) {
+    array x(0.0, float64);
+    auto out = sin(x);
+    CHECK_EQ(out.dtype(), float64);
+    CHECK_EQ(out.item<double>(), 0.0);
+
+    x = array(M_PI_2, float64);
+    CHECK_EQ(sin(x).item<double>(), doctest::Approx(std::sin(M_PI_2)));
+
+    x = array(0.123456789012345, float64);
+    CHECK_EQ(
+        sin(x).item<double>(), doctest::Approx(std::sin(0.123456789012345)));
+  }
+
   // Test cos
   {
     array x(0.0);
@@ -1463,6 +1493,21 @@ TEST_CASE("test arithmetic unary ops") {
     x = split(array({0.0f, 1.0f, 2.0f, 3.0f}, {2, 2}), 2, 1)[0];
     auto expected = array({std::cos(0.0f), std::cos(2.0f)}, {2, 1});
     CHECK(allclose(cos(x), expected).item<bool>());
+  }
+
+  // float64 cos
+  if (default_device() == Device::cpu) {
+    array x(0.0, float64);
+    auto out = cos(x);
+    CHECK_EQ(out.dtype(), float64);
+    CHECK_EQ(out.item<double>(), 1.0);
+
+    x = array(M_PI_2, float64);
+    CHECK_EQ(cos(x).item<double>(), doctest::Approx(std::cos(M_PI_2)));
+
+    x = array(0.123456789012345, float64);
+    CHECK_EQ(
+        cos(x).item<double>(), doctest::Approx(std::cos(0.123456789012345)));
   }
 
   // Test degrees
@@ -1704,6 +1749,49 @@ TEST_CASE("test error functions") {
       x = array(vals.begin()[i]);
       CHECK_EQ(erfinv(x).item<float>(), doctest::Approx(expected.begin()[i]));
     }
+  }
+
+  // float64
+  if (default_device() == Device::cpu) {
+    array x(0.0, float64);
+    auto out = erf(x);
+    CHECK_EQ(out.dtype(), float64);
+    CHECK_EQ(out.item<double>(), 0.0);
+
+    constexpr double inf_d = std::numeric_limits<double>::infinity();
+    x = array(inf_d, float64);
+    CHECK_EQ(erf(x).item<double>(), 1.0);
+    x = array(-inf_d, float64);
+    CHECK_EQ(erf(x).item<double>(), -1.0);
+
+    // Test precision with scipy-generated values
+    x = array(0.9, float64);
+    CHECK_EQ(erf(x).item<double>(), doctest::Approx(0.7969082124228322));
+    x = array(0.5, float64);
+    CHECK_EQ(erf(x).item<double>(), doctest::Approx(0.5204998778130465));
+
+    // erfinv float64
+    x = array(0.0, float64);
+    out = erfinv(x);
+    CHECK_EQ(out.dtype(), float64);
+    CHECK_EQ(out.item<double>(), 0.0);
+
+    x = array(1.0, float64);
+    CHECK_EQ(erfinv(x).item<double>(), inf_d);
+    x = array(-1.0, float64);
+    CHECK_EQ(erfinv(x).item<double>(), -inf_d);
+
+    // Test precision with scipy-generated values
+    x = array(0.9, float64);
+    CHECK_EQ(erfinv(x).item<double>(), doctest::Approx(1.1630871536766738));
+    x = array(0.5, float64);
+    CHECK_EQ(erfinv(x).item<double>(), doctest::Approx(0.4769362762044699));
+    x = array(0.1, float64);
+    CHECK_EQ(erfinv(x).item<double>(), doctest::Approx(0.08885599049425778));
+
+    // Test tail values (region3 of erfinv)
+    x = array(0.99, float64);
+    CHECK_EQ(erfinv(x).item<double>(), doctest::Approx(1.8213863677184496));
   }
 
   // float16_t


### PR DESCRIPTION
## Proposed changes

Fixes #3047 - These functions were using float32 polynomial approximations for all inputs, causing precision loss for float64. Added proper double precision paths using element-wise `std::` calls for exp/sin/cos/erf, and Julia's SpecialFunctions.jl rational approximation for erfinv.

**Questions for @awni:**
1. For `erfinv`, I used coefficients from [Julia's SpecialFunctions.jl](https://github.com/JuliaMath/SpecialFunctions.jl/blob/master/src/erf.jl) (Blair et al. 1976, 3-region rational approximation, ~1e-13 relative error). Is this acceptable?
2. I added float64 variants and a `--cpu` flag to the benchmark. Is it useful to include this or rather remove these changes?

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)