### PR TITLE
Add MLX_NUMERICAL_STRICT_MODE for shape-independent quantized_matmul

### DIFF
--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -1408,6 +1408,32 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
 
   int vector_limit = transpose_ ? get_qmv_batch_limit(K, N, d) : 4;
   auto mode = quantization_mode_to_string(mode_);
+
+  // Numerical strict mode (MLX_NUMERICAL_STRICT_MODE=1): bypass the
+  // shape-dependent fast paths (qmv, qmm_splitk, qvm_split_k) so output is
+  // bit-identical regardless of M. Costs ~1.5-2.3x slower decode at M=1
+  // (qmv is heavily optimized for the M=1 case) but gives path-independence
+  // required for prefix-cache reuse, batched-vs-streaming eval comparison,
+  // and distillation/RLHF teacher-student equality. See
+  // env::numerical_strict_mode() in mlx/utils.h.
+  if (env::numerical_strict_mode()) {
+    qmm(x,
+        w,
+        scales,
+        biases,
+        out,
+        transpose_,
+        group_size_,
+        bits_,
+        M,
+        N,
+        K,
+        d,
+        s,
+        mode);
+    return;
+  }
+
   // It is a matrix matrix product.
   if (M >= vector_limit) {
     // Use split-K qmm for small M with transposed weights (non-batched only)
@@ -1476,6 +1502,33 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
   int E = w.size() / w.shape(-1) / w.shape(-2);
   int vector_limit = transpose_ ? get_qmv_batch_limit(K, N, d) : 4;
   auto mode = quantization_mode_to_string(mode_);
+
+  // Numerical strict mode (MLX_NUMERICAL_STRICT_MODE=1): bypass the
+  // shape-dependent fast paths (gather_qmv, gather_qvm, gather_qmm_rhs) so
+  // GatherQMM output is bit-identical regardless of M. Same justification as
+  // QuantizedMatmul::eval_gpu — gather_qmm is the reference path that uses
+  // sequential register-fma accumulation matching qmm. Necessary for
+  // bit-equivalence in MoE models (Mixtral-MoE, DeepSeek-MoE, etc.).
+  if (env::numerical_strict_mode()) {
+    gather_qmm(
+        x,
+        w,
+        scales,
+        biases,
+        lhs_indices,
+        rhs_indices,
+        out,
+        transpose_,
+        group_size_,
+        bits_,
+        M,
+        N,
+        K,
+        d,
+        s,
+        mode);
+    return;
+  }
 
   // We are walking x in order and w is also in order so we can batch up the
   // matmuls and reuse reading x and w.

--- a/mlx/utils.h
+++ b/mlx/utils.h
@@ -173,6 +173,25 @@ inline bool enable_tf32() {
   return enable_tf32_;
 }
 
+// When set, QuantizedMatmul forces the no-split qmm path for all 2D shapes,
+// bypassing the qmv (M < vector_limit) and qmm_splitk fast paths. This
+// guarantees that quantized_matmul output is independent of input shape:
+// q_proj(x[:, -L:]) is bit-identical to q_proj(x)[:, -L:] for any L.
+//
+// The fast paths use parallel reductions across K (simd-butterfly in qmv,
+// partition-then-sum in splitk) which produce different fp32 sums than qmm's
+// sequential register-level accumulation. Even when both paths use fp32
+// throughout, fp32 is non-associative so the bit patterns differ by ~ULP.
+//
+// This bites workloads that compare two equivalent paths — prefix-cache reuse,
+// batched-vs-streaming eval, distillation/RLHF teacher-student equality. For
+// straight inference / training the diff is invisible. Off by default.
+inline bool numerical_strict_mode() {
+  static bool numerical_strict_mode_ =
+      get_var("MLX_NUMERICAL_STRICT_MODE", 0);
+  return numerical_strict_mode_;
+}
+
 inline int nccl_timeout(int default_value) {
   static int nccl_timeout = get_var("MLX_NCCL_TIMEOUT", default_value);
   return nccl_timeout;


### PR DESCRIPTION
# Upstream issue + PR for ml-explore/mlx

## Issue title

`quantized_matmul` output depends on input shape (M dimension); add `MLX_NUMERICAL_STRICT_MODE` opt-in for path-independent output

## Summary

`mx.quantized_matmul` dispatches to one of three GPU kernels based on the M (batch/sequence) dimension of the input:

- **`qmv`** for `M < vector_limit` (~10–32 depending on K, N, arch)
- **`qmm_splitk`** for `vector_limit ≤ M < ~65` and transposed weights (B=1)
- **`qmm`** for everything else

All three kernels accumulate K in fp32 internally (BlockMMA's `AccumType=float`, qmv uses fp32 accumulators). However, they use **different reduction trees** across K:

| Kernel | K reduction structure |
|---|---|
| `qmm` | sequential register-fma chain over BK=32 fragments, in order |
| `qmm_splitk` | partition K into split_k blocks, each accumulated independently in registers, summed in a separate reduction kernel |
| `qmv` | parallelize K across simd lanes, collapse with `simd_sum` (hardware butterfly) |

fp32 floating-point sum is **not associative**: `(a + b) + c ≠ a + (b + c)` in general. So three kernels computing the same dot product over the same K=4096 produce three different bit patterns, differing by ~1.5–2.7 × 10⁻⁵ per element.

For straight inference and training this is invisible. But it **silently breaks** any workload that compares two equivalent execution paths:

- **Prefix-cache reuse** (e.g. vLLM-style inference engines): `q_proj(x_full)` vs `q_proj(x_full[:, -L:])` should match for the overlapping tokens. They don't.
- **Batched-vs-streaming eval** (lm-evaluation-harness, custom eval frameworks): batching changes M, output diverges.
- **Distillation / RLHF**: teacher and student forward passes are expected to be deterministic functions of the same inputs.

## Reproducer

Tested on MLX v0.31.2, Apple M1 16GB, Qwen3-8B-4bit (`mlx-community/Qwen3-8B-4bit`).

```python
import mlx.core as mx
from mlx_lm import load

m, _ = load('mlx-community/Qwen3-8B-4bit')
attn = m.model.layers[0].self_attn

x_full = mx.random.normal(shape=(1, 2200, m.args.hidden_size)).astype(mx.float16)
full = attn.q_proj(x_full)

for L in [8, 16, 32, 48, 64, 65, 128]:
    sliced = attn.q_proj(x_full[:, -L:, :])
    diff = float(mx.max(mx.abs(full[:, -L:, :] - sliced)))
    print(f"q_proj L={L:3d}: max_abs_diff = {diff:.4e}")
```

Output (without strict mode):
```
q_proj L=  8: max_abs_diff = 1.9073e-05    ← qmv path
q_proj L= 16: max_abs_diff = 2.1458e-05    ← qmv path
q_proj L= 32: max_abs_diff = 2.1458e-05    ← qmv path
q_proj L= 48: max_abs_diff = 2.0504e-05    ← qmm_splitk path
q_proj L= 64: max_abs_diff = 2.0504e-05    ← qmm_splitk path
q_proj L= 65: max_abs_diff = 0.0000e+00    ← qmm path (matches reference)
q_proj L=128: max_abs_diff = 0.0000e+00    ← qmm path
```

Same pattern in `k_proj` with the boundary at L=256→257 (because N=1024 instead of 4096 changes the splitk threshold).

## Important: this is NOT just an fp16 ULP issue

An earlier analysis suggested the bug was fp16 partial-sum rounding in splitk's intermediate buffer (with the fix being: store partials in fp32 instead of fp16). I implemented that fix and **verified it produces bit-identical output to pristine** on the actual reproducer above. The reason: with bf16 scales the model output is auto-promoted to fp32 by MLX, so there's no fp16 cast anywhere in the splitk path that would benefit from precision promotion. The ~2 × 10⁻⁵ diff is purely fp32 non-associativity from differing reduction trees.

The implication: **promoting partial-sums to fp32 does not fix the bit-equivalence problem for fp32-output paths.** Only matching the reduction tree (or skipping the fast paths entirely) gives bit-equivalence.

## Proposed fix: `MLX_NUMERICAL_STRICT_MODE` opt-in

Add an opt-in env-var-controlled flag matching MLX's existing convention (`MLX_ENABLE_TF32`, `MLX_METAL_FAST_SYNCH`, etc.):

**`mlx/utils.h`** — add helper:
```cpp
inline bool numerical_strict_mode() {
  static bool numerical_strict_mode_ = get_var("MLX_NUMERICAL_STRICT_MODE", 0);
  return numerical_strict_mode_;
}
```

**`mlx/backend/metal/quantized.cpp::QuantizedMatmul::eval_gpu`** — gate at top of dispatch:
```cpp
if (env::numerical_strict_mode()) {
  qmm(x, w, scales, biases, out, transpose_, group_size_, bits_,
      M, N, K, d, s, mode);
  return;
}
// ... existing qmv / qmm_splitk / qmm dispatch logic ...
```

That single gate at `eval_gpu` top covers all three shape-dependent paths (qmv, qmm_splitk, qvm_split_k) because qmm is the canonical reference.

## Validation

With `MLX_NUMERICAL_STRICT_MODE=1`:
```
q_proj L=  8: max_abs_diff = 0.0000e+00
q_proj L= 16: max_abs_diff = 0.0000e+00
q_proj L= 32: max_abs_diff = 0.0000e+00
q_proj L= 48: max_abs_diff = 0.0000e+00
q_proj L= 64: max_abs_diff = 0.0000e+00
q_proj L= 65: max_abs_diff = 0.0000e+00
q_proj L=128: max_abs_diff = 0.0000e+00
```

Bit-identical at every L for every projection.

## Performance cost (honest numbers)

Measured on M1 16GB with Qwen3-8B-4bit:

| Workload | OFF | ON | Slowdown |
|---|---|---|---|
| Short-prompt decode (~10 tok prefix) | 2.18 tok/s | 0.96 tok/s | **2.3× slower** |
| Long-prompt decode (~80 tok prefix) | 2.39 tok/s | 1.51 tok/s | **1.6× slower** |

The decode-loop slowdown is significant because `qmv` is heavily optimized for M=1 generation; bypassing it forces `qmm` to use a 32×32 tile for a single output row.

**This is why the flag is opt-in, not default-on.** For users running:

- Single-stream chat inference: don't enable. Speed matters; bit-equivalence doesn't.
- Eval frameworks comparing batched and streaming runs: enable. Decode tok/s isn't the bottleneck; correctness is.
- Distillation/RLHF teacher-student loops: enable. You need deterministic forward passes.
- Prefix-cache reuse engines: enable for any path-comparison testing; can disable in production hot loops.

## Files changed

- `mlx/utils.h` — +20 LoC (env helper + comment block)
- `mlx/backend/metal/quantized.cpp` — +18 LoC (gate at QuantizedMatmul::eval_gpu)

Total: ~40 LoC. No new kernels, no new tests of existing behavior, no breaking changes. Off-by-default → zero impact on any existing user.

## Test

Reproducer in `mac-llm-bench/eval/test_numerical_strict_mode.py` — script that runs the boundary check in both modes:

- Without flag: prints diffs at all small-L boundaries (informational, no assertion)
- With flag: asserts `diff == 0.0` at every L; exits 1 if any L fails

## Reference

Hardware: Apple M1 (16 GB unified memory)
MLX version: 0.31.2
Model: mlx-community/Qwen3-8B-4bit

Discovered while building an Apple Silicon eval harness for Qwen3-8B (mac-llm-bench). The original symptom was a ~0.5pp MMLU accuracy regression when prefix-cache reuse was enabled; root-caused to this path-dependence by sweeping L and observing the boundary at L=64 (q/o_proj) and L=256 (k/v_proj) match the dispatcher's split_k threshold.
