### PR TITLE
docs: Add logo usage guidelines and attribution requirements

### DIFF
--- a/docs/LOGO_USAGE.md
+++ b/docs/LOGO_USAGE.md
@@ -1,0 +1,109 @@
+# MLX Logo Usage Guidelines
+
+## License
+
+The MLX logo is part of the MLX project and is licensed under the [MIT License](../LICENSE).
+
+**Copyright:** © 2023 Apple Inc.
+
+## Available Formats
+
+### PNG Versions (Current)
+
+- **Light mode:** [`docs/src/_static/mlx_logo.png`](src/_static/mlx_logo.png) (924×924px, 76KB)
+- **Dark mode:** [`docs/src/_static/mlx_logo_dark.png`](src/_static/mlx_logo_dark.png) (924×924px, 48KB)
+
+### SVG Version
+
+**Status:** Not yet available. See [Issue #3291](https://github.com/ml-explore/mlx/issues/3291).
+
+We welcome contributions to add SVG versions of the logo. If you're interested in creating one, please:
+1. Comment on [Issue #3291](https://github.com/ml-explore/mlx/issues/3291)
+2. Ensure the SVG accurately represents the existing PNG design
+3. Submit a PR following our [Contributing Guidelines](../CONTRIBUTING.md)
+
+## Attribution Requirements
+
+When using the MLX logo:
+
+### Minimal Attribution (Required)
+
+Include this notice near the logo or in your project's attribution section:
+
+```
+MLX logo © 2023 Apple Inc.
+```
+
+### Recommended Attribution (Preferred)
+
+For better context, we recommend:
+
+```
+MLX logo © 2023 Apple Inc.
+MLX is an open-source machine learning framework for Apple silicon.
+https://github.com/ml-explore/mlx
+```
+
+### Example Usage in Markdown
+
+```markdown
+<div align="center">
+  <img src="https://github.com/ml-explore/mlx/blob/main/docs/src/_static/mlx_logo.png" 
+       alt="MLX Logo" width="200" />
+  
+  <p><em>MLX logo © 2023 Apple Inc.</em></p>
+</div>
+```
+
+### Example Usage in HTML
+
+```html
+<div style="text-align: center;">
+  <img src="mlx_logo.png" alt="MLX Logo" width="200" />
+  <p><small>MLX logo © 2023 Apple Inc. | 
+    <a href="https://github.com/ml-explore/mlx">Learn more</a>
+  </small></p>
+</div>
+```
+
+## Permitted Uses
+
+Under the MIT License, you may:
+
+- ✅ Use the logo in documentation for projects using MLX
+- ✅ Use the logo in educational materials about MLX
+- ✅ Use the logo in presentations or blog posts discussing MLX
+- ✅ Modify the logo (with attribution to the original)
+- ✅ Use commercially (with attribution)
+
+## Best Practices
+
+### Do
+
+- ✅ Provide clear attribution
+- ✅ Link back to the MLX project
+- ✅ Maintain aspect ratio when resizing
+- ✅ Use appropriate format (light/dark) for your background
+
+### Don't
+
+- ❌ Remove or obscure the attribution
+- ❌ Imply official endorsement without permission
+- ❌ Use the logo as your own project's primary branding
+- ❌ Distort or alter the logo in misleading ways
+
+## Trademark Notice
+
+"MLX" and the MLX logo are trademarks or registered trademarks of Apple Inc.
+
+Use of the logo does not grant trademark rights. If you're unsure whether your use case is appropriate, please reach out to the MLX maintainers via [GitHub Discussions](https://github.com/ml-explore/mlx/discussions).
+
+## Questions?
+
+- **General logo questions:** [Issue #3291](https://github.com/ml-explore/mlx/issues/3291)
+- **Usage questions:** [GitHub Discussions](https://github.com/ml-explore/mlx/discussions)
+- **Bug reports:** [Issues](https://github.com/ml-explore/mlx/issues)
+
+---
+
+_This document provides guidance for logo usage. For questions not covered here, please refer to the [MIT License](../LICENSE) or contact the maintainers._


### PR DESCRIPTION
Addresses #3291 

## Summary

Adds comprehensive logo usage documentation to help users understand how to properly use and attribute the MLX logo in their projects.

## Changes

- Created `docs/LOGO_USAGE.md` with:
  - Clear MIT License attribution requirements
  - Available formats documentation (PNG light/dark)
  - Recommended attribution examples (Markdown, HTML)
  - Permitted uses and best practices
  - Note about SVG availability (pending)

## Why This Helps

Users like the `mlx-docs-l10n` project maintainer (Issue #3291) need clear guidance on:
1. What license governs the logo
2. How to properly attribute it
3. What formats are available
4. What uses are permitted

This document provides all that information in one place.

## Future Work

- An SVG version of the logo could be added later (currently only PNG available)
- Community members interested in creating an SVG can follow the guidelines in this doc

## Testing

- [x] Documentation is clear and complete
- [x] Examples are valid Markdown/HTML
- [x] Links work correctly

Closes #3291