### PR TITLE
Faster vector SDPA in CUDA

### DIFF
--- a/mlx/backend/cuda/scaled_dot_product_attention.cu
+++ b/mlx/backend/cuda/scaled_dot_product_attention.cu
@@ -39,7 +39,7 @@ struct AttnParams {
 };
 
 template <int N, typename T, typename U>
-__device__ void load(const T *src, U *dst, int idx) {
+__device__ void load(const T* src, U* dst, int idx) {
   if constexpr (N % 2 == 0) {
     auto local = load_vector<N>(src, idx);
     PRAGMA_LOOP_UNROLL
@@ -55,7 +55,7 @@ __device__ void load(const T *src, U *dst, int idx) {
 }
 
 template <int N, typename T, typename U>
-__device__ void store(T *src, U *dst, int idx) {
+__device__ void store(T* src, U* dst, int idx) {
   if constexpr (N % 2 == 0) {
     AlignedVector<U, N> local;
     PRAGMA_LOOP_UNROLL


### PR DESCRIPTION
A pretty straight forward port of the changes in https://github.com/ml-explore/mlx/pull/3023 for CUDA. The main difference is the use of shared memory to store keys and values.