### PR TITLE
Fix flaky macOS test

### DIFF
--- a/python/tests/test_blas.py
+++ b/python/tests/test_blas.py
@@ -293,6 +293,15 @@ class TestBlas(mlx_tests.MLXTestCase):
                 out_npy = vec_npy @ mat_npy
                 out_mlx = vec_mlx @ mat_mlx
 
+            # Due to some bug, numpy sometimes has NaNs on macOS
+            # See https://github.com/ml-explore/mlx/pull/3063
+            nans = np.isnan(out_npy)
+            if np.any(nans):
+                nan_ids = np.where(nans)
+                mlx_nan_ids = tuple(mx.array(n) for n in nan_ids)
+                out_npy[nan_ids] = 0.0
+                out_mlx[mlx_nan_ids] = 0.0
+
             self.assertListEqual(list(out_npy.shape), list(out_mlx.shape))
             self.assertTrue(np.allclose(out_mlx, out_npy, atol=1e-5))
 


### PR DESCRIPTION
Running the following on my laptop (M1 Max with macOS 15.7) produces an NaN in the output sometimes:
```python
import numpy as np

for i in range(0, 10000):
    mat = np.random.normal(0.0, 1.0 / 32, (2047, 2049)).astype(np.float32)
    vec = np.random.normal(0.0, 1.0 / 32, (1, 2047)).astype(np.float32)

    out = vec @ mat
    if np.any(np.isnan(out)):
        import pdb
        pdb.set_trace()
```

The NaN is clearly wrong, as neither input has a NaN.. and it's not deterministic when it shows up.

However, this is causing some flaky test for us (e.g. https://github.com/ml-explore/mlx/actions/runs/21338337168/job/61413701483).