### PR TITLE
Pass deployment target when linking metallib

### DIFF
--- a/mlx/backend/metal/kernels/CMakeLists.txt
+++ b/mlx/backend/metal/kernels/CMakeLists.txt
@@ -177,9 +177,14 @@ if(NOT MLX_METAL_JIT)
 
 endif()
 
+set(METAL_LINK_FLAGS)
+if(NOT CMAKE_OSX_DEPLOYMENT_TARGET STREQUAL "")
+  set(METAL_LINK_FLAGS "-mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}")
+endif()
+
 add_custom_command(
   OUTPUT ${MLX_METAL_PATH}/mlx.metallib
-  COMMAND xcrun -sdk macosx metal ${KERNEL_AIR} -o
+  COMMAND xcrun -sdk macosx metal ${METAL_LINK_FLAGS} ${KERNEL_AIR} -o
           ${MLX_METAL_PATH}/mlx.metallib
   DEPENDS ${KERNEL_AIR}
   COMMENT "Building mlx.metallib"


### PR DESCRIPTION
MLX compiles each Metal kernel AIR file with -mmacosx-version-min from CMAKE_OSX_DEPLOYMENT_TARGET, but the final metal driver invocation did not receive that deployment target.

With the macOS 26 SDK and CMAKE_OSX_DEPLOYMENT_TARGET=14.0, the metal driver otherwise invokes air-lld with the SDK default platform version and can stamp mlx.metallib as macOS 26 even though the input AIR files target macOS 14.

Repro:
```
cmake -S . -B build-macos14 -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0

cmake --build build-macos14 --target mlx-metallib --parallel

strings -a build-macos14/mlx/backend/metal/kernels/mlx.metallib | grep -Eo 'air64[^[:space:]]*macosx[0-9.]+' | sort -u
```
Keep using metal as the linker front-end and pass -mmacosx-version-min through the final link step. Verified with macOS SDK 26.4 that the resulting library reports air64_v26-apple-macosx14.0.0.

## Proposed changes

Please include a description of the problem or feature this PR is addressing. If there is a corresponding issue, include the issue #.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
