### PR TITLE
ci: use larger Windows runner to prevent OOM

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -79,7 +79,7 @@ jobs:
   windows_build_and_test:
     name: Windows (cpu, x86_64)
     needs: check_lint
-    runs-on: windows-2025
+    runs-on: windows-2025-large
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-windows


### PR DESCRIPTION
Switch from windows-2025 to windows-2025-large (8 cores, 32GB RAM) to handle heavy C++ template instantiations in the CPU backend.

## Proposed changes

The Windows CI job runs on a standard windows-2025 GitHub Actions runner which has limited RAM. Heavy template-heavy compilation units in the CPU backend (notably quantized.cpp, conv.cpp, indexing.cpp, and   
  reduce.cpp) can cause OOM when compiled in parallel with MSVC. This PR switches to windows-2025-large to provide sufficient memory headroom.                                                                    
                                                                                                                                                                                                                  
  Related to #3441 which addresses the same OOM class for CUDA builds via job pool serialization.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
