### PR TITLE
Fix kernel cache collision in Compiled constructor

### DIFF
--- a/mlx/compile.cpp
+++ b/mlx/compile.cpp
@@ -137,8 +137,9 @@ Compiled::Compiled(
     }
   }
   os << "_";
-  for (const auto& x : inputs) {
-    if (constant_ids.find(x.id()) != constant_ids.end()) {
+  // Iterate the moved-into members; the parameters are moved-from above.
+  for (const auto& x : inputs_) {
+    if (constant_ids_.find(x.id()) != constant_ids_.end()) {
       continue;
     }
     os << kindof(x.dtype()) << x.itemsize();


### PR DESCRIPTION
The constructor moves `inputs` and `constant_ids` into members but the loop building `kernel_lib_` continued to iterate the moved-from parameters. After the move those parameters are empty, so the kernel name omits the per-input dtype suffix and a kernel compiled for one input type can be incorrectly reused for another. With ops fused around the cast (e.g. chained `astype` feeding `matmul` or `einsum`), this surfaces as byte-level corruption of the output.

Reproducer:

```python
import mlx.core as mx

def f(x_u16, y_i8):
    a = x_u16.astype(mx.int32)
    b = y_i8.astype(mx.int32)
    af = a.astype(mx.float32)
    bf = b.astype(mx.float32)
    return mx.matmul(bf.reshape(2, 1), af.reshape(1, 2))

x = mx.array([10, 20], dtype=mx.uint16)
y = mx.array([1, 2], dtype=mx.int8)
print(f(x, y))                 # [[10, 20], [20, 40]]
print(mx.compile(f)(x, y))     # [[5130, 10260], [0, 0]]  <-- wrong
```

`5130 = 0x140A` is the little-endian byte pattern of the two `uint16` inputs packed into one `int32`, confirming the kernel was specialized for the wrong dtype.

Switching the loop to use the `inputs_` / `constant_ids_` members restores the dtype suffix and the bug goes away.

Verified locally against the issue reproducer, exhaustive dtype matrix, and fresh-process isolation tests (44/44 + 9/9 pass). I can add an inline regression test if you guys would like a specific format / location. 

Fixes #3338.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
