### PR TITLE
Fix mx.prod vjp for complex types

### DIFF
--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -3951,7 +3951,7 @@ std::vector<array> Reduce::vjp(
           auto p1 = cumprod(x, axis, /*reverse=*/false, /*inclusive=*/false, s);
           auto p2 = cumprod(x, axis, /*reverse=*/true, /*inclusive=*/false, s);
           auto exclusive_prod = multiply(p1, p2, s);
-          return multiply(exclusive_prod, cotan, s);
+          return multiply(conjugate(exclusive_prod, s), cotan, s);
         };
 
     // To compute a numerically stable gradient for prod we need an exclusive

--- a/python/tests/test_autograd.py
+++ b/python/tests/test_autograd.py
@@ -966,6 +966,27 @@ class TestAutograd(mlx_tests.MLXTestCase):
         out, jout = mx.jvp(mx.max, primals=(a,), tangents=(b,))
         self.assertEqual(jout[0].item(), 0)
 
+    def test_complex_prod_vjp(self):
+        def prod(x):
+            return x.prod(axis=0)
+
+        primal = mx.random.normal((2, 20), dtype=mx.complex64)
+        cotangent = mx.random.normal((20,), dtype=mx.complex64)
+
+        _, vjps = mx.vjp(prod, [primal], [cotangent])
+
+        expected = mx.stack(
+            [mx.conj(primal[1]) * cotangent, mx.conj(primal[0]) * cotangent]
+        )
+
+        # Check against hand-computed vjps
+        self.assertTrue(mx.array_equal(vjps[0], expected))
+
+        # Ensure that prod agrees with multiply for complex values
+        _, vjps_multiply = mx.vjp(mx.multiply, [primal[0], primal[1]], [cotangent])
+
+        self.assertTrue(mx.array_equal(mx.stack(vjps_multiply), vjps[0]))
+
 
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner()


### PR DESCRIPTION
## Fix bug in VJP for Product Reduction

I was running some experiments and noticed some strange gradient behavior. After some digging, it turned out the issue was with how `mx.prod` handles complex numbers. My understanding is that MLX uses the conjugate-transpose formulation as seen in `Matmul::vjp` here:

```c++
std::vector<array> Matmul::vjp(
    const std::vector<array>& primals,
    const std::vector<array>& cotangents,
    const std::vector<int>& argnums,
    const std::vector<array>&) {
  std::vector<array> vjps;
  auto& cotan = cotangents[0];
  std::vector<int> reorder(cotan.ndim());
  std::iota(reorder.begin(), reorder.end(), 0);
  std::iter_swap(reorder.end() - 1, reorder.end() - 2);
  auto& s = stream();

  auto complex_transpose = [&](const array& x) {
    return transpose(conjugate(x, s), reorder, s);
  };

  for (auto arg : argnums) {
    if (arg == 0) {
      // M X N * (K X N).T -> M X K
      vjps.push_back(matmul(cotan, complex_transpose(primals[1]), s));
    } else {
      // (M X K).T * M X N -> K X N
      vjps.push_back(matmul(complex_transpose(primals[0]), cotan, s));
    }
  }
  return vjps;
}
```

And also in `Multiply::vjp` here:

```c++
std::vector<array> Multiply::vjp(
    const std::vector<array>& primals,
    const std::vector<array>& cotangents,
    const std::vector<int>& argnums,
    const std::vector<array>&) {
  std::vector<array> vjps;
  for (auto arg : argnums) {
    vjps.push_back(multiply(
        conjugate(primals[1 - arg], stream()), cotangents[0], stream()));
  }
  return vjps;
}
```

This PR fixes `Reduce::vjp` to use the same convention by conjugating `exclusive_prod` before multiplying it with the cotangent.

I added a test which checks that the updated vjp agrees both with a hand-computed version as well as with the vjp implementation of `multiply`, since they should always agree. I also tested these changes in a toy example and in a tiny experiment and the gradient divergence issues I was seeing before are gone now.

To my knowledge, no documentation needs to be updated.

One thing to note is that there may be other operations in MLX which also fail to follow this convention. I have checked `fft`, `ifft`, and `multiply` since those are the other ops I was using at the time, and those appear to be fine.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
