### PR TITLE
[CUDA] Guard qmm_naive scale and bias loads at tile boundaries

### DIFF
--- a/mlx/backend/cuda/quantized/qmm/qmm_naive.cu
+++ b/mlx/backend/cuda/quantized/qmm/qmm_naive.cu
@@ -46,7 +46,6 @@ void qmm_naive_kernel(
   Tensor mC_mnl = make_tensor(make_gmem_ptr(C),        select<0,1,3>(shape_MNKL), dC); // (M,N,L)
 
   Tensor mS_nkl = make_tensor(make_gmem_ptr(S), S_layout); // (N,(group_size,K/group_size),L)
-  Tensor mZ_nkl = make_tensor(make_gmem_ptr(Z), S_layout); // (N,(group_size,K/group_size),L)
 
   // For gather, use index lookup for input batch slicing.
   uint32_t a_batch = lhs_indices ? lhs_indices[l_coord] : l_coord;
@@ -58,7 +57,6 @@ void qmm_naive_kernel(
   Tensor mC = mC_mnl(_,_,l_coord); // (M,N)
 
   Tensor mS = mS_nkl(_,_,b_batch); // (N,(group_size,K/group_size))
-  Tensor mZ = mZ_nkl(_,_,b_batch); // (N,(group_size,K/group_size))
 
   // Get the appropriate blocks for this thread block.
   auto cta_coord = make_coord(m_coord, n_coord, _); // (m,n,k)
@@ -67,7 +65,16 @@ void qmm_naive_kernel(
   Tensor gC = local_tile(mC, cta_tiler, cta_coord, Step<_1,_1, X>{}); // (BLK_M,BLK_N)
 
   Tensor gS = local_tile(mS, cta_tiler, cta_coord, Step< X,_1,_1>{}); // (BLK_N,BLK_K,k)
-  Tensor gZ = local_tile(mZ, cta_tiler, cta_coord, Step< X,_1,_1>{}); // (BLK_N,BLK_K,k)
+  auto gZ = [&]() {
+    if constexpr (quant_has_bias_v<Quant>) {
+      Tensor mZ_nkl = make_tensor(make_gmem_ptr(Z), S_layout); // (N,(group_size,K/group_size),L)
+      Tensor mZ = mZ_nkl(_,_,b_batch); // (N,(group_size,K/group_size))
+      return local_tile(mZ, cta_tiler, cta_coord, Step< X,_1,_1>{}); // (BLK_N,BLK_K,k)
+    } else {
+      // Dummy tensor; no-bias paths never offset or load gZ.
+      return gS;
+    }
+  }();
 
   // Compute tile residues for predication.
   int m_max_coord = size<0>(shape_MNKL) - size<0>(cta_tiler) * m_coord; // M - BLK_M * m_coord

--- a/mlx/backend/cuda/quantized/qmm/qmm_naive.cuh
+++ b/mlx/backend/cuda/quantized/qmm/qmm_naive.cuh
@@ -114,7 +114,9 @@ CUTE_DEVICE void qmm_naive_mainloop(
     gB.data() = recast_ptr<Quant>(raw_pointer_cast(gB.data()) + gB.layout()(0, k_residue, 0) * cuda::std::min(8, sizeof_bits_v<Quant>) / 8);
   }
   gS = domain_offset(make_coord(0, k_residue, 0), gS);
-  gZ = domain_offset(make_coord(0, k_residue, 0), gZ);
+  if constexpr (quant_has_bias_v<Quant>) {
+    gZ = domain_offset(make_coord(0, k_residue, 0), gZ);
+  }
 
   // Define smem layouts.
   auto [sA_layout, sB_layout] = make_smem_layouts(cta_tiler);
@@ -177,8 +179,15 @@ CUTE_DEVICE void qmm_naive_mainloop(
   auto fetch_gmem = [&](int tile) {
     copy_if(copy_a, tApA, tAgA(_,_,_,tile), tArA);
     copy_if(copy_b, tBpB, tBgB(_,_,_,tile), tBrB);
-    copy(tBgS(_,_,_,tile), tBrS);
-    copy(tBgZ(_,_,_,tile), tBrZ);
+    CUTE_UNROLL
+    for (int n = 0; n < size<1>(tBrS); ++n) {
+      if (tBpB(n,0)) {
+        copy(tBgS(_,n,_,tile), tBrS(_,n,_));
+        if constexpr (quant_has_bias_v<Quant>) {
+          copy(tBgZ(_,n,_,tile), tBrZ(_,n,_));
+        }
+      }
+    }
   };
   // RMEM => SMEM.
   auto store_smem = [&]() {
@@ -219,8 +228,15 @@ CUTE_DEVICE void qmm_naive_mainloop(
     for (int k = 0; k < size<2>(tBrB); ++k) {
       if (get<1>(tBcB(0,0,k)) >= -k_residue) {
         copy_if(copy_b, tBpB(_,k), tBgB_k(_,_,k), tBrB(_,_,k));
-        copy(tBgS_k(_,_,k), tBrS(_,_,k));
-        copy(tBgZ_k(_,_,k), tBrZ(_,_,k));
+        CUTE_UNROLL
+        for (int n = 0; n < size<1>(tBrS); ++n) {
+          if (tBpB(n,k)) {
+            copy(tBgS_k(_,n,k), tBrS(_,n,k));
+            if constexpr (quant_has_bias_v<Quant>) {
+              copy(tBgZ_k(_,n,k), tBrZ(_,n,k));
+            }
+          }
+        }
       }
     }
   } else {


### PR DESCRIPTION
Fixes #3487 

## Proposed changes

Fix invalid global reads in the CUDA `qmm_naive` kernel when the output `N` dimension only partially fills the current tile. scale/bias loads are now predicated by the existing N-tile predicate.

## Reproduce

using script `repro_qmm_partial_n.py`

```python
import mlx.core as mx

mx.set_default_device(mx.gpu)

M, N, K = 17, 1, 16384
group_size = 64
bits = 4
transpose = True

key = mx.random.key(0)
k1, k2 = mx.random.split(key)

x = (mx.random.normal((M, K), key=k1) / K**0.5).astype(mx.float16)
w = (mx.random.normal((N, K), key=k2) / K**0.5).astype(mx.float16)
w_q, scales, biases = mx.quantize(w, group_size, bits)

print(
    "shapes:",
    f"x={x.shape}",
    f"w_q={w_q.shape}",
    f"scales={scales.shape}",
    f"biases={biases.shape}",
)

y = mx.quantized_matmul(x, w_q, scales, biases, transpose, group_size, bits)
mx.eval(y)
mx.synchronize()

print("completed")
```

run with:

```bash
CUDA_LAUNCH_BLOCKING=1 MLX_USE_CUDA_GRAPHS=0 \
/usr/local/cuda/bin/compute-sanitizer --tool memcheck \
--padding 4096 --error-exitcode 99 \
python repro_qmm_partial_n.py
```

before:

```text
========= COMPUTE-SANITIZER
========= Invalid __global__ read of size 2 bytes
=========     at void cutlass_gemm::qmm_naive_kernel<(bool)1, (bool)0, (bool)1, cutlass::half_t, cutlass::integer_subbyte<(int)4, (bool)0>, cutlass::half_t, cute::tuple<int, int, int, int>, cute::tuple<cute::C<(int)32>, cute::C<(int)128>, cute::C<(int)64>>, cute::tuple<int, cute::C<(int)1>, int>, cute::tuple<int, cute::C<(int)1>, int>, cute::Layout<cute::tuple<int, cute::tuple<cute::C<(int)64>, int>, int>, cute::tuple<int, cute::tuple<cute::C<(int)0>, cute::C<(int)1>>, int>>, cute::tuple<int, cute::C<(int)1>, int>, cute::TiledMMA<cute::MMA_Atom<cute::SM80_16x8x16_F32F16F16F32_TN>, cute::Layout<cute::tuple<cute::C<(int)2>, cute::C<(int)2>, cute::C<(int)1>>, cute::tuple<cute::C<(int)1>, cute::C<(int)2>, cute::C<(int)0>>>, cute::tuple<cute::C<(int)32>, cute::C<(int)32>, cute::C<(int)16>>>>(T7, T8, const T4 *, T9, const T5 *, T10, const T6 *, const T4 *, T11, const unsigned int *, const unsigned int *, T4 *, T12, T13)+0x10d0
=========     by thread (32,0,0) in block (0,0,0)
=========     Access at 0x8d0130c00 is out of bounds
...
Traceback (most recent call last):
  File "~/mlx/repro_qmm_partial_n.py", line 33, in <module>
    mx.eval(y)
RuntimeError: cudaLaunchKernelExC(&config, func, params) failed: unspecified launch failure
========= Program hit cudaErrorLaunchFailure (error 719) due to "unspecified launch failure" on CUDA API call to cudaStreamSynchronize.
========= 
terminate called after throwing an instance of 'std::runtime_error'
  what():  cudaStreamSynchronize(stream_) failed: unspecified launch failure
========= Error: process didn't terminate successfully
========= Target application returned an error
========= ERROR SUMMARY: 42 errors
```

after:

```text
========= COMPUTE-SANITIZER
shapes: x=(17, 16384) w_q=(1, 2048) scales=(1, 256) biases=(1, 256)
completed
========= ERROR SUMMARY: 0 errors
```
