### PR TITLE
fix: respect MLX_DISTRIBUTED_BACKEND env var in init(backend='any')

### DIFF
--- a/mlx/distributed/distributed.cpp
+++ b/mlx/distributed/distributed.cpp
@@ -159,6 +159,14 @@ Group init(bool strict /* = false */, const std::string& bk /* = "any" */) {
   } else if (bk == "jaccl") {
     group = jaccl::init(strict);
   } else if (bk == "any") {
+    // Check if the launcher specified a preferred backend via env var.
+    // This prevents the wrong backend from being selected when
+    // mlx.launch --backend jaccl sets JACCL env vars but ring::init()
+    // succeeds first as a singleton (MLX_RANK is set, MLX_HOSTFILE is not).
+    auto env_bk = std::getenv("MLX_DISTRIBUTED_BACKEND");
+    if (env_bk && *env_bk) {
+      return init(strict, std::string(env_bk));
+    }
     if (mlx::core::cu::is_available()) {
       group = nccl::init(false);
       bk_ = "nccl";

--- a/python/mlx/_distributed_utils/launch.py
+++ b/python/mlx/_distributed_utils/launch.py
@@ -377,6 +377,7 @@ def launch_jaccl(parser, hosts, args, command):
     env = args.env
     cwd = args.cwd
     env.append(f"MLX_JACCL_COORDINATOR={coordinator}:{args.starting_port}")
+    env.append(f"MLX_DISTRIBUTED_BACKEND={'jaccl-ring' if jaccl_ring else 'jaccl'}")
     if jaccl_ring:
         env.append("MLX_JACCL_RING=1")
     files = {"MLX_IBV_DEVICES": json.dumps([h.rdma for h in hosts])}


### PR DESCRIPTION
## Problem

When `mlx.launch --backend jaccl` launches a script, it sets JACCL-specific env vars (`MLX_JACCL_COORDINATOR`, `MLX_IBV_DEVICES`), but the launched script typically calls `mx.distributed.init()` without specifying a backend (defaults to `backend="any"`).

With `backend="any"`, the try order in `distributed.cpp` is: **nccl -> ring -> mpi -> jaccl**. On Mac (no CUDA), `ring::init(false)` is tried first. It sees `MLX_RANK` (set by the launcher) but no `MLX_HOSTFILE` (not set for JACCL launches), so it creates a **singleton group of size 1** and returns it as "successful." JACCL is never attempted.

The result: distributed inference launched with `--backend jaccl` silently falls back to single-node. This affects `mlx_lm.server`, `mlx_lm.chat`, and any user script that calls `init()` without explicitly specifying `backend="jaccl"`.

### Reproduction

```bash
# Launch with JACCL backend
mlx.launch --backend jaccl --hostfile hosts.json -- \
  python3 -c "import mlx.core as mx; g = mx.distributed.init(); print(f'size={g.size()}')"

# Expected: size=2 (or however many nodes)
# Actual: size=1 (ring singleton won the race)
```

## Fix

Two-line fix across two files:

1. **launch.py**: `launch_jaccl()` now sets `MLX_DISTRIBUTED_BACKEND=jaccl` (or `jaccl-ring`) as an env var on all launched processes.

2. **distributed.cpp**: `init(backend="any")` checks for `MLX_DISTRIBUTED_BACKEND` env var before trying the default order. If set, it delegates to `init(strict, env_backend)` directly.

This is **backwards-compatible**:
- The env var is only set by `mlx.launch` -- direct calls to `init()` are unaffected
- Programs that call `init(backend="jaccl")` explicitly are unaffected
- The env var acts as a hint, not a requirement

## Testing

Tested on a 3-node M3 Ultra cluster connected via Thunderbolt 5 RDMA. Before the fix, `mlx_lm.server` launched with `--backend jaccl` reported `world_size=1`. After the fix, it correctly initializes JACCL and reports the correct world size.

## Related

- #3418 -- Fix jaccl init bug (C++ null optional dereference, different issue)
- #3412 -- Jaccl refactor (standalone lib extraction)

Our workaround for this bug has been deployed on production clusters since March 2026 as a Python import hook. This PR is the proper upstream fix.