### PR TITLE
Support indexing with any type which implmented `__index__`

### DIFF
--- a/python/src/indexing.cpp
+++ b/python/src/indexing.cpp
@@ -16,7 +16,20 @@ bool is_none_slice(const nb::slice& in_slice) {
 }
 
 bool is_index_scalar(const nb::object& obj) {
-  return !nb::isinstance<nb::bool_>(obj) && PyIndex_Check(obj.ptr());
+  if (nb::isinstance<nb::bool_>(obj)) {
+    return false;
+  }
+  if (!PyIndex_Check(obj.ptr())) {
+    return false;
+  }
+  // Exclude multi-dimensional arrays (mx.array, np.ndarray) by checking ndim
+  if (nb::hasattr(obj, "ndim")) {
+    auto ndim = nb::getattr(obj, "ndim");
+    if (nb::isinstance<nb::int_>(ndim) && nb::cast<int>(ndim) > 0) {
+      return false;
+    }
+  }
+  return true;
 }
 
 int safe_to_int32(nb::object obj) {

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -1130,7 +1130,7 @@ class TestArray(mlx_tests.MLXTestCase):
         self.assertEqual(a.tolist(), [2, 9, 2])
 
         a[0] = mx.array([[[1]]])
-        self.assertEqual(a.tolist(), [1, 2, 2])
+        self.assertEqual(a.tolist(), [1, 9, 2])
 
         a[:] = 0
         self.assertEqual(a.tolist(), [0, 0, 0])


### PR DESCRIPTION
## Proposed changes

Any type which implemented `__index__` can be used to indexing mlx array, so we can use numpy scalar to indexing array.

`bool` is not supported also it implemented `__index__` (actually, `bool` is a subclass of `int`) because it's to quirky.

Close: https://github.com/ml-explore/mlx/issues/2710

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
