### PR TITLE
Use `metal` as the front-end for the metal linker

### DIFF
--- a/mlx/backend/metal/kernels/CMakeLists.txt
+++ b/mlx/backend/metal/kernels/CMakeLists.txt
@@ -176,7 +176,7 @@ endif()
 
 add_custom_command(
   OUTPUT ${MLX_METAL_PATH}/mlx.metallib
-  COMMAND xcrun -sdk macosx metallib ${KERNEL_AIR} -o
+  COMMAND xcrun -sdk macosx metal ${KERNEL_AIR} -o
           ${MLX_METAL_PATH}/mlx.metallib
   DEPENDS ${KERNEL_AIR}
   COMMENT "Building mlx.metallib"


### PR DESCRIPTION
## Proposed changes

Since [WWDC 2020](https://developer.apple.com/videos/play/wwdc2020/10615/?time=2006) `metal` is now the preferred front-end to both compile metal and link `.metallib` files. This also matches how recent Xcode versions ( 12 and later) have been compiling and linking metallibs (see e.g. [*building a shader library by precompiling source files*](https://developer.apple.com/documentation/metal/building-a-shader-library-by-precompiling-source-files?language=objc) or [*Teaching CMake to Compile Apple Metal Shaders*](https://dpogue.ca/articles/cmake-metal.html)) 

This PR simply changes the linker tool for `metal`.

## Checklist

Put an `x` in the boxes that apply.

- [X] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [X] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
