### PR TITLE
Fix JACCL GID selection on Apple Thunderbolt RDMA (errno 22 RTR fail)

### DIFF
--- a/mlx/distributed/jaccl/lib/jaccl/rdma.cpp
+++ b/mlx/distributed/jaccl/lib/jaccl/rdma.cpp
@@ -181,13 +181,61 @@ const Destination& Connection::info() {
 
   ibv_port_attr port_attr;
   ibv().query_port(ctx, 1, &port_attr);
-  ibv_gid gid;
-  for (int i = 0; i < port_attr.gid_tbl_len; i++) {
+  ibv_gid gid = {};
+
+  auto try_gid = [&](int i, bool require_ipv4_mapped) -> bool {
+    if (i < 0 || i >= port_attr.gid_tbl_len) {
+      return false;
+    }
     ibv_gid tmp;
-    if (ibv().query_gid(ctx, 1, i, &tmp) == 0) {
-      if (*(uint64_t*)&tmp.raw[0] == 0 && *(uint16_t*)&tmp.raw[8] == 0 &&
-          *(uint16_t*)&tmp.raw[10] == 0xffff) {
-        gid = tmp;
+    if (ibv().query_gid(ctx, 1, i, &tmp) != 0) {
+      return false;
+    }
+    if (require_ipv4_mapped) {
+      if (*(uint64_t*)&tmp.raw[0] != 0 || *(uint16_t*)&tmp.raw[8] != 0 ||
+          *(uint16_t*)&tmp.raw[10] != 0xffff) {
+        return false;
+      }
+    } else {
+      bool is_zero = true;
+      for (int j = 0; j < 16; j++) {
+        if (tmp.raw[j] != 0) {
+          is_zero = false;
+          break;
+        }
+      }
+      if (is_zero) {
+        return false;
+      }
+    }
+    gid = tmp;
+    return true;
+  };
+
+  // 1. Prefer IPv4-mapped IPv6 GID (RoCE v2 standard).
+  bool found = false;
+  for (int i = 0; i < port_attr.gid_tbl_len; i++) {
+    if (try_gid(i, /*require_ipv4_mapped=*/true)) {
+      found = true;
+      break;
+    }
+  }
+
+  // 2. Fallback for Apple Thunderbolt RDMA, which exposes only link-local
+  //    IPv6 (fe80::...) GIDs. Prefer index 1 (the actual rdma_enX port GID;
+  //    index 0 on Apple TB is typically derived from a non-RDMA interface
+  //    and routes elsewhere, surfacing as RTR errno 60 ETIMEDOUT).
+  if (!found) {
+    for (int i : {1, 0}) {
+      if (try_gid(i, /*require_ipv4_mapped=*/false)) {
+        found = true;
+        break;
+      }
+    }
+  }
+  if (!found) {
+    for (int i = 2; i < port_attr.gid_tbl_len; i++) {
+      if (try_gid(i, /*require_ipv4_mapped=*/false)) {
         break;
       }
     }


### PR DESCRIPTION
Closes #3467.

## Proposed changes

Fix `[jaccl] Changing queue pair to RTR failed with errno 22` on Apple Thunderbolt RDMA.

`Connection::info()` in `rdma.cpp` selects the local GID by scanning the GID table for an IPv4-mapped IPv6 GID (`::ffff:x.x.x.x` — the RoCE v2 standard). Apple Thunderbolt RDMA exposes only link-local IPv6 GIDs (`fe80::...`), so the filter never matches and `gid` is left uninitialized. The garbage value is propagated to the peer via the side channel, causing the kernel to reject the QP RTR transition with EINVAL.

This regression was introduced by #3412 (Jaccl refactor) when the pre-existing hardcoded `query_gid(ctx, 1, 1, &gid)` was replaced with the filter loop. See full root-cause analysis in the linked issue.

## Changes

`mlx/distributed/jaccl/lib/jaccl/rdma.cpp`:
- Zero-initialize `gid` to avoid undefined behavior when no GID matches.
- After the IPv4-mapped scan, fall back to the first non-zero GID — preferring index 1 (matches pre-refactor behavior; index 0 on Apple TB is typically derived from a non-RDMA interface and routes elsewhere, causing errno 60 ETIMEDOUT instead of errno 22).

The IPv4-mapped path remains the preferred match, so RoCE v2 setups are unaffected.

## Test plan

- 2× Mac Studio M4 Max, Thunderbolt 5 mesh, macOS 26.4.1
- Before patch: `mlx.distributed.init(backend="jaccl")` → `errno 22 RTR fail`
- After patch (preferring index 0 in fallback): `errno 60 ETIMEDOUT` (wrong port — index 0 is non-RDMA on Apple)
- After patch (preferring index 1 in fallback): JACCL init succeeds, `all_sum` benchmark runs, sustained tensor-parallel inference (Qwen3.6-27B-4bit) works end-to-end

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

Note: no unit tests added — the GID selection is platform-dependent (Apple TB vs RoCE v2 hardware) and the tests in `mlx/distributed/jaccl/lib/examples/` are runtime benchmarks rather than unit tests. Happy to add a mock-based unit test if reviewers prefer.
