### PR TITLE
[CUDA][NCCL] group split 

### DIFF
--- a/mlx/distributed/nccl/nccl.cpp
+++ b/mlx/distributed/nccl/nccl.cpp
@@ -276,13 +276,6 @@ struct NCCLComm {
   NCCLComm(ncclComm_t c, int rank, int size)
       : comm(c), rank_(rank), size_(size) {}
 
-  ~NCCLComm() {
-    if (comm != nullptr) {
-      ncclCommFinalize(comm);
-      ncclCommDestroy(comm);
-    }
-  }
-
   static std::shared_ptr<NCCLComm>
   create(int numRanks, int rank, ncclUniqueId commId) {
     ncclComm_t raw;


### PR DESCRIPTION
Add group split to NCCL backend for multi-parallelism support.

Refactored communicator creation by introducing a dedicated helper struct. It is probably not very important but I also updated the communicator storage from a raw pointer to a shared one for better ownership management.