### PR TITLE
Fix bytes_per_key truncation in random kernels (Metal + CUDA)

### DIFF
--- a/mlx/backend/cuda/random.cu
+++ b/mlx/backend/cuda/random.cu
@@ -49,7 +49,7 @@ __global__ void rbitsc(
     uint8_t* out,
     dim3 grid_dims,
     bool odd,
-    uint32_t bytes_per_key) {
+    uint64_t bytes_per_key) {
   auto grid = cg::this_grid();
   uint32_t thread_index = grid.thread_rank();
   uint32_t index_x = thread_index % grid_dims.x;
@@ -89,7 +89,7 @@ __global__ void rbits(
     uint8_t* out,
     dim3 grid_dims,
     bool odd,
-    uint32_t bytes_per_key,
+    uint64_t bytes_per_key,
     int32_t ndim,
     const __grid_constant__ Shape key_shape,
     const __grid_constant__ Strides key_strides) {

--- a/mlx/backend/metal/kernels/random.metal
+++ b/mlx/backend/metal/kernels/random.metal
@@ -35,7 +35,7 @@ rbits threefry2x32_hash(const thread uint2& key, uint2 count) {
     device const uint32_t* keys,
     device char* out,
     constant const bool& odd,
-    constant const uint& bytes_per_key,
+    constant const ulong& bytes_per_key,
     uint2 grid_dim [[threads_per_grid]],
     uint2 index [[thread_position_in_grid]]) {
   auto kidx = 2 * index.x;
@@ -68,7 +68,7 @@ rbits threefry2x32_hash(const thread uint2& key, uint2 count) {
     device const uint32_t* keys,
     device char* out,
     constant const bool& odd,
-    constant const uint& bytes_per_key,
+    constant const ulong& bytes_per_key,
     constant const int& ndim,
     constant const int* key_shape,
     constant const int64_t* key_strides,


### PR DESCRIPTION
C++ passes bytes_per_key as size_t (8 bytes) but the kernels declared it as uint/uint32_t, truncating values above UINT32_MAX. Promote the kernel parameter to ulong/uint64_t so the full 64-bit value is read.

no measurable performance impact.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
