### PR TITLE
[CUDA] Fix qmm_naive K-tail dispatch for FP quantized kernels

### DIFF
--- a/mlx/backend/cuda/quantized/qmm/qmm.cu
+++ b/mlx/backend/cuda/quantized/qmm/qmm.cu
@@ -265,7 +265,7 @@ void qmm_naive(
     if constexpr (k_major.value) {
       if (has_k_residue) {
         throw std::invalid_argument(
-            "[quantized_matmul] K must be multiples of group_size.");
+            "[quantized_matmul] K must be multiples of max(64, group_size).");
       }
       f.template operator()<false>();
     } else {

--- a/mlx/backend/cuda/quantized/qmm/qmm.cu
+++ b/mlx/backend/cuda/quantized/qmm/qmm.cu
@@ -276,7 +276,8 @@ void qmm_naive(
   };
   int m = out.ndim() > 1 ? out.shape(-2) : 1;
   int k = x.shape(-1);
-  bool has_k_residue = k % group_size != 0;
+  int tile_k = std::max(64, group_size);
+  bool has_k_residue = k % tile_k != 0;
   bool sm80 = encoder.device().compute_capability_major() >= 8;
   dispatch_bool(transpose, [&](auto k_major) {
     dispatch_k(k_major, has_k_residue, [&]<bool HasKResidue>() {


### PR DESCRIPTION
Fixes: #3444

## Root Cause

In [qmm.cu](mlx/backend/cuda/quantized/qmm/qmm.cu), `qmm_naive` selected the `HasKResidue` specialization using:

```cpp
bool has_k_residue = k % group_size != 0;
```

but the kernel tiles the K dimension using `max(64, group_size)`.

For FP quantization modes:

- `mxfp4` / `mxfp8` use `group_size = 32`
- `nvfp4` uses `group_size = 16`

So shapes like `K=544` satisfy:

- `K % group_size == 0`
- `K % 64 != 0`

The old dispatch therefore selected the no-residue specialization even when the kernel still had a real K tail.

## Fix

Change the residue check to match the kernel's actual K tiling
