### PR TITLE
feat: implement mlx.core.blackman

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -2346,6 +2346,33 @@ array hamming(int M, StreamOrDevice s /* = {} */) {
   return subtract(left_coef, multiply(right_coef, cos_vals, s), s);
 }
 
+array blackman(int M, StreamOrDevice s /* = {} */) {
+  if (M < 1) {
+    return array({});
+  }
+  if (M == 1) {
+    return ones({1}, float32, s);
+  }
+
+  auto n = arange(0, M, float32, s);
+
+  float arg_val = (2.0 * M_PI) / (M - 1);
+  auto x = multiply(array(arg_val, float32), n, s);
+
+  auto cos_x = cos(x, s);
+
+  auto alpha = array(0.34f, float32);
+  auto beta = array(0.5f, float32);
+  auto gamma = array(0.16f, float32);
+
+  auto term1 = multiply(beta, cos_x, s);
+
+  auto cos_sq = square(cos_x, s);
+  auto term2 = multiply(gamma, cos_sq, s);
+
+  return add(subtract(alpha, term1, s), term2, s);
+}
+
 /** Returns a sorted copy of the flattened array. */
 array sort(const array& a, StreamOrDevice s /* = {} */) {
   int size = a.size();

--- a/mlx/ops.h
+++ b/mlx/ops.h
@@ -672,6 +672,9 @@ MLX_API array hanning(int M, StreamOrDevice s = {});
 /** Returns the Hamming window of size M. */
 MLX_API array hamming(int M, StreamOrDevice s = {});
 
+/** Returns the Blackmann window of size M. */
+MLX_API array blackman(int M, StreamOrDevice s = {});
+
 /** Returns the index of the minimum value in the array. */
 MLX_API array argmin(const array& a, bool keepdims, StreamOrDevice s = {});
 inline array argmin(const array& a, StreamOrDevice s = {}) {

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -1475,6 +1475,30 @@ void init_ops(nb::module_& m) {
                    appears only if the number of samples is odd).
     )pbdoc");
   m.def(
+      "blackman",
+      &mlx::core::blackman,
+      "M"_a,
+      nb::kw_only(),
+      "stream"_a = nb::none(),
+      nb::sig(
+          "def blackman(M: int, *, stream: Union[None, Stream, Device] = None) -> array"), // <--- J'ai rajouté ça
+      R"pbdoc(
+        Return the Blackman window.
+        
+        The Blackman window is a taper formed by using the first three terms of a summation of cosines.
+
+        .. math::
+          w(n) = 0.42 - 0.5 \cos\left(\frac{2\pi n}{M-1}\right) + 0.08 \cos\left(\frac{4\pi n}{M-1}\right)
+           \qquad 0 \le n \le M-1
+        
+        Args:
+            M (int): Number of points in the output window.
+            
+        Returns:
+            array: The window, with the maximum value normalized to one (the value one
+                   appears only if the number of samples is odd).
+    )pbdoc");
+  m.def(
       "linspace",
       [](Scalar start,
          Scalar stop,

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -1474,6 +1474,18 @@ class TestOps(mlx_tests.MLXTestCase):
         self.assertEqual(a.size, 0)
         self.assertEqual(a.dtype, mx.float32)
 
+    def test_blackman_general(self):
+        a = mx.blackman(10)
+        expected = np.blackman(10)
+        self.assertTrue(np.allclose(a, expected, atol=1e-5))
+
+        a = mx.blackman(1)
+        self.assertEqual(a.item(), 1.0)
+
+        a = mx.blackman(0)
+        self.assertEqual(a.size, 0)
+        self.assertEqual(a.dtype, mx.float32)
+
     def test_unary_ops(self):
         def test_ops(npop, mlxop, x, y, atol, rtol):
             r_np = npop(x)


### PR DESCRIPTION
## Description

This PR implements the Blackman window function (`mlx.core.blackman`), completing the standard trio of window functions (Hanning, Hamming, Blackman) and improving feature parity with NumPy.

## Implementation Details

- **C++**: Implemented in `mlx/ops.cpp`.
    - **Optimization**: Instead of computing two separate cosine terms ($\cos(x)$ and $\cos(2x)$ ), I utilized the double-angle identity: $\cos(2x) = 2\cos^2(x) - 1$.
    - **Performance**: This reduces the computational cost to a single transcendental `cos` operation followed by cheap polynomial arithmetic ($0.34 - 0.5\cos(x) + 0.16\cos^2(x)$ ).
    - **Edge Cases**: Explicitly handles `M < 1` (empty) and `M = 1` (returns `[1.0]`), matching NumPy's behavior exactly.
- **Python Bindings**: Exposed via `nanobind` with `nb::sig` for proper type hinting and full LaTeX documentation.

## Test Plan

Verified locally against NumPy for numerical accuracy and edge cases.

**Verification script:**
```python
import mlx.core as mx
import numpy as np

# 1. Standard Case
M = 100
mx_blackman = mx.blackman(M)
np_blackman = np.blackman(M)

assert np.allclose(mx_blackman, np_blackman, atol=1e-6), "Mismatch in values"

# 2. Edge Case M=1
# Verified that both return [1.0]
assert mx.blackman(1).item() == 1.0
assert np.blackman(1).item() == 1.0

# 3. Edge Case M=0
assert mx.blackman(0).size == 0

print("✅ All verifications passed against numpy.blackman")
```
## Unit Tests:
Added `test_blackman` in `python/tests/test_ops.py`.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
