### PR TITLE
Make device_count() return 0 when there is no GPU

### DIFF
--- a/mlx/backend/metal/device_info.cpp
+++ b/mlx/backend/metal/device_info.cpp
@@ -13,7 +13,12 @@ bool is_available() {
 }
 
 int device_count() {
-  return 1;
+  try {
+    metal::device(Device::gpu);
+    return 1;
+  } catch (...) {
+    return 0;
+  }
 }
 
 const std::unordered_map<std::string, std::variant<std::string, size_t>>&


### PR DESCRIPTION
Close #3148: crash on import was gone after the thread safety changes, the mysterious NSRangeException error message was improved by https://github.com/ml-explore/mlx/pull/3428, and this PR solves the last piece by making it possible to detect if there is GPU access at run time.