### PR TITLE
Add mx.metal.dispatch_count() for kernel-dispatch diagnostics

### DIFF
--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -1,5 +1,6 @@
 // Copyright © 2023-2024 Apple Inc.
 
+#include <atomic>
 #include <cstdlib>
 #include <sstream>
 
@@ -30,6 +31,13 @@ struct hash<NS::SharedPtr<T>> {
 namespace mlx::core::metal {
 
 namespace {
+
+// Global counter incremented on every Metal kernel dispatch (one per
+// dispatch_threadgroups / dispatch_threads call). Useful for fused-kernel
+// validation and dispatch-scheduling diagnostics: read after `eval()` to
+// know how many kernels a region of work compiled to. Relaxed ordering is
+// fine — the counter is observed only after a full eval barrier.
+std::atomic<uint64_t> g_dispatch_count_{0};
 
 constexpr const char* default_mtllib_path = METAL_PATH;
 
@@ -358,6 +366,7 @@ void CommandEncoder::dispatch_threadgroups(
     MTL::Size group_dims) {
   maybeInsertBarrier();
   buffer_ops_++;
+  g_dispatch_count_.fetch_add(1, std::memory_order_relaxed);
   get_command_encoder()->dispatchThreadgroups(grid_dims, group_dims);
 }
 
@@ -366,6 +375,7 @@ void CommandEncoder::dispatch_threads(
     MTL::Size group_dims) {
   maybeInsertBarrier();
   buffer_ops_++;
+  g_dispatch_count_.fetch_add(1, std::memory_order_relaxed);
   get_command_encoder()->dispatchThreads(grid_dims, group_dims);
 }
 
@@ -844,6 +854,14 @@ bool is_nax_available() {
   static bool is_nax_available_ = _check_nax();
   return is_nax_available_;
 #endif
+}
+
+uint64_t dispatch_count() {
+  return g_dispatch_count_.load(std::memory_order_relaxed);
+}
+
+void reset_dispatch_count() {
+  g_dispatch_count_.store(0, std::memory_order_relaxed);
 }
 
 } // namespace mlx::core::metal

--- a/mlx/backend/metal/metal.h
+++ b/mlx/backend/metal/metal.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 #include <variant>
@@ -16,6 +17,14 @@ MLX_API bool is_available();
 /** Capture a GPU trace, saving it to an absolute file `path` */
 MLX_API void start_capture(std::string path = "");
 MLX_API void stop_capture();
+
+/** Total number of GPU kernel dispatches issued since process start or the
+ * last call to ``reset_dispatch_count()``. Counts every
+ * ``dispatch_threadgroups`` and ``dispatch_threads`` call across all
+ * command encoders. Intended for fused-kernel validation and dispatch
+ * diagnostics. Call ``eval()`` first so in-flight work is flushed. */
+MLX_API uint64_t dispatch_count();
+MLX_API void reset_dispatch_count();
 
 /** Get information about the GPU and system settings. */
 MLX_API const

--- a/mlx/backend/metal/no_metal.cpp
+++ b/mlx/backend/metal/no_metal.cpp
@@ -16,6 +16,11 @@ bool is_available() {
 void start_capture(std::string) {}
 void stop_capture() {}
 
+uint64_t dispatch_count() {
+  return 0;
+}
+void reset_dispatch_count() {}
+
 const std::unordered_map<std::string, std::variant<std::string, size_t>>&
 device_info() {
   throw std::runtime_error(

--- a/python/src/metal.cpp
+++ b/python/src/metal.cpp
@@ -91,6 +91,29 @@ void init_metal(nb::module_& m) {
       R"pbdoc(
       Stop a Metal capture.
       )pbdoc");
+  metal.def(
+      "dispatch_count",
+      &mx::metal::dispatch_count,
+      R"pbdoc(
+      Total number of GPU kernel dispatches issued since process start or
+      the last call to :func:`reset_dispatch_count`. Counts every
+      ``dispatch_threadgroups`` and ``dispatch_threads`` call across all
+      command encoders. Intended for fused-kernel validation and dispatch
+      diagnostics — for example, asserting in a test that a fused op
+      compiles to the expected number of kernels.
+
+      Call :func:`mlx.core.eval` (or read a result back) before reading
+      so in-flight work is flushed.
+
+      Returns:
+          int: cumulative dispatch count.
+      )pbdoc");
+  metal.def(
+      "reset_dispatch_count",
+      &mx::metal::reset_dispatch_count,
+      R"pbdoc(
+      Reset the dispatch counter exposed by :func:`dispatch_count` to zero.
+      )pbdoc");
   metal.def("device_info", []() {
     DEPRECATE("mx.metal.device_info", "mx.device_info");
     return mx::device_info(mx::Device(mx::Device::gpu, 0));

--- a/python/tests/test_metal.py
+++ b/python/tests/test_metal.py
@@ -1,0 +1,33 @@
+# Copyright © 2026 Apple Inc.
+
+import unittest
+
+import mlx.core as mx
+import mlx_tests
+
+
+class TestDispatchCount(mlx_tests.MLXTestCase):
+    def test_counts_increase_then_reset(self):
+        if not mx.metal.is_available():
+            return
+
+        mx.metal.reset_dispatch_count()
+        self.assertEqual(mx.metal.dispatch_count(), 0)
+
+        a = mx.array([1.0, 2.0, 3.0])
+        b = a + 1.0
+        mx.eval(b)
+
+        after_one_op = mx.metal.dispatch_count()
+        self.assertGreater(after_one_op, 0)
+
+        c = b * 2.0
+        mx.eval(c)
+        self.assertGreater(mx.metal.dispatch_count(), after_one_op)
+
+        mx.metal.reset_dispatch_count()
+        self.assertEqual(mx.metal.dispatch_count(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a global atomic counter that increments on every Metal kernel dispatch (`dispatch_threadgroups` / `dispatch_threads`), exposed as:

- C++: `mx::metal::dispatch_count()` / `mx::metal::reset_dispatch_count()`
- Python: `mx.metal.dispatch_count()` / `mx.metal.reset_dispatch_count()`

Use case: asserting in a test or benchmark that a fused op compiles to the expected number of kernels, or quickly catching dispatch-scheduling regressions without firing up Xcode capture. We've been carrying a private version of this in a downstream fork to validate fused-attention kernel work — putting it forward in case it's useful upstream.

## Cost

One relaxed-order atomic increment per dispatch, invisible next to the microsecond-scale dispatch cost it sits beside. Counter is always-on so tests can use it without an environment-variable dance.

## API

```python
import mlx.core as mx

mx.metal.reset_dispatch_count()
y = (mx.array([1.0, 2.0, 3.0]) + 1.0) * 2.0
mx.eval(y)
print(mx.metal.dispatch_count())  # > 0
```

`reset_dispatch_count()` is included so a test can scope counts to a region. Both functions are also wired up in `no_metal.cpp` (return 0 / no-op) for non-Metal builds.

## Files

- `mlx/backend/metal/device.cpp` — atomic counter + increments + accessors
- `mlx/backend/metal/metal.h` — public C++ API
- `mlx/backend/metal/no_metal.cpp` — non-Metal stubs
- `python/src/metal.cpp` — Python bindings
- `python/tests/test_metal.py` — unit test (counts increase, reset returns to 0)

## Open question for reviewers

Happy to switch to a build-time `#ifdef MLX_DISPATCH_COUNT` guard, an env-var gate, or a runtime setter if you'd rather not pay the atomic increment unconditionally — just let me know your preference. Single-cycle relaxed atomic on Apple Silicon is the rationale for keeping it always-on as the simplest API.