### PR TITLE
Tune CUDA gaph sizes on B200 and H100

### DIFF
--- a/mlx/backend/cuda/device.cpp
+++ b/mlx/backend/cuda/device.cpp
@@ -214,13 +214,7 @@ std::pair<int, int> get_graph_limits(Device& d) {
       mb = 400;
       break;
     case 900: // H100
-      ops = 30;
-      mb = 400;
-      break;
     case 1000: // B200
-      ops = 50;
-      mb = 500;
-      break;
     case 1200: // Consumer Blackwell
       ops = 100;
       mb = 1000;


### PR DESCRIPTION
Benchmarks for inference. I also ran a training benchmark (1B Transformer) and didn't notice much change.

```
mlx_lm.benchmark --model Qwen/Qwen3-4B-Thinking-2507 --prompt-tokens 1024 -g 128 -b 1 
```

H100
Pre:   prompt_tps=27330.184, generation_tps=184.120, peak_memory=9.545
Post: prompt_tps=30322.676, generation_tps=209.213, peak_memory=10.007

B200
Pre: prompt_tps=45910.345, generation_tps=228.303, peak_memory=9.332
Post: prompt_tps=45875.251, generation_tps=239.479, peak_memory=9.787



```
mlx_lm.benchmark --model Qwen/Qwen3-30B-A3B-Thinking-2507 --prompt-tokens 1024 -g 128 -b 1 -n 4
```

H100
Pre: prompt_tps=6885.463, generation_tps=87.226, peak_memory=62.217
Post: prompt_tps=6910.998, generation_tps=96.125, peak_memory=64.219


B200
Pre: prompt_tps=7885.334, generation_tps=114.522, peak_memory=62.715
Post: prompt_tps=7905.644, generation_tps=118.695, peak_memory=64.219