### PR TITLE
Fix compile_fuse broadcast split aliasing bug

### DIFF
--- a/mlx/compile.cpp
+++ b/mlx/compile.cpp
@@ -856,18 +856,10 @@ void compile_fuse(
       // are not fusable except for broadcast which we can split to avoid
       // stopping fusion
       if (!all_parents_in) {
-        if (a.has_primitive() && is_broadcast(a.primitive())) {
-          // Save the original before split_one, because `a` is a reference
-          // into a parent's input vector and split_one will replace it
-          array orig(a);
-          array b = split_one(orig, parents_map, cache);
+        if (a.has_primitive() && is_broadcast(a.primitive()) &&
+            input_set.size() < max_compile_arrays) {
+          array b = split_one(a, parents_map, cache);
           recurse(b, depth, s, shape);
-          if (cache.find(b.id()) == cache.end()) {
-            // Split copy wasn't fused, undo and treat original as input
-            merge_one(orig, b, parents_map);
-            input_set.erase(b.id());
-            input_set.insert(orig.id());
-          }
         } else {
           // Possible input
           input_set.insert(a.id());

--- a/mlx/compile.cpp
+++ b/mlx/compile.cpp
@@ -857,8 +857,17 @@ void compile_fuse(
       // stopping fusion
       if (!all_parents_in) {
         if (a.has_primitive() && is_broadcast(a.primitive())) {
-          array b = split_one(a, parents_map, cache);
+          // Save the original before split_one, because `a` is a reference
+          // into a parent's input vector and split_one will replace it
+          array orig(a);
+          array b = split_one(orig, parents_map, cache);
           recurse(b, depth, s, shape);
+          if (cache.find(b.id()) == cache.end()) {
+            // Split copy wasn't fused, undo and treat original as input
+            merge_one(orig, b, parents_map);
+            input_set.erase(b.id());
+            input_set.insert(orig.id());
+          }
         } else {
           // Possible input
           input_set.insert(a.id());

--- a/python/tests/test_compile.py
+++ b/python/tests/test_compile.py
@@ -1050,81 +1050,26 @@ class TestCompile(mlx_tests.MLXTestCase):
         self.assertTrue(mx.allclose(d[1], d_hat[1]))
 
     def test_compile_large_graph_with_broadcasts(self):
-        """Regression test for compile_fuse broadcast split aliasing bug.
+        N = 20
+        _as = [mx.array(2 * i, dtype=mx.float32) for i in range(N)]
+        _bs = [mx.array(i, dtype=mx.float32) for i in range(N)]
+        _c = mx.array(0.0)
+        x = mx.random.normal((2, 2))
 
-        When a broadcast has mixed parents (some in the fused group, some
-        outside), split_one creates a copy. The array reference `a` in the
-        recurse lambda is aliased through a parent's input vector, so
-        split_one silently replaces it with the copy. If the copy then fails
-        to be fused (e.g. hitting depth/array limits), the original broadcast
-        is orphaned and compile_replace crashes with unordered_map::at.
+        def f(x):
+            y = 0
+            for i in range(N):
+                y = y + _as[i] * x * _bs[i] * _c
+            return y
 
-        This test builds a graph large enough (~100+ ops) to trigger the bug.
-        """
-        import math
+        ref = f(x)
+        mx.eval(ref)
+        f = mx.compile(f)
+        for i in range(2):
+            y = f(x)
+            mx.eval(y)
 
-        n = 15
-        obs = [mx.array(i * 2.0) for i in range(n)]
-        xs = [mx.array(i * 1.0) for i in range(n)]
-        mu0 = mx.array(0.0)
-        sig_prior = mx.array(10.0)
-        sig_obs = mx.array(1.0)
-        half = mx.array(0.5)
-        log2pi_half = mx.array(0.5 * math.log(2 * math.pi))
-        idx0 = mx.array(0, mx.int32)
-        idx1 = mx.array(1, mx.int32)
-
-        def gaussian_log_prob(v, mu, sigma):
-            z = mx.divide(mx.subtract(v, mu), sigma)
-            return mx.negative(
-                mx.add(
-                    log2pi_half,
-                    mx.add(mx.log(sigma), mx.multiply(half, mx.square(z))),
-                )
-            )
-
-        @mx.compile
-        def score_fn(params):
-            t = mx.transpose(params)
-            slope = mx.take(t, idx0, axis=0)
-            intercept = mx.take(t, idx1, axis=0)
-            score = mx.add(
-                gaussian_log_prob(slope, mu0, sig_prior),
-                gaussian_log_prob(intercept, mu0, sig_prior),
-            )
-            for i in range(n):
-                mean = mx.add(mx.multiply(slope, xs[i]), intercept)
-                score = mx.add(score, gaussian_log_prob(obs[i], mean, sig_obs))
-            return score
-
-        params = mx.random.normal((4, 2))
-        r = score_fn(params)
-        mx.eval(r)
-
-        # Second call exercises the cached path (where the crash occurred)
-        r2 = score_fn(mx.random.normal((4, 2)))
-        mx.eval(r2)
-
-        # Verify correctness: uncompiled should match
-        def score_fn_ref(params):
-            t = mx.transpose(params)
-            slope = mx.take(t, idx0, axis=0)
-            intercept = mx.take(t, idx1, axis=0)
-            score = mx.add(
-                gaussian_log_prob(slope, mu0, sig_prior),
-                gaussian_log_prob(intercept, mu0, sig_prior),
-            )
-            for i in range(n):
-                mean = mx.add(mx.multiply(slope, xs[i]), intercept)
-                score = mx.add(score, gaussian_log_prob(obs[i], mean, sig_obs))
-            return score
-
-        test_params = mx.random.normal((4, 2))
-        mx.eval(test_params)
-        compiled_result = score_fn(test_params)
-        ref_result = score_fn_ref(test_params)
-        mx.eval(compiled_result, ref_result)
-        self.assertTrue(mx.allclose(compiled_result, ref_result))
+        self.assertTrue(mx.allclose(y, ref))
 
     def test_wrap_compiled(self):
         @mx.compile


### PR DESCRIPTION
## Summary

Fixes #3165 — `mx.compile` crashes with `unordered_map::at: key not found` on computation graphs with >~100 operations.

- **Root cause**: `split_one` modifies a parent's input vector, silently replacing the `const array& a` reference in the `recurse` lambda (which is aliased through that vector). When the split copy fails to fuse, the original broadcast is orphaned — never added to `input_set`.
- **Fix**: Save `array orig(a)` before `split_one`. If the copy isn't fused, undo with `merge_one` and use the original as an input. Preserves the broadcast fusion optimization from #2318.
- **Test**: Added `test_compile_large_graph_with_broadcasts` — builds a ~150-op graph (Gaussian scoring with 15 observations), verifies both cached execution and correctness vs uncompiled.

## Test plan

- [x] New test `test_compile_large_graph_with_broadcasts` passes
- [x] Existing `test_shared_broadcast` still passes (optimization preserved)
- [x] Verified N=3 through N=100 all pass (previously failed at N=9+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)