### PR TITLE
More useful error for large indices

### DIFF
--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -2127,6 +2127,13 @@ class TestArray(mlx_tests.MLXTestCase):
         self.assertEqual(x.imag.item(), 1.0)
         self.assertEqual(x.real.item(), 1.0)
 
+    def test_large_indices(self):
+        x = mx.array([0, 1, 2])
+        with self.assertRaises(ValueError):
+            x[: 2**32]
+        with self.assertRaises(ValueError):
+            x[2**32]
+
 
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner()


### PR DESCRIPTION
Instead of `bad_cast` show a more useful error message for indexing arrays with > int32 indices.

Closes #3054