### PR TITLE
Gate NAX JIT sources by macOS SDK version

### DIFF
--- a/mlx/backend/metal/CMakeLists.txt
+++ b/mlx/backend/metal/CMakeLists.txt
@@ -83,19 +83,45 @@ if(MLX_METAL_JIT)
 
   make_jit_source(steel/attn/kernels/steel_attention)
 
-  make_jit_source(
-    steel/gemm/gemm_nax kernels/steel/utils.h kernels/steel/gemm/nax.h
-    kernels/steel/gemm/params.h kernels/steel/gemm/transforms.h)
-  make_jit_source(steel/gemm/kernels/steel_gemm_fused_nax)
-  make_jit_source(steel/gemm/kernels/steel_gemm_gather_nax)
-  make_jit_source(steel/gemm/kernels/steel_gemm_splitk_nax)
-  make_jit_source(steel/gemm/kernels/steel_gemm_segmented_nax)
+  # NAX JIT sources transitively #include
+  # <MetalPerformancePrimitives/MetalPerformancePrimitives.h>, which only ships
+  # with the macOS 26.2+ SDK. The AOT branch in kernels/CMakeLists.txt already
+  # gates NAX by the same SDK check; mirror it here so JIT=ON can also be built
+  # on older SDKs. When gated out, MLX_METAL_NO_NAX is defined so
+  # is_nax_available() returns false at runtime, and we emit empty-string stubs
+  # for the NAX JIT source providers so jit_kernels.cpp still links.
+  if((MLX_METAL_VERSION GREATER_EQUAL 400) AND (MACOS_SDK_VERSION GREATER_EQUAL
+                                                26.2))
+    make_jit_source(
+      steel/gemm/gemm_nax kernels/steel/utils.h kernels/steel/gemm/nax.h
+      kernels/steel/gemm/params.h kernels/steel/gemm/transforms.h)
+    make_jit_source(steel/gemm/kernels/steel_gemm_fused_nax)
+    make_jit_source(steel/gemm/kernels/steel_gemm_gather_nax)
+    make_jit_source(steel/gemm/kernels/steel_gemm_splitk_nax)
+    make_jit_source(steel/gemm/kernels/steel_gemm_segmented_nax)
 
-  make_jit_source(quantized_nax kernels/quantized_utils.h)
-  make_jit_source(fp_quantized_nax kernels/quantized_utils.h kernels/fp8.h
-                  kernels/fp4.h)
+    make_jit_source(quantized_nax kernels/quantized_utils.h)
+    make_jit_source(fp_quantized_nax kernels/quantized_utils.h kernels/fp8.h
+                    kernels/fp4.h)
 
-  make_jit_source(steel/attn/kernels/steel_attention_nax)
+    make_jit_source(steel/attn/kernels/steel_attention_nax)
+  else()
+    target_compile_definitions(mlx PRIVATE MLX_METAL_NO_NAX)
+    set(_nax_stub_cpp "${CMAKE_CURRENT_BINARY_DIR}/jit/nax_stubs.cpp")
+    file(
+      WRITE "${_nax_stub_cpp}"
+      "namespace mlx::core::metal {\n"
+      "const char* gemm_nax() { return \"\"; }\n"
+      "const char* steel_gemm_fused_nax() { return \"\"; }\n"
+      "const char* steel_gemm_gather_nax() { return \"\"; }\n"
+      "const char* steel_gemm_splitk_nax() { return \"\"; }\n"
+      "const char* steel_gemm_segmented_nax() { return \"\"; }\n"
+      "const char* quantized_nax() { return \"\"; }\n"
+      "const char* fp_quantized_nax() { return \"\"; }\n"
+      "const char* steel_attention_nax() { return \"\"; }\n"
+      "}\n")
+    target_sources(mlx PRIVATE "${_nax_stub_cpp}")
+  endif()
 
 else()
   target_sources(mlx PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/nojit_kernels.cpp)


### PR DESCRIPTION
## Proposed changes

When `MLX_METAL_JIT=ON`, `backend/metal/CMakeLists.txt` unconditionally invokes `make_jit_source()` on the NAX kernel sources. Those headers transitively `#include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>`, which only ships with the macOS 26.2+ SDK, so JIT builds currently fail on older SDKs (e.g. Xcode 15.x on GitHub-hosted `macos-14` runners):

```
fatal error: 'MetalPerformancePrimitives/MetalPerformancePrimitives.h' file not found
  included from vendor/mlx/mlx/backend/metal/kernels/steel/gemm/nax.h:12
```

The AOT branch in `kernels/CMakeLists.txt` already gates NAX by the same SDK check (`MLX_METAL_VERSION GREATER_EQUAL 400 AND MACOS_SDK_VERSION GREATER_EQUAL 26.2`). This PR mirrors that gate in the JIT branch:

- When the SDK gate passes: no behavioural change — NAX JIT sources are emitted as before.
- When it fails: define `MLX_METAL_NO_NAX` (so `is_nax_available()` returns `false` at runtime) and emit a tiny generated `nax_stubs.cpp` with empty-string stubs for the NAX JIT source providers (`metal::gemm_nax`, `metal::quantized_nax`, …). The stubs are needed only so `jit_kernels.cpp` still links; they are never exercised at runtime because the NAX code paths are guarded by `is_nax_available()`.

On older SDKs, `MLX_METAL_JIT=ON` now produces the same no-NAX binary that `MLX_METAL_JIT=OFF` already does — it just uses the JIT path for the non-NAX kernels.

### Context

Discovered while plumbing `MLX_METAL_JIT=ON` through a downstream consumer's CI (GitHub-hosted `macos-14` / Xcode 15.x). MLX's own CI builds JIT on a self-hosted runner with Xcode 26, so the upstream CI does not currently exercise the JIT path on older SDKs.

### Tested

- Local build on macOS 26.4 / Xcode 26 — SDK gate passes, all NAX JIT sources emitted, behaviour identical to current main.
- Build + run the downstream consumer's full test suite with `MLX_METAL_JIT=ON` on GitHub-hosted `macos-14` — previously broken at the `nax.h` preprocess step, now links and passes after this patch.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes — CMake-only change; happy to run `cmake-format` if the maintainers prefer a specific output.
- [x] I have added tests that prove my fix is effective or that my feature works — no test changes; this is a build-system guard mirroring an existing one.
- [x] I have updated the necessary documentation (if needed) — no public doc change.