### PR TITLE
Define ST_F8_E8M0

### DIFF
--- a/mlx/io/safetensors.cpp
+++ b/mlx/io/safetensors.cpp
@@ -28,6 +28,7 @@ using json = nlohmann::json;
 #define ST_U32 "U32"
 #define ST_U64 "U64"
 #define ST_F8_E4M3 "F8_E4M3"
+#define ST_F8_E8M0 "F8_E8M0"
 
 // Note: Complex numbers aren't in the spec yet so this could change -
 // https://github.com/huggingface/safetensors/issues/389
@@ -96,6 +97,8 @@ Dtype dtype_from_safetensor_str(std::string_view str) {
   } else if (str == ST_C64) {
     return complex64;
   } else if (str == ST_F8_E4M3) {
+    return uint8;
+  } else if (str == ST_F8_E8M0) {
     return uint8;
   } else {
     std::ostringstream msg;


### PR DESCRIPTION
Opening for discussion. I saw #3374, so perhaps this should go there instead. The goal is just to be able to load the native DeepSeek V4 safetensors files, since the [attention scales use F8_E8M0](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash/tree/main?show_file_info=model.safetensors.index.json).

If this direction is ok, I'm happy to add tests or update docs as needed.

## Proposed changes

Define ST_F8_E8M0 so loading safetensor files that include this type succeed. Handling would be deferred to `sanitize` functions in `mlx_lm` and other user code.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
