### PR TITLE
[Metal] Fix 32-bit integer overflow in conv3d unfold kernel

### DIFF
--- a/mlx/backend/metal/kernels/conv.metal
+++ b/mlx/backend/metal/kernels/conv.metal
@@ -93,7 +93,8 @@ template <typename T, int N>
     out_pixels *= params->oS[i];
 
   // Set out
-  out += (size_t)gid.z * filter_size + (size_t)gid.x * (filter_size / params->C);
+  out +=
+      (size_t)gid.z * filter_size + (size_t)gid.x * (filter_size / params->C);
 
   // Coordinates in input
   int is[N] = {0};


### PR DESCRIPTION
## Proposed changes

Fixes #3138 
Bug: Large 3D convolutions ($M \times K > 2^{32}$) were causing silent data corruption due to 32-bit integer overflow in the naive_unfold_Nd kernel index calculation.
The Fix: Explicitly cast gid's to size_t before multiplying by filter_size to ensure 64-bit arithmetic for the output offset.
Verification: Verified locally (macOS 26.2, MLX 0.30.7, Apple M2) with a script very similar to the one described in the issue. Except using float16, and T=2500, H=64, W=64, C=16, to be just on the edge of 2^32, and my system's memory limit for a single buffer (some 9.5GB).
Result before change: ``M*K= 4,423,680,000  > 2^32  max_diff=152.884216  corr=0.956153  [FAIL]``
Result after change: ``M*K= 4,423,680,000  > 2^32  max_diff=0.031334  corr=1.000000  [OK]``

Didn't add a new test for this because it would need to allocate at least 2^32 * sizeof(type) to reproduce.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
