### PR TITLE
[Metal] Fix depthwise conv 1D kernel name for large variant

### DIFF
--- a/mlx/backend/metal/conv.cpp
+++ b/mlx/backend/metal/conv.cpp
@@ -1041,8 +1041,8 @@ void depthwise_conv_1D_gpu(
   concatenate(
       base_name,
       "depthwise_conv_1d_",
-      large ? "_large" : "",
-      type_to_name(out));
+      type_to_name(out),
+      large ? "_large" : "");
 
   auto& compute_encoder = d.get_command_encoder(s.index);
   auto kernel = d.get_kernel(base_name);


### PR DESCRIPTION
The kernel name was constructed with the wrong argument order, producing `depthwise_conv_1d__largefloat16` instead of `depthwise_conv_1d_float16_large` which matches the Metal kernel registration.
