### PR TITLE
is_available() should check the device index too

### DIFF
--- a/mlx/device.cpp
+++ b/mlx/device.cpp
@@ -36,9 +36,9 @@ bool operator!=(const Device& lhs, const Device& rhs) {
 bool is_available(const Device& d) {
   switch (d.type) {
     case Device::cpu:
-      return cpu::is_available();
+      return cpu::is_available() && (d.index < cpu::device_count());
     case Device::gpu:
-      return gpu::is_available();
+      return gpu::is_available() && (d.index < gpu::device_count());
   }
   // appease compiler
   return false;


### PR DESCRIPTION
## Proposed changes

is_available() takes a device but only checks the device type - not if the device index is valid.
fix checks device index too.
