### PR TITLE
Fix CMake finding wrong Python during pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ import os
 import platform
 import re
 import subprocess
+import sys
 from functools import partial
 from pathlib import Path
 
@@ -91,6 +92,7 @@ class CMakeBuild(build_ext):
             f"-DCMAKE_INSTALL_PREFIX={install_prefix}",
             f"-DMLX_PYTHON_BINDINGS_OUTPUT_DIRECTORY={pybind_out_dir}",
             f"-DCMAKE_BUILD_TYPE={cfg}",
+            f"-DPython_EXECUTABLE={sys.executable}",
             "-DMLX_BUILD_PYTHON_BINDINGS=ON",
             "-DMLX_BUILD_TESTS=OFF",
             "-DMLX_BUILD_BENCHMARKS=OFF",


### PR DESCRIPTION
## Summary
- When building mlx via `pip install`, CMake's `find_package(Python 3.10 ...)` independently searches for Python and may find a different version than the one running pip. For example, if Python 3.13 is installed via Homebrew but the user builds with Python 3.11, CMake finds 3.13 and produces `core.cpython-313-darwin.so` — which Python 3.11 cannot load, resulting in `ModuleNotFoundError: No module named 'mlx.core'`.
- Fix: pass `-DPython_EXECUTABLE={sys.executable}` to CMake so it uses the exact Python that invoked `pip install`.

## Reproduction
1. Have multiple Python versions installed (e.g. 3.11 via pyenv, 3.13 via Homebrew)
2. `pip install mlx` using Python 3.11
3. `import mlx.core` → `ModuleNotFoundError`
4. Inspect: `ls site-packages/mlx/core*` shows `core.cpython-313-darwin.so`

## Test plan
- [x] Build with Python 3.11 while 3.13 is also installed — verify `.so` is `cpython-311`
- [x] Build with Python 3.13 — verify still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)