### PR TITLE
Use CUTLASS to convert fp4/fp8 to float

### DIFF
--- a/mlx/backend/cuda/quantized/cuda_fp4.h
+++ b/mlx/backend/cuda/quantized/cuda_fp4.h
@@ -81,20 +81,3 @@ struct __nv_fp4_e2m1 {
   }
   uint8_t __x{0};
 };
-
-struct __nv_fp4x4_e2m1 {
-  __device__ operator float4() {
-    float4 out;
-    auto bits = __high & 0xf;
-    out.x = float(*(__nv_fp4_e2m1*)(&bits));
-    bits = (__high >> 4) & 0xf;
-    out.y = float(*(__nv_fp4_e2m1*)(&bits));
-    bits = (__low) & 0xf;
-    out.z = float(*(__nv_fp4_e2m1*)(&bits));
-    bits = (__low >> 4) & 0xf;
-    out.w = float(*(__nv_fp4_e2m1*)(&bits));
-    return out;
-  }
-  uint8_t __high{0};
-  uint8_t __low{0};
-};

--- a/mlx/backend/cuda/quantized/fp_quantize.cu
+++ b/mlx/backend/cuda/quantized/fp_quantize.cu
@@ -13,6 +13,7 @@
 #include <cooperative_groups/reduce.h>
 #include <cuda_fp4.h>
 #include <cuda_fp8.h>
+#include <cutlass/numeric_conversion.h>
 
 constexpr float F8E4M3_MAX = 448.0f;
 constexpr float F4E2M1_MAX = 6.0f;
@@ -45,7 +46,6 @@ __global__ void fp_quantize_dequantize(
   const float inv_scale_enc = use_global_scale ? 1.0f / scale_enc : 1.0f;
 
   using Tx2 = Vector2_t<T>;
-  using Tx4 = Vector4_t<T>;
   uint32_t rbits = 0; // reserved bits for future use
   auto block_size = cg::this_thread_block().dim_threads();
   auto block_idx = cg::this_thread_block().group_index();
@@ -87,22 +87,25 @@ __global__ void fp_quantize_dequantize(
   AlignedVector<T, group_size> w_hat;
 
 #pragma unroll
-  for (int i = 0; i < group_size / 4; i++) {
-    Tx4 w_Tx4 = *reinterpret_cast<Tx4*>(&w_tile[i * 4]);
-    float4 dq;
+  for (int i = 0; i < group_size / 8; i++) {
+    auto& w = *reinterpret_cast<cutlass::Array<T, 8>*>(&w_tile[i * 8]);
+    cutlass::NumericArrayConverter<float, T, 8> fp32_t;
+    auto scaled = fp32_t(w) * scale_enc_b;
+    cutlass::Array<float, 8> dq;
     if constexpr (bits == 8) {
-      uint32_t quantized_val =
-          scale_cvt_Tx4_to_fp8x4<T, USE_SR>(w_Tx4, scale_enc_b, rbits);
-      dq = dequant_fp8(quantized_val);
+      cutlass::NumericArrayConverter<cutlass::float_e4m3_t, float, 8> fp8_fp32;
+      auto quant = fp8_fp32(scaled);
+      cutlass::NumericArrayConverter<float, cutlass::float_e4m3_t, 8> fp32_fp8;
+      dq = fp32_fp8(quant);
     } else {
-      uint16_t quantized_val =
-          scale_cvt_Tx4_to_fp4x4<T, USE_SR>(w_Tx4, scale_enc_b, rbits);
-      dq = dequant_fp4(quantized_val);
+      cutlass::NumericArrayConverter<cutlass::float_e2m1_t, float, 8> fp4_fp32;
+      auto quant = fp4_fp32(scaled);
+      cutlass::NumericArrayConverter<float, cutlass::float_e2m1_t, 8> fp32_fp4;
+      dq = fp32_fp4(quant);
     }
-    w_hat[i * 4] = static_cast<T>(dq.x * scale_dec);
-    w_hat[i * 4 + 1] = static_cast<T>(dq.y * scale_dec);
-    w_hat[i * 4 + 2] = static_cast<T>(dq.z * scale_dec);
-    w_hat[i * 4 + 3] = static_cast<T>(dq.w * scale_dec);
+    cutlass::NumericArrayConverter<T, float, 8> t_fp32;
+    *reinterpret_cast<cutlass::Array<T, 8>*>(&w_hat[i * 8]) =
+        t_fp32(dq * scale_dec);
   }
   store_vector<group_size>(out, thread_idx, w_hat);
 }

--- a/mlx/backend/cuda/quantized/mxfp8_quantize.cuh
+++ b/mlx/backend/cuda/quantized/mxfp8_quantize.cuh
@@ -1,32 +1,23 @@
 #pragma once
 
-#include <cuda.h>
-#include <cuda_fp8.h>
-#include <cuda_runtime.h>
 #include "mlx/backend/cuda/vector_types.cuh"
 
-namespace mlx::core::cu {
+#include <cutlass/numeric_conversion.h>
 
-// TODO implement fast path
-template <typename T>
-__device__ __forceinline__ uint32_t
-scale_cvt_Tx4_to_fp8x4_fallback(const Vector4_t<T> input, const float scale) {
-  uint32_t out_fp8x4 = 0;
-  float4 scaled;
-  scaled.x = static_cast<float>(input.x) * scale;
-  scaled.y = static_cast<float>(input.y) * scale;
-  scaled.z = static_cast<float>(input.z) * scale;
-  scaled.w = static_cast<float>(input.w) * scale;
-  out_fp8x4 = __nv_fp8x4_e4m3(scaled).__x;
-  return out_fp8x4;
-}
+namespace mlx::core::cu {
 
 // Place holder for future fast path implementation
 template <typename T, bool USE_SR>
 __device__ __forceinline__ uint32_t scale_cvt_Tx4_to_fp8x4(
-    const Vector4_t<T> input,
+    const Vector4_t<T>& input,
     const float scale,
     uint32_t rbits) {
-  return scale_cvt_Tx4_to_fp8x4_fallback(input, scale);
+  cutlass::NumericArrayConverter<float, T, 4> fp32_t;
+  auto scaled =
+      fp32_t(*reinterpret_cast<const cutlass::Array<T, 4>*>(&input)) * scale;
+  cutlass::NumericArrayConverter<cutlass::float_e4m3_t, float, 4> fp8_fp32;
+  auto quant = fp8_fp32(scaled);
+  return *reinterpret_cast<uint32_t*>(&quant);
 }
+
 } // namespace mlx::core::cu

--- a/mlx/backend/cuda/quantized/nvfp4_quantize.cuh
+++ b/mlx/backend/cuda/quantized/nvfp4_quantize.cuh
@@ -1,9 +1,8 @@
 #pragma once
 
-#include <cuda.h>
-#include <cuda_fp4.h>
-#include <cuda_runtime.h>
 #include "mlx/backend/cuda/vector_types.cuh"
+
+#include <cutlass/numeric_conversion.h>
 
 namespace mlx::core::cu {
 
@@ -13,23 +12,15 @@ using f32x4 = Vector4_t<float>;
 
 template <typename T>
 __device__ __forceinline__ uint16_t
-scale_cvt_Tx4_to_fp4x4_fallback(const Vector4_t<T> input, const float scale) {
+scale_cvt_Tx4_to_fp4x4_fallback(const Vector4_t<T>& input, const float scale) {
   // Fallback implementation for architectures that do not support cvt
   // instructions or for cuda versions with no fp4 support (< 12.8) -> scalar
-  uint16_t out_fp4x4 = 0;
-  fp32x4 scaled;
-  scaled.x = static_cast<float>(input.x) * scale;
-  scaled.y = static_cast<float>(input.y) * scale;
-  scaled.z = static_cast<float>(input.z) * scale;
-  scaled.w = static_cast<float>(input.w) * scale;
-  uint8_t q0 = __nv_fp4_e2m1(scaled.x).__x;
-  uint8_t q1 = __nv_fp4_e2m1(scaled.y).__x;
-  uint8_t q2 = __nv_fp4_e2m1(scaled.z).__x;
-  uint8_t q3 = __nv_fp4_e2m1(scaled.w).__x;
-  out_fp4x4 = (static_cast<uint16_t>(q3) << 12) |
-      (static_cast<uint16_t>(q2) << 8) | (static_cast<uint16_t>(q1) << 4) |
-      static_cast<uint16_t>(q0);
-  return out_fp4x4;
+  cutlass::NumericArrayConverter<float, T, 4> fp32_t;
+  auto scaled =
+      fp32_t(*reinterpret_cast<const cutlass::Array<T, 4>*>(&input)) * scale;
+  cutlass::NumericArrayConverter<cutlass::float_e2m1_t, float, 4> fp4_fp32;
+  auto quant = fp4_fp32(scaled);
+  return *reinterpret_cast<uint16_t*>(&quant);
 }
 
 #if (CUDART_VERSION >= 12080) && (__CUDA_ARCH__ >= 1000) && \
@@ -318,7 +309,7 @@ __device__ __forceinline__ uint16_t scale_cvt_Tx4_to_fp4x4_fast(
 
 template <typename T, bool USE_SR>
 __device__ __forceinline__ uint16_t scale_cvt_Tx4_to_fp4x4(
-    const Vector4_t<T> input,
+    const Vector4_t<T>& input,
     const float scale,
     uint32_t rbits) {
 #if (CUDART_VERSION >= 12080) && (__CUDA_ARCH__ >= 1000) && \
@@ -331,4 +322,5 @@ __device__ __forceinline__ uint16_t scale_cvt_Tx4_to_fp4x4(
   return scale_cvt_Tx4_to_fp4x4_fallback(input, scale);
 #endif
 }
+
 } // namespace mlx::core::cu

--- a/mlx/backend/cuda/quantized/qmm/fp_qmv.cu
+++ b/mlx/backend/cuda/quantized/qmm/fp_qmv.cu
@@ -9,6 +9,9 @@
 
 #include <cooperative_groups.h>
 #include <cooperative_groups/reduce.h>
+#include <cuda_fp4.h>
+#include <cuda_fp8.h>
+#include <cutlass/numeric_conversion.h>
 
 namespace mlx::core {
 
@@ -102,35 +105,41 @@ __device__ void fp_qmv_impl(
         for (int j = 0; j < n_per_step; ++j) {
           int k = n_per_step * i + j;
           if constexpr (bits == 8) {
-            auto v = dequant_fp8(local_mat[k]);
+            cutlass::NumericArrayConverter<float, cutlass::float_e4m3_t, 4>
+                converter;
+            auto v = converter(
+                *reinterpret_cast<cutlass::Array<cutlass::float_e4m3_t, 4>*>(
+                    &local_mat[k]));
             local_sum.x +=
-                v.x * static_cast<float>(local_vec[vals_per_item * k]);
+                v[0] * static_cast<float>(local_vec[vals_per_item * k]);
             local_sum.x +=
-                v.y * static_cast<float>(local_vec[vals_per_item * k + 1]);
+                v[1] * static_cast<float>(local_vec[vals_per_item * k + 1]);
             local_sum.y +=
-                v.z * static_cast<float>(local_vec[vals_per_item * k + 2]);
+                v[2] * static_cast<float>(local_vec[vals_per_item * k + 2]);
             local_sum.y +=
-                v.w * static_cast<float>(local_vec[vals_per_item * k + 3]);
+                v[3] * static_cast<float>(local_vec[vals_per_item * k + 3]);
           } else {
-            auto v = dequant_fp4(local_mat[k]);
+            cutlass::NumericArrayConverter<float, cutlass::float_e2m1_t, 8>
+                converter;
+            auto v = converter(
+                *reinterpret_cast<cutlass::Array<cutlass::float_e2m1_t, 8>*>(
+                    &local_mat[k]));
             local_sum.x +=
-                v.x * static_cast<float>(local_vec[vals_per_item * k]);
+                v[0] * static_cast<float>(local_vec[vals_per_item * k]);
             local_sum.y +=
-                v.y * static_cast<float>(local_vec[vals_per_item * k + 1]);
+                v[1] * static_cast<float>(local_vec[vals_per_item * k + 1]);
             local_sum.x +=
-                v.z * static_cast<float>(local_vec[vals_per_item * k + 2]);
+                v[2] * static_cast<float>(local_vec[vals_per_item * k + 2]);
             local_sum.y +=
-                v.w * static_cast<float>(local_vec[vals_per_item * k + 3]);
-
-            v = dequant_fp4(local_mat[k] >> 16);
+                v[3] * static_cast<float>(local_vec[vals_per_item * k + 3]);
             local_sum.x +=
-                v.x * static_cast<float>(local_vec[vals_per_item * k + 4]);
+                v[4] * static_cast<float>(local_vec[vals_per_item * k + 4]);
             local_sum.y +=
-                v.y * static_cast<float>(local_vec[vals_per_item * k + 5]);
+                v[5] * static_cast<float>(local_vec[vals_per_item * k + 5]);
             local_sum.x +=
-                v.z * static_cast<float>(local_vec[vals_per_item * k + 6]);
+                v[6] * static_cast<float>(local_vec[vals_per_item * k + 6]);
             local_sum.y +=
-                v.w * static_cast<float>(local_vec[vals_per_item * k + 7]);
+                v[7] * static_cast<float>(local_vec[vals_per_item * k + 7]);
           }
         }
         sum += (local_sum.x + local_sum.y) * float(scales[i]);

--- a/mlx/backend/cuda/quantized/quantized_utils.cuh
+++ b/mlx/backend/cuda/quantized/quantized_utils.cuh
@@ -1,21 +1,8 @@
 // Copyright © 2025 Apple Inc.
 
-#include <cuda_fp4.h>
-#include <cuda_fp8.h>
-
 namespace mlx::core {
 
 namespace cu {
-
-inline __device__ float4 dequant_fp8(uint32_t bits) {
-  auto out = *(__nv_fp8x4_e4m3*)(&bits);
-  return out.operator float4();
-}
-
-inline __device__ float4 dequant_fp4(uint16_t bits) {
-  auto out = *(__nv_fp4x4_e2m1*)(&bits);
-  return out.operator float4();
-}
 
 template <int bits, int wsize = 8>
 inline constexpr __device__ short get_pack_factor() {


### PR DESCRIPTION
The `__nv_fp8x4_e4m3` and `__nv_fp4x4_e2m1` APIs use CVT instructions under the hood which do not work for sm80 and earlier, this PR uses CUTLASS to convert the numbers instead which uses CVT when available and switches to fallbacks otherwise (for example LUT for fp4).

Tested the memory bandwidth of `fp_qmv` on DGX and there is no meaningful change.

The tricky part is `scale_cvt_Tx4_to_fp8x4`/`scale_cvt_Tx4_to_fp4x4`, I think the code would be cleaner if we replace them with the `cutlass::NumericArrayConverter`, but CUTLASS does not provide a specialization for stochastic rounding and we would have to write our own. So I just modified their fallback implementations.