### PR TITLE
Fix shapeless compile eliding reductions on size-1 dimensions

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -51,6 +51,13 @@ std::tuple<Shape, std::vector<int>, bool> compute_reduce_shape(
     is_noop &= (out_shape.back() == shape[i]);
   }
   std::vector<int> sorted_axes(axes_set.begin(), axes_set.end());
+  // During dynamic (shapeless) tracing, dimensions that happen to be size 1
+  // at trace time may have different sizes on replay.  Never elide the
+  // reduction in that case, otherwise the Reduce primitive is missing from
+  // the traced graph and replays produce wrong results.
+  if (detail::in_dynamic_tracing()) {
+    is_noop = false;
+  }
   return {out_shape, sorted_axes, is_noop};
 }
 

--- a/python/tests/test_compile.py
+++ b/python/tests/test_compile.py
@@ -1017,6 +1017,55 @@ class TestCompile(mlx_tests.MLXTestCase):
         self.assertEqual(out[0].shape, (3, 1, 4, 2))
         self.assertEqual(out[1].shape, (2, 2, 5))
 
+    def test_shapeless_compile_reduce_after_gather(self):
+        # Regression test: when the first call to a shapeless-compiled function
+        # has a size-1 reduced dimension, the reduction was elided as a no-op
+        # during tracing. On replay with larger sizes, the missing reduction
+        # caused stale (first-call) values to be returned.
+        buf = mx.array([10.0, 20.0, 30.0, 40.0, 50.0])
+
+        # take + sum
+        def fn_sum(buf, idx):
+            return mx.take(buf, idx, axis=0).sum()
+
+        cfn = mx.compile(fn_sum, shapeless=True)
+        for n in [1, 2, 3, 4]:
+            idx = mx.arange(n)
+            expected = fn_sum(buf, idx)
+            result = cfn(buf, idx)
+            self.assertTrue(
+                mx.allclose(result, expected),
+                f"sum failed for n={n}: got {result.item()}, expected {expected.item()}",
+            )
+
+        # take + mean
+        def fn_mean(buf, idx):
+            return mx.take(buf, idx, axis=0).mean()
+
+        cfn = mx.compile(fn_mean, shapeless=True)
+        for n in [1, 2, 3, 4]:
+            idx = mx.arange(n)
+            expected = fn_mean(buf, idx)
+            result = cfn(buf, idx)
+            self.assertTrue(
+                mx.allclose(result, expected),
+                f"mean failed for n={n}: got {result.item()}, expected {expected.item()}",
+            )
+
+        # take + max
+        def fn_max(buf, idx):
+            return mx.take(buf, idx, axis=0).max()
+
+        cfn = mx.compile(fn_max, shapeless=True)
+        for n in [1, 2, 3, 4]:
+            idx = mx.arange(n)
+            expected = fn_max(buf, idx)
+            result = cfn(buf, idx)
+            self.assertTrue(
+                mx.allclose(result, expected),
+                f"max failed for n={n}: got {result.item()}, expected {expected.item()}",
+            )
+
     def test_leaks(self):
         gc.collect()
         if mx.metal.is_available():


### PR DESCRIPTION
## Summary

Fixes #3201 — `mx.compile(shapeless=True)` returns stale values when a reduction (`sum`, `mean`, `max`, etc.) operates on a dynamically-shaped input from `take`/`gather`.

## Root Cause

`compute_reduce_shape()` reports `is_noop=true` when a reduced dimension is size 1 at trace time. This causes `sum()` et al. to skip creating the `Reduce` primitive entirely. On replay with a larger dimension, the missing reduction means the graph goes from `GatherAxis` → `Squeeze` with no reduction in between, and only the first element survives.

## Fix

Disable the `is_noop` optimisation during `in_dynamic_tracing()`, following the same pattern already used for no-op broadcast elision (lines 1489, 1543 of `ops.cpp`).

**One-line change** in `compute_reduce_shape()`:
```cpp
if (detail::in_dynamic_tracing()) {
    is_noop = false;
}
```

This fixes all 8 affected reduction operations (`sum`, `prod`, `min`, `max`, `all`, `any`, `argmin`, `argmax`) in one place.

## Test Plan

- Added `test_shapeless_compile_reduce_after_gather` covering `sum`, `mean`, and `max` with varying index sizes starting from size 1
- Existing `test_shapeless_compile_with_reduction` continues to pass (it doesn't trigger the bug because its reduced dimensions are never size 1 at trace time)
