### PR TITLE
Fix return value in einsum_path for simple contractions

### DIFF
--- a/mlx/einsum.cpp
+++ b/mlx/einsum.cpp
@@ -813,9 +813,8 @@ std::pair<std::vector<PathNode>, PathInfo> einsum_path_helper(
     std::iota(positions.begin(), positions.end(), 0);
     path.emplace_back(
         std::move(inputs), std::move(output), std::move(positions));
-    path_info.optimized_cost = path_info.naive_cost;     
+    path_info.optimized_cost = path_info.naive_cost;
     path_info.optimized_scaling = path_info.naive_scaling;
-
   } else {
     std::tie(path, path_info.optimized_cost, path_info.optimized_scaling) =
         greedy_path(inputs, output, dim_map, path_info.naive_cost, max_size);


### PR DESCRIPTION
## Proposed changes

#3222 

**Describe the bug**
User-visible API output (einsum_path info string) can be incorrect and nondeterministic for common equations with one or two operands. The output produced is garbage and should be fixed.
## Checklist

Put an `x` in the boxes that apply.

- [X] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [X] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have updated the necessary documentation (if needed)
