### PR TITLE
Introduce Array API Tests suite

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -86,6 +86,34 @@ jobs:
       - uses: ./.github/actions/build-windows
       - uses: ./.github/actions/test-windows
 
+  array_api_tests:
+    name: Array API Tests
+    if: github.repository == 'ml-explore/mlx'
+    needs: check_lint
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-linux
+      - uses: ./.github/actions/build-linux
+      - name: Checkout array-api-tests
+        uses: actions/checkout@v6
+        with:
+          repository: data-apis/array-api-tests
+          ref: '41379d15d26d67a1e66c840e775d41a8a7fb1516'  # v2026.02.26
+          submodules: 'true'
+          path: 'array-api-tests'
+          persist-credentials: false
+      - name: Install dependencies
+        run: |
+          python -m pip install pytest-xdist -r array-api-tests/requirements.txt
+      - name: Run the test suite
+        env:
+          ARRAY_API_TESTS_MODULE: mlx.core
+          PYTHONWARNINGS: 'ignore::UserWarning::,ignore::DeprecationWarning::,ignore::RuntimeWarning::'
+        run: |
+          cd ${GITHUB_WORKSPACE}/array-api-tests
+          pytest array_api_tests -v -c pytest.ini -n 2 --max-examples=1000 --derandomize --disable-deadline
+
   build_documentation:
     name: Build Documentation
     if: github.repository == 'ml-explore/mlx'


### PR DESCRIPTION
Addresses https://github.com/ml-explore/mlx/issues/3514

Hi @ilan-gold,
Here's an array-api-tests CI setup based on:
- JAX: https://github.com/jax-ml/jax/blob/main/.github/workflows/jax-array-api.yml
- NumPy: https://github.com/numpy/numpy/blob/3bea241a0fbf5610f876dc54d4caf7380f75471e/.github/workflows/linux.yml#L296

I anticipate that the library isn't 100% compatible (there's always some edge case) so we still need to prepare:
`--skips-file "${GITHUB_WORKSPACE}/tests/array_api_skips.txt"` file. 