### PR TITLE
fix: There is no Stream(gpu, {}) in current thread

### DIFF
--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -799,8 +799,13 @@ CommandEncoder& get_command_encoder(Stream s) {
   auto& encoders = get_command_encoders();
   auto it = encoders.find(s.index);
   if (it == encoders.end()) {
-    throw std::runtime_error(
-        fmt::format("There is no Stream(gpu, {}) in current thread.", s.index));
+    // Auto-register the stream on this thread.  MLX streams are thread-local,
+    // but arrays may carry references to streams created on other threads
+    // (e.g. module-level streams created at import time).  Rather than
+    // throwing, lazily create a CommandEncoder so the current thread can
+    // dispatch work for that stream.
+    auto& d = device(s.device);
+    it = encoders.try_emplace(s.index, d, s.index, d.residency_set()).first;
   }
   return it->second;
 }


### PR DESCRIPTION
## Proposed changes

This is for quickly discussing the following idea:

```cpp
CommandEncoder& get_command_encoder(Stream s) {
  auto& encoders = get_command_encoders();
  auto it = encoders.find(s.index);
  if (it == encoders.end()) {
    // Auto-register the stream on this thread.  MLX streams are thread-local,
    // but arrays may carry references to streams created on other threads
    // (e.g. module-level streams created at import time).  Rather than
    // throwing, lazily create a CommandEncoder so the current thread can
    // dispatch work for that stream.
    auto& d = device(s.device);
    it = encoders.try_emplace(s.index, d, s.index, d.residency_set()).first;
  }
  return it->second;
}
```

Instead of:

```cpp
CommandEncoder& get_command_encoder(Stream s) {
  auto& encoders = get_command_encoders();
  auto it = encoders.find(s.index);
  if (it == encoders.end()) {
  throw std::runtime_error(
        fmt::format("There is no Stream(gpu, {}) in current thread.", s.index));
  }
  return it->second;
}
```

When MLX operations in any client application are serialized through a single executor, this is safe. If people use it without serialization... it might break anyways? But for all consumers who build sane, multi-threaded code, this will simply work instead of giving them unnecessary headaches? 

I'm wondering what I'm overlooking.

_(I tested this with oMLX which had issues with newer versions of mlx - anything above 0.31.1 in my custom fork - and it works flawlessly)_ 

https://github.com/ml-explore/mlx/issues/3078

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
