### PR TITLE
Fixing deserializer missing upper bounds check as per PR#3368

### DIFF
--- a/mlx/export.cpp
+++ b/mlx/export.cpp
@@ -1062,6 +1062,13 @@ ImportedFunction::ImportedFunction(const std::string& file)
 
     std::vector<array> tape;
     auto tape_size = deserialize<uint64_t>(is);
+    constexpr uint64_t kMaxTapeSize = 10'000'000;
+    if (tape_size > kMaxTapeSize) {
+      throw std::runtime_error(
+          "[import_function] tape_size=" + std::to_string(tape_size) +
+          " exceeds maximum allowed size (" + std::to_string(kMaxTapeSize) +
+          ")");
+    }
     tape.reserve(tape_size);
 
     auto factory = PrimitiveFactory();

--- a/tests/export_import_tests.cpp
+++ b/tests/export_import_tests.cpp
@@ -1,6 +1,7 @@
 // Copyright © 2024 Apple Inc.
 
 #include <filesystem>
+#include <fstream>
 #include <stdexcept>
 #include <vector>
 
@@ -160,4 +161,41 @@ TEST_CASE("test export function on different stream") {
 
   // Should make a new stream that we can run computation on
   eval(import_function(file_path)({array({0, 1, 2})}));
+}
+
+TEST_CASE("test import rejects oversized tape_size") {
+  // Craft a minimal .mlxfn with tape_size = UINT64_MAX.
+  // Verifies the importer rejects it instead of allocating unbounded memory.
+  std::string file_path = get_temp_file("test_bad_tape.mlxfn");
+
+  auto write_le64 = [](std::ofstream& f, uint64_t v) {
+    f.write(reinterpret_cast<const char*>(&v), 8);
+  };
+  auto write_le32 = [](std::ofstream& f, int32_t v) {
+    f.write(reinterpret_cast<const char*>(&v), 4);
+  };
+
+  {
+    std::ofstream f(file_path, std::ios::binary);
+    // Version string: "0.0.0"
+    std::string ver = "0.0.0";
+    write_le64(f, ver.size());
+    f.write(ver.data(), ver.size());
+    // function_count = 1
+    write_le32(f, 1);
+    // shapeless = false
+    f.put(0x00);
+    // kwarg_keys = [] (empty vector: size=0)
+    write_le64(f, 0);
+    // trace_input_ids = [] (empty vector: size=0)
+    write_le64(f, 0);
+    // trace_inputs = [] (empty vector: size=0)
+    write_le64(f, 0);
+    // trace_output_ids = [] (empty vector: size=0)
+    write_le64(f, 0);
+    // tape_size = UINT64_MAX (malicious)
+    write_le64(f, UINT64_MAX);
+  }
+
+  CHECK_THROWS_AS(import_function(file_path), std::runtime_error);
 }


### PR DESCRIPTION
## Proposed changes

The fix adds a bounds check on tape_size in import_one() (mlx/export.cpp) immediately after it's deserialized from the .mlxfn file and before it's passed to tape.reserve(). If tape_size exceeds 10,000,000 entries, a std::runtime_error is thrown with a descriptive message. This prevents an attacker-controlled uint64_t from flowing into an unbounded std::vector::reserve() call, which would otherwise attempt to allocate up to exabytes of memory from a 58-byte file. The cap of 10 million is well above any realistic computation graph while eliminating the allocation amplification vector.

Fix for #3368 

## Checklist

Put an `x` in the boxes that apply.

- [X] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [X] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have updated the necessary documentation (if needed)
