### PR TITLE
Add array.data_ptr() Python binding for low-level interop

### DIFF
--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -498,6 +498,27 @@ void init_array(nb::module_& m) {
               new (&arr) mx::array(nd_array_to_mlx(nd, std::nullopt));
             }
           })
+      .def(
+          "data_ptr",
+          [](mx::array& a) {
+            {
+              nb::gil_scoped_release nogil;
+              a.eval();
+            }
+            return reinterpret_cast<uintptr_t>(a.data<void>());
+          },
+          nb::sig("def data_ptr(self) -> int"),
+          R"pbdoc(
+            Return the address of the first element as an integer.
+
+            This returns a pointer to the array's underlying storage and is
+            intended for low-level interop.
+
+            .. warning::
+
+               The pointer is only valid while the array's underlying storage
+               remains alive.
+          )pbdoc")
       .def("__dlpack__", [](const mx::array& a) { return mlx_to_dlpack(a); })
       .def(
           "__dlpack_device__",

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -1,5 +1,6 @@
 # Copyright © 2023-2024 Apple Inc.
 
+import ctypes
 import gc
 import operator
 import os
@@ -1781,6 +1782,42 @@ class TestArray(mlx_tests.MLXTestCase):
         self.assertIsNotNone(wr())
         a_np = None
         self.assertIsNone(wr())
+
+    def test_data_ptr(self):
+        base = mx.arange(24, dtype=mx.float32).reshape(4, 6) + 1.5
+
+        base_ptr = base.data_ptr()
+        self.assertIsInstance(base_ptr, int)
+        self.assertGreater(base_ptr, 0)
+        base_np = np.array(base, copy=False)
+        self.assertEqual(base_ptr, base_np.__array_interface__["data"][0])
+        self.assertAlmostEqual(ctypes.c_float.from_address(base_ptr).value, 1.5)
+
+        view = base[:, 2:]
+        view_ptr = view.data_ptr()
+        self.assertGreater(view_ptr, base_ptr)
+        view_np = np.array(view, copy=False)
+        self.assertEqual(view_ptr, view_np.__array_interface__["data"][0])
+        self.assertEqual(view_ptr - base_ptr, 2 * base.itemsize)
+        self.assertAlmostEqual(ctypes.c_float.from_address(view_ptr).value, 3.5)
+
+        transposed = view.T
+        transposed_ptr = transposed.data_ptr()
+        transposed_np = np.array(transposed, copy=False)
+        self.assertEqual(transposed_ptr, transposed_np.__array_interface__["data"][0])
+        self.assertEqual(transposed_ptr, view_ptr)
+        self.assertAlmostEqual(ctypes.c_float.from_address(transposed_ptr).value, 3.5)
+
+        reversed_cols = base[:, ::-1]
+        reversed_cols_ptr = reversed_cols.data_ptr()
+        reversed_cols_np = np.array(reversed_cols, copy=False)
+        self.assertEqual(
+            reversed_cols_ptr, reversed_cols_np.__array_interface__["data"][0]
+        )
+        self.assertEqual(reversed_cols_ptr - base_ptr, 5 * base.itemsize)
+        self.assertAlmostEqual(
+            ctypes.c_float.from_address(reversed_cols_ptr).value, 6.5
+        )
 
     @unittest.skipIf(not has_tf, "requires TensorFlow")
     def test_buffer_protocol_tf(self):


### PR DESCRIPTION
## Proposed changes

Exposes `array.data<void>()` in Python as data_ptr() -> int, returning the address of the first element after evaluation.

Implementation:
- Release GIL before `eval()` to avoid blocking during synchronization
- Return `uintptr_t` cast to Python `int`
- Pointer validity is tied to underlying storage lifetime

Tests:
- Add `test_data_ptr` in `python/tests/test_array.py`
- Cover base contiguous array, positive-offset slice, transpose view, and negative-stride view
- Validate pointers against NumPy `__array_interface__` and verify pointed values via `ctypes`

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
