### PR TITLE
register pressure

### DIFF
--- a/mlx/backend/cuda/quantized/fp_quantize.cu
+++ b/mlx/backend/cuda/quantized/fp_quantize.cu
@@ -174,7 +174,7 @@ __global__ void fp_quantize_columnwise(
   auto block_idx = cg::this_thread_block().group_index();
   auto idx_in_block = cg::this_thread_block().thread_index();
 
-  constexpr int BLOCK_X = 32;
+  constexpr int BLOCK_X = 16;
   constexpr int BLOCK_Y = 32;
   constexpr int elem_per_byte = (bits == 8) ? 1 : 2;
   constexpr int bytes_per_group = group_size / elem_per_byte;
@@ -323,7 +323,7 @@ fp_dequantize(const uint8_t* w, const uint8_t* scales, T* out, size_t size) {
 
 inline std::tuple<dim3, dim3>
 get_columnwise_quantize_launch_args(size_t size, int group_size, int M, int K) {
-  constexpr int BLOCK_X = 32;
+  constexpr int BLOCK_X = 16;
   constexpr int BLOCK_Y = 32;
   int rows_per_block = BLOCK_X;
   int cols_per_block = BLOCK_Y * group_size;


### PR DESCRIPTION
There is a register pressure in `fp_quantize_columnwise`. We (I) were (was) using 40 registers per thread and launch 1 block. 
`mxfp8`:
| Size (M×N) | Time (us) –after | Time (us) – before |
|---|---:|---:|
| 4096×4096 | 77.89 | 78.98 |
| 4096×8192 | 101.11 | 105.38 |
| 8192×4096 | 99.76 | 105.91 |
| 8192×8192 | 140.29 | 152.07 |
| 4096×16384 | 144.56 | 154.76 |
| 16384×4096 | 136.55 | 148.44 |

I tried to tune it more, `block_size.x = 16` seems like an optimal value for the current kernel. 