### PR TITLE
Add buffer-count introspection probes (get_active_resource_count, get_cache_count)

### DIFF
--- a/docs/src/python/memory_management.rst
+++ b/docs/src/python/memory_management.rst
@@ -10,6 +10,8 @@ Memory Management
   get_peak_memory
   reset_peak_memory
   get_cache_memory
+  get_active_resource_count
+  get_cache_count
   set_memory_limit
   set_cache_limit
   set_wired_limit

--- a/mlx/backend/common/buffer_cache.h
+++ b/mlx/backend/common/buffer_cache.h
@@ -102,6 +102,10 @@ class BufferCache {
     return pool_size_;
   }
 
+  size_t cache_count() const {
+    return buffer_pool_.size();
+  }
+
   size_t page_size() const {
     return page_size_;
   }

--- a/mlx/backend/cuda/allocator.cpp
+++ b/mlx/backend/cuda/allocator.cpp
@@ -443,6 +443,16 @@ void clear_cache() {
   cu::allocator().clear_cache();
 }
 
+// Resource-count introspection is Metal-specific (descriptor pressure on
+// M-series GPUs, see ml-explore/mlx-lm#1185). CUDA does not expose an
+// equivalent buffer-count limit, so these stubs return 0.
+size_t get_active_resource_count() {
+  return 0;
+}
+size_t get_cache_count() {
+  return 0;
+}
+
 // Not supported in CUDA.
 size_t set_wired_limit(size_t) {
   return 0;

--- a/mlx/backend/metal/allocator.cpp
+++ b/mlx/backend/metal/allocator.cpp
@@ -261,6 +261,12 @@ void reset_peak_memory() {
 size_t get_cache_memory() {
   return metal::allocator().get_cache_memory();
 }
+size_t get_active_resource_count() {
+  return metal::allocator().get_active_resource_count();
+}
+size_t get_cache_count() {
+  return metal::allocator().get_cache_count();
+}
 void clear_cache() {
   return metal::allocator().clear_cache();
 }

--- a/mlx/backend/metal/allocator.h
+++ b/mlx/backend/metal/allocator.h
@@ -36,6 +36,12 @@ class MetalAllocator : public allocator::Allocator {
   size_t get_cache_memory() {
     return buffer_cache_.cache_size();
   };
+  size_t get_active_resource_count() {
+    return num_resources_;
+  };
+  size_t get_cache_count() {
+    return buffer_cache_.cache_count();
+  };
   size_t set_cache_limit(size_t limit);
   size_t set_memory_limit(size_t limit);
   size_t get_memory_limit();

--- a/mlx/memory.h
+++ b/mlx/memory.h
@@ -33,6 +33,18 @@ MLX_API void reset_peak_memory();
  * */
 MLX_API size_t get_cache_memory();
 
+/* Get the total number of GPU buffers (active + cached) currently allocated
+ * by mlx.
+ *
+ * On Metal this is the count of MTLBuffer objects, useful for diagnosing
+ * descriptor-pressure bugs (see ml-explore/mlx-lm#1185). CUDA returns 0
+ * (the resource limit on CUDA is bytes, not handles).
+ * */
+MLX_API size_t get_active_resource_count();
+
+/* Get the number of GPU buffers currently sitting in the buffer cache. */
+MLX_API size_t get_cache_count();
+
 /* Set the memory limit.
  * The memory limit is a guideline for the maximum amount of memory to use
  * during graph evaluation. If the memory limit is exceeded and there is no

--- a/python/src/memory.cpp
+++ b/python/src/memory.cpp
@@ -122,4 +122,24 @@ void init_memory(nb::module_& m) {
 
       After calling this, :func:`get_cache_memory` should return ``0``.
       )pbdoc");
+  m.def(
+      "get_active_resource_count",
+      &mx::get_active_resource_count,
+      R"pbdoc(
+      Get the total number of GPU buffers (active + cached) currently
+      allocated by mlx.
+
+      On Metal this is the count of MTLBuffer objects, useful for diagnosing
+      descriptor-pressure bugs such as ml-explore/mlx-lm#1185. CUDA returns
+      ``0`` (the resource limit on CUDA is bytes, not handles).
+      )pbdoc");
+  m.def(
+      "get_cache_count",
+      &mx::get_cache_count,
+      R"pbdoc(
+      Get the number of GPU buffers currently sitting in the buffer cache.
+
+      Useful in conjunction with :func:`get_active_resource_count` for
+      debugging descriptor-pressure issues. Returns ``0`` on CUDA.
+      )pbdoc");
 }

--- a/tests/allocator_tests.cpp
+++ b/tests/allocator_tests.cpp
@@ -5,6 +5,7 @@
 #include "doctest/doctest.h"
 
 #include "mlx/allocator.h"
+#include "mlx/memory.h"
 
 using namespace mlx::core;
 
@@ -38,4 +39,30 @@ TEST_CASE("test large allocations") {
     auto buffer = allocator::malloc(size);
     allocator::free(buffer);
   }
+}
+
+TEST_CASE("buffer-count introspection probes track alloc/free/cache state") {
+  // Probes added for ml-explore/mlx-lm#1185, where descriptor pressure was
+  // diagnosed only after a crash because there was no way to observe the
+  // MTLBuffer count from Python. These checks verify the probes report
+  // sensible deltas under a controlled alloc/free pattern. They do not
+  // depend on any specific eviction policy — only that the counters are
+  // monotonic with respect to alloc/free/cache operations.
+
+  clear_cache();
+  size_t active_baseline = get_active_resource_count();
+  size_t cache_baseline = get_cache_count();
+
+  auto buffer = allocator::malloc(1 << 20); // 1 MB
+  // After a fresh malloc the active count must have grown by at least 1.
+  CHECK_GE(get_active_resource_count(), active_baseline + 1);
+
+  allocator::free(buffer);
+  // After free, the buffer either landed in the cache or was released.
+  // Either way, the cache count must be >= baseline (cache only grows here).
+  CHECK_GE(get_cache_count(), cache_baseline);
+
+  clear_cache();
+  // clear_cache must drop cache count to zero.
+  CHECK_EQ(get_cache_count(), 0u);
 }


### PR DESCRIPTION
## Summary

Adds two read-only diagnostic functions to `mlx.core` (and the matching C++ API):

- `get_active_resource_count()` — total GPU buffers (active + cached)
- `get_cache_count()` — buffers currently in the buffer cache

On Metal these return the MTLBuffer count, which is the dimension that hits the per-process resource limit (~499000 on Apple silicon) when descriptor pressure builds up. CUDA returns `0` from both probes (the CUDA resource limit is bytes, not handles), mirroring how `set_wired_limit` is stubbed there.

**No behavior change.** The cache eviction policy is unchanged; this PR only exposes counters that already existed internally (`num_resources_` and `buffer_pool_.size()`).

## Why

Filed in response to a direct request from the [ml-explore/mlx-lm#1185](https://github.com/ml-explore/mlx-lm/issues/1185) thread:

> An `mx.metal.active_resource_count()` probe would be incredibly useful — currently we're inferring the leak from crash iteration rather than measuring it.
> — @lawcontinue ([comment](https://github.com/ml-explore/mlx-lm/issues/1185#issuecomment-4322261257))

That issue is the descriptor-count leak in LoRA training of Qwen3.5/3.6 and Gemma3 — flat memory, crash at `[metal::malloc] Resource limit (499000) exceeded` rather than byte OOM. Without these probes, users can only diagnose post-mortem by counting iterations until crash; with them, you can see the count climbing in real time and try workarounds (`mx.synchronize() + mx.clear_cache()` at a coarser cadence, fixed-shape padding, etc.) deliberately rather than by trial.

I held back the eviction-policy commit from this PR — see "What's NOT in this PR" below.

## What's in this PR

| File | Change |
|------|--------|
| `mlx/memory.h` | Two new `MLX_API` declarations |
| `mlx/backend/common/buffer_cache.h` | `cache_count()` accessor on `BufferCache` |
| `mlx/backend/metal/allocator.{h,cpp}` | Member fns + free-fn dispatchers |
| `mlx/backend/cuda/allocator.cpp` | Stubs returning 0 |
| `python/src/memory.cpp` | Two `m.def` bindings with docstrings |
| `docs/src/python/memory_management.rst` | Two new entries |
| `tests/allocator_tests.cpp` | Monotonicity test (no eviction-policy assumptions) |

87 lines added, 0 removed.

## What's NOT in this PR

A separate count-aware eviction policy (count-driven trigger alongside the existing byte trigger in `MetalAllocator::malloc`) gets the synthetic 1000-unique-size test passing, but in real LoRA training of Qwen3.6-35B-A3B-4bit cache_limit values of 8/2/1 buffers all still crashed. So either (a) eviction isn't releasing buffers as fast as they're allocated, (b) there's a second leak source upstream of the cache (the compile cache?), or (c) something else. I have empirical probe data per-iter showing 47k → 128k → 145k MTLBuffer jumps under that workload that I'd be happy to share separately if it's useful for diagnosis. I didn't want to put a behavior change in front of you while the root cause isn't fully nailed down.

This PR is therefore strictly a diagnostic foundation that helps users (and you) measure the bug in mlx-lm#1185 without committing to a specific fix.

## Test plan

- [x] `cmake --build . --target tests` builds clean (Metal backend, MLX_BUILD_TESTS=ON)
- [x] `./tests/tests --test-case="*introspection*"` — 1 passed, 0 failed
- [x] `./tests/tests --test-case="*allocation*"` — existing tests still pass
- [x] `clang-format -i` produces no diff on changed files
- [ ] CUDA build — I don't have a CUDA box; the stubs follow the `set_wired_limit` pattern but please flag if the wiring needs adjustment