### PR TITLE
Validate GGUF tensor dimensions

### DIFF
--- a/mlx/io/CMakeLists.txt
+++ b/mlx/io/CMakeLists.txt
@@ -13,11 +13,13 @@ if(MLX_BUILD_GGUF)
     GIT_REPOSITORY https://github.com/antirez/gguf-tools/
     GIT_TAG 8fa6eb65236618e28fd7710a0fba565f7faa1848)
   FetchContent_MakeAvailable(gguflib)
-  target_include_directories(mlx
-                             PRIVATE $<BUILD_INTERFACE:${gguflib_SOURCE_DIR}>)
-  add_library(gguflib STATIC ${gguflib_SOURCE_DIR}/fp16.c
+  add_library(gguflib OBJECT ${gguflib_SOURCE_DIR}/fp16.c
                              ${gguflib_SOURCE_DIR}/gguflib.c)
-  target_link_libraries(mlx PRIVATE $<BUILD_INTERFACE:gguflib>)
+  target_include_directories(gguflib
+                             PUBLIC $<BUILD_INTERFACE:${gguflib_SOURCE_DIR}>)
+  target_include_directories(
+    mlx PRIVATE $<TARGET_PROPERTY:gguflib,INTERFACE_INCLUDE_DIRECTORIES>)
+  target_sources(mlx PRIVATE $<TARGET_OBJECTS:gguflib>)
   target_sources(mlx PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/gguf.cpp
                              ${CMAKE_CURRENT_SOURCE_DIR}/gguf_quants.cpp)
 else()

--- a/mlx/io/CMakeLists.txt
+++ b/mlx/io/CMakeLists.txt
@@ -13,14 +13,11 @@ if(MLX_BUILD_GGUF)
     GIT_REPOSITORY https://github.com/antirez/gguf-tools/
     GIT_TAG 8fa6eb65236618e28fd7710a0fba565f7faa1848)
   FetchContent_MakeAvailable(gguflib)
-  add_library(gguflib OBJECT ${gguflib_SOURCE_DIR}/fp16.c
-                             ${gguflib_SOURCE_DIR}/gguflib.c)
-  target_include_directories(gguflib
-                             PUBLIC $<BUILD_INTERFACE:${gguflib_SOURCE_DIR}>)
-  target_include_directories(
-    mlx PRIVATE $<TARGET_PROPERTY:gguflib,INTERFACE_INCLUDE_DIRECTORIES>)
-  target_sources(mlx PRIVATE $<TARGET_OBJECTS:gguflib>)
-  target_sources(mlx PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/gguf.cpp
+  target_include_directories(mlx
+                             PRIVATE $<BUILD_INTERFACE:${gguflib_SOURCE_DIR}>)
+  target_sources(mlx PRIVATE ${gguflib_SOURCE_DIR}/fp16.c
+                             ${gguflib_SOURCE_DIR}/gguflib.c
+                             ${CMAKE_CURRENT_SOURCE_DIR}/gguf.cpp
                              ${CMAKE_CURRENT_SOURCE_DIR}/gguf_quants.cpp)
 else()
   target_sources(mlx PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/no_gguf.cpp)

--- a/mlx/io/gguf.cpp
+++ b/mlx/io/gguf.cpp
@@ -4,6 +4,8 @@
 #include <cstring>
 #include <fstream>
 #include <numeric>
+#include <sstream>
+#include <stdexcept>
 
 #include "mlx/io/gguf.h"
 #include "mlx/ops.h"
@@ -48,6 +50,13 @@ std::optional<Dtype> gguf_type_to_dtype(const uint32_t& gguf_type) {
 }
 
 Shape get_shape(const gguf_tensor& tensor) {
+  if (tensor.ndim > GGUF_TENSOR_MAX_DIM) {
+    std::ostringstream msg;
+    msg << "[load_gguf] tensor has too many dimensions: " << tensor.ndim
+        << " > " << GGUF_TENSOR_MAX_DIM;
+    throw std::runtime_error(msg.str());
+  }
+
   Shape shape;
   // The dimension order in GGML is the reverse of the order used in MLX.
   for (int i = tensor.ndim - 1; i >= 0; i--) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,12 @@ target_sources(
           ${METAL_TEST_SOURCES})
 
 target_link_libraries(tests PRIVATE mlx doctest)
+target_compile_definitions(
+  tests PRIVATE MLX_TEST_BUILD_GGUF=$<BOOL:${MLX_BUILD_GGUF}>)
+if(MLX_BUILD_GGUF)
+  target_include_directories(
+    tests PRIVATE $<TARGET_PROPERTY:gguflib,INTERFACE_INCLUDE_DIRECTORIES>)
+endif()
 target_compile_options(tests PRIVATE ${SANITIZER_COMPILE_FLAGS})
 target_link_options(tests PRIVATE ${SANITIZER_LINK_FLAGS})
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,7 +41,7 @@ target_compile_definitions(
   tests PRIVATE MLX_TEST_BUILD_GGUF=$<BOOL:${MLX_BUILD_GGUF}>)
 if(MLX_BUILD_GGUF)
   target_include_directories(
-    tests PRIVATE $<TARGET_PROPERTY:gguflib,INTERFACE_INCLUDE_DIRECTORIES>)
+    tests PRIVATE $<BUILD_INTERFACE:${gguflib_SOURCE_DIR}>)
 endif()
 target_compile_options(tests PRIVATE ${SANITIZER_COMPILE_FLAGS})
 target_link_options(tests PRIVATE ${SANITIZER_LINK_FLAGS})

--- a/tests/load_tests.cpp
+++ b/tests/load_tests.cpp
@@ -7,6 +7,13 @@
 
 #include "doctest/doctest.h"
 
+#ifndef MLX_TEST_BUILD_GGUF
+#define MLX_TEST_BUILD_GGUF 0
+#endif
+
+#if MLX_TEST_BUILD_GGUF
+#include "mlx/io/gguf.h"
+#endif
 #include "mlx/mlx.h"
 
 using namespace mlx::core;
@@ -167,6 +174,14 @@ TEST_CASE("test gguf") {
     CHECK(array_equal(loaded_weights.at("test"), arr).item<bool>());
   }
 }
+
+#if MLX_TEST_BUILD_GGUF
+TEST_CASE("test gguf tensor ndim validation") {
+  gguf_tensor tensor{};
+  tensor.ndim = GGUF_TENSOR_MAX_DIM + 1;
+  CHECK_THROWS_AS(get_shape(tensor), std::runtime_error);
+}
+#endif
 
 TEST_CASE("test gguf metadata") {
   std::string file_path = get_temp_file("test_arr.gguf");


### PR DESCRIPTION
Fixes #3358.

## Summary
- Reject GGUF tensors whose `ndim` exceeds `GGUF_TENSOR_MAX_DIM` before converting tensor dimensions to an MLX shape, including both values in the error message.
- Add a regression test for malformed GGUF tensor rank.
- Compile gguflib sources directly into `mlx` via `target_sources` so downstream static-link consumers don't hit unresolved symbols, and expose gguflib headers only to MLX sources and the GGUF-specific test via `BUILD_INTERFACE`.

## Tests
```bash
clang-format -i mlx/io/gguf.cpp tests/load_tests.cpp
cmake -S . -B build-cpu -DMLX_BUILD_TESTS=ON -DMLX_BUILD_PYTHON_BINDINGS=OFF -DMLX_BUILD_METAL=OFF -DMLX_BUILD_EXAMPLES=OFF -DMLX_BUILD_BENCHMARKS=OFF
cmake --build build-cpu --target tests -j8
./build-cpu/tests/tests -tc="test gguf tensor ndim validation"
./build-cpu/tests/tests -tc="test gguf*"
git diff --check
```