### PR TITLE
Fix JACCL GID index for multi-node Thunderbolt 5 setups

### DIFF
--- a/mlx/distributed/jaccl/utils.cpp
+++ b/mlx/distributed/jaccl/utils.cpp
@@ -181,8 +181,20 @@ const Destination& Connection::info() {
 
   ibv_port_attr port_attr;
   ibv().query_port(ctx, 1, &port_attr);
-  ibv_gid gid;
-  ibv().query_gid(ctx, 1, 1, &gid);
+  // Scan GID table for a valid entry. On some Thunderbolt interfaces the
+  // IPv4-mapped GID is not at index 1 (e.g. index 2 on certain TB5 configs).
+  ibv_gid gid = {};
+  for (int idx = 1; idx <= 3; idx++) {
+    ibv_gid tmp;
+    if (ibv().query_gid(ctx, 1, idx, &tmp) == 0 &&
+        tmp.global.interface_id != 0) {
+      gid = tmp;
+      break;
+    }
+  }
+  if (gid.global.interface_id == 0) {
+    ibv().query_gid(ctx, 1, 0, &gid);
+  }
 
   src.local_id = port_attr.lid;
   src.queue_pair_number = queue_pair->qp_num;
@@ -227,7 +239,16 @@ void Connection::queue_pair_rtr(const Destination& dst) {
     attr.ah_attr.is_global = 1;
     attr.ah_attr.grh.hop_limit = 1;
     attr.ah_attr.grh.dgid = dst.global_identifier;
-    attr.ah_attr.grh.sgid_index = 1;
+    // Find valid local sgid_index dynamically (matches info() scan)
+    attr.ah_attr.grh.sgid_index = 0;
+    for (int idx = 1; idx <= 3; idx++) {
+      ibv_gid tmp;
+      if (ibv().query_gid(ctx, 1, idx, &tmp) == 0 &&
+          tmp.global.interface_id != 0) {
+        attr.ah_attr.grh.sgid_index = idx;
+        break;
+      }
+    }
   }
 
   int mask = IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN |


### PR DESCRIPTION
## Summary

Fixes hardcoded `sgid_index=1` in JACCL connection setup that prevents 3-node Thunderbolt 5 RDMA clusters from working.

## Problem

`Connection::info()` and `queue_pair_rtr()` both hardcode GID index 1 when querying the InfiniBand GID table and setting up queue pairs. On some Thunderbolt 5 interfaces (observed on Mac mini M4 Pro with `rdma_en3`/`rdma_en4`), the valid IPv4-mapped GID is at index 2, not 1. This causes the QP transition to RTR state to fail with `errno 22` (EINVAL).

2-node setups often work because both interfaces happen to have GID at index 1. When a third node with GID at index 2 is added, the connection fails.

## Fix

Scan GID indices 1-3 for a valid entry (non-zero `interface_id`), falling back to index 0 if none found. Applied to both `Connection::info()` and `queue_pair_rtr()`.

## Test plan

- [x] 3-node TB5 mesh: Mac Studio M3 Ultra + 2x Mac mini M4 Pro
- [x] Before fix: 2-node works, 3-node fails with errno 22
- [x] After fix: 3-node works reliably (tested with Qwen3-235B pipeline parallel)
- [x] 2-node operation unaffected