### PR TITLE
Fix vmap + floor_divide: preserve integer dtype

### DIFF
--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -1789,10 +1789,6 @@ std::pair<std::vector<array>, std::vector<int>> Divide::vmap(
     const std::vector<array>& inputs,
     const std::vector<int>& axes) {
   auto [a, b, to_ax] = vmap_binary_op(inputs, axes, stream());
-  // The high-level divide() promotes integers to float via at_least_float.
-  // But floor_divide() creates a Divide primitive with integer dtype
-  // for integer division. Preserve that: if inputs are integer, keep
-  // integer semantics by constructing the primitive directly.
   auto out = issubdtype(a.dtype(), integer) ? floor_divide(a, b, stream())
                                             : divide(a, b, stream());
   return {{out}, {to_ax}};

--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -1793,19 +1793,9 @@ std::pair<std::vector<array>, std::vector<int>> Divide::vmap(
   // But floor_divide() creates a Divide primitive with integer dtype
   // for integer division. Preserve that: if inputs are integer, keep
   // integer semantics by constructing the primitive directly.
-  auto dtype = promote_types(a.dtype(), b.dtype());
-  if (issubdtype(dtype, integer)) {
-    auto bcast = broadcast_arrays(
-        {astype(a, dtype, stream()), astype(b, dtype, stream())}, stream());
-    return {
-        {array(
-            bcast[0].shape(),
-            dtype,
-            std::make_shared<Divide>(stream()),
-            std::move(bcast))},
-        {to_ax}};
-  }
-  return {{divide(a, b, stream())}, {to_ax}};
+  auto out = issubdtype(a.dtype(), integer) ? floor_divide(a, b, stream())
+                                            : divide(a, b, stream());
+  return {{out}, {to_ax}};
 }
 
 std::vector<array> Remainder::vjp(

--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -1789,6 +1789,22 @@ std::pair<std::vector<array>, std::vector<int>> Divide::vmap(
     const std::vector<array>& inputs,
     const std::vector<int>& axes) {
   auto [a, b, to_ax] = vmap_binary_op(inputs, axes, stream());
+  // The high-level divide() promotes integers to float via at_least_float.
+  // But floor_divide() creates a Divide primitive with integer dtype
+  // for integer division. Preserve that: if inputs are integer, keep
+  // integer semantics by constructing the primitive directly.
+  auto dtype = promote_types(a.dtype(), b.dtype());
+  if (issubdtype(dtype, integer)) {
+    auto bcast = broadcast_arrays(
+        {astype(a, dtype, stream()), astype(b, dtype, stream())}, stream());
+    return {
+        {array(
+            bcast[0].shape(),
+            dtype,
+            std::make_shared<Divide>(stream()),
+            std::move(bcast))},
+        {to_ax}};
+  }
   return {{divide(a, b, stream())}, {to_ax}};
 }
 

--- a/tests/vmap_tests.cpp
+++ b/tests/vmap_tests.cpp
@@ -545,3 +545,52 @@ TEST_CASE("test vmap dynamic slices") {
     CHECK(array_equal(out, array({0, 0, 1, 1}, {2, 2})).item<bool>());
   }
 }
+
+TEST_CASE("test vmap floor_divide integer") {
+  // floor_divide with integer inputs should preserve integer dtype under vmap.
+  // Bug: Divide::vmap called divide() which promotes integers to float.
+  {
+    auto x = arange(0, 25, int32);
+    auto divisor = array(5, int32);
+
+    // Without vmap: floor_divide returns int32
+    auto expected = floor_divide(x, divisor);
+    CHECK_EQ(expected.dtype(), int32);
+
+    // With vmap: should also return int32
+    auto vfun = vmap([&divisor](array s) {
+      return floor_divide(s, divisor);
+    });
+    auto result = vfun(x);
+    CHECK_EQ(result.dtype(), int32);
+    CHECK(array_equal(result, expected).item<bool>());
+  }
+
+  // Also check remainder preserves integer dtype under vmap
+  {
+    auto x = arange(0, 10, int32);
+    auto divisor = array(3, int32);
+
+    auto expected = remainder(x, divisor);
+    auto vfun = vmap([&divisor](array s) {
+      return remainder(s, divisor);
+    });
+    auto result = vfun(x);
+    CHECK_EQ(result.dtype(), int32);
+    CHECK(array_equal(result, expected).item<bool>());
+  }
+
+  // floor_divide + remainder: should reconstruct original
+  {
+    auto x = arange(0, 25, int32);
+    auto w = array(5, int32);
+
+    auto vfun = vmap([&w](array s) {
+      auto q = floor_divide(s, w);
+      auto r = remainder(s, w);
+      return add(multiply(q, w), r);
+    });
+    auto result = vfun(x);
+    CHECK(array_equal(result, x).item<bool>());
+  }
+}

--- a/tests/vmap_tests.cpp
+++ b/tests/vmap_tests.cpp
@@ -558,9 +558,7 @@ TEST_CASE("test vmap floor_divide integer") {
     CHECK_EQ(expected.dtype(), int32);
 
     // With vmap: should also return int32
-    auto vfun = vmap([&divisor](array s) {
-      return floor_divide(s, divisor);
-    });
+    auto vfun = vmap([&divisor](array s) { return floor_divide(s, divisor); });
     auto result = vfun(x);
     CHECK_EQ(result.dtype(), int32);
     CHECK(array_equal(result, expected).item<bool>());
@@ -572,9 +570,7 @@ TEST_CASE("test vmap floor_divide integer") {
     auto divisor = array(3, int32);
 
     auto expected = remainder(x, divisor);
-    auto vfun = vmap([&divisor](array s) {
-      return remainder(s, divisor);
-    });
+    auto vfun = vmap([&divisor](array s) { return remainder(s, divisor); });
     auto result = vfun(x);
     CHECK_EQ(result.dtype(), int32);
     CHECK(array_equal(result, expected).item<bool>());


### PR DESCRIPTION
## Summary

`Divide::vmap` calls `divide(a, b)` which promotes integers to float via `at_least_float`. But `floor_divide` creates a `Divide` primitive with integer dtype for integer division. Under vmap, the integer dtype is lost.

**Before:**
```python
import mlx.core as mx
f = lambda s: mx.floor_divide(s, mx.array(5, mx.int32))
vf = mx.vmap(f)
result = vf(mx.arange(25, dtype=mx.int32))
# result.dtype == float32, values are [0.0, 0.2, 0.4, ...] (wrong)
```

**After:**
```python
result = vf(mx.arange(25, dtype=mx.int32))
# result.dtype == int32, values are [0, 0, 0, 0, 0, 1, 1, ...] (correct)
```

## Fix

In `Divide::vmap`, check if inputs are integer type and construct the `Divide` primitive directly (preserving dtype) instead of calling the high-level `divide()` which promotes to float.

## Test plan

- [x] New test case `test vmap floor_divide integer` with 3 sub-tests:
  - `floor_divide` preserves int32 dtype under vmap
  - `remainder` preserves int32 dtype under vmap  
  - `floor_divide + remainder` reconstructs original values under vmap
- [x] All existing vmap tests pass (38 assertions)