### PR TITLE
Add `copy` keyword to `mx.asarray`

### DIFF
--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -1765,23 +1765,35 @@ void init_ops(nb::module_& m) {
       )pbdoc");
   m.def(
       "asarray",
-      [](const nb::object& a, std::optional<mx::Dtype> dtype) {
+      [](const nb::object& a,
+         std::optional<mx::Dtype> dtype,
+         std::optional<bool> copy) {
+        if (copy.has_value() && !*copy) {
+          throw std::invalid_argument("[asarray] copy=False is not supported.");
+        }
         return create_array(a, dtype);
       },
       nb::arg(),
       "dtype"_a = nb::none(),
+      nb::kw_only(),
+      "copy"_a = nb::none(),
       nb::sig(
-          "def asarray(a: Union[scalar, array, Sequence], dtype: "
-          "Optional[Dtype] = None) -> array"),
+          "def asarray(a: Union[scalar, array, Sequence], dtype: Optional[Dtype] = None, *, copy: Optional[bool] = None) -> array"),
       R"pbdoc(
         Convert the input to an array.
 
         Args:
             a: Input data.
             dtype (Dtype, optional): The desired data-type for the array.
+            copy (bool, optional): Must be ``True`` or unspecified. ``False``
+              is not supported, since MLX has no in-place operations and
+              cannot return a non-copying view.
 
         Returns:
             array: An array interpretation of the input.
+
+        Raises:
+            ValueError: If ``copy`` is ``False``.
       )pbdoc");
   m.def(
       "zeros_like",

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -2152,6 +2152,17 @@ class TestArray(mlx_tests.MLXTestCase):
         arr_pass = xp.asarray(existing)
         self.assertEqual(arr_pass.tolist(), [4, 5, 6])
 
+    def test_asarray_copy(self):
+        existing = mx.array([1, 2, 3])
+
+        self.assertEqual(mx.asarray(existing, copy=True).tolist(), [1, 2, 3])
+        self.assertEqual(
+            mx.asarray(existing, dtype=mx.float32, copy=True).dtype, mx.float32
+        )
+
+        with self.assertRaises(ValueError):
+            mx.asarray(existing, copy=False)
+
     def test_asarray(self):
         # List inputs
         self.assertEqual(mx.asarray([1, 2, 3]).tolist(), [1, 2, 3])


### PR DESCRIPTION
## Proposed changes

`mx.asarray` doesn't accept the `copy` keyword from the array-API spec. References #3484.

This adds `copy` as a keyword-only argument. MLX has no in-place operations, so a non-copying conversion isn't meaningful: `copy=False` raises `ValueError`, and `copy=True` or unspecified behave the same as before.

The `from_dlpack` half of #3484 is left out, since PR #3495 reworks dlpack consumption through the `mx.array(...)` constructor and the namespace wiring depends on that landing.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
