### PR TITLE
[CUDA] Heuristics for Hopper QMM

### DIFF
--- a/.github/actions/build-linux/action.yml
+++ b/.github/actions/build-linux/action.yml
@@ -21,7 +21,7 @@ runs:
       run: |
         if ${{ startsWith(inputs.toolkit, 'cuda') && runner.arch == 'arm64' }} ; then
           # There is no GPU in arm64 runner, use a common arch.
-          CMAKE_ARGS="$CMAKE_ARGS -DMLX_CUDA_ARCHITECTURES=90a"
+          CMAKE_ARGS="$CMAKE_ARGS -DMLX_CUDA_ARCHITECTURES=80"
           # Can not build tests and stubs when the built executables can not run.
           CMAKE_ARGS="$CMAKE_ARGS -DMLX_BUILD_TESTS=OFF -DMLX_BUILD_PYTHON_STUBS=OFF"
         fi

--- a/mlx/backend/cuda/CMakeLists.txt
+++ b/mlx/backend/cuda/CMakeLists.txt
@@ -56,7 +56,6 @@ target_sources(
           ${CMAKE_CURRENT_SOURCE_DIR}/utils.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/quantized/affine_quantize.cu
           ${CMAKE_CURRENT_SOURCE_DIR}/quantized/fp_quantize.cu
-          ${CMAKE_CURRENT_SOURCE_DIR}/quantized/qmm_sm90.cu
           ${CMAKE_CURRENT_SOURCE_DIR}/quantized/qmv.cu
           ${CMAKE_CURRENT_SOURCE_DIR}/quantized/quantized.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/quantized/qqmm.cpp
@@ -65,6 +64,7 @@ target_sources(
           ${CMAKE_CURRENT_SOURCE_DIR}/worker.cpp)
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/binary)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/quantized/qmm)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/unary)
 
 # fp4 is not available on < 12.8
@@ -145,12 +145,11 @@ if(NOT DEFINED MLX_CUDA_ARCHITECTURES)
     COMMAND __nvcc_device_query
     OUTPUT_VARIABLE MLX_CUDA_ARCHITECTURES
     OUTPUT_STRIP_TRAILING_WHITESPACE)
-  set(UPGRADABLE_ARCHITECTURES "90;100;121")
   if(MLX_CUDA_ARCHITECTURES STREQUAL "")
     message(
       FATAL_ERROR
         "Can not get native CUDA arch, must set MLX_CUDA_ARCHITECTURES")
-  elseif(MLX_CUDA_ARCHITECTURES IN_LIST UPGRADABLE_ARCHITECTURES)
+  elseif(MLX_CUDA_ARCHITECTURES GREATER_EQUAL 90)
     # Use arch-specific compute capability whenever possible.
     set(MLX_CUDA_ARCHITECTURES "${MLX_CUDA_ARCHITECTURES}a")
   endif()
@@ -158,6 +157,11 @@ endif()
 message(STATUS "CUDA architectures: ${MLX_CUDA_ARCHITECTURES}")
 set_target_properties(mlx PROPERTIES CUDA_ARCHITECTURES
                                      "${MLX_CUDA_ARCHITECTURES}")
+
+if(("90a" IN_LIST MLX_CUDA_ARCHITECTURES) OR ("90a-real" IN_LIST
+                                              MLX_CUDA_ARCHITECTURES))
+  target_compile_definitions(mlx PRIVATE MLX_CUDA_SM90A_ENABLED)
+endif()
 
 # Search CUDA libs from installed python packages.
 if(WIN32)

--- a/mlx/backend/cuda/device.cpp
+++ b/mlx/backend/cuda/device.cpp
@@ -281,8 +281,8 @@ void CommandEncoder::add_kernel_node_raw(
     config.blockDim = block_dim;
     config.dynamicSmemBytes = smem_bytes;
     config.stream = stream();
+    cudaLaunchAttribute attr = {};
     if (use_cluster) {
-      cudaLaunchAttribute attr;
       attr.id = cudaLaunchAttributeClusterDimension;
       attr.val.clusterDim.x = cluster_dim.x;
       attr.val.clusterDim.y = cluster_dim.y;
@@ -332,16 +332,16 @@ void CommandEncoder::add_kernel_node_raw(
     config.blockDimZ = block_dim.z;
     config.sharedMemBytes = smem_bytes;
     config.hStream = stream();
+    CUlaunchAttribute attr = {};
     if (use_cluster) {
-      CUlaunchAttribute attr = {};
       attr.id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION;
       attr.value.clusterDim.x = cluster_dim.x;
       attr.value.clusterDim.y = cluster_dim.y;
       attr.value.clusterDim.z = cluster_dim.z;
       config.attrs = &attr;
       config.numAttrs = 1;
-      CHECK_CUDA_ERROR(cuLaunchKernelEx(&config, func, params, nullptr));
     }
+    CHECK_CUDA_ERROR(cuLaunchKernelEx(&config, func, params, nullptr));
     return;
   }
 

--- a/mlx/backend/cuda/quantized/qmm/CMakeLists.txt
+++ b/mlx/backend/cuda/quantized/qmm/CMakeLists.txt
@@ -1,0 +1,8 @@
+target_sources(
+  mlx
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/qmm.cpp
+          ${CMAKE_CURRENT_SOURCE_DIR}/qmm_impl_sm90_m128_n16_m1.cu
+          ${CMAKE_CURRENT_SOURCE_DIR}/qmm_impl_sm90_m128_n32_m1.cu
+          ${CMAKE_CURRENT_SOURCE_DIR}/qmm_impl_sm90_m128_n64_m2.cu
+          ${CMAKE_CURRENT_SOURCE_DIR}/qmm_impl_sm90_m128_n128_m2.cu
+          ${CMAKE_CURRENT_SOURCE_DIR}/qmm_impl_sm90_m128_n256_m2.cu)

--- a/mlx/backend/cuda/quantized/qmm/qmm.cpp
+++ b/mlx/backend/cuda/quantized/qmm/qmm.cpp
@@ -1,0 +1,60 @@
+// Copyright © 2026 Apple Inc.
+
+#include "mlx/backend/cuda/quantized/qmm/qmm.h"
+
+#include <cute/tensor.hpp>
+
+namespace mlx::core {
+
+#if defined(MLX_CUDA_SM90A_ENABLED)
+// Defined in qmm_impl_sm90_xxx.cu files.
+template <typename TileShape, typename ClusterShape>
+void qmm_impl_sm90(
+    const array& x,
+    const array& w,
+    const array& scales,
+    const array& biases,
+    array& out,
+    int bits,
+    int group_size,
+    cu::CommandEncoder& encoder,
+    Stream s);
+#endif // defined(MLX_CUDA_SM90A_ENABLED)
+
+void qmm_sm90(
+    const array& x,
+    const array& w,
+    const array& scales,
+    const array& biases,
+    array& out,
+    int bits,
+    int group_size,
+    cu::CommandEncoder& encoder,
+    Stream s) {
+#if defined(MLX_CUDA_SM90A_ENABLED)
+  auto dispatch = [&]<int tile_m, int tile_n, int cluster_m>() {
+    using cute::Int;
+    using TileShapeMN = cute::Shape<Int<tile_m>, Int<tile_n>>;
+    using ClusterShape = cute::Shape<Int<cluster_m>, Int<1>, Int<1>>;
+    qmm_impl_sm90<TileShapeMN, ClusterShape>(
+        x, w, scales, biases, out, bits, group_size, encoder, s);
+  };
+  int m = out.shape(-2);
+  if (m <= 16) {
+    dispatch.template operator()<128, 16, 1>();
+  } else if (m <= 32) {
+    dispatch.template operator()<128, 32, 1>();
+  } else if (m <= 64) {
+    dispatch.template operator()<128, 64, 2>();
+  } else if (m <= 128) {
+    dispatch.template operator()<128, 128, 2>();
+  } else {
+    dispatch.template operator()<128, 256, 2>();
+  }
+#else
+  throw std::runtime_error(
+      "[quantized_matmul] Hopper-only kernel is not available.");
+#endif // defined(MLX_CUDA_SM90A_ENABLED)
+}
+
+} // namespace mlx::core

--- a/mlx/backend/cuda/quantized/qmm/qmm.h
+++ b/mlx/backend/cuda/quantized/qmm/qmm.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include "mlx/backend/cuda/device.h"
-#include "mlx/primitives.h"
 
 #include <optional>
 
@@ -13,11 +12,10 @@ void qmm_sm90(
     const array& x,
     const array& w,
     const array& scales,
-    const std::optional<array>& biases,
+    const array& biases,
     array& out,
     int bits,
     int group_size,
-    QuantizationMode mode,
     cu::CommandEncoder& encoder,
     Stream s);
 

--- a/mlx/backend/cuda/quantized/qmm/qmm_impl_sm90_m128_n128_m2.cu
+++ b/mlx/backend/cuda/quantized/qmm/qmm_impl_sm90_m128_n128_m2.cu
@@ -1,0 +1,10 @@
+// Copyright © 2026 Apple Inc.
+
+#include "mlx/backend/cuda/quantized/qmm/qmm_impl_sm90.cuh"
+
+using namespace cute;
+
+using TileShapeMN = Shape<_128, _128>;
+using ClusterShape = Shape<_2, _1, _1>;
+
+QMM_SM90_GPU(TileShapeMN, ClusterShape)

--- a/mlx/backend/cuda/quantized/qmm/qmm_impl_sm90_m128_n16_m1.cu
+++ b/mlx/backend/cuda/quantized/qmm/qmm_impl_sm90_m128_n16_m1.cu
@@ -1,0 +1,10 @@
+// Copyright © 2026 Apple Inc.
+
+#include "mlx/backend/cuda/quantized/qmm/qmm_impl_sm90.cuh"
+
+using namespace cute;
+
+using TileShapeMN = Shape<_128, _16>;
+using ClusterShape = Shape<_1, _1, _1>;
+
+QMM_SM90_GPU(TileShapeMN, ClusterShape)

--- a/mlx/backend/cuda/quantized/qmm/qmm_impl_sm90_m128_n256_m2.cu
+++ b/mlx/backend/cuda/quantized/qmm/qmm_impl_sm90_m128_n256_m2.cu
@@ -1,0 +1,10 @@
+// Copyright © 2026 Apple Inc.
+
+#include "mlx/backend/cuda/quantized/qmm/qmm_impl_sm90.cuh"
+
+using namespace cute;
+
+using TileShapeMN = Shape<_128, _256>;
+using ClusterShape = Shape<_2, _1, _1>;
+
+QMM_SM90_GPU(TileShapeMN, ClusterShape)

--- a/mlx/backend/cuda/quantized/qmm/qmm_impl_sm90_m128_n32_m1.cu
+++ b/mlx/backend/cuda/quantized/qmm/qmm_impl_sm90_m128_n32_m1.cu
@@ -1,0 +1,10 @@
+// Copyright © 2026 Apple Inc.
+
+#include "mlx/backend/cuda/quantized/qmm/qmm_impl_sm90.cuh"
+
+using namespace cute;
+
+using TileShapeMN = Shape<_128, _32>;
+using ClusterShape = Shape<_1, _1, _1>;
+
+QMM_SM90_GPU(TileShapeMN, ClusterShape)

--- a/mlx/backend/cuda/quantized/qmm/qmm_impl_sm90_m128_n64_m2.cu
+++ b/mlx/backend/cuda/quantized/qmm/qmm_impl_sm90_m128_n64_m2.cu
@@ -1,0 +1,10 @@
+// Copyright © 2026 Apple Inc.
+
+#include "mlx/backend/cuda/quantized/qmm/qmm_impl_sm90.cuh"
+
+using namespace cute;
+
+using TileShapeMN = Shape<_128, _64>;
+using ClusterShape = Shape<_2, _1, _1>;
+
+QMM_SM90_GPU(TileShapeMN, ClusterShape)

--- a/mlx/backend/cuda/quantized/quantized.cpp
+++ b/mlx/backend/cuda/quantized/quantized.cpp
@@ -2,7 +2,7 @@
 
 #include "mlx/backend/cuda/quantized/quantized.h"
 #include "mlx/backend/cuda/device.h"
-#include "mlx/backend/cuda/quantized/qmm.h"
+#include "mlx/backend/cuda/quantized/qmm/qmm.h"
 #include "mlx/backend/cuda/quantized/qmv.h"
 #include "mlx/backend/cuda/quantized/quantized_utils.h"
 #include "mlx/fast_primitives.h"
@@ -38,8 +38,10 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
     return;
   }
 
-  if (transpose_ && encoder.device().compute_capability_major() == 9) {
-    qmm_sm90(x, w, scales, biases, out, bits_, group_size_, mode_, encoder, s);
+  if (transpose_ && mode_ == QuantizationMode::Affine &&
+      encoder.device().compute_capability_major() == 9) {
+    assert(biases);
+    qmm_sm90(x, w, scales, *biases, out, bits_, group_size_, encoder, s);
     return;
   }
 


### PR DESCRIPTION
Refs https://github.com/ml-explore/mlx/issues/2536, #3160.

Add simple heuristics for QMM by dispatching to different tile shapes depending on the M. This does not change anything for small M problems and intends to fix bad performance for large M.

| M  | N     | K     | CUTE (TFLOP/s) | CUBLAS (TFLOP/s) | Speedup (x) |
|----|-------|-------|----------------|------------------|-------------|
| 16 | 16384 | 16384 | 96.8           | 45.4             | 2.13        |
| 32 | 16384 | 16384 | 177.4          | 84.4             | 2.10        |
| 64 | 16384 | 16384 | 302.8          | 170.5            | 1.78        |
|128 | 16384 | 16384 | 537.5          | 339.4            | 1.58        |

Also I realized that it is not possible to implement fp quantizations with the cutlass kernel because minimum group size is 64, so I simplified the checks in `qmm_sm90`.