### PR TITLE
fix: defer error propagation from Metal completion handlers

### DIFF
--- a/mlx/backend/metal/eval.cpp
+++ b/mlx/backend/metal/eval.cpp
@@ -1,5 +1,6 @@
 // Copyright © 2023-2024 Apple Inc.
 #include <memory>
+#include <mutex>
 
 #include "mlx/backend/gpu/eval.h"
 #include "mlx/backend/metal/device.h"
@@ -8,6 +9,31 @@
 #include "mlx/scheduler.h"
 
 namespace mlx::core::gpu {
+
+namespace {
+// Thread-safe deferred error from Metal completion handlers.
+// Completion handlers run on GCD threads where C++ exceptions
+// hit std::terminate. Instead, we store the error and re-throw
+// at the next eval() or synchronize() call.
+std::mutex deferred_error_mutex;
+std::string deferred_error_message;
+
+void set_deferred_error(const std::string& msg) {
+  std::lock_guard<std::mutex> lock(deferred_error_mutex);
+  if (deferred_error_message.empty()) {
+    deferred_error_message = msg;
+  }
+}
+
+void check_deferred_error() {
+  std::lock_guard<std::mutex> lock(deferred_error_mutex);
+  if (!deferred_error_message.empty()) {
+    std::string msg = std::move(deferred_error_message);
+    deferred_error_message.clear();
+    throw std::runtime_error(msg);
+  }
+}
+} // namespace
 
 void init() {}
 
@@ -26,7 +52,20 @@ inline void check_error(MTL::CommandBuffer* cbuf) {
   }
 }
 
+// Safe version for Metal completion handlers (GCD callbacks).
+// Cannot throw — stores error for deferred propagation.
+inline void check_error_deferred(MTL::CommandBuffer* cbuf) {
+  if (cbuf->status() == MTL::CommandBufferStatusError) {
+    std::ostringstream msg;
+    msg << "[METAL] Command buffer execution failed: "
+        << cbuf->error()->localizedDescription()->utf8String();
+    set_deferred_error(msg.str());
+  }
+}
+
 void eval(array& arr) {
+  // Re-throw any deferred error from a prior completion handler
+  check_deferred_error();
   auto pool = metal::new_scoped_memory_pool();
   auto s = arr.primitive().stream();
   auto& d = metal::device(s.device);
@@ -62,13 +101,13 @@ void eval(array& arr) {
     command_buffer->addCompletedHandler(
         [s, buffers = std::move(buffers)](MTL::CommandBuffer* cbuf) {
           scheduler::notify_task_completion(s);
-          check_error(cbuf);
+          check_error_deferred(cbuf);
         });
     d.commit_command_buffer(s.index);
   } else {
     command_buffer->addCompletedHandler(
         [buffers = std::move(buffers)](MTL::CommandBuffer* cbuf) {
-          check_error(cbuf);
+          check_error_deferred(cbuf);
         });
   }
 }
@@ -78,11 +117,13 @@ void finalize(Stream s) {
   auto& d = metal::device(s.device);
   auto cb = d.get_command_buffer(s.index);
   d.end_encoding(s.index);
-  cb->addCompletedHandler([](MTL::CommandBuffer* cbuf) { check_error(cbuf); });
+  cb->addCompletedHandler(
+      [](MTL::CommandBuffer* cbuf) { check_error_deferred(cbuf); });
   d.commit_command_buffer(s.index);
 }
 
 void synchronize(Stream s) {
+  check_deferred_error();
   auto pool = metal::new_scoped_memory_pool();
   auto& d = metal::device(s.device);
   auto cb = d.get_command_buffer(s.index);


### PR DESCRIPTION
## Summary

`check_error()` throws `std::runtime_error` inside Metal completion handlers (GCD callbacks). C++ exceptions cannot be caught in GCD dispatch contexts, so the throw hits `std::terminate` -> `abort()` -> SIGABRT.

This is a production crash. On M2 Ultra 128GB running Qwen3.5-122B (5-bit, 32K context), it occurs after ~3.5 hours of sustained inference. The crash stack:

```
libc++abi: __cxa_throw -> failed_throw -> std::terminate -> abort
libmlx.dylib: check_error(MTL::CommandBuffer*)
libmlx.dylib: [completion handler block]
Metal: -[_MTLCommandBuffer didCompleteWithStartTime:endTime:error:]
IOGPU: -[IOGPUMetalCommandBuffer fillCommandBufferArgs:]_block_invoke
```

## Fix

Replace `check_error()` with `check_error_deferred()` in all 3 completion handler sites in `eval.cpp`. Errors are stored in a thread-safe slot and re-thrown at the next `eval()` or `synchronize()` call, where C++ exception handling works correctly.

The error is never lost -- it surfaces as the same `std::runtime_error` at the next synchronization point.

## Changes

- `eval.cpp`: Add `check_error_deferred()` with mutex-protected error store
- `eval()`: Check for deferred errors at entry
- `synchronize()`: Check for deferred errors at entry
- All 3 `addCompletedHandler` sites: `check_error` -> `check_error_deferred`

## Testing

- SDPA verification passes
- Production 122B inference verified after rebuild
- Previously crashed after ~3.5h sustained load; fix deployed, monitoring

## Related

- #3317 (issue filed with full crash analysis)
- #3216 (separate Metal thread safety issue, fixed by #3281)

Fixes #3317.