### PR TITLE
Disable managed memory on WSL when concurrentManagedAccess is not supported

### DIFF
--- a/mlx/backend/cuda/allocator.cpp
+++ b/mlx/backend/cuda/allocator.cpp
@@ -40,8 +40,8 @@ bool is_windows() {
       std::string line;
       std::getline(version, line);
       return line.find("microsoft") != std::string::npos ||
-             line.find("Microsoft") != std::string::npos ||
-             line.find("WSL") != std::string::npos;
+          line.find("Microsoft") != std::string::npos ||
+          line.find("WSL") != std::string::npos;
     }
     return false;
   }();


### PR DESCRIPTION
Extend the Windows managed memory check from #3075 to also apply to WSL, as the underlying behavior is the same.

Otherwise, on WSL we get a segfault on load 