### PR TITLE
Fix GRU hidden=None handling for biased new-gate path

### DIFF
--- a/python/mlx/nn/layers/recurrent.py
+++ b/python/mlx/nn/layers/recurrent.py
@@ -159,6 +159,9 @@ class GRU(Module):
         else:
             x = x @ self.Wx.T
 
+        if hidden is None:
+            hidden = mx.zeros(x.shape[:-2] + (self.hidden_size,), dtype=x.dtype)
+
         x_rz = x[..., : -self.hidden_size]
         x_n = x[..., -self.hidden_size :]
 
@@ -166,30 +169,24 @@ class GRU(Module):
 
         for idx in range(x.shape[-2]):
             rz = x_rz[..., idx, :]
-            if hidden is not None:
-                h_proj = hidden @ self.Wh.T
-                h_proj_rz = h_proj[..., : -self.hidden_size]
-                h_proj_n = h_proj[..., -self.hidden_size :]
+            h_proj = hidden @ self.Wh.T
+            h_proj_rz = h_proj[..., : -self.hidden_size]
+            h_proj_n = h_proj[..., -self.hidden_size :]
 
-                if self.bhn is not None:
-                    h_proj_n += self.bhn
+            if self.bhn is not None:
+                h_proj_n += self.bhn
 
-                rz = rz + h_proj_rz
+            rz = rz + h_proj_rz
 
             rz = mx.sigmoid(rz)
 
             r, z = mx.split(rz, 2, axis=-1)
 
             n = x_n[..., idx, :]
-
-            if hidden is not None:
-                n = n + r * h_proj_n
+            n = n + r * h_proj_n
             n = mx.tanh(n)
 
-            if hidden is not None:
-                hidden = (1 - z) * n + z * hidden
-            else:
-                hidden = (1 - z) * n
+            hidden = (1 - z) * n + z * hidden
 
             all_hidden.append(hidden)
 

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -1941,6 +1941,24 @@ class TestLayers(mlx_tests.MLXTestCase):
         h_out = layer(inp, h_out[-1, :])
         self.assertEqual(h_out.shape, (44, 12))
 
+    def test_gru_none_hidden_matches_zeros(self):
+        mx.random.seed(42)
+
+        for bias in (False, True):
+            layer = nn.GRU(5, 12, bias=bias)
+
+            batched = mx.random.normal((2, 25, 5))
+            h_none = layer(batched)
+            h_zeros = layer(batched, hidden=mx.zeros((2, 12), dtype=batched.dtype))
+            mx.eval(h_none, h_zeros)
+            self.assertTrue(mx.allclose(h_none, h_zeros, atol=1e-6).item())
+
+            unbatched = mx.random.normal((25, 5))
+            h_none = layer(unbatched)
+            h_zeros = layer(unbatched, hidden=mx.zeros((12,), dtype=unbatched.dtype))
+            mx.eval(h_none, h_zeros)
+            self.assertTrue(mx.allclose(h_none, h_zeros, atol=1e-6).item())
+
     def test_lstm(self):
         layer = nn.LSTM(5, 12)
         inp = mx.random.normal((2, 25, 5))


### PR DESCRIPTION
## Proposed changes

Fix `nn.GRU` so `hidden=None` is treated the same as an explicit zero initial state.

Previously, the `hidden=None` path skipped the hidden-side new-gate contribution at the first timestep, including `bhn`, so `gru(x)` could differ from `gru(x, hidden=zeros)` when `bias=True`.

This change initializes a zero hidden state before the loop and adds a regression test covering batched and unbatched inputs.

Closes #3249

## Tests

```bash
PYTHONPATH=python pytest python/tests/test_nn.py
```

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
