### PR TITLE
Add bounds checking on GPU

### DIFF
--- a/mlx/CMakeLists.txt
+++ b/mlx/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(
           ${CMAKE_CURRENT_SOURCE_DIR}/dtype_utils.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/export.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/einsum.cpp
+          ${CMAKE_CURRENT_SOURCE_DIR}/failure.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/fast.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/fft.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/ops.cpp

--- a/mlx/backend/gpu/failure.h
+++ b/mlx/backend/gpu/failure.h
@@ -1,0 +1,10 @@
+// Copyright © 2026 Apple Inc.
+
+#pragma once
+
+namespace mlx::core::gpu {
+
+void reset_failure();
+bool has_failure();
+
+} // namespace mlx::core::gpu

--- a/mlx/backend/metal/CMakeLists.txt
+++ b/mlx/backend/metal/CMakeLists.txt
@@ -112,6 +112,7 @@ target_sources(
           ${CMAKE_CURRENT_SOURCE_DIR}/device.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/event.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/eval.cpp
+          ${CMAKE_CURRENT_SOURCE_DIR}/failure.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/fence.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/fft.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/hadamard.cpp

--- a/mlx/backend/metal/eval.cpp
+++ b/mlx/backend/metal/eval.cpp
@@ -4,6 +4,7 @@
 #include "mlx/backend/gpu/eval.h"
 #include "mlx/backend/metal/device.h"
 #include "mlx/backend/metal/utils.h"
+#include "mlx/failure.h"
 #include "mlx/primitives.h"
 #include "mlx/scheduler.h"
 
@@ -25,12 +26,17 @@ inline void check_error(MTL::CommandBuffer* cbuf) {
 }
 
 void eval(array& arr) {
+  if (global_failure()) {
+    return;
+  }
+
   auto pool = metal::new_scoped_memory_pool();
   auto s = arr.primitive().stream();
   auto& d = metal::device(s.device);
   auto command_buffer = d.get_command_buffer(s.index);
 
   auto outputs = arr.outputs();
+
   {
     // If the array is a tracer hold a reference
     // to its inputs so they don't get donated

--- a/mlx/backend/metal/failure.cpp
+++ b/mlx/backend/metal/failure.cpp
@@ -1,0 +1,72 @@
+// Copyright © 2026 Apple Inc.
+
+#include <atomic>
+#include <cstdint>
+
+#include "mlx/allocator.h"
+#include "mlx/backend/gpu/failure.h"
+#include "mlx/backend/metal/failure.h"
+#include "mlx/failure.h"
+
+namespace mlx::core {
+
+namespace {
+
+class Failure {
+ public:
+  static Failure& get() {
+    static Failure instance;
+    return instance;
+  }
+
+  Failure(const Failure&) = delete;
+  Failure& operator=(const Failure&) = delete;
+
+  allocator::Buffer& buffer() {
+    return buffer_;
+  }
+
+  void reset() {
+    atomic_ptr()->store(FailureCode::NoFailure, std::memory_order_relaxed);
+  }
+
+  FailureCode value() {
+    return atomic_ptr()->load(std::memory_order_relaxed);
+  }
+
+ private:
+  Failure() : buffer_(allocator::malloc(sizeof(int32_t))) {
+    reset();
+  }
+  ~Failure() = default;
+
+  std::atomic<FailureCode>* atomic_ptr() {
+    return reinterpret_cast<std::atomic<FailureCode>*>(buffer_.raw_ptr());
+  }
+
+  allocator::Buffer buffer_;
+};
+
+} // namespace
+
+namespace gpu {
+
+void reset_failure() {
+  Failure::get().reset();
+}
+
+bool has_failure() {
+  return Failure::get().value() != FailureCode::NoFailure;
+}
+
+} // namespace gpu
+
+namespace metal {
+
+MTL::Buffer* get_failure_buffer() {
+  return static_cast<MTL::Buffer*>(Failure::get().buffer().ptr());
+}
+
+} // namespace metal
+
+} // namespace mlx::core

--- a/mlx/backend/metal/failure.h
+++ b/mlx/backend/metal/failure.h
@@ -1,0 +1,11 @@
+// Copyright © 2026 Apple Inc.
+
+#pragma once
+
+#include "Metal/MTLBuffer.hpp"
+
+namespace mlx::core::metal {
+
+MTL::Buffer* get_failure_buffer();
+
+} // namespace mlx::core::metal

--- a/mlx/backend/metal/jit/indexing.h
+++ b/mlx/backend/metal/jit/indexing.h
@@ -9,10 +9,11 @@ constexpr std::string_view gather_kernels = R"(
     const constant size_t& src_ndim [[buffer(4)]],
     const constant int* slice_sizes [[buffer(5)]],
     const constant int* axes [[buffer(6)]],
-    const constant int* idx_shapes [[buffer(7)]],
-    const constant int64_t* idx_strides [[buffer(8)]],
-    const constant bool* idx_contigs [[buffer(9)]],
-    const constant int& idx_ndim [[buffer(10)]],
+    device atomic<int32_t>* global_failure [[buffer(7)]],
+    const constant int* idx_shapes [[buffer(8)]],
+    const constant int64_t* idx_strides [[buffer(9)]],
+    const constant bool* idx_contigs [[buffer(10)]],
+    const constant int& idx_ndim [[buffer(11)]],
     {4}
     uint3 index [[thread_position_in_grid]],
     uint3 grid_dim [[threads_per_grid]]) {{
@@ -27,6 +28,7 @@ constexpr std::string_view gather_kernels = R"(
       src_ndim,
       slice_sizes,
       axes,
+      global_failure,
       idxs,
       index,
       grid_dim);
@@ -50,6 +52,7 @@ constexpr std::string_view scatter_kernels = R"(
     const constant bool* idx_contigs [[buffer(13)]],
     const constant int& idx_ndim [[buffer(14)]],
     const constant size_t& idx_size [[buffer(15)]],
+    device atomic<int32_t>* global_failure [[buffer(16)]],
     {5}
     uint2 gid [[thread_position_in_grid]]) {{
   Indices<{2}, {4}> idxs{{ {{ {6} }}, idx_shapes, idx_strides, idx_contigs, idx_ndim}};
@@ -66,6 +69,7 @@ constexpr std::string_view scatter_kernels = R"(
       out_ndim,
       axes,
       idx_size,
+      global_failure,
       idxs,
       gid);
 }}

--- a/mlx/backend/metal/kernels/indexing/gather_front.h
+++ b/mlx/backend/metal/kernels/indexing/gather_front.h
@@ -11,11 +11,16 @@ template <typename T, typename IdxT, typename LocT, int N>
     device T* out,
     const constant int64_t& stride,
     const constant int& size,
+    device atomic<int32_t>* global_failure,
     uint2 index [[thread_position_in_grid]],
     uint2 grid_dim [[threads_per_grid]]) {
   auto idx = offset_neg_idx(indices[index.y], size);
   LocT src_idx = static_cast<LocT>(stride) * idx;
   LocT out_idx = static_cast<LocT>(stride) * index.y;
+
+  if (!check_bounds(idx, size, global_failure)) {
+    return;
+  }
 
   int s_idx = N * index.x;
   for (int i = 0; i < N && s_idx < stride; ++i, ++s_idx) {

--- a/mlx/backend/metal/kernels/indexing/indexing.h
+++ b/mlx/backend/metal/kernels/indexing/indexing.h
@@ -21,3 +21,13 @@ METAL_FUNC size_t offset_neg_idx(IdxT idx, int size) {
     return (idx < 0) ? idx + size : idx;
   }
 }
+
+template <typename IdxT>
+METAL_FUNC bool
+check_bounds(IdxT idx, int size, device atomic<int32_t>* global_failure) {
+  if (idx < 0 || idx >= size) {
+    atomic_store_explicit(global_failure, BOUNDS_FAILURE, memory_order_relaxed);
+    return false;
+  }
+  return true;
+}

--- a/mlx/backend/metal/kernels/indexing/scatter.h
+++ b/mlx/backend/metal/kernels/indexing/scatter.h
@@ -24,6 +24,7 @@ METAL_FUNC void scatter_impl(
     const constant size_t& out_ndim,
     const constant int* axes,
     const constant size_t& idx_size,
+    device atomic<int32_t>* global_failure,
     const thread Indices<IdxT, NIDX>& indices,
     uint2 gid [[thread_position_in_grid]]) {
   Op op;
@@ -47,6 +48,11 @@ METAL_FUNC void scatter_impl(
                 indices.ndim);
       auto ax = axes[i];
       auto idx_val = offset_neg_idx(indices.buffers[i][idx_loc], out_shape[ax]);
+
+      if (!check_bounds(idx_val, out_shape[ax], global_failure)) {
+        return;
+      }
+
       out_idx +=
           static_cast<LocT>(idx_val) * static_cast<LocT>(out_strides[ax]);
     }

--- a/mlx/failure.cpp
+++ b/mlx/failure.cpp
@@ -1,0 +1,24 @@
+// Copyright © 2026 Apple Inc.
+
+#include "mlx/backend/gpu/failure.h"
+#include "mlx/backend/gpu/device_info.h"
+#include "mlx/failure.h"
+
+namespace mlx::core {
+
+void reset_global_failure() {
+  // TODO also reset CPU failure.
+  if (gpu::is_available()) {
+    gpu::reset_failure();
+  }
+}
+
+bool global_failure() {
+  // TODO also check CPU failure.
+  if (gpu::is_available()) {
+    return gpu::has_failure();
+  }
+  return false;
+}
+
+} // namespace mlx::core

--- a/mlx/failure.h
+++ b/mlx/failure.h
@@ -1,0 +1,18 @@
+// Copyright © 2026 Apple Inc.
+
+#pragma once
+
+#include <cstdint>
+
+namespace mlx::core {
+
+enum class FailureCode : int32_t {
+  NoFailure = -1,
+  BoundsFailure,
+};
+
+void reset_global_failure();
+
+bool global_failure();
+
+} // namespace mlx::core

--- a/mlx/mlx.h
+++ b/mlx/mlx.h
@@ -12,6 +12,7 @@
 #include "mlx/distributed/ops.h"
 #include "mlx/einsum.h"
 #include "mlx/export.h"
+#include "mlx/failure.h"
 #include "mlx/fast.h"
 #include "mlx/fft.h"
 #include "mlx/io.h"

--- a/python/src/indexing.cpp
+++ b/python/src/indexing.cpp
@@ -813,7 +813,14 @@ auto mlx_slice_update(
       throw std::invalid_argument(msg.str());
     }
     auto idx = nb::cast<int>(obj);
-    idx = idx < 0 ? idx + stops[0] : idx;
+    auto axis_size = stops[0];
+    if (idx < -axis_size || idx >= axis_size) {
+      std::ostringstream msg;
+      msg << "Index " << idx << " is out of bounds for axis 0 with size "
+          << axis_size << ".";
+      throw std::out_of_range(msg.str());
+    }
+    idx = idx < 0 ? idx + axis_size : idx;
     starts[0] = idx;
     stops[0] = idx + 1;
     auto out = slice_update(
@@ -874,7 +881,14 @@ auto mlx_slice_update(
       upd_ax--;
     } else if (nb::isinstance<nb::int_>(pyidx)) {
       int st = nb::cast<int>(pyidx);
-      st = (st < 0) ? st + src.shape(i) : st;
+      int axis_size = src.shape(ax);
+      if (st < -axis_size || st >= axis_size) {
+        std::ostringstream msg;
+        msg << "Index " << st << " is out of bounds for axis " << ax
+            << " with size " << axis_size << ".";
+        throw std::out_of_range(msg.str());
+      }
+      st = (st < 0) ? st + axis_size : st;
       starts[ax] = st;
       stops[ax] = st + 1;
       if (upd_ax >= 0) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(
           array_tests.cpp
           arg_reduce_tests.cpp
           autograd_tests.cpp
+          bounds_checks_tests.cpp
           blas_tests.cpp
           compile_tests.cpp
           custom_vjp_tests.cpp

--- a/tests/bounds_checks_tests.cpp
+++ b/tests/bounds_checks_tests.cpp
@@ -1,0 +1,116 @@
+// Copyright © 2024 Apple Inc.
+
+#include "doctest/doctest.h"
+#include "mlx/mlx.h"
+
+using namespace mlx::core;
+
+TEST_CASE("test bounds checks gather") {
+  if (!metal::is_available()) {
+    return;
+  }
+
+  auto stream = default_stream(Device::gpu);
+  reset_global_failure();
+
+  // 1. 1D Array failure (gather_front kernel)
+  {
+    auto src = array({10, 20, 30, 40, 50}, {5});
+    auto bad_indices = array({0, 2, 5}, {3});
+    auto bad_op = gather(src, bad_indices, 0, {1});
+    CHECK_THROWS_AS(eval(bad_op), std::out_of_range);
+    reset_global_failure();
+  }
+
+  // 2. 2D Array failure (general gather kernel)
+  {
+    auto src_2d = array({1, 2, 3, 4, 5, 6}, {2, 3});
+    auto bad_indices = array({0, 30}, {2});
+    auto bad_op = gather(src_2d, bad_indices, 0, {1, 2});
+    CHECK_THROWS_AS(eval(bad_op), std::out_of_range);
+    reset_global_failure();
+  }
+
+  // 3. Valid 2D gather
+  {
+    auto src_2d = array({1, 2, 3, 4, 5, 6}, {2, 3});
+    auto valid_indices = array({0, 1, 0}, {3});
+    auto op = gather(src_2d, valid_indices, 0, {1, 3});
+    eval(op);
+    CHECK(op.is_available());
+  }
+}
+
+TEST_CASE("test bounds checks dependent op failure propagation") {
+  if (!metal::is_available()) {
+    return;
+  }
+
+  auto stream = default_stream(Device::gpu);
+  reset_global_failure();
+
+  auto src = array({1, 2, 3, 4, 5}, {5});
+
+  auto bad_indices = array({100}, {1});
+  auto fail_op = gather(src, bad_indices, 0, {3});
+  auto next_op = gather(fail_op, array({0}, {1}), 0, {1, 3});
+
+  CHECK_THROWS_AS(eval(next_op), std::out_of_range);
+
+  reset_global_failure();
+  auto valid_op = gather(src, array({0}, {1}), 0, {3});
+  eval(valid_op);
+  CHECK(valid_op.is_available());
+}
+
+TEST_CASE("test bounds checks scatter") {
+  if (!metal::is_available()) {
+    return;
+  }
+
+  auto stream = default_stream(Device::gpu);
+  reset_global_failure();
+
+  auto dst = array({1.0f, 2.0f, 3.0f, 4.0f, 5.0f}, {5});
+
+  // 1. 1D Scatter failure
+  {
+    auto indices = array({100}, {1});
+    auto updates = array({10.0f}, {1, 1});
+    auto bad_op = scatter(dst, indices, updates, 0);
+    CHECK_THROWS_AS(eval(bad_op), std::out_of_range);
+    reset_global_failure();
+  }
+
+  // 2. 2D Scatter failure
+  {
+    auto dst_2d = array({1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f}, {2, 3});
+    auto indices = std::vector<array>{array({0, 10}, {2})};
+    auto updates = reshape(
+        array({10.0f, 20.0f, 30.0f, 40.0f, 50.0f, 60.0f}, {2, 3}), {2, 1, 3});
+    auto bad_op = scatter(dst_2d, indices, updates, {0});
+    CHECK_THROWS_AS(eval(bad_op), std::out_of_range);
+    reset_global_failure();
+  }
+
+  // 3. Valid scatter
+  {
+    auto updates = reshape(array({10.0f, 20.0f}, {2}), {2, 1});
+    auto indices = array({0, 4}, {2});
+    auto op = scatter(dst, indices, updates, 0);
+    eval(op);
+    CHECK(op.is_available());
+    auto expected = std::vector<float>{10.0f, 2.0f, 3.0f, 4.0f, 20.0f};
+    CHECK(array_equal(op, array(expected.data(), {5}, float32)).item<bool>());
+  }
+
+  // 4. scatter_add failure
+  {
+    auto dst = array({1.0f, 2.0f, 3.0f, 4.0f, 5.0f}, {5});
+    auto indices = array({100}, {1});
+    auto updates = array({1.0f}, {1, 1});
+    auto bad_op = scatter_add(dst, indices, updates, 0);
+    CHECK_THROWS_AS(eval(bad_op), std::out_of_range);
+    reset_global_failure();
+  }
+}


### PR DESCRIPTION
## Proposed changes

I propose to slow things down a bit. This is a draft implementation of array bounds checking in the Metal backend. The scatter and gather benchmarks show a 2% median runtime overhead on an 8-core M4 GPU (see results below). Is this something you'd be interested in merging? I'll probably be working on it for fun, so I'd appreciate your thoughts either way :)

The low overhead is due to @athas's strategy described in [Bounds Checking on GPU](https://futhark-lang.org/publications/hlpp20.pdf): errors are propagated from the GPU to the CPU by writing a single global 32-bit integer. This is just a draft to play around with the essence of it. I've matched the behaviour against pytorch's MPS backend, which appears to prioritize performance over safety. I don't yet report the out-of-bounds index value or the axis size, but it'd be straightforward to add this. Also I assume that gathers and scatters are never fused. A non-draft PR should add bounds checking to the CPU and CUDA backends too, of course.

Details
---

The strategy/implementation has limitations:
1. Only one error is recorded and, if there are multiple errors at runtime, it's indeterministic which one.
2. Handling index errors is disallowed.

The global error is written/read/thrown asynchronously and really means "there is at least one error", so handling the thrown error may leave us in a bad state. I check the global error in `array::wait()` and reset it right before throwing. (Otherwise the error would persist, being thrown on every eval when MLX is used in the Python REPL.) So the program must terminate on index errors.

3. My implementation doesn't make indexing safe.

The paper prevents memory corruption by checking global failure in the prelude of every kernel. I didn't implement this, so kernels that have been enqueued before the global failure was set may operate on invalid inputs such as uninitialized arrays. This means _all_ arrays have to be considered invalid on an index error. Still, there can be no out-of-bounds reading or writing and an index error will get reported to the user. I'm unsure whether pytorch allows memory corruption, I did not study their implementation.

Possible improvements:
* Better error information.
* Optimization: disable bounds checking for safe gather/scatter calls (e.g., I imagine some `jvp`/`vjp` operations are safe if the corresponding primal has been checked).
* Bounds checking specialized fused kernels like `gather_mm`.
* Preventing memory corruption by checking for global failure in every GPU kernel. The paper demonstrates low overhead.
* As the paper mentions, you can use this method to report any kind of error (e.g., division by zero).

Related to #206.

Evaluation
---

I ran `benchmarks/python/gather_bench.py` and `benchmarks/python/scatter_bench.py` to get the below results.

Benchmark                       | main (ms) | bounds (ms) | Overhead
--------------------------------|-----------|-------------|---------
Gather: X(100, 64)              |     3.331 |       3.409 |   +2%
Gather: X(100, 1024)            |     4.903 |       4.928 |   +0.5%
Gather: X(4, 1000000)           |     0.312 |       0.311 |   -0.3%
Scatter: Dst(10, 64)            |     3.800 |       4.127 |   +8%
Scatter: Dst(100000, 64)        |     7.373 |       7.595 |   +3%
Scatter: Dst(1000000, 64)       |     1.185 |       1.209 |   +2%
Scatter: Dst(100000,)           |     0.408 |       0.403 |   -1%
Scatter: Dst(200000,)           |     3.030 |       3.000 |   -1%
Scatter: Dst(20000000,)         |    31.614 |      31.682 |   +0.2%
Scatter: Dst(10000, 64)         |     4.071 |       4.315 |   +6%
Scatter: Dst(100, 64)           |    35.631 |      38.184 |   +7%
Scatter: Dst(100, 10000, 64)    |    49.503 |      52.397 |   +6%
Scatter: Dst(10, 100, 100, 21)  |   210.873 |     219.162 |   +4%
Scatter: Dst(1000, 1000, 10)    |     0.910 |       0.761 |  -16%

Summary _disregarding the -16% test_ (which I guess is just noise):

Average Overhead: 2.85%
Max Overhead: 8.61%
Median Overhead: 2.34%

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
