### PR TITLE
Throw meaningful error when Metal device is not found

### DIFF
--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -50,10 +50,21 @@ auto get_metal_version() {
 NS::SharedPtr<MTL::Device> load_device() {
   auto pool = new_scoped_memory_pool();
   auto devices = NS::TransferPtr(MTL::CopyAllDevices());
-  auto device = NS::RetainPtr(static_cast<MTL::Device*>(devices->object(0)))
-      ?: NS::TransferPtr(MTL::CreateSystemDefaultDevice());
+  // In headless, sandboxed, or virtualized macOS sessions CopyAllDevices()
+  // returns an empty NSArray. Indexing object(0) on an empty array raises
+  // an unrecoverable NSRangeException, so guard the access and fall back to
+  // CreateSystemDefaultDevice (which can also return null).
+  MTL::Device* first = nullptr;
+  if (devices && devices->count() > 0) {
+    first = static_cast<MTL::Device*>(devices->object(0));
+  }
+  auto device = first ? NS::RetainPtr(first)
+                      : NS::TransferPtr(MTL::CreateSystemDefaultDevice());
   if (!device) {
-    throw std::runtime_error("Failed to load device");
+    throw std::runtime_error(
+        "[metal::load_device] No Metal device available. This typically "
+        "occurs in headless, sandboxed, or virtualized macOS sessions "
+        "where the GPU is not accessible.");
   }
   return device;
 }


### PR DESCRIPTION
## Proposed changes                                                                                                                                                                                                                                                
                                               
  In headless, sandboxed, or virtualized macOS sessions (PyInstaller                                                                                                                                                                                                 
  bundles, CI containers, automation runs) `MTL::CopyAllDevices()` returns
  an empty NSArray. The current code immediately calls `devices->object(0)`,                                                                                                                                                                                         
  which raises an Objective-C `NSRangeException` that aborts the process
  before the Python layer can catch it.                                                                                                                                                                                                                              
                                                       
  Guard the access with a `count() > 0` check and surface a clear                                                                                                                                                                                                    
  `std::runtime_error` if both `CopyAllDevices()` and  
  `CreateSystemDefaultDevice()` fail. The fallback path is preserved.                                                                                                                                                                                                
   
   This is the guard @awni proposed on the issue thread.                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                     
  Refs #3148.                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                     
  Verified locally: GPU build still loads and the full `python/tests/`
  suite passes (662 passed, 9007 subtests, 0 regressions); patch source
  review confirms guard + fallback + clear error message.


## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
