### PR TITLE
 Fix command buffer memory tracking to use bytes instead of  elements

### DIFF
--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -259,7 +259,7 @@ void CommandEncoder::set_input_array(
     int idx,
     int64_t offset /* = 0 */) {
   if (all_inputs_.insert(a.buffer().ptr()).second) {
-    stream_.buffer_sizes += a.data_size();
+    stream_.buffer_sizes += a.data_size() * a.itemsize();
   }
   auto r_buf = static_cast<MTL::Resource*>(const_cast<void*>(a.buffer().ptr()));
   needs_barrier_ =

--- a/mlx/backend/metal/device.h
+++ b/mlx/backend/metal/device.h
@@ -137,7 +137,7 @@ struct DeviceStream {
   // Data updated between command buffers
   MTL::CommandBuffer* buffer{nullptr};
   int buffer_ops{0};
-  size_t buffer_sizes{0};
+  size_t buffer_sizes{0}; // bytes referenced by the command buffer
 
   // The command encoder, fence, and temporaries are updated between command
   // encoders


### PR DESCRIPTION
## Proposed changes

buffer_sizes is compared against a megabyte threshold (can be set by user with `MLX_MAX_MB_PER_BUFFER`), but was accumulating data_size() which is in elements, not bytes. This made the commit heuristic dtype-blind, a 4MB float32 buffer counted the same as a 2MB float16 buffer with the same number of elements.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works **(please lmk if new tests are needed)**
- [x] I have updated the necessary documentation (if needed)
