### PR TITLE
chore: update copyright year to 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ MLX useful in your research and wish to cite it, please use the following
 BibTex entry:
 
 ```text
-@software{mlx2023,
+@software{mlx2026,
   author = {Awni Hannun and Jagrit Digani and Angelos Katharopoulos and Ronan Collobert},
   title = {{MLX}: Efficient and flexible machine learning on Apple silicon},
   url = {https://github.com/ml-explore},


### PR DESCRIPTION
## Proposed changes

Update the copyright year from 2023 to 2026 in the documentation footer.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)