### PR TITLE
fix: use retained command buffer to prevent use-after-free with custom Metal kernels

### DIFF
--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -264,7 +264,7 @@ CommandEncoder::CommandEncoder(
     queue_->addResidencySet(residency_set.mtl_residency_set());
   }
   debug_set_stream_queue_label(queue_.get(), index);
-  buffer_ = NS::RetainPtr(queue_->commandBufferWithUnretainedReferences());
+  buffer_ = NS::RetainPtr(queue_->commandBuffer());
 }
 
 CommandEncoder::~CommandEncoder() {
@@ -438,7 +438,7 @@ bool CommandEncoder::needs_commit() const {
 
 void CommandEncoder::commit() {
   buffer_->commit();
-  buffer_ = NS::RetainPtr(queue_->commandBufferWithUnretainedReferences());
+  buffer_ = NS::RetainPtr(queue_->commandBuffer());
   buffer_ops_ = 0;
   buffer_sizes_ = 0;
 }


### PR DESCRIPTION
Fixes #3347

## Summary

Switch `commandBufferWithUnretainedReferences()` to `commandBuffer()` in `Device::get_command_buffer()` to fix a use-after-free when multiple `mx.fast.metal_kernel` calls compose in a single lazy evaluation graph.

## Problem

When multiple custom Metal kernels are composed lazily (e.g., rotation kernels + `gated_delta_update` in GatedDeltaNet layers), intermediate GPU buffers can be deallocated before the command buffer finishes executing. Metal API Validation confirms:

```
-[MTLDebugCommandBuffer preCommit]:1167: failed assertion
`command buffer references deallocated object which previously
existed at address 0x490994e30.'
```

Without validation, this manifests as non-deterministic NaN outputs (~2% per forward pass, amplified to ~100% in autoregressive generation).

**Root cause**: `commandBufferWithUnretainedReferences()` relies on MLX to manually retain all GPU buffers. Built-in primitives handle this correctly through the dependency graph, but `mx.fast.metal_kernel`'s internal contiguous copies (created by `ensure_row_contiguous`) are added as temporaries, which are excluded from fence tracking in `end_encoding()`. Their buffers can be freed while still referenced by the GPU.

## Fix

One-line change — use `commandBuffer()` (retained references) so Metal automatically retains all referenced buffers until the command buffer completes.

## Reproduction

```bash
MTL_DEBUG_LAYER=1 python -c "
import mlx.core as mx
from paroquant.inference.backends.mlx.load import load
from paroquant.inference.backends.mlx.modules import RotateQuantizedLinear
from mlx_lm.models.cache import make_prompt_cache

model, proc, _ = load('z-lab/Qwen3.5-4B-PARO', force_text=True)
for _, m in model.named_modules():
    if isinstance(m, RotateQuantizedLinear):
        m._force_eval = False

inner = model.language_model.model
h = inner.embed_tokens(mx.array([[0]]))
mx.eval(h)

cache = make_prompt_cache(model.language_model)
out = inner.layers[0](h, mask=None, cache=cache[0])
mx.eval(out)
# Crashes: 'command buffer references deallocated object'
"
```

Requires `pip install paroquant` and a ParoQuant model (e.g., `z-lab/Qwen3.5-4B-PARO`).

## Performance

No regression on standard models (no custom kernels):

| Model | Before (unretained) | After (retained) | Delta |
|-------|-------------------|-----------------|-------|
| Qwen3-4B-4bit | 127.3 tok/s | 126.8 tok/s | -0.4% |
| Qwen3-8B-4bit | 75.8 tok/s | 75.6 tok/s | -0.3% |
| Qwen3.5-4B-MLX-4bit | 120.1 tok/s | 119.2 tok/s | -0.7% |
| Qwen3-4B-MLX-4bit | 127.7 tok/s | 127.3 tok/s | -0.3% |
| Qwen3-8B-MLX-4bit | 76.0 tok/s | 75.9 tok/s | -0.1% |

All within ±1% (measurement noise). Benchmarked on Apple M3 Max 48GB.

For models using `mx.fast.metal_kernel`, removing the `mx.eval()` workaround yields **2.3x speedup** (e.g., 21 → 48 tok/s on Qwen3.5-35B-A3B MoE).

<!-- benchmark chart will be attached as image -->

## Testing

This bug is non-deterministic (~2% per forward pass) and requires `MTL_DEBUG_LAYER=1` to reproduce reliably as a crash. Adding a deterministic unit test is difficult because the failure depends on GPU buffer allocation patterns. The reproduction script above triggers it consistently with Metal validation enabled.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code
- [ ] I have added tests that prove my fix is effective or that my feature works (see Testing section above)
- [x] I have updated the necessary documentation (if needed)
