### PR TITLE
Fix test "test get streams" missing initialization

### DIFF
--- a/tests/scheduler_tests.cpp
+++ b/tests/scheduler_tests.cpp
@@ -87,6 +87,8 @@ TEST_CASE("test access stream in other thread") {
 }
 
 TEST_CASE("test get streams") {
+  // Initialize default CPU stream before querying
+  default_stream(Device::cpu);
   auto streams = get_streams();
 
   // At least the default CPU stream exists


### PR DESCRIPTION
The test "test get streams" assumes get_streams() would return at least the default CPU stream without any initialisation. This seems to be true before df7f7db9, which removed initialization from Scheduler's constructor.

The failure can be reproduced by running the test in isolation:
./build/tests/tests --test-case="test get streams"

Fix by calling default_stream(Device::cpu) before get_streams() to match the test expectation.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
