### PR TITLE
[CUDA] Fix gather_mm

### DIFF
--- a/mlx/backend/cuda/gemms/gather_gemm.cu
+++ b/mlx/backend/cuda/gemms/gather_gemm.cu
@@ -1,297 +1,378 @@
 // Copyright © 2026 Apple Inc.
 
-#include "mlx/backend/cuda/cutlass_utils.cuh"
 #include "mlx/backend/cuda/device.h"
 #include "mlx/backend/cuda/kernel_utils.cuh"
 #include "mlx/dtype_utils.h"
 
-#include <cutlass/epilogue/collective/collective_epilogue.hpp>
-#include <cutlass/epilogue/thread/linear_combination.h>
-#include <cutlass/gemm/collective/collective_mma.hpp>
-#include <cutlass/gemm/device/gemm_universal_adapter.h>
-#include <cutlass/gemm/dispatch_policy.hpp>
-#include <cutlass/gemm/kernel/gemm_universal.hpp>
+#include <cute/tensor.hpp>
+
+// clang-format off
 
 // We can't put kernel code in mlx::core due to name conflicts of "Shape".
 namespace cutlass_gemm {
 
 using namespace cute;
 
-// Modified from cutlass/include/cutlass/gemm/kernel/sm70_gemm.hpp to fuse
-// gather into GEMM.
-template <
-    class ProblemShape_,
-    class CollectiveMainloop_,
-    class CollectiveEpilogue_>
-class GatherGemm {
- public:
-  using ProblemShape = ProblemShape_;
-  using CollectiveMainloop = CollectiveMainloop_;
-  using TileShape = typename CollectiveMainloop::TileShape;
-  using TiledMma = typename CollectiveMainloop::TiledMma;
-  using ArchTag = typename CollectiveMainloop::ArchTag;
-  using ElementA = typename CollectiveMainloop::ElementA;
-  using StrideA = typename CollectiveMainloop::StrideA;
-  using ElementB = typename CollectiveMainloop::ElementB;
-  using StrideB = typename CollectiveMainloop::StrideB;
-  using DispatchPolicy = typename CollectiveMainloop::DispatchPolicy;
-  using ElementAccumulator = typename CollectiveMainloop::ElementAccumulator;
-
-  using CollectiveEpilogue = CollectiveEpilogue_;
-  using ElementC = typename CollectiveEpilogue::ElementC;
-  using StrideC = typename CollectiveEpilogue::StrideC;
-  using ElementD = typename CollectiveEpilogue::ElementD;
-  using StrideD = typename CollectiveEpilogue::StrideD;
-
-  static_assert(
-      cute::is_same_v<
-          ElementAccumulator,
-          typename CollectiveEpilogue::ElementAccumulator>,
-      "Mainloop and epilogue do not agree on accumulator value type.");
-
-  static constexpr int SharedStorageSize = static_cast<int>(cute::max(
-      sizeof(typename CollectiveMainloop::SharedStorage),
-      sizeof(typename CollectiveEpilogue::SharedStorage)));
-  static constexpr uint32_t MaxThreadsPerBlock =
-      CUTE_STATIC_V(size(TiledMma{}));
-  static constexpr uint32_t MinBlocksPerMultiprocessor = 1;
-
-  struct Arguments {
-    ProblemShape problem_shape;
-    const uint32_t* lhs_indices;
-    const uint32_t* rhs_indices;
-    typename CollectiveMainloop::Arguments mainloop;
-    typename CollectiveEpilogue::Arguments epilogue;
-  };
-
-  struct Params {
-    ProblemShape problem_shape;
-    const uint32_t* lhs_indices;
-    const uint32_t* rhs_indices;
-    typename CollectiveMainloop::Params mainloop;
-    typename CollectiveEpilogue::Params epilogue;
-  };
-
-  static Params to_underlying_arguments(
-      const Arguments& args,
-      void* workspace) {
-    return {
-        args.problem_shape,
-        args.lhs_indices,
-        args.rhs_indices,
-        CollectiveMainloop::to_underlying_arguments(
-            args.problem_shape, args.mainloop, workspace),
-        CollectiveEpilogue::to_underlying_arguments(
-            args.problem_shape, args.epilogue, workspace)};
-  }
-
-  static cutlass::Status
-  initialize_workspace(const Arguments&, void*, cudaStream_t, void*) {
-    return cutlass::Status::kSuccess;
-  }
-
-  static dim3 get_grid_shape(const Params& params) {
-    auto [m, n, k, l] = params.problem_shape;
-    return dim3{
-        uint32_t(ceil_div(m, shape<0>(TileShape{}))),
-        uint32_t(ceil_div(n, shape<1>(TileShape{}))),
-        uint32_t(l)};
-  }
-
-  static dim3 get_block_shape() {
-    return dim3{MaxThreadsPerBlock, 1, 1};
-  }
-
-  CUTLASS_DEVICE void operator()(const Params& params, char* smem_buf) {
-    int thread_idx = int(threadIdx.x);
-    int m_coord = int(blockIdx.x);
-    int n_coord = int(blockIdx.y);
-    int l_coord = int(blockIdx.z);
-
-    auto shape_MNKL = append<4>(params.problem_shape, Int<1>{});
-    auto cta_tile = TileShape{};
-    auto cta_coord = make_coord(m_coord, n_coord, _, l_coord);
-
-    // Represent the full tensors.
-    Tensor mA_mkl = make_tensor(
-        make_gmem_ptr(params.mainloop.ptr_A),
-        select<0, 2, 3>(shape_MNKL),
-        params.mainloop.dA);
-    Tensor mB_nkl = make_tensor(
-        make_gmem_ptr(params.mainloop.ptr_B),
-        select<1, 2, 3>(shape_MNKL),
-        params.mainloop.dB);
-
-    // Get batch slice.
-    Tensor mA_mk = mA_mkl(_, _, params.lhs_indices[l_coord]);
-    Tensor mB_nk = mB_nkl(_, _, params.rhs_indices[l_coord]);
-
-    // Slice to get the tiles this thread block is responsible for.
-    Tensor gA =
-        local_tile(mA_mk, cta_tile, take<0, 3>(cta_coord), Step<_1, X, _1>{});
-    Tensor gB =
-        local_tile(mB_nk, cta_tile, take<0, 3>(cta_coord), Step<X, _1, _1>{});
-
-    // Compute tile residues for predication.
-    auto m_max_coord = size<0>(shape_MNKL) - size<0>(gA) * get<0>(cta_coord);
-    auto n_max_coord = size<1>(shape_MNKL) - size<0>(gB) * get<1>(cta_coord);
-    auto k_residue = size<2>(shape_MNKL) - size<1>(gA) * size<2>(gA);
-    auto residue_mnk = make_tuple(m_max_coord, n_max_coord, k_residue);
-
-    // Allocate the tiled_mma and the accumulators for the (M,N) cta_tile.
-    TiledMma tiled_mma;
-    Tensor accum = partition_fragment_C(tiled_mma, take<0, 2>(cta_tile));
-    clear(accum);
-
-    auto k_tile_iter = make_coord_iterator(shape<2>(gA));
-    int k_tile_count = size<2>(gA);
-
-    // Perform the collective scoped MMA.
-    CollectiveMainloop collective_mma;
-    collective_mma(
-        accum,
-        gA,
-        gB,
-        accum,
-        k_tile_iter,
-        k_tile_count,
-        residue_mnk,
-        thread_idx,
-        smem_buf);
-
-    // Epilogue and write to out.
-    CollectiveEpilogue epilogue(params.epilogue);
-    epilogue(
-        shape_MNKL,
-        cta_tile,
-        cta_coord,
-        accum,
-        tiled_mma,
-        residue_mnk,
-        thread_idx,
-        smem_buf);
-  }
+template <typename Element, typename SmemLayoutA, typename SmemLayoutB>
+struct SharedStorage {
+  ArrayEngine<Element, cosize_v<SmemLayoutA>> A;
+  ArrayEngine<Element, cosize_v<SmemLayoutB>> B;
 };
 
-template <typename Element, bool KMajor>
-struct SimtCopyTraits {};
-
-template <typename Element>
-struct SimtCopyTraits<Element, true> {
-  using GmemTiledCopy = decltype(make_tiled_copy(
-      Copy_Atom<UniversalCopy<Element>, Element>{},
-      Layout<Shape<_32, _8>, Stride<_8, _1>>{},
-      Layout<Shape<_1, _1>>{}));
-  using SmemLayout = Layout<Shape<_128, _8>, Stride<_1, Int<128 + 1>>>;
-  using SmemCopyAtom = Copy_Atom<DefaultCopy, Element>;
-};
-
-template <typename Element>
-struct SimtCopyTraits<Element, false> {
-  using GmemTiledCopy = decltype(make_tiled_copy(
-      Copy_Atom<UniversalCopy<Element>, Element>{},
-      Layout<Shape<_32, _8>, Stride<_1, _32>>{},
-      Layout<Shape<_1, _1>>{}));
-  using SmemLayout = Layout<Shape<_128, _8>, Stride<_1, _128>>;
-  using SmemCopyAtom = Copy_Atom<DefaultCopy, Element>;
-};
-
-template <typename F>
-void dispatch_stride(bool k_major, int m, int k, F&& f) {
-  if (k_major) {
-    f(make_stride(k, Int<1>{}, m * k), std::true_type{});
+template <bool KMajor = true>
+inline constexpr auto make_smem_layout(auto bM, auto bK) {
+  // TODO: Calculate swizzle based on tile shape.
+  if constexpr (KMajor) {
+    auto swizzle = composition(Swizzle<3,3,3>{},
+                               Layout<Shape <_8,Shape <_8, _8>>,
+                                      Stride<_8,Stride<_1,_64>>>{});
+    return tile_to_shape(swizzle, make_shape(bM, bK));
   } else {
-    f(make_stride(Int<1>{}, m, m * k), std::false_type{});
+    auto swizzle = composition(Swizzle<3,3,3>{},
+                               Layout<Shape<_16,_8>, Stride<_8,_1>>{});
+    return tile_to_shape(swizzle, make_shape(bM, bK));
   }
 }
 
-template <typename Element, typename F>
+template <bool KMajorA, bool KMajorB>
+inline constexpr auto make_smem_layouts(auto cta_tiler) {
+  auto [bM, bN, bK] = cta_tiler;
+  auto sA_layout = make_smem_layout<KMajorA>(bM, bK);
+  auto sB_layout = make_smem_layout<KMajorB>(bN, bK);
+  return std::make_tuple(sA_layout, sB_layout);
+}
+
+template <typename T, bool Aligned, bool KMajor = true>
+inline constexpr auto make_tiled_copy(auto num_threads, auto bM, auto bK) {
+  auto n_read = Int<Aligned ? 8 : 1>{};
+  auto atom = Copy_Atom<UniversalCopy<uint_bit_t<n_read * sizeof_bits_v<T>>>, T>{};
+  if constexpr (KMajor) {
+    auto k_threads = bK / n_read;
+    return make_tiled_copy(
+        atom,
+        make_layout(make_shape(Int<num_threads / k_threads>{}, k_threads), LayoutRight{}),
+        make_layout(make_shape(Int<1>{}, n_read)));
+  } else {
+    auto m_threads = bM / n_read;
+    return make_tiled_copy(
+        atom,
+        make_layout(make_shape(m_threads, Int<num_threads / m_threads>{}), LayoutLeft{}),
+        make_layout(make_shape(n_read, Int<1>{})));
+  }
+}
+
+template <bool KMajorA, bool KMajorB, bool SM80, bool Aligned,
+          typename CtaTiler,
+          typename TensorA,
+          typename TensorB,
+          typename TensorC,
+          typename TiledMma>
+CUTE_DEVICE void gemm_sm70_mainloop(
+    CtaTiler cta_tiler,
+    TensorA gA,
+    TensorB gB,
+    TensorC gC,
+    TiledMma mma,
+    int m_max_coord,
+    int n_max_coord,
+    int k_residue,
+    int thread_idx) {
+  // Get the types of operands.
+  using Element = decltype(gA)::value_type;
+
+  // Shift tensor so we handle residue of K in the 0th tile.
+  gA = domain_offset(make_coord(0, k_residue, 0), gA);
+  gB = domain_offset(make_coord(0, k_residue, 0), gB);
+
+  // Define smem layouts.
+  auto [sA_layout, sB_layout] = make_smem_layouts<KMajorA, KMajorB>(cta_tiler);
+
+  // Shared memory buffer.
+  extern __shared__ char smem_buf[];
+  using SharedStorage = SharedStorage<Element, decltype(sA_layout), decltype(sB_layout)>;
+  SharedStorage& smem = *reinterpret_cast<SharedStorage*>(smem_buf);
+  Tensor sA = make_tensor(make_smem_ptr(smem.A.begin()), sA_layout); // (BLK_M,BLK_K)
+  Tensor sB = make_tensor(make_smem_ptr(smem.B.begin()), sB_layout); // (BLK_N,BLK_K)
+
+  // Define copy atoms.
+  auto num_threads = size(mma);
+  auto [bM, bN, bK] = cta_tiler;
+  TiledCopy copy_a = make_tiled_copy<Element, Aligned, KMajorA>(num_threads, bM, bK);
+  TiledCopy copy_b = make_tiled_copy<Element, Aligned, KMajorB>(num_threads, bN, bK);
+
+  // Partition the copying of A/B/C tiles across the threads.
+  ThrCopy thr_copy_a = copy_a.get_slice(thread_idx);
+  Tensor tAgA = thr_copy_a.partition_S(gA); // (ACPY,ACPY_M,ACPY_K,k)
+  Tensor tAsA = thr_copy_a.partition_D(sA); // (ACPY,ACPY_M,ACPY_K)
+  Tensor tArA = make_fragment_like(tAsA);   // (ACPY,ACPY_M,ACPY_K)
+
+  ThrCopy thr_copy_b = copy_b.get_slice(thread_idx);
+  Tensor tBgB = thr_copy_b.partition_S(gB); // (BCPY,BCPY_N,BCPY_K,k)
+  Tensor tBsB = thr_copy_b.partition_D(sB); // (BCPY,BCPY_N,BCPY_K)
+  Tensor tBrB = make_fragment_like(tBsB);   // (BCPY,BCPY_M,BCPY_K)
+
+  // MMA.
+  ThrMMA thr_mma = mma.get_slice(thread_idx);
+  Tensor tCsA = thr_mma.partition_A(sA);       // (MMA,MMA_M,MMA_K)
+  Tensor tCsB = thr_mma.partition_B(sB);       // (MMA,MMA_N,MMA_K)
+  Tensor tCgC = thr_mma.partition_C(gC);       // (MMA,MMA_M,MMA_N)
+  Tensor tCrC = thr_mma.make_fragment_C(tCgC); // (MMA,MMA_M,MMA_N)
+
+  // Predicates for m/n bounds.
+  Tensor tApA = make_tensor<bool>(make_shape(size<1>(tAsA), size<2>(tAsA)), Stride<_1,_0>{}); // (CPY_M,CPY_K)
+  Tensor tBpB = make_tensor<bool>(make_shape(size<1>(tBsB), size<2>(tBsB)), Stride<_1,_0>{}); // (CPY_N,CPY_K)
+  Tensor cA = make_identity_tensor(make_shape(size<0>(sA), size<1>(sA))); // (BLK_M,BLK_K)
+  Tensor cB = make_identity_tensor(make_shape(size<0>(sB), size<1>(sB))); // (BLK_N,BLK_K)
+  Tensor cC = make_identity_tensor(make_shape(size<0>(gC), size<1>(gC))); // (M,N)
+  Tensor tAcA = thr_copy_a.partition_S(cA); // (CPY,CPY_M,CPY_K)
+  Tensor tBcB = thr_copy_b.partition_S(cB); // (CPY,CPY_N,CPY_K)
+  Tensor tCcC = thr_mma.partition_C(cC);    // (MMA,MMA_M,MMA_N)
+  CUTE_UNROLL
+  for (int m = 0; m < size<0>(tApA); ++m) {
+    tApA(m,0) = get<0>(tAcA(0,m,0)) < m_max_coord;
+  }
+  CUTE_UNROLL
+  for (int n = 0; n < size<0>(tBpB); ++n) {
+    tBpB(n,0) = get<0>(tBcB(0,n,0)) < n_max_coord;
+  }
+
+  // GMEM => RMEM.
+  auto fetch_gmem = [&](int tile) {
+    copy_if(copy_a, tApA, tAgA(_,_,_,tile), tArA);
+    copy_if(copy_b, tBpB, tBgB(_,_,_,tile), tBrB);
+  };
+  // RMEM => SMEM.
+  auto store_smem = [&]() {
+    __syncthreads();
+    copy(tArA, tAsA);
+    copy(tBrB, tBsB);
+    __syncthreads();
+  };
+
+  // Clear the rmem tiles to account for predicated off loads.
+  clear(tArA);
+  clear(tBrB);
+
+  // Prefetch first tile.
+  Tensor tAgA_k = tAgA(_,_,_,0);
+  Tensor tBgB_k = tBgB(_,_,_,0);
+  CUTE_UNROLL
+  for (int k = 0; k < size<2>(tArA); ++k) {
+    if (get<1>(tAcA(0,0,k)) >= -k_residue) {
+      copy_if(copy_a, tApA(_,k), tAgA_k(_,_,k), tArA(_,_,k));
+    }
+  }
+  CUTE_UNROLL
+  for (int k = 0; k < size<2>(tBrB); ++k) {
+    if (get<1>(tBcB(0,0,k)) >= -k_residue) {
+      copy_if(copy_b, tBpB(_,k), tBgB_k(_,_,k), tBrB(_,_,k));
+    }
+  }
+
+  // Clear accumulators.
+  clear(tCrC);
+
+  // Loop over CTA tiles.
+  auto K_TILE_MAX = size<3>(tAgA);
+  for (int tile = 0; tile < K_TILE_MAX; ++tile) {
+    store_smem();
+    // Avoid fetching full 0th-tile when there is residue.
+    if (K_TILE_MAX > 1) {
+      fetch_gmem((tile + 1 < K_TILE_MAX) ? tile + 1 : tile);
+    }
+    gemm(mma, tCsA, tCsB, tCrC);
+  }
+
+  // Epilogue.
+  CUTE_UNROLL
+  for (int i = 0; i < size(tCrC); ++i) {
+    if ((get<0>(tCcC(i)) < m_max_coord) && (get<1>(tCcC(i)) < n_max_coord)) {
+      tCgC(i) = Element(tCrC(i));
+    }
+  }
+}
+
+template <bool KMajor>
+inline constexpr auto make_matrix_stride(auto m, auto k) {
+  if constexpr (KMajor) {
+    return cute::make_stride(k, cute::Int<1>{}, m * k);
+  } else {
+    return cute::make_stride(cute::Int<1>{}, m, m * k);
+  }
+}
+
+template <bool SM80, typename Element>
+inline constexpr auto make_tiled_mma(auto cta_tiler) {
+  using Atom = std::conditional_t<
+      SM80,
+      std::conditional_t<
+          std::is_same_v<Element, half_t>,
+          SM80_16x8x16_F32F16F16F32_TN,
+          std::conditional_t<
+              std::is_same_v<Element, bfloat16_t>,
+              SM80_16x8x16_F32BF16BF16F32_TN,
+              UniversalFMA<float>
+          >
+      >,
+      UniversalFMA<float, Element, Element>>;
+  if constexpr (!SM80 || std::is_same_v<Element, float>) {
+    return make_tiled_mma(Atom{}, Layout<Shape<_16,_8,_1>>{});
+  } else {
+    if constexpr (size<0>(cta_tiler) >= 32) {
+      return make_tiled_mma(Atom{}, Layout<Shape<_2,_2,_1>>{}, Tile<_32,_32,_16>{});
+    } else {
+      return make_tiled_mma(Atom{}, Layout<Shape<_1,_4,_1>>{}, Tile<_16,_32,_16>{});
+    }
+  }
+}
+
+template <bool KMajorA, bool KMajorB, bool SM80, typename Element,
+          typename ProblemShape,
+          typename CtaTiler,
+          typename StrideA,
+          typename StrideB,
+          typename StrideC,
+          typename TiledMma>
+__global__
+__launch_bounds__(decltype(size(TiledMma{}))::value)
+void gather_mm_kernel(
+    ProblemShape shape_MNKL,
+    CtaTiler cta_tiler,
+    const Element* A, StrideA dA,
+    const Element* B, StrideB dB,
+    const uint32_t* lhs_indices,
+    const uint32_t* rhs_indices,
+    Element* C, StrideC dC,
+    TiledMma mma) {
+  CUTE_STATIC_ASSERT_V(congruent(select<0,2,3>(shape_MNKL), dA));
+  CUTE_STATIC_ASSERT_V(congruent(select<1,2,3>(shape_MNKL), dB));
+  CUTE_STATIC_ASSERT_V(congruent(select<0,1,3>(shape_MNKL), dC));
+
+  int thread_idx = int(threadIdx.x);
+  int m_coord = int(blockIdx.x);
+  int n_coord = int(blockIdx.y);
+  int l_coord = int(blockIdx.z);
+
+  // Represent the full tensors.
+  Tensor mA_mkl = make_tensor(make_gmem_ptr(A), select<0,2,3>(shape_MNKL), dA); // (M,K,L)
+  Tensor mB_nkl = make_tensor(make_gmem_ptr(B), select<1,2,3>(shape_MNKL), dB); // (N,K,L)
+  Tensor mC_mnl = make_tensor(make_gmem_ptr(C), select<0,1,3>(shape_MNKL), dC); // (M,N,L)
+
+  // For gather, use index lookup for input batch slicing.
+  uint32_t a_batch = lhs_indices ? lhs_indices[l_coord] : l_coord;
+  uint32_t b_batch = rhs_indices ? rhs_indices[l_coord] : l_coord;
+
+  // Get batch slice.
+  Tensor mA = mA_mkl(_,_,a_batch); // (M,K)
+  Tensor mB = mB_nkl(_,_,b_batch); // (N,K)
+  Tensor mC = mC_mnl(_,_,l_coord); // (M,N)
+
+  // Get the appropriate blocks for this thread block.
+  auto cta_coord = make_coord(m_coord, n_coord, _); // (m,n,k)
+  Tensor gA = local_tile(mA, cta_tiler, cta_coord, Step<_1, X,_1>{}); // (BLK_M,BLK_K,k)
+  Tensor gB = local_tile(mB, cta_tiler, cta_coord, Step< X,_1,_1>{}); // (BLK_N,BLK_K,k)
+  Tensor gC = local_tile(mC, cta_tiler, cta_coord, Step<_1,_1, X>{}); // (BLK_M,BLK_N)
+
+  // Compute tile residues for predication.
+  int m_max_coord = size<0>(shape_MNKL) - size<0>(cta_tiler) * m_coord; // M - BLK_M * m_coord
+  int n_max_coord = size<1>(shape_MNKL) - size<1>(cta_tiler) * n_coord; // N - BLK_N * n_coord
+  int k_residue = size<2>(shape_MNKL) - size<1>(gA) * size<2>(gA);
+
+  if (k_residue % 8 == 0) {
+    gemm_sm70_mainloop<KMajorA, KMajorB, SM80, true>(
+        cta_tiler,
+        gA,
+        gB,
+        gC,
+        mma,
+        m_max_coord, n_max_coord, k_residue,
+        thread_idx);
+  } else {
+    gemm_sm70_mainloop<KMajorA, KMajorB, SM80, false>(
+        cta_tiler,
+        gA,
+        gB,
+        gC,
+        mma,
+        m_max_coord, n_max_coord, k_residue,
+        thread_idx);
+  }
+}
+
+template <bool KMajorA, bool KMajorB, bool SM80, typename Element>
 void gather_mm(
-    int m,
-    int n,
-    int k,
-    int l,
-    bool a_transposed,
-    bool b_transposed,
     const Element* A,
     const Element* B,
     const uint32_t* lhs_indices,
     const uint32_t* rhs_indices,
     Element* C,
-    F&& launch_kernel) {
-  auto problem_shape = make_shape(m, n, k, l);
-  auto dC = make_stride(m, Int<1>{}, m * n);
-  dispatch_stride(!a_transposed, m, k, [&](auto dA, auto k_major_a) {
-    dispatch_stride(b_transposed, n, k, [&](auto dB, auto k_major_b) {
-      using Accumulator =
-          std::conditional_t<(sizeof(Element) < 4), float, Element>;
-      using TileShape = Shape<_128, _128, _8>;
-      using DispatchPolicy = cutlass::gemm::MainloopSm70TwoStage;
-      using TiledMma = TiledMMA<
-          MMA_Atom<UniversalFMA<Accumulator, Element, Element, Accumulator>>,
-          Layout<Shape<_16, _16, _1>>>;
+    int m, int n, int k, int l,
+    auto&& launch_kernel) {
+  // Define shapes (dynamic).
+  auto shape_MNKL = make_shape(m, n, k, l); // (M,N,K,L)
 
-      using CopyTraitsA = SimtCopyTraits<Element, k_major_a.value>;
-      using CopyTraitsB = SimtCopyTraits<Element, k_major_b.value>;
+  // Define layouts (mixed).
+  auto dA = make_matrix_stride<KMajorA>(m, k); // (dM,dK,dL)
+  auto dB = make_matrix_stride<KMajorB>(n, k); // (dN,dK,dL)
+  auto dC = make_stride(n, Int<1>{}, m * n);   // (dM,dN,dL)
 
-      using CollectiveMainloop = cutlass::gemm::collective::CollectiveMma<
-          DispatchPolicy,
-          TileShape,
-          Element,
-          decltype(dA),
-          Element,
-          decltype(dB),
-          TiledMma,
-          typename CopyTraitsA::GmemTiledCopy,
-          typename CopyTraitsA::SmemLayout,
-          typename CopyTraitsA::SmemCopyAtom,
-          identity,
-          typename CopyTraitsB::GmemTiledCopy,
-          typename CopyTraitsB::SmemLayout,
-          typename CopyTraitsB::SmemCopyAtom,
-          identity>;
+  // Define CTA tile size (static).
+  auto cta_tiler = make_shape(Int<16>{}, Int<128>{}, Int<64>{});
 
-      using CollectiveEpilogue = cutlass::epilogue::collective::DefaultEpilogue<
-          Element,
-          decltype(dC),
-          decltype(dC),
-          cutlass::epilogue::thread::
-              LinearCombination<Element, 1, Accumulator, Accumulator>,
-          cutlass::gemm::EpilogueDefault>;
+  // Define MMA.
+  auto mma = make_tiled_mma<SM80, Element>(cta_tiler);
+  auto num_threads = size(mma);
 
-      using GemmKernel = GatherGemm<
-          decltype(problem_shape),
-          CollectiveMainloop,
-          CollectiveEpilogue>;
-      using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  // Shared memory size.
+  auto [sA_layout, sB_layout] = make_smem_layouts<KMajorA, KMajorB>(cta_tiler);
+  size_t smem_bytes = sizeof(SharedStorage<Element, decltype(sA_layout), decltype(sB_layout)>);
 
-      Gemm gemm;
-      typename Gemm::Arguments args{
-          problem_shape,
-          lhs_indices,
-          rhs_indices,
-          {A, dA, B, dB},
-          {{1.f, 0.f}, C, dC, C, dC}};
+  auto* kernel = &gather_mm_kernel<
+      KMajorA, KMajorB, SM80, Element,
+      decltype(shape_MNKL),
+      decltype(cta_tiler),
+      decltype(dA),
+      decltype(dB),
+      decltype(dC),
+      decltype(mma)>;
+  cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_bytes);
 
-      CHECK_CUTLASS_ERROR(gemm.initialize(args, nullptr));
-
-      auto* kernel = &cutlass::device_kernel<GemmKernel>;
-      void* kernel_params[] = {const_cast<Gemm::Params*>(&gemm.params())};
-      launch_kernel(
-          reinterpret_cast<void*>(kernel),
-          gemm.get_grid_shape(gemm.params()),
-          GemmKernel::get_block_shape(),
-          GemmKernel::SharedStorageSize,
-          kernel_params);
-    });
-  });
+  dim3 num_blocks{uint32_t(ceil_div(m, size<0>(cta_tiler))),
+                  uint32_t(ceil_div(n, size<1>(cta_tiler))),
+                  uint32_t(l)};
+  dim3 block_dims{num_threads};
+  void* args[] = {
+      &shape_MNKL,
+      &cta_tiler,
+      &A, &dA,
+      &B, &dB,
+      &lhs_indices, &rhs_indices,
+      &C, &dC,
+      &mma};
+  launch_kernel(reinterpret_cast<void*>(kernel), num_blocks, block_dims, smem_bytes, args);
 }
 
 } // namespace cutlass_gemm
 
+// clang-format on
+
 namespace mlx::core {
 
-void cutlass_gather_mm(
+template <typename F>
+inline void dispatch_element_types(Dtype dtype, const char* tag, F&& f) {
+  if (dtype == float32) {
+    f.template operator()<float>();
+  } else if (dtype == float16) {
+    f.template operator()<cutlass::half_t>();
+  } else if (dtype == bfloat16) {
+    f.template operator()<cutlass::bfloat16_t>();
+  } else {
+    throw std::invalid_argument(
+        fmt::format("{} Unsupported dtype: {}.", tag, dtype_to_string(dtype)));
+  }
+}
+
+void gather_mm(
     bool a_transposed,
     bool b_transposed,
     const array& a,
@@ -300,6 +381,8 @@ void cutlass_gather_mm(
     const array& rhs_indices,
     array& out,
     cu::CommandEncoder& encoder) {
+  bool sm80 = encoder.device().compute_capability_major() >= 8;
+
   int m = out.shape(-2);
   int n = out.shape(-1);
   int k = a.shape(-1);
@@ -311,28 +394,31 @@ void cutlass_gather_mm(
   encoder.set_input_array(rhs_indices);
   encoder.set_output_array(out);
 
-  dispatch_float_types(out.dtype(), "gather_mm", [&](auto type_tag) {
-    using Element = cutlass_type_t<MLX_GET_TYPE(type_tag)>;
-    cutlass_gemm::gather_mm(
-        m,
-        n,
-        k,
-        l,
-        a_transposed,
-        b_transposed,
-        gpu_ptr<Element>(a),
-        gpu_ptr<Element>(b),
-        gpu_ptr<uint32_t>(lhs_indices),
-        gpu_ptr<uint32_t>(rhs_indices),
-        gpu_ptr<Element>(out),
-        [&](auto* kernel,
-            dim3 num_blocks,
-            dim3 block_dims,
-            uint32_t smem_bytes,
-            void** args) {
-          encoder.add_kernel_node_raw(
-              kernel, num_blocks, block_dims, {}, smem_bytes, args);
+  dispatch_element_types(out.dtype(), "[gather_mm]", [&]<typename Element>() {
+    dispatch_bool(!a_transposed, [&](auto k_major_a) {
+      dispatch_bool(b_transposed, [&](auto k_major_b) {
+        dispatch_bool(sm80, [&](auto sm80) {
+          cutlass_gemm::gather_mm<k_major_a.value, k_major_b.value, sm80.value>(
+              gpu_ptr<Element>(a),
+              gpu_ptr<Element>(b),
+              gpu_ptr<uint32_t>(lhs_indices),
+              gpu_ptr<uint32_t>(rhs_indices),
+              gpu_ptr<Element>(out),
+              m,
+              n,
+              k,
+              l,
+              [&](auto* kernel,
+                  dim3 num_blocks,
+                  dim3 block_dims,
+                  uint32_t smem_bytes,
+                  void** args) {
+                encoder.add_kernel_node_raw(
+                    kernel, num_blocks, block_dims, {}, smem_bytes, args);
+              });
         });
+      });
+    });
   });
 }
 

--- a/mlx/backend/cuda/gemms/gather_gemm.h
+++ b/mlx/backend/cuda/gemms/gather_gemm.h
@@ -10,7 +10,7 @@ class CommandEncoder;
 
 class array;
 
-void cutlass_gather_mm(
+void gather_mm(
     bool a_transposed,
     bool b_transposed,
     const array& a,

--- a/mlx/backend/cuda/matmul.cpp
+++ b/mlx/backend/cuda/matmul.cpp
@@ -421,7 +421,7 @@ void GatherMM::eval_gpu(const std::vector<array>& inputs, array& out) {
     return;
   }
 
-  cutlass_gather_mm(
+  gather_mm(
       a_transposed, b_transposed, a, b, lhs_indices, rhs_indices, out, encoder);
 }
 

--- a/python/tests/cuda_skip.py
+++ b/python/tests/cuda_skip.py
@@ -1,5 +1,0 @@
-cuda_skip = {
-    # Quantization NYI
-    "TestQuantized.test_gather_matmul_grad",
-    "TestQuantized.test_gather_qmm",
-}

--- a/python/tests/mlx_tests.py
+++ b/python/tests/mlx_tests.py
@@ -23,37 +23,6 @@ class MLXTestRunner(unittest.TestProgram):
         kwargs["exit"] = False
         super().__init__(*args, **kwargs)
 
-    def createTests(self, *args, **kwargs):
-        super().createTests(*args, **kwargs)
-
-        # Asume CUDA backend in this case
-        device = os.getenv("DEVICE", None)
-        if device is not None:
-            device = getattr(mx, device)
-        else:
-            device = mx.default_device()
-
-        if not (device == mx.gpu and not mx.metal.is_available()):
-            return
-
-        from cuda_skip import cuda_skip
-
-        filtered_suite = unittest.TestSuite()
-
-        def filter_and_add(t):
-            if isinstance(t, unittest.TestSuite):
-                for sub_t in t:
-                    filter_and_add(sub_t)
-            else:
-                t_id = ".".join(t.id().split(".")[-2:])
-                if t_id in cuda_skip:
-                    print(f"Skipping {t_id}")
-                else:
-                    filtered_suite.addTest(t)
-
-        filter_and_add(self.test)
-        self.test = filtered_suite
-
     def runTests(self):
         super().runTests()
         mx.clear_streams()

--- a/python/tests/test_conv.py
+++ b/python/tests/test_conv.py
@@ -1085,7 +1085,7 @@ class TestConv(mlx_tests.MLXTestCase):
                         groups=groups,
                         flip=flip,
                         np_dtype=dtype,
-                        atol=2e-5 if dtype == np.float32 else 5e-4,
+                        atol=2e-5 if dtype == np.float32 else 5e-3,
                     )
 
     @unittest.skipIf(not has_torch, "requires Torch")

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -1877,7 +1877,7 @@ class TestOps(mlx_tests.MLXTestCase):
             a = (10 * mx.random.normal(shape=(1024,))).astype(t)
             out_expect = mx.softmax(a.astype(mx.float32)).astype(t)
             out = mx.softmax(a, axis=-1, precise=True)
-            self.assertTrue(mx.allclose(out_expect, out))
+            self.assertTrue(mx.allclose(out_expect, out, atol=1e-6))
 
         # All Infs give NaNs
         for n in [127, 128, 129]:
@@ -2979,6 +2979,7 @@ class TestOps(mlx_tests.MLXTestCase):
             H = np.vstack((np.hstack((H, H)), np.hstack((H, -H))))
         return H
 
+    @unittest.skipIf("CI" in os.environ, "too slow in CI")
     def test_hadamard(self):
         with self.assertRaises(ValueError):
             mx.hadamard_transform(mx.array([]))

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -22,5 +22,7 @@ int main(int argc, char** argv) {
   }
 
   context.applyCommandLine(argc, argv);
-  return context.run();
+  int exit_code = context.run();
+  clear_streams();
+  return exit_code;
 }


### PR DESCRIPTION
The sm70/sm80 kernels of CUTLASS v3 are in a weird state: no one uses them, no one maintains them, they have bugs and I had a really hard time trying to find a maintainer who actually understand the kernels to look into the bugs.

Anyway it is much easier to just write the kernel in plain CuTe and it should be better for long term maintenance since the code no longer requires domain-specific knowledge of CUTLASS C++ APIs.

This PR removes the last entries in `cuda_skip.py‎` and I'm deleting the file, for future TODO items in CUDA backend we can just use `@unittest.skipIf`.