### PR TITLE
[CUDA] Fix QMM boundary handling for scales and biases

### DIFF
--- a/mlx/backend/cuda/quantized/qmm/qmm_naive.cu
+++ b/mlx/backend/cuda/quantized/qmm/qmm_naive.cu
@@ -159,8 +159,8 @@ __global__ void qmm_naive_kernel(
   auto fetch_gmem = [&](int tile) {
     copy_if(copy_a, tApA, tAgA(_,_,_,tile), tArA);
     copy_if(copy_b, tBpB, tBgB(_,_,_,tile), tBrB);
-    copy(tBgS(_,_,_,tile), tBrS);
-    copy(tBgZ(_,_,_,tile), tBrZ);
+    copy_if(copy_b, tBpB, tBgS(_,_,_,tile), tBrS);
+    copy_if(copy_b, tBpB, tBgZ(_,_,_,tile), tBrZ);
   };
   // RMEM => SMEM.
   auto store_smem = [&]() {
@@ -201,8 +201,8 @@ __global__ void qmm_naive_kernel(
     for (int k = 0; k < size<2>(tBrB); ++k) {
       if (get<1>(tBcB(0,0,k)) >= -k_residue) {
         copy_if(copy_b, tBpB(_,k), tBgB_k(_,_,k), tBrB(_,_,k));
-        copy(tBgS_k(_,_,k), tBrS(_,_,k));
-        copy(tBgZ_k(_,_,k), tBrZ(_,_,k));
+        copy_if(copy_b, tBpB(_,k), tBgS_k(_,_,k), tBrS(_,_,k));
+        copy_if(copy_b, tBpB(_,k), tBgZ_k(_,_,k), tBrZ(_,_,k));
       }
     }
   } else {

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -753,6 +753,28 @@ class TestQuantized(mlx_tests.MLXTestCase):
                     self.assertEqual(y_q.shape, y_hat.shape)
                     self.assertLess((y_q - y_hat).abs().max(), 1e-3)
 
+    def test_qmm_non_multiple_n_regression(self):
+        # Force the qmm path with an N dimension that leaves an edge tile.
+        # On CUDA this should hit the naive kernel rather than the qmv fallback.
+        M, K, N = 8, 128, 129
+        group_size = 64
+        bits = 4
+        dtype = mx.float16 if (mx.default_device() == mx.gpu) else mx.float32
+
+        x = (mx.random.normal(shape=(M, K)) / K**0.5).astype(dtype)
+        w = (mx.random.normal(shape=(N, K)) / K**0.5).astype(dtype)
+
+        w_q, scales, biases = mx.quantize(w, group_size, bits)
+        w_hat = mx.dequantize(w_q, scales, biases, group_size, bits)
+        y_q = mx.quantized_matmul(
+            x, w_q, scales, biases, True, group_size, bits
+        )
+        y_hat = x @ w_hat.T
+
+        self.assertEqual(y_q.shape, y_hat.shape)
+        tol = 1e-3 if dtype == mx.float32 else 1.5e-3
+        self.assertLess((y_q - y_hat).abs().max(), tol)
+
     def test_gather_qmm(self):
         def quantize(w, transpose=True, group_size=None, bits=None, mode="affine"):
             if mode == "affine":


### PR DESCRIPTION
Fixes #3487

## Summary

This updates the CUDA naive QMM kernel to predicate scale and bias loads with the same `tBpB` mask already used for quantized weight loads.

Previously, edge tiles where `N` was not a multiple of the tile size could still perform unconditional loads for scales/biases, which could lead to illegal memory access and flaky tests.

## Changes

- Use `copy_if(...)` instead of unconditional `copy(...)` for scale loads in `qmm_naive.cu`
- Use `copy_if(...)` instead of unconditional `copy(...)` for bias loads in `qmm_naive.cu`
- Apply the same fix in the residue preload path
- Add a regression test for a non-multiple `N` case intended to exercise the `qmm` path

## Notes

I could not validate the CUDA path locally on this machine, so CUDA verification still needs to be run in a Linux/NVIDIA environment.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
