### PR TITLE
[CUDA] Set current device before allocating memory

### DIFF
--- a/mlx/backend/cuda/event.h
+++ b/mlx/backend/cuda/event.h
@@ -54,7 +54,7 @@ class CudaEvent {
 // CudaEvent so the latter should always be preferred when possible.
 class AtomicEvent {
  public:
-  AtomicEvent();
+  AtomicEvent(Device& d);
 
   void wait(uint32_t value);
   void wait(cudaStream_t stream, uint32_t value);

--- a/mlx/backend/cuda/fence.cpp
+++ b/mlx/backend/cuda/fence.cpp
@@ -14,7 +14,8 @@ struct FenceImpl {
 
 Fence::Fence(Stream s) {
   fence_ = std::shared_ptr<void>(
-      new FenceImpl{0}, [](void* ptr) { delete static_cast<FenceImpl*>(ptr); });
+      new FenceImpl{0, cu::device(s.device)},
+      [](void* ptr) { delete static_cast<FenceImpl*>(ptr); });
 }
 
 void Fence::wait(Stream s, const array&) {


### PR DESCRIPTION
This is a followup to https://github.com/ml-explore/mlx/pull/3100 that fixes illegal memory access when using MLX under multi-device environment.