### PR TITLE
[CUDA] Use cuDNN SDPA for decoding when using fixed-size KV cache

### DIFF
--- a/mlx/backend/cuda/scaled_dot_product_attention.cu
+++ b/mlx/backend/cuda/scaled_dot_product_attention.cu
@@ -665,9 +665,7 @@ bool supports_sdpa_vector(
     const array& q,
     const array& k,
     const array& v,
-    bool has_mask,
     bool has_arr_mask,
-    bool do_causal,
     bool output_logsumexp) {
   if (output_logsumexp) {
     return false;


### PR DESCRIPTION
The kv cache in mlx-lm has fixed-size and keys/values passed to `fast.sdpa` are slices, using this information we can create cuDNN graphs with fixed sequence length and use padding masks to set the actual sequence lengths.

This makes decoding (`T_q == 1`) 30%~100% faster for large sequence lengths. For small sequence lengths the cuDNN SDPA is still faster but the overhead of creating cuDNN graphs would eliminate the advantage so we fallback to vector SDPA.

This approach however does not support custom array masks, we can add more options to reduce the uses of array masks but cuDNN does not support left padding masks, so integrating with `BatchKVCache` would require extra efforts.