### PR TITLE
Handle non-multiple-of-8 spatial dims in depthwise conv2d Metal path

### DIFF
--- a/mlx/backend/metal/conv.cpp
+++ b/mlx/backend/metal/conv.cpp
@@ -962,7 +962,9 @@ void depthwise_conv_2D_gpu(
 
   MTL::Size group_dims = MTL::Size(tc, tw, th);
   MTL::Size grid_dims = MTL::Size(
-      conv_params.C / tc, conv_params.oS[1] / tw, (conv_params.oS[0] / th) * N);
+      conv_params.C / tc,
+      (conv_params.oS[1] + tw - 1) / tw,
+      ((conv_params.oS[0] + th - 1) / th) * N);
 
   compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
 }
@@ -986,7 +988,6 @@ void dispatch_conv_2D_gpu(
     if (C_per_group == 1 && O_per_group == 1 && is_kdil_one &&
         conv_params.wS[0] <= 7 && conv_params.wS[1] <= 7 &&
         conv_params.str[0] <= 2 && conv_params.str[1] <= 2 &&
-        conv_params.oS[0] % 8 == 0 && conv_params.oS[1] % 8 == 0 &&
         conv_params.wt_strides[1] == conv_params.wS[1] &&
         conv_params.C % 16 == 0 && conv_params.C == conv_params.O) {
       return depthwise_conv_2D_gpu(s, d, in, wt, out, conv_params);

--- a/mlx/backend/metal/kernels/conv.metal
+++ b/mlx/backend/metal/kernels/conv.metal
@@ -206,7 +206,7 @@ template <typename T>
 
   threadgroup T ins[TGH * TGW * TGC];
 
-  const int n_tgblocks_h = params.oS[0] / th;
+  const int n_tgblocks_h = (params.oS[0] + th - 1) / th;
   const int n = tid.z / n_tgblocks_h;
   const int tghid = tid.z % n_tgblocks_h;
   const int oh = tghid * th + lid.z;
@@ -276,6 +276,10 @@ template <typename T>
     }
   }
   threadgroup_barrier(mem_flags::mem_none);
+
+  if (oh >= params.oS[0] || ow >= params.oS[1]) {
+    return;
+  }
 
   out += n * params.out_strides[0] + oh * params.out_strides[1] +
       ow * params.out_strides[2];

--- a/tests/gpu_tests.cpp
+++ b/tests/gpu_tests.cpp
@@ -563,3 +563,43 @@ TEST_CASE("test scatter_prod with NaN does not hang") {
     CHECK(std::isnan(out.data<float>()[0]));
   }
 }
+
+TEST_CASE("test gpu depthwise conv2d non-mod-8 spatial") {
+  // Depthwise Metal kernel is gated on C_per_group == 1, C == O, C % 16 == 0,
+  // kernel <= 7, stride <= 2. Previously the dispatch also required the
+  // output spatial dims to be multiples of 8; non-multiples fell back to the
+  // gemm path. These cases exercise the tail-tile dispatch now handled by
+  // the depthwise kernel itself and verify GPU ≈ CPU.
+  struct Case {
+    int N, H, W, C, kH, kW;
+    std::pair<int, int> stride;
+    std::pair<int, int> padding;
+  };
+  std::vector<Case> cases = {
+      // Matches the issue reproducer resolutions, reduced batch.
+      {1, 15, 15, 16, 3, 3, {1, 1}, {1, 1}},
+      {1, 30, 30, 32, 3, 3, {1, 1}, {1, 1}},
+      {1, 60, 60, 16, 3, 3, {1, 1}, {1, 1}},
+      // Non-square and non-matching alignment on the two spatial axes.
+      {1, 17, 30, 16, 5, 5, {1, 1}, {2, 2}},
+      {1, 8, 13, 16, 3, 3, {1, 1}, {1, 1}},
+      // Stride 2 with non-mod-8 output.
+      {1, 19, 19, 32, 3, 3, {2, 2}, {1, 1}},
+  };
+
+  auto key = random::key(42);
+  for (const auto& c : cases) {
+    auto in = random::normal(
+        {c.N, c.H, c.W, c.C}, float32, 0.0f, 1.0f, key, Device::cpu);
+    auto wt = random::normal(
+        {c.C, c.kH, c.kW, 1}, float32, 0.0f, 1.0f, key, Device::cpu);
+    eval(in);
+    eval(wt);
+
+    auto out_cpu =
+        conv2d(in, wt, c.stride, c.padding, {1, 1}, c.C, Device::cpu);
+    auto out_gpu =
+        conv2d(in, wt, c.stride, c.padding, {1, 1}, c.C, Device::gpu);
+    CHECK(allclose(out_cpu, out_gpu, 1e-4, 1e-4).item<bool>());
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #3324. Relaxes the `oS % 8 == 0` dispatch gate on the depthwise Metal kernel and makes it tail-aware, so non-mod-8 output spatial dims stay on the fast path instead of falling back to the gemm path.

## Root cause

`depthwise_conv_2D_gpu` dispatches `(tc=8, tw=8, th=4)` threadgroups across `(C/tc, oW/tw, (oH/th)*N)`. In `dispatch_conv_2D_gpu` the selection guard is

```cpp
conv_params.oS[0] % 8 == 0 && conv_params.oS[1] % 8 == 0
```

so any non-mod-8 output spatial shape routes to `implicit_gemm_conv_2D_gpu` / `explicit_gemm_conv_group_ND_gpu`, which is 2-5x slower for depthwise on M-series. The issue title says "mod 16" but the real boundary is mod 8: `240` (not mod 16, but mod 8) stays on the fast path, while `60`, `30`, `15` do not.

## Change

- `mlx/backend/metal/conv.cpp`
  - `depthwise_conv_2D_gpu`: ceil-div `grid_dims` for the two spatial dims so tail tiles are dispatched.
  - `dispatch_conv_2D_gpu`: drop the `oS % 8 == 0` guard.
- `mlx/backend/metal/kernels/conv.metal`
  - `depthwise_conv_2d`: ceil-div `n_tgblocks_h` to match the dispatch, and early-return from threads whose `oh` / `ow` are past `oS` before the output store. The shared-memory input load is already bounds-checked (`ih`/`iw` guards), and out-of-range threads still cooperate in that load, so only the final store needs guarding.

The C, kernel-size, stride, and `wt_strides` constraints on the depthwise path are unchanged.

## Perf (M5 32GB, issue reproducer, 3x3 / pad=1 / stride=1 / depthwise, median of 3 runs)

| channels | res    | baseline ms | patched ms | speedup |
|---------:|:-------|------------:|-----------:|--------:|
|      384 | 60x60  |        1.64 |       0.34 | **4.8x**|
|      768 | 30x30  |        0.94 |       0.28 | **3.4x**|
|     1536 | 15x15  |        0.61 |       0.23 | **2.7x**|

Mod-8 shapes are unchanged (within +/-2% across runs). The previously-slow shapes now match their mod-8 siblings: `60x60 @ 384ch` is `0.34 ms` vs `64x64 @ 384ch` at `0.35 ms`.

## Tests

- Added `test gpu depthwise conv2d non-mod-8 spatial` in `tests/gpu_tests.cpp`. It computes depthwise conv2d on GPU and CPU for six shapes (issue reproducer sizes, non-square, asymmetric spatial alignment, stride 2) and asserts `allclose` at `1e-4`.
- Full `./build/tests/tests` suite: 245 passed, 0 failed.

## Checklist

- [x] Ran `clang-format` on all changed files (no changes).
- [x] Added a test (`tests/gpu_tests.cpp`).
- [x] Benchmarked before / after, numbers above.
- [x] No API changes; no doc changes needed.