### PR TITLE
docs: fix PyTorch to MLX conversion example

### DIFF
--- a/docs/src/usage/numpy.rst
+++ b/docs/src/usage/numpy.rst
@@ -90,7 +90,7 @@ PyTorch supports the buffer protocol, but it requires an explicit
 
   a = mx.arange(3)
   b = torch.tensor(memoryview(a))
-  c = mx.array(b)  # works directly, including for bfloat16
+  c = mx.array(b)
 
 JAX
 ---


### PR DESCRIPTION
`mx.array()` accepts PyTorch tensors directly (including `bfloat16`) via DLPack since [#1305](https://github.com/ml-explore/mlx/pull/1305) (Aug 2024). The docs still showed `mx.array(b.numpy())` and stated conversion "must be done via intermediate NumPy arrays", which is no longer true.

Tested locally on MLX 0.30.6, PyTorch 2.9.1, macOS 15.7.


Screenshots:
<img width="671" height="334" alt="Screenshot 2026-03-16 at 2 14 27 PM" src="https://github.com/user-attachments/assets/ecda6985-26db-4327-8a04-313bb88243ba" />
<img width="433" height="176" alt="Screenshot 2026-03-16 at 2 19 28 PM" src="https://github.com/user-attachments/assets/4b32bcf2-7bc1-441b-9875-305952ebc1ce" />
