### PR TITLE
Fix 2pass sdpa on < M2

### DIFF
--- a/mlx/backend/metal/kernels/sdpa_vector.h
+++ b/mlx/backend/metal/kernels/sdpa_vector.h
@@ -323,6 +323,7 @@ template <typename T, int D>
     const device float* sums [[buffer(1)]],
     const device float* maxs [[buffer(2)]],
     device T* out [[buffer(3)]],
+    const constant int& blocks [[buffer(4)]],
     uint3 tid [[threadgroup_position_in_grid]],
     uint3 tpg [[threadgroups_per_grid]],
     uint simd_gid [[simdgroup_index_in_threadgroup]],
@@ -368,7 +369,7 @@ template <typename T, int D>
 
     // Update the output accumulator
     for (int i = 0; i < elem_per_thread; i++) {
-      o[i] += factor * partials[i];
+      o[i] += factor * static_cast<U>(partials[i]);
     }
     maxs += BN;
     sums += BN;

--- a/mlx/backend/metal/utils.h
+++ b/mlx/backend/metal/utils.h
@@ -81,4 +81,19 @@ inline size_t ceildiv(size_t n, size_t m) {
   return (n + m - 1) / m;
 }
 
+inline void check_kernel_threadgroup_size(
+    const MTL::ComputePipelineState* kernel,
+    MTL::Size group_dims,
+    const std::string& name) {
+  auto max_size = kernel->maxTotalThreadsPerThreadgroup();
+  auto requested_size = group_dims.width * group_dims.height * group_dims.depth;
+
+  if (max_size < requested_size) {
+    std::ostringstream msg;
+    msg << "Maximum threads per threadgroup is " << max_size
+        << " but requested " << requested_size << " for kernel " << name << ".";
+    throw std::runtime_error(msg.str());
+  }
+}
+
 } // namespace mlx::core


### PR DESCRIPTION
Closes https://github.com/ml-explore/mlx-lm/issues/844

Honestly I think this is a lower level issue. For some reason using blocks = 128 when blocks is a function constant makes the kernel support < 1024 threads per thread group. Other values (64, 256, etc) do not have that issue. This is just for bfloat16 on M1 and M2 🤷‍♂️ 