### PR TITLE
Improve DLPack-compatible array imports

### DIFF
--- a/docs/src/usage/numpy.rst
+++ b/docs/src/usage/numpy.rst
@@ -75,13 +75,7 @@ even though no in-place operations on MLX memory are executed.
 PyTorch
 -------
 
-.. warning::
-
-   PyTorch Support for :obj:`memoryview` is experimental and can break for
-   multi-dimensional arrays. Casting to NumPy first is advised for now.
-
-PyTorch supports the buffer protocol, but it requires an explicit
-:obj:`memoryview`.
+PyTorch supports DLPack inputs and can import MLX arrays directly.
 
 .. code-block:: python
 
@@ -89,8 +83,8 @@ PyTorch supports the buffer protocol, but it requires an explicit
   import torch
 
   a = mx.arange(3)
-  b = torch.tensor(memoryview(a))
-  c = mx.array(b)
+  b = torch.tensor(a)
+  c = mx.array(b.cpu())
 
 JAX
 ---

--- a/python/mlx/_stub_patterns.txt
+++ b/python/mlx/_stub_patterns.txt
@@ -1,5 +1,5 @@
 mlx.core.__prefix__:
-  from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union, ParamSpec, TypeVar
+  from typing import Any, Callable, Dict, List, Optional, Protocol, Sequence, Tuple, Union, ParamSpec, TypeVar
   import sys
   if sys.version_info >= (3, 10):
     from typing import TypeAlias
@@ -7,6 +7,9 @@ mlx.core.__prefix__:
     from typing_extensions import TypeAlias
   P = ParamSpec("P")
   R = TypeVar("R")
+  class DLPackCompatible(Protocol):
+    __dlpack__: Callable[..., Any]
+    __dlpack_device__: Callable[..., Any]
 
 mlx.core.__suffix__:
   from typing import Union

--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -300,7 +300,7 @@ void init_array(nb::module_& m) {
           "val"_a,
           "dtype"_a = nb::none(),
           nb::sig(
-              "def __init__(self: array, val: Union[scalar, list, tuple, numpy.ndarray, array], dtype: Optional[Dtype] = None)"))
+              "def __init__(self: array, val: Union[scalar, list, tuple, DLPackCompatible, array], dtype: Optional[Dtype] = None)"))
       .def_prop_ro(
           "size",
           &mx::array::size,

--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -479,7 +479,7 @@ void init_array(nb::module_& m) {
               throw std::invalid_argument(
                   "Invalid pickle state: expected (ndarray, Dtype::Val)");
             }
-            using ND = nb::ndarray<nb::ro, nb::c_contig, nb::device::cpu>;
+            using ND = nb::ndarray<nb::ro, nb::c_contig>;
             ND nd = nb::cast<ND>(state[0]);
             auto val = static_cast<mx::Dtype::Val>(nb::cast<uint8_t>(state[1]));
             if (val == mx::Dtype::Val::bfloat16) {

--- a/python/src/convert.cpp
+++ b/python/src/convert.cpp
@@ -501,17 +501,15 @@ mx::array create_array(nb::object v, std::optional<mx::Dtype> t) {
     return mx::astype(arr, t.value_or(arr.dtype()));
   } else if (nb::ndarray_check(v)) {
     using ContigArray = nb::ndarray<nb::ro, nb::c_contig>;
-    nb::object src = v;
     ContigArray nd;
     std::optional<nb::dlpack::dtype> nb_dtype;
     // Nanobind does not recognize bfloat16 numpy array:
     // https://github.com/wjakob/nanobind/discussions/560
-    if (nb::hasattr(src, "dtype") &&
-        src.attr("dtype").equal(nb::str("bfloat16"))) {
-      nd = nb::cast<ContigArray>(src.attr("view")("uint16"));
+    if (nb::hasattr(v, "dtype") && v.attr("dtype").equal(nb::str("bfloat16"))) {
+      nd = nb::cast<ContigArray>(v.attr("view")("uint16"));
       nb_dtype = nb::dtype<mx::bfloat16_t>();
     } else {
-      nd = nb::cast<ContigArray>(src);
+      nd = nb::cast<ContigArray>(v);
     }
     return nd_array_to_mlx(nd, t, nb_dtype);
   } else {

--- a/python/src/convert.cpp
+++ b/python/src/convert.cpp
@@ -33,7 +33,7 @@ int check_shape_dim(int64_t dim) {
 
 template <typename T>
 mx::array nd_array_to_mlx_contiguous(
-    nb::ndarray<nb::ro, nb::c_contig, nb::device::cpu> nd_array,
+    nb::ndarray<nb::ro, nb::c_contig> nd_array,
     const mx::Shape& shape,
     mx::Dtype dtype) {
   // Make a copy of the numpy buffer
@@ -43,9 +43,14 @@ mx::array nd_array_to_mlx_contiguous(
 }
 
 mx::array nd_array_to_mlx(
-    nb::ndarray<nb::ro, nb::c_contig, nb::device::cpu> nd_array,
+    nb::ndarray<nb::ro, nb::c_contig> nd_array,
     std::optional<mx::Dtype> dtype,
     std::optional<nb::dlpack::dtype> nb_dtype) {
+  if (nd_array.device_type() != nb::device::cpu::value) {
+    throw std::invalid_argument(
+        "Cannot convert non-CPU DLPack array to mlx array.");
+  }
+
   // Compute the shape and size
   mx::Shape shape;
   shape.reserve(nd_array.ndim());
@@ -495,16 +500,18 @@ mx::array create_array(nb::object v, std::optional<mx::Dtype> t) {
     auto arr = nb::cast<mx::array>(v);
     return mx::astype(arr, t.value_or(arr.dtype()));
   } else if (nb::ndarray_check(v)) {
-    using ContigArray = nb::ndarray<nb::ro, nb::c_contig, nb::device::cpu>;
+    using ContigArray = nb::ndarray<nb::ro, nb::c_contig>;
+    nb::object src = v;
     ContigArray nd;
     std::optional<nb::dlpack::dtype> nb_dtype;
     // Nanobind does not recognize bfloat16 numpy array:
     // https://github.com/wjakob/nanobind/discussions/560
-    if (nb::hasattr(v, "dtype") && v.attr("dtype").equal(nb::str("bfloat16"))) {
-      nd = nb::cast<ContigArray>(v.attr("view")("uint16"));
+    if (nb::hasattr(src, "dtype") &&
+        src.attr("dtype").equal(nb::str("bfloat16"))) {
+      nd = nb::cast<ContigArray>(src.attr("view")("uint16"));
       nb_dtype = nb::dtype<mx::bfloat16_t>();
     } else {
-      nd = nb::cast<ContigArray>(v);
+      nd = nb::cast<ContigArray>(src);
     }
     return nd_array_to_mlx(nd, t, nb_dtype);
   } else {

--- a/python/src/convert.h
+++ b/python/src/convert.h
@@ -62,7 +62,7 @@ struct ArrayLike {
 };
 
 mx::array nd_array_to_mlx(
-    nb::ndarray<nb::ro, nb::c_contig, nb::device::cpu> nd_array,
+    nb::ndarray<nb::ro, nb::c_contig> nd_array,
     std::optional<mx::Dtype> mx_dtype,
     std::optional<nb::dlpack::dtype> nb_dtype = std::nullopt);
 

--- a/python/src/indexing.cpp
+++ b/python/src/indexing.cpp
@@ -926,7 +926,7 @@ mlx_compute_slice_update_args(
 }
 
 std::optional<mx::array> extract_boolean_mask(const nb::object& obj) {
-  using NDArray = nb::ndarray<nb::ro, nb::c_contig, nb::device::cpu>;
+  using NDArray = nb::ndarray<nb::ro, nb::c_contig>;
   if (nb::isinstance<nb::bool_>(obj)) {
     return mx::array(nb::cast<bool>(obj), mx::bool_);
   } else if (nb::isinstance<mx::array>(obj)) {

--- a/python/src/mlx_func.cpp
+++ b/python/src/mlx_func.cpp
@@ -2,8 +2,6 @@
 
 #include "python/src/mlx_func.h"
 
-#include <structmember.h>
-
 // A garbage collected function which wraps nb::cpp_function
 // See https://github.com/wjakob/nanobind/discussions/919
 

--- a/python/src/mlx_func.cpp
+++ b/python/src/mlx_func.cpp
@@ -2,6 +2,8 @@
 
 #include "python/src/mlx_func.h"
 
+#include <structmember.h>
+
 // A garbage collected function which wraps nb::cpp_function
 // See https://github.com/wjakob/nanobind/discussions/919
 

--- a/python/src/utils.cpp
+++ b/python/src/utils.cpp
@@ -38,9 +38,7 @@ mx::array to_array(
     return mx::array(static_cast<mx::complex64_t>(*pv), mx::complex64);
   } else if (auto pv = std::get_if<mx::array>(&v); pv) {
     return *pv;
-  } else if (auto pv = std::get_if<
-                 nb::ndarray<nb::ro, nb::c_contig, nb::device::cpu>>(&v);
-             pv) {
+  } else if (auto pv = std::get_if<nb::ndarray<nb::ro, nb::c_contig>>(&v); pv) {
     return nd_array_to_mlx(*pv, dtype);
   } else {
     return to_array_with_accessor(std::get<ArrayLike>(v).obj);

--- a/python/src/utils.h
+++ b/python/src/utils.h
@@ -24,7 +24,7 @@ using ScalarOrArray = std::variant<
     // Must be above ndarray
     mx::array,
     // Must be above complex
-    nb::ndarray<nb::ro, nb::c_contig, nb::device::cpu>,
+    nb::ndarray<nb::ro, nb::c_contig>,
     std::complex<float>,
     ArrayLike>;
 

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -20,8 +20,16 @@ try:
     import tensorflow as tf
 
     has_tf = True
-except ImportError as e:
+except ImportError:
     has_tf = False
+
+try:
+    import torch
+
+    has_torch_mps = hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
+except ImportError:
+    torch = None
+    has_torch_mps = False
 
 
 class TestVersion(mlx_tests.MLXTestCase):
@@ -2038,6 +2046,21 @@ class TestArray(mlx_tests.MLXTestCase):
         x = x[::2, ::2]
         y = np.from_dlpack(x)
         self.assertTrue(mx.array_equal(y, x))
+
+    @unittest.skipUnless(has_torch_mps, "PyTorch MPS is required")
+    def test_torch_mps_dlpack_non_cpu_error(self):
+        x = torch.arange(12, device="mps", dtype=torch.float32).reshape(3, 4)
+        self.assertEqual(x.__dlpack_device__()[0], 8)
+
+        with self.assertRaisesRegex(ValueError, "non-CPU DLPack"):
+            mx.array(x)
+
+        a = mx.array([1])
+        b = torch.tensor([2])
+        self.assertTrue(mx.array_equal(a + b, mx.array([3])))
+
+        with self.assertRaisesRegex(ValueError, "non-CPU DLPack"):
+            a + b.to("mps")
 
     def test_getitem_with_list(self):
         a = mx.array([1, 2, 3, 4, 5])


### PR DESCRIPTION
## Proposed changes

This PR improves `mx.array` import behavior for DLPack-compatible inputs.

Changes include:

- Update the `mx.array` constructor signature to use a `DLPackCompatible` protocol instead of naming `numpy.ndarray` directly.
- Reject non-CPU DLPack inputs consistently, including both `mx.array(...)` and operator argument conversion paths.
- Add test coverage for PyTorch MPS tensors to ensure non-CPU DLPack inputs raise an explicit error.
- Update the PyTorch interoperability docs to use DLPack directly via `torch.tensor(a)` and then move the tensor to CPU before importing it back into MLX.

PyTorch supports the DLPack import path directly: `torch.tensor(data)` checks for `__dlpack__` and routes through `torch.utils.dlpack.from_dlpack` in [`tensor_new.cpp`](https://github.com/pytorch/pytorch/blob/7d9afa6e839cead35485c328d36f91b1eabf317e/torch/csrc/utils/tensor_new.cpp#L347-L363).

This PR intentionally does not add direct Metal buffer import or zero-copy semantics. That path depends on nanobind support that is not upstream yet: ndarray import needs to request the producer's DLPack device with `dl_device` and `copy=False` for non-CPU devices, and MLX needs access to the raw DLPack `data` handle and `byte_offset` to wrap the Metal allocation directly.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
