### PR TITLE
Make Scheduler::enqueue thread safe

### DIFF
--- a/mlx/scheduler.cpp
+++ b/mlx/scheduler.cpp
@@ -32,12 +32,24 @@ Scheduler::Scheduler() {
 
 Scheduler::~Scheduler() = default;
 
-void Scheduler::new_thread(Device::DeviceType type) {
-  if (type == Device::gpu) {
-    threads_.push_back(nullptr);
-  } else {
-    threads_.push_back(std::make_unique<StreamThread>());
+void Scheduler::enqueue(Stream s, std::function<void()> task) {
+  StreamThread* st = nullptr;
+  {
+    std::shared_lock lock(threads_mtx_);
+    auto it = threads_.find(s.index);
+    if (it != threads_.end()) {
+      st = it->second.get();
+    }
   }
+  if (!st) {
+    std::unique_lock lock(threads_mtx_);
+    auto it = threads_.find(s.index);
+    if (it == threads_.end()) {
+      it = threads_.emplace(s.index, std::make_unique<StreamThread>()).first;
+    }
+    st = it->second.get();
+  }
+  st->enqueue(std::move(task));
 }
 
 /** A singleton scheduler to manage devices, streams, and task execution. */

--- a/mlx/scheduler.h
+++ b/mlx/scheduler.h
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <future>
 #include <queue>
+#include <shared_mutex>
 #include <thread>
 #include <unordered_map>
 
@@ -50,21 +51,20 @@ struct StreamThread {
     }
   }
 
-  template <typename F>
-  void enqueue(F&& f) {
+  void enqueue(std::function<void()> f) {
     {
       std::lock_guard<std::mutex> lk(mtx);
       if (stop) {
         throw std::runtime_error(
             "Cannot enqueue work after stream is stopped.");
       }
-      q.emplace(std::forward<F>(f));
+      q.emplace(std::move(f));
     }
     cond.notify_one();
   }
 };
 
-class Scheduler {
+class MLX_API Scheduler {
  public:
   Scheduler();
   ~Scheduler();
@@ -75,8 +75,7 @@ class Scheduler {
   Scheduler& operator=(const Scheduler&) = delete;
   Scheduler& operator=(Scheduler&&) = delete;
 
-  template <typename F>
-  void enqueue(const Stream& stream, F&& f);
+  void enqueue(Stream s, std::function<void()> task);
 
   void notify_new_task(const Stream& stream) {
     {
@@ -111,18 +110,12 @@ class Scheduler {
  private:
   friend Stream mlx::core::new_stream(Device d);
 
-  void new_thread(Device::DeviceType type);
-
   int n_active_tasks_{0};
-  std::vector<std::unique_ptr<StreamThread>> threads_;
+  std::unordered_map<int, std::unique_ptr<StreamThread>> threads_;
+  std::shared_mutex threads_mtx_;
   std::condition_variable completion_cv;
   std::mutex mtx;
 };
-
-template <typename F>
-void Scheduler::enqueue(const Stream& stream, F&& f) {
-  threads_[stream.index]->enqueue(std::forward<F>(f));
-}
 
 MLX_API Scheduler& scheduler();
 

--- a/mlx/stream.cpp
+++ b/mlx/stream.cpp
@@ -3,7 +3,7 @@
 #include "mlx/stream.h"
 #include "mlx/backend/cpu/device_info.h"
 #include "mlx/backend/gpu/device_info.h"
-#include "mlx/scheduler.h"
+#include "mlx/backend/gpu/eval.h"
 
 #include <array>
 #include <map>
@@ -68,7 +68,6 @@ Stream new_stream(Device d) {
   std::unique_lock lock(mtx);
   int index = streams.size();
   auto& s = streams.emplace_back(index, d);
-  scheduler::scheduler().new_thread(d.type);
   if (d == Device::gpu) {
     gpu::new_stream(s);
   }


### PR DESCRIPTION
Fix a race condition caused by `Scheduler::enqueue` not using locks when reading `threads_` which might be updated concurrently.

```console
===============================================================================
/home/runner/work/mlx/mlx/tests/scheduler_tests.cpp:107:
TEST CASE:  test thread local stream

/home/runner/work/mlx/mlx/tests/scheduler_tests.cpp:107: FATAL ERROR: test case CRASHED: SIGSEGV - Segmentation violation signal

===============================================================================
[doctest] test cases:  212 |  211 passed | 1 failed | 20 skipped
[doctest] assertions: 3024 | 3024 passed | 0 failed |
[doctest] Status: FAILURE!
    #0 0xff050d0d3410 in __pthread_mutex_lock (/lib/aarch64-linux-gnu/libc.so.6+0x83410)
    #1 0xab086196f06c in __gthread_mutex_lock /usr/include/aarch64-linux-gnu/c++/11/bits/gthr-default.h:749
    #2 0xab086196f7fc in std::mutex::lock() /usr/include/c++/11/bits/std_mutex.h:100
    #3 0xab086197a204 in std::lock_guard<std::mutex>::lock_guard(std::mutex&) /usr/include/c++/11/bits/std_mutex.h:229
    #4 0xab08639fcdf8 in enqueue<mlx::core::Fence::wait(mlx::core::Stream, const mlx::core::array&)::<lambda()> > /home/runner/work/mlx/mlx/mlx/scheduler.h:56
    #5 0xab08639fcae0 in enqueue<mlx::core::Fence::wait(mlx::core::Stream, const mlx::core::array&)::<lambda()> > /home/runner/work/mlx/mlx/mlx/scheduler.h:124
    #6 0xab08639fc838 in enqueue<mlx::core::Fence::wait(mlx::core::Stream, const mlx::core::array&)::<lambda()> > /home/runner/work/mlx/mlx/mlx/scheduler.h:131
    #7 0xab08639fbf4c in mlx::core::Fence::wait(mlx::core::Stream, mlx::core::array const&) /home/runner/work/mlx/mlx/mlx/backend/no_gpu/fence.cpp:26
    #8 0xab08626e0610 in mlx::core::eval_impl(std::vector<mlx::core::array, std::allocator<mlx::core::array> >, bool) /home/runner/work/mlx/mlx/mlx/transforms.cpp:247
    #9 0xab08626e1fb0 in mlx::core::eval(std::vector<mlx::core::array, std::allocator<mlx::core::array> >) /home/runner/work/mlx/mlx/mlx/transforms.cpp:344
    #10 0xab08621ca684 in mlx::core::array::eval() /home/runner/work/mlx/mlx/mlx/array.cpp:157
```