### PR TITLE
Manage stream placement in import function

### DIFF
--- a/mlx/export.cpp
+++ b/mlx/export.cpp
@@ -446,6 +446,7 @@ struct PrimitiveFactory {
       SERIALIZE_PRIMITIVE(ScaledDotProductAttention),
       SERIALIZE_PRIMITIVE(CustomKernel)};
   std::unordered_map<std::string, std::string> name_remap;
+  std::unordered_map<int, Stream> stream_map;
 
   PrimitiveFactory() {
     for (auto& [n, f] : factory) {
@@ -471,13 +472,25 @@ struct PrimitiveFactory {
     }
   };
 
-  std::shared_ptr<Primitive> load(Reader& is) {
-    auto stream = deserialize<Stream>(is);
-    if (get_stream(stream.index) != stream) {
-      std::ostringstream msg;
-      msg << "[import_function] Invalid stream encountered " << stream << ".";
-      throw std::invalid_argument(msg.str());
+  Stream resolve_stream(const Stream& stream) {
+    if (auto it = stream_map.find(stream.index); it != stream_map.end()) {
+      return it->second;
     }
+    // Try to find an existing stream on the same device
+    for (auto& s : get_streams()) {
+      if (s.device == stream.device) {
+        stream_map.emplace(stream.index, s);
+        return s;
+      }
+    }
+    // No stream on that device, make a new one
+    Stream s = new_stream(stream.device);
+    stream_map.emplace(stream.index, s);
+    return s;
+  }
+
+  std::shared_ptr<Primitive> load(Reader& is) {
+    auto stream = resolve_stream(deserialize<Stream>(is));
     auto name = deserialize<std::string>(is);
     if (auto it = factory.find(name); it != factory.end()) {
       return it->second.deserialize(is, stream);

--- a/mlx/scheduler.cpp
+++ b/mlx/scheduler.cpp
@@ -26,6 +26,10 @@ Stream get_stream(int index) {
   return scheduler::scheduler().get_stream(index);
 }
 
+std::vector<Stream> get_streams() {
+  return scheduler::scheduler().get_streams();
+}
+
 Stream new_stream(Device d) {
   if (!gpu::is_available() && d == Device::gpu) {
     throw std::invalid_argument(

--- a/mlx/scheduler.h
+++ b/mlx/scheduler.h
@@ -99,6 +99,9 @@ class Scheduler {
   Stream get_stream(int index) const {
     return streams_.at(index);
   }
+  std::vector<Stream> get_streams() const {
+    return streams_;
+  }
 
   void set_default_stream(const Stream& s) {
     default_streams_.at(s.device.type) = s;

--- a/mlx/stream.h
+++ b/mlx/stream.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <vector>
+
 #include "mlx/api.h"
 #include "mlx/device.h"
 
@@ -24,6 +26,9 @@ MLX_API Stream new_stream(Device d);
 
 /** Get the stream with the given index. */
 MLX_API Stream get_stream(int index);
+
+/** Get all available streams. */
+MLX_API std::vector<Stream> get_streams();
 
 inline bool operator==(const Stream& lhs, const Stream& rhs) {
   return lhs.index == rhs.index;

--- a/tests/export_import_tests.cpp
+++ b/tests/export_import_tests.cpp
@@ -152,13 +152,12 @@ TEST_CASE("test export function with variable inputs") {
 TEST_CASE("test export function on different stream") {
   std::string file_path = get_temp_file("model.mlxfn");
 
-  // Caller is responsible for setting up streams before
-  // importing functoins
   auto fun = [](const std::vector<array>& args) -> std::vector<array> {
     return {abs(args[0], Stream(1000, Device::cpu))};
   };
 
   export_function(file_path, fun, {array({0, 1, 2})});
 
-  CHECK_THROWS(import_function(file_path));
+  // Should make a new stream that we can run computation on
+  eval(import_function(file_path)({array({0, 1, 2})}));
 }

--- a/tests/scheduler_tests.cpp
+++ b/tests/scheduler_tests.cpp
@@ -36,6 +36,34 @@ TEST_CASE("test stream management") {
   }
 }
 
+TEST_CASE("test get streams") {
+  auto streams = get_streams();
+
+  // At least the default CPU stream exists
+  CHECK(streams.size() >= 1);
+
+  // All default streams should be in the list
+  auto s_cpu = default_stream(Device::cpu);
+  bool found_cpu = false;
+  for (auto& s : streams) {
+    if (s == s_cpu) {
+      found_cpu = true;
+    }
+  }
+  CHECK(found_cpu);
+
+  // New streams show up
+  auto s_new = new_stream(Device::cpu);
+  streams = get_streams();
+  bool found_new = false;
+  for (auto& s : streams) {
+    if (s == s_new) {
+      found_new = true;
+    }
+  }
+  CHECK(found_new);
+}
+
 TEST_CASE("test asynchronous launch") {
   auto s1 = default_stream(Device::cpu);
   auto s2 = new_stream(Device::cpu);


### PR DESCRIPTION
Previously if you export a function on a stream that is not present at import then there would be a crash. This requires the user to make sure all the streams are present which is hard to manage and impossible in some cases as the defualt stream on a CPU-only machine is different than the CPU+GPU machine.

Closes #3125 