### PR TITLE
fix: fail build when Metal compiler header resolution fails

### DIFF
--- a/mlx/backend/metal/make_compiled_preamble.sh
+++ b/mlx/backend/metal/make_compiled_preamble.sh
@@ -34,6 +34,22 @@ mkdir -p "$OUTPUT_DIR"
 CCC="xcrun -sdk macosx metal -x metal"
 HDRS=$( $CCC -I"$SRC_DIR" -I"$JIT_INCLUDES" -DMLX_METAL_JIT -E -P -CC -C -H "$INPUT_FILE" $CFLAGS -w 2>&1 1>/dev/null )
 
+# Fail early if the Metal compiler returned errors instead of header paths.
+# Valid lines start with '.' chars (depth indicators); anything else means
+# xcrun/metal failed (e.g. missing SDK, misconfigured toolchain).
+if [ -n "$HDRS" ]; then
+  invalid_lines=$(echo "$HDRS" | grep -v '^\.*\.' || true)
+  if [ -n "$invalid_lines" ]; then
+    echo "Error: Metal compiler header resolution failed for ${INPUT_FILE}" >&2
+    echo "Expected lines starting with '.' but got:" >&2
+    echo "$invalid_lines" >&2
+    echo "" >&2
+    echo "This usually means xcrun or the Metal toolchain is not configured correctly." >&2
+    echo "Try running: xcrun -sdk macosx metal --version" >&2
+    exit 1
+  fi
+fi
+
 # Remove any included system frameworks (for MetalPerformancePrimitive headers)
 HDRS=$(echo "$HDRS" | grep -v "Xcode")
 


### PR DESCRIPTION
## Summary                                                      

  `make_compiled_preamble.sh` silently produces broken JIT Metal kernel sources when `xcrun -sdk macosx metal` fails during the build (e.g. due to misconfigured Xcode CLI tools or missing SDK path).            
  
  The script uses `xcrun metal -H` to resolve header dependencies, but never checks whether the command succeeded. When it fails, the error message words (e.g. `"error:"`, `"to"`, `"not"`, `"utility"`, `"or"`, 
  `"developer"`, `"PATH"`) are parsed as header file names. This causes critical headers like `bf16.h` (which defines `typedef bfloat bfloat16_t;`) to be silently omitted from the embedded Metal kernel sources
  in `libmlx.dylib`.                                                                                                                                                                                              
                                                                  
  The build completes successfully, but at runtime any operation requiring JIT Metal compilation (e.g. `gather_front` on bfloat16 tensors) fails with:                                                            
  
  RuntimeError: [metal::Device] Unable to build metal library from source                                                                                                                                         
  mlx/backend/metal/kernels/utils.h: error: unknown type name 'bfloat16_t'
                                                                                                                                                                                                                  
  This is extremely difficult to diagnose because:                
  - The build reports no errors                                                                                                                                                                                   
  - Simple operations (using precompiled metallib kernels) work fine
  - The error only appears at runtime when a JIT-compiled kernel is needed                                                                                                                                        
  - The root cause (missing `bf16.h` in the embedded source) is not visible from the error message                                                                                                                
                                                                                                                                                                                                                  
  ## Fix                                                                                                                                                                                                          
                                                                                                                                                                                                                  
  Add validation after the `xcrun metal -H` call to check that the output contains valid header dependency lines (starting with `.` characters). If invalid lines are detected, the build fails immediately with a
   clear error message pointing to the Metal toolchain configuration.
                                                                                                                                                                                                                  
  ## Checklist                                                    

  - [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document                                                                                                      
  - [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
  - [ ] I have added tests that prove my fix is effective or that my feature works                                                                                                                                
  - [ ] I have updated the necessary documentation (if needed)    
                                                                                                                                                                                                                  
  No test added — there is no existing test infrastructure for build shell scripts. The fix is a straightforward validation guard that fails early instead of silently continuing.