### PR TITLE
fix nn.GRU skipping bhn bias when hidden is None

### DIFF
--- a/python/mlx/nn/layers/recurrent.py
+++ b/python/mlx/nn/layers/recurrent.py
@@ -184,6 +184,8 @@ class GRU(Module):
 
             if hidden is not None:
                 n = n + r * h_proj_n
+            elif self.bhn is not None:
+                n = n + r * self.bhn
             n = mx.tanh(n)
 
             if hidden is not None:

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -1941,6 +1941,14 @@ class TestLayers(mlx_tests.MLXTestCase):
         h_out = layer(inp, h_out[-1, :])
         self.assertEqual(h_out.shape, (44, 12))
 
+        # hidden=None should be equivalent to hidden=zeros (issue #3249)
+        for bias in [True, False]:
+            layer = nn.GRU(5, 12, bias=bias)
+            inp = mx.random.normal((2, 25, 5))
+            h_none = layer(inp)
+            h_zeros = layer(inp, hidden=mx.zeros((2, 12)))
+            self.assertTrue(mx.allclose(h_none, h_zeros).item())
+
     def test_lstm(self):
         layer = nn.LSTM(5, 12)
         inp = mx.random.normal((2, 25, 5))


### PR DESCRIPTION
## Proposed changes

#3249

when `hidden=None` (the default), the GRU new-gate computation skips the
hidden-side bias `bhn` entirely. the first timestep computes:

    n = tanh(W_xn·x + b_n)

but with an implicit zero hidden state it should compute:

    n = tanh(W_xn·x + b_n + r ⊙ b_hn)

this makes `gru(x)` produce different results from
`gru(x, hidden=mx.zeros(...))` whenever `bias=True`.

the fix adds an `elif` branch that applies `r * self.bhn` when there is
no hidden state but the bias exists.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)