### PR TITLE
Fix flaky TestVmap.test_vmap_masked_scatter

### DIFF
--- a/mlx/backend/cuda/indexing.cpp
+++ b/mlx/backend/cuda/indexing.cpp
@@ -458,7 +458,7 @@ void MaskedScatter::eval_gpu(const std::vector<array>& inputs, array& out) {
   }
 
   array mask_flat = flatten_in_eval(mask, 1, -1, s);
-  if (mask_flat.data<void>() != mask.data<void>()) {
+  if (gpu_ptr<void>(mask_flat) != gpu_ptr<void>(mask)) {
     encoder.add_temporary(mask_flat);
   }
   if (!mask_flat.flags().row_contiguous) {

--- a/mlx/backend/cuda/scan.cu
+++ b/mlx/backend/cuda/scan.cu
@@ -364,7 +364,7 @@ constexpr bool supports_scan_op() {
 }
 
 void scan_gpu_inplace(
-    array in,
+    const array& in,
     array& out,
     Scan::ReduceType reduce_type,
     int axis,

--- a/mlx/backend/gpu/scan.h
+++ b/mlx/backend/gpu/scan.h
@@ -6,7 +6,7 @@
 namespace mlx::core {
 
 void scan_gpu_inplace(
-    array in,
+    const array& in,
     array& out,
     Scan::ReduceType reduce_type,
     int axis,

--- a/mlx/backend/metal/scan.cpp
+++ b/mlx/backend/metal/scan.cpp
@@ -13,7 +13,7 @@
 namespace mlx::core {
 
 void scan_gpu_inplace(
-    array in,
+    const array& in,
     array& out,
     Scan::ReduceType reduce_type,
     int axis,


### PR DESCRIPTION
This test is [flaky in CI](https://github.com/ml-explore/mlx/actions/runs/24481559921/job/71756465584) and luckily I can reproduce it locally:

```
  ======================================================================
  FAIL: test_vmap_masked_scatter (test_vmap.TestVmap.test_vmap_masked_scatter)
  ----------------------------------------------------------------------
  Traceback (most recent call last):
    File "/home/runner/work/mlx/mlx/python/tests/test_vmap.py", line 900, in test_vmap_masked_scatter
      self.assertTrue(mx.array_equal(expected, out))
      ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  AssertionError: array(False, dtype=bool) is not true
  
  ----------------------------------------------------------------------
```