### PR TITLE
Prevent allocator from operating on residency set during metal capture

### DIFF
--- a/mlx/backend/metal/allocator.h
+++ b/mlx/backend/metal/allocator.h
@@ -41,6 +41,7 @@ class MetalAllocator : public allocator::Allocator {
   size_t set_memory_limit(size_t limit);
   size_t get_memory_limit();
   size_t set_wired_limit(size_t limit);
+  void on_capture_stop();
   void clear_cache();
 
  private:
@@ -68,6 +69,8 @@ class MetalAllocator : public allocator::Allocator {
   size_t peak_memory_{0};
   size_t max_pool_size_;
   size_t wired_limit_{0};
+  bool wired_limit_pending_apply_{false};
+  bool residency_set_attached_{false};
   size_t num_resources_{0};
   size_t resource_limit_{0};
 

--- a/mlx/backend/metal/device.h
+++ b/mlx/backend/metal/device.h
@@ -144,6 +144,7 @@ struct DeviceStream {
   std::unique_ptr<CommandEncoder> encoder{nullptr};
   std::shared_ptr<Fence> fence;
   std::vector<array> temporaries;
+  bool residency_set_attached{false};
 };
 
 class MLX_API Device {
@@ -206,8 +207,13 @@ class MLX_API Device {
   void add_temporaries(std::vector<array> arrays, int index);
 
   void set_residency_set(const MTL::ResidencySet* residency_set);
+  void on_capture_start();
+  void on_capture_stop();
 
  private:
+  void attach_residency_set_to_stream_(DeviceStream& stream);
+  void attach_residency_set_to_existing_queues_if_needed_();
+
   DeviceStream& get_stream_(int index) {
     return stream_map_.find(index)->second;
   }
@@ -255,6 +261,7 @@ class MLX_API Device {
       std::unordered_map<std::string, MTL::ComputePipelineState*>>
       library_kernels_;
   const MTL::ResidencySet* residency_set_{nullptr};
+  bool residency_set_pending_attach_{false};
   std::string arch_;
   int arch_gen_;
   int max_ops_per_buffer_;

--- a/mlx/backend/metal/metal.cpp
+++ b/mlx/backend/metal/metal.cpp
@@ -1,18 +1,35 @@
 // Copyright © 2023-2024 Apple Inc.
+#include <atomic>
 #include <memory>
 
+#include "mlx/backend/metal/allocator.h"
 #include "mlx/backend/metal/device.h"
 #include "mlx/backend/metal/metal.h"
 #include "mlx/backend/metal/utils.h"
 
 namespace mlx::core::metal {
+namespace {
+std::atomic<bool> g_residency_sets_enabled{true};
+} // namespace
 
 bool is_available() {
   return true;
 }
 
+bool residency_sets_enabled() {
+  return g_residency_sets_enabled.load(std::memory_order_relaxed);
+}
+
+void set_residency_sets_enabled(bool enabled) {
+  g_residency_sets_enabled.store(enabled, std::memory_order_relaxed);
+}
+
 void start_capture(std::string path, NS::Object* object) {
   auto pool = new_scoped_memory_pool();
+  set_residency_sets_enabled(false);
+  // Detach queue residency sets before capture starts to keep traces replayable
+  // when collecting derived counters.
+  metal::device(mlx::core::Device::gpu).on_capture_start();
 
   auto descriptor = MTL::CaptureDescriptor::alloc()->init();
   descriptor->setCaptureObject(object);
@@ -29,6 +46,9 @@ void start_capture(std::string path, NS::Object* object) {
   bool started = manager->startCapture(descriptor, &error);
   descriptor->release();
   if (!started) {
+    set_residency_sets_enabled(true);
+    metal::device(mlx::core::Device::gpu).on_capture_stop();
+    metal::allocator().on_capture_stop();
     std::ostringstream msg;
     msg << "[metal::start_capture] Failed to start: "
         << error->localizedDescription()->utf8String();
@@ -45,6 +65,15 @@ void stop_capture() {
   auto pool = new_scoped_memory_pool();
   auto manager = MTL::CaptureManager::sharedCaptureManager();
   manager->stopCapture();
+  set_residency_sets_enabled(true);
+  metal::device(mlx::core::Device::gpu).on_capture_stop();
+  metal::allocator().on_capture_stop();
+}
+
+bool is_capture_active() {
+  auto pool = new_scoped_memory_pool();
+  auto manager = MTL::CaptureManager::sharedCaptureManager();
+  return manager->isCapturing();
 }
 
 } // namespace mlx::core::metal

--- a/mlx/backend/metal/metal.h
+++ b/mlx/backend/metal/metal.h
@@ -16,6 +16,9 @@ MLX_API bool is_available();
 /** Capture a GPU trace, saving it to an absolute file `path` */
 MLX_API void start_capture(std::string path = "");
 MLX_API void stop_capture();
+MLX_API bool is_capture_active();
+MLX_API bool residency_sets_enabled();
+MLX_API void set_residency_sets_enabled(bool enabled);
 
 /** Get information about the GPU and system settings. */
 MLX_API const

--- a/mlx/backend/metal/no_metal.cpp
+++ b/mlx/backend/metal/no_metal.cpp
@@ -15,6 +15,13 @@ bool is_available() {
 
 void start_capture(std::string) {}
 void stop_capture() {}
+bool is_capture_active() {
+  return false;
+}
+bool residency_sets_enabled() {
+  return false;
+}
+void set_residency_sets_enabled(bool) {}
 
 const std::unordered_map<std::string, std::variant<std::string, size_t>>&
 device_info() {

--- a/mlx/backend/metal/resident.h
+++ b/mlx/backend/metal/resident.h
@@ -24,6 +24,9 @@ class ResidencySet {
   void resize(size_t size);
 
  private:
+  void ensure_wired_set_();
+
+  MTL::Device* device_{nullptr};
   MTL::ResidencySet* wired_set_{nullptr};
   std::unordered_set<const MTL::Allocation*> unwired_set_;
   size_t capacity_{0};


### PR DESCRIPTION
## Proposed changes

In issue #2846, it was reported that when profiling a `.gputrace` generated by MLX, Xcode could fail to rebuild the graph due to residency-set replay errors (`command queue residency set limit of 32 exceeded`).

This PR makes Metal capture replay-safe by preventing residency-set queue attachment/mutation while capture is active, and restoring normal behavior after capture ends.

### What changed

- Added capture-aware residency gating in the Metal backend:
  - Introduced `metal::residency_sets_enabled()` / `metal::set_residency_sets_enabled(bool)`.
  - Disabled residency sets at `start_capture(...)` and re-enabled them at `stop_capture()`.
- Updated device residency attachment flow to respect capture state:
  - Queue-level residency sets are detached at capture start.
  - Deferred re-attachment occurs after capture stop.
- Updated allocator wired-limit handling:
  - Residency-set resize/attach operations are deferred while capture is active.
  - Deferred state is applied on capture stop.
- Updated residency-set creation logic:
  - Avoid creating/attaching residency sets during active capture.
  - Keep allocations tracked and apply when safe.

These changes preserve normal runtime behavior outside capture while avoiding replay-time residency-set explosions during Xcode profiling/counters.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
