### PR TITLE
Fix Metal library ownership when clearing compiled function cache

### DIFF
--- a/mlx/compile.cpp
+++ b/mlx/compile.cpp
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <cstdlib>
 #include <map>
+#include <mutex>
 #include <sstream>
 #include <unordered_map>
 #include <unordered_set>
@@ -22,6 +23,84 @@ namespace mlx::core {
 
 constexpr int max_compile_depth = 11;
 constexpr int max_compile_arrays = 24;
+
+namespace {
+
+#ifdef METAL_AVAILABLE
+class MetalLibraryOwnership {
+ public:
+  static MetalLibraryOwnership& instance() {
+    static MetalLibraryOwnership ownership;
+    return ownership;
+  }
+
+  void retain(const std::unordered_set<std::string>& lib_names) {
+    if (lib_names.empty()) {
+      return;
+    }
+    std::lock_guard<std::mutex> lock(mtx_);
+    for (const auto& lib_name : lib_names) {
+      refcounts_[lib_name]++;
+    }
+  }
+
+  void release(
+      const Device& device,
+      const std::unordered_set<std::string>& lib_names) {
+    if (device.type != Device::gpu || lib_names.empty()) {
+      return;
+    }
+
+    std::vector<std::string> libraries_to_clear;
+    {
+      std::lock_guard<std::mutex> lock(mtx_);
+      for (const auto& lib_name : lib_names) {
+        auto it = refcounts_.find(lib_name);
+        if (it == refcounts_.end()) {
+          continue;
+        }
+        if (--it->second == 0) {
+          libraries_to_clear.push_back(lib_name);
+          refcounts_.erase(it);
+        }
+      }
+    }
+
+    if (!libraries_to_clear.empty()) {
+      auto& d = metal::device(device);
+      for (const auto& lib_name : libraries_to_clear) {
+        d.clear_library(lib_name);
+      }
+    }
+  }
+
+ private:
+  std::mutex mtx_;
+  std::unordered_map<std::string, size_t> refcounts_;
+};
+#endif
+
+void retain_metal_libraries(
+    const Device& device,
+    const std::unordered_set<std::string>& lib_names) {
+#ifdef METAL_AVAILABLE
+  if (device.type == Device::gpu && !lib_names.empty()) {
+    MetalLibraryOwnership::instance().retain(lib_names);
+  }
+#endif
+}
+
+void release_metal_libraries(
+    const Device& device,
+    const std::unordered_set<std::string>& lib_names) {
+#ifdef METAL_AVAILABLE
+  if (device.type == Device::gpu && !lib_names.empty()) {
+    MetalLibraryOwnership::instance().release(device, lib_names);
+  }
+#endif
+}
+
+} // namespace
 
 bool is_unary(const Primitive& p) {
   return (
@@ -310,6 +389,7 @@ class CompilerCache {
     bool empty{true};
     std::vector<uint64_t> constants;
     std::shared_ptr<void> extra;
+    std::unordered_set<std::string> metal_libs;
   };
 
   // Returns a reference to a CacheEntry which can be updated
@@ -367,11 +447,26 @@ class CompilerCache {
   }
 
   void erase(std::uintptr_t fun_id) {
-    cache_.erase(fun_id);
+    auto it = cache_.find(fun_id);
+    if (it == cache_.end()) {
+      return;
+    }
+    cleanup_cache_entries(it->second);
+    cache_.erase(it);
   }
 
   void clear() {
+    for (auto& [_, entries] : cache_) {
+      cleanup_cache_entries(entries);
+    }
     cache_.clear();
+  }
+
+  void cleanup_cache_entries(std::vector<CacheEntry>& entries) {
+    for (auto& entry : entries) {
+      release_metal_libraries(entry.stream.device, entry.metal_libs);
+      entry.metal_libs.clear();
+    }
   }
 
  private:
@@ -780,7 +875,8 @@ void compile_fuse(
     std::vector<array>& tape,
     ParentsMap& parents_map,
     const std::vector<array>& inputs,
-    std::vector<array>& outputs) {
+    std::vector<array>& outputs,
+    std::unordered_set<std::string>& metal_libs) {
   // Track outputs to replace with new compiled outputs
   std::unordered_map<uintptr_t, array> output_map;
   for (auto& o : outputs) {
@@ -970,16 +1066,17 @@ void compile_fuse(
         constant_ids.insert(in.id());
       }
     }
+    auto compiled_primitive = std::make_shared<Compiled>(
+        old_outputs.back().primitive().stream(),
+        inputs,
+        old_outputs,
+        std::move(fused_tape),
+        std::move(constant_ids));
+    if (compiled_primitive->stream().device.type == Device::gpu) {
+      metal_libs.insert(compiled_primitive->lib_name());
+    }
     auto compiled_outputs = array::make_arrays(
-        std::move(shapes),
-        types,
-        std::make_shared<Compiled>(
-            old_outputs.back().primitive().stream(),
-            inputs,
-            old_outputs,
-            std::move(fused_tape),
-            std::move(constant_ids)),
-        inputs);
+        std::move(shapes), types, compiled_primitive, inputs);
 
     // One output per primitive
     new_tape.push_back(compiled_outputs.back());
@@ -1144,8 +1241,15 @@ ArrayFnWithExtra compile(
       // Kernel fusion to generate Compiled primitives. The tape and
       // new outputs must be updated accordingly
       if (mode != CompileMode::no_fuse) {
-        compile_fuse(entry.tape, parents_map, entry.inputs, entry.outputs);
+        compile_fuse(
+            entry.tape,
+            parents_map,
+            entry.inputs,
+            entry.outputs,
+            entry.metal_libs);
       }
+
+      retain_metal_libraries(entry.stream.device, entry.metal_libs);
     }
 
     // At this point we must have a tape, now replace the placeholders

--- a/tests/compile_tests.cpp
+++ b/tests/compile_tests.cpp
@@ -5,6 +5,7 @@
 
 #include "doctest/doctest.h"
 
+#include "mlx/compile_impl.h"
 #include "mlx/mlx.h"
 #include "mlx/primitives.h"
 
@@ -35,6 +36,28 @@ TEST_CASE("test simple compile") {
 
   out = compfn({array(2.0f), array({1, 2}, int32)})[0];
   CHECK(array_equal(out, array({3.0f, 4.0f})).item<bool>());
+}
+
+TEST_CASE("test compile erase rebuilds cache entry") {
+  auto compfn = compile(simple_fun);
+  auto out = compfn({array(1.0f), array(2.0f)})[0];
+  CHECK_EQ(out.item<float>(), 3.0f);
+
+  detail::compile_erase(reinterpret_cast<std::uintptr_t>(simple_fun));
+
+  out = compfn({array(3.0f), array(4.0f)})[0];
+  CHECK_EQ(out.item<float>(), 7.0f);
+}
+
+TEST_CASE("test compile clear cache rebuilds entries") {
+  auto compfn = compile(simple_fun);
+  auto out = compfn({array(1.0f), array(2.0f)})[0];
+  CHECK_EQ(out.item<float>(), 3.0f);
+
+  detail::compile_clear_cache();
+
+  out = compfn({array(5.0f), array(6.0f)})[0];
+  CHECK_EQ(out.item<float>(), 11.0f);
 }
 
 std::vector<array> grad_fun(const std::vector<array>& inputs) {
@@ -657,6 +680,37 @@ TEST_CASE("test fusion kernel reuse") {
   CHECK(!lib_name_z.empty());
 
   CHECK_EQ(lib_name, lib_name_z);
+}
+
+TEST_CASE("test fusion library ownership") {
+#ifdef METAL_AVAILABLE
+  if (!metal::is_available()) {
+    return;
+  }
+
+  auto cfun1 = compile(unary_fused_1);
+  auto cfun2 = compile(unary_fused_1_copy);
+  auto x = array(1.0f, float32);
+
+  auto y1 = cfun1({x})[0];
+  auto y2 = cfun2({x})[0];
+  eval(y1);
+  eval(y2);
+
+  auto p1 = std::dynamic_pointer_cast<Compiled>(y1.primitive_ptr());
+  auto p2 = std::dynamic_pointer_cast<Compiled>(y2.primitive_ptr());
+  REQUIRE(p1);
+  REQUIRE(p2);
+  CHECK_EQ(p1->lib_name(), p2->lib_name());
+
+  detail::compile_erase(reinterpret_cast<std::uintptr_t>(unary_fused_1));
+  auto y2_after = cfun2({x})[0];
+  CHECK(array_equal(y2_after, y2).item<bool>());
+
+  detail::compile_erase(reinterpret_cast<std::uintptr_t>(unary_fused_1_copy));
+  auto y1_recompiled = cfun1({x})[0];
+  CHECK(array_equal(y1_recompiled, y1).item<bool>());
+#endif
 }
 
 auto add3(const std::vector<array>& xs) {


### PR DESCRIPTION
Fixes #3297.

Compiled-function cache erasure removed `CompilerCache` entries but did not release the corresponding Metal shader libraries and pipeline states. The missing piece is that `CompilerCache` is thread-local while the Metal device library cache is global, so cleanup needs explicit ownership tracking.

An earlier fix attempt (#3311) was closed because it inferred Metal ownership from generic `Compiled` nodes without accounting for the backend-generic nature of `Compiled` or the fact that `metal::device()` does not dispatch by backend.

This change fixes the ownership model directly:

- capture Metal library names when fused `Compiled` primitives are created in `compile_fuse()`
- retain/release those library names through a process-wide refcount registry
- only clear a Metal library when the last live GPU-backed cache entry owning it is erased
- keep the generic compiler/Metal interaction behind a narrow retain/release boundary
- never call into the Metal device for CPU-backed cache entries

Tests added:

- `compile_erase()` rebuilds a cache entry correctly
- `compile_clear_cache()` rebuilds entries correctly
- shared fused-library ownership: erasing one owner does not break the surviving owner, and erasing the last owner does not break future recompilation

Verification:

- `pre-commit run --all-files`
- `cmake --build build --target tests -j8`
- `./build/tests/tests`
