### PR TITLE
Document sort stability and NaN handling

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -2546,13 +2546,15 @@ array blackman(int M, StreamOrDevice s /* = {} */) {
   return add(subtract(alpha, term1, s), term2, s);
 }
 
-/** Returns a sorted copy of the flattened array. */
+/** Returns a sorted copy of the flattened array.
+ * The sort is stable and NaN values are placed at the end. */
 array sort(const array& a, StreamOrDevice s /* = {} */) {
   int size = a.size();
   return sort(reshape(a, {size}, s), 0, s);
 }
 
-/** Returns a sorted copy of the array along a given axis. */
+/** Returns a sorted copy of the array along a given axis.
+ * The sort is stable and NaN values are placed at the end. */
 array sort(const array& a, int axis, StreamOrDevice s /* = {} */) {
   // Check for valid axis
   if (axis + static_cast<int>(a.ndim()) < 0 ||
@@ -2567,13 +2569,15 @@ array sort(const array& a, int axis, StreamOrDevice s /* = {} */) {
       a.shape(), a.dtype(), std::make_shared<Sort>(to_stream(s), axis), {a});
 }
 
-/** Returns indices that sort the flattened array. */
+/** Returns indices that sort the flattened array.
+ * The sort is stable and NaN values are placed at the end. */
 array argsort(const array& a, StreamOrDevice s /* = {} */) {
   int size = a.size();
   return argsort(reshape(a, {size}, s), 0, s);
 }
 
-/** Returns indices that sort the array along a given axis. */
+/** Returns indices that sort the array along a given axis.
+ * The sort is stable and NaN values are placed at the end. */
 array argsort(const array& a, int axis, StreamOrDevice s /* = {} */) {
   // Check for valid axis
   if (axis + static_cast<int>(a.ndim()) < 0 ||

--- a/mlx/ops.h
+++ b/mlx/ops.h
@@ -770,16 +770,28 @@ inline array argmax(const array& a, StreamOrDevice s = {}) {
 MLX_API array
 argmax(const array& a, int axis, bool keepdims = false, StreamOrDevice s = {});
 
-/** Returns a sorted copy of the flattened array. */
+/**
+ * Returns a sorted copy of the flattened array.
+ * The sort is stable and NaN values are placed at the end.
+ */
 MLX_API array sort(const array& a, StreamOrDevice s = {});
 
-/** Returns a sorted copy of the array along a given axis. */
+/**
+ * Returns a sorted copy of the array along a given axis.
+ * The sort is stable and NaN values are placed at the end.
+ */
 MLX_API array sort(const array& a, int axis, StreamOrDevice s = {});
 
-/** Returns indices that sort the flattened array. */
+/**
+ * Returns indices that sort the flattened array.
+ * The sort is stable and NaN values are placed at the end.
+ */
 MLX_API array argsort(const array& a, StreamOrDevice s = {});
 
-/** Returns indices that sort the array along a given axis. */
+/**
+ * Returns indices that sort the array along a given axis.
+ * The sort is stable and NaN values are placed at the end.
+ */
 MLX_API array argsort(const array& a, int axis, StreamOrDevice s = {});
 
 /**

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -2821,6 +2821,9 @@ void init_ops(nb::module_& m) {
       R"pbdoc(
         Returns a sorted copy of the array.
 
+        The sort is stable, meaning equal elements preserve their relative
+        order. ``NaN`` values are placed at the end.
+
         Args:
             a (array): Input array.
             axis (int or None, optional): Optional axis to sort over.
@@ -2847,6 +2850,9 @@ void init_ops(nb::module_& m) {
           "def argsort(a: array, /, axis: Union[None, int] = -1, *, stream: Union[None, Stream, Device] = None) -> array"),
       R"pbdoc(
         Returns the indices that sort the array.
+
+        The sort is stable, meaning equal elements preserve their relative
+        order. ``NaN`` values are placed at the end.
 
         Args:
             a (array): Input array.


### PR DESCRIPTION
## Summary

Addresses #2057.

Documents that `sort` and `argsort` are **stable** across all backends and place **NaN values at the end** to match NumPy/JAX.

- CPU: `std::stable_sort` with a NaN-aware comparator (`mlx/backend/cpu/sort.cpp`)
- Metal/CUDA: merge sort with the same NaN handling (`mlx/backend/metal/kernels/sort.h`, `mlx/backend/cuda/sort.cu`)

Both guarantees are true in the current implementation (NaN handling introduced in #2667) but weren't documented, so users couldn't rely on them.

## Changes

- `python/src/ops.cpp` — add note to `sort` and `argsort` docstrings
- `mlx/ops.h` — add note to the four C++ declarations
- `mlx/ops.cpp` — add note to the four C++ definitions

## Test plan

- [x] `pre-commit run --all-files` passes
- [x] C++ build succeeds, `ctest` passes
- [x] `python -m pytest python/tests/test_ops.py -k sort` passes
- [x] `help(mx.sort)` renders the new docstring at runtime