### PR TITLE
win: fix cuda build

### DIFF
--- a/mlx/backend/cuda/CMakeLists.txt
+++ b/mlx/backend/cuda/CMakeLists.txt
@@ -122,7 +122,8 @@ target_compile_options(
 
 # Ignore warnings from CUTLASS.
 target_compile_options(
-  mlx PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe="--diag_suppress=2908,2361">)
+  mlx
+  PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe="--diag_suppress=186,2908,2361">)
 
 if(NOT MSVC)
   # Required for generating optimized CUTLASS code.

--- a/mlx/backend/cuda/gemms/gather_gemm.cu
+++ b/mlx/backend/cuda/gemms/gather_gemm.cu
@@ -340,7 +340,7 @@ void gather_mm(
   dim3 num_blocks{uint32_t(ceil_div(m, size<0>(cta_tiler))),
                   uint32_t(ceil_div(n, size<1>(cta_tiler))),
                   uint32_t(l)};
-  dim3 block_dims{num_threads};
+  dim3 block_dims{uint32_t(num_threads)};
   void* args[] = {
       &shape_MNKL,
       &cta_tiler,

--- a/mlx/backend/cuda/quantized/qmm/qmm_naive.cu
+++ b/mlx/backend/cuda/quantized/qmm/qmm_naive.cu
@@ -141,7 +141,7 @@ void qmm_naive(
   dim3 num_blocks{uint32_t(ceil_div(m, size<0>(cta_tiler))),
                   uint32_t(ceil_div(n, size<1>(cta_tiler))),
                   uint32_t(l)};
-  dim3 block_dims{num_threads};
+  dim3 block_dims(static_cast<uint32_t>(num_threads));
   void* args[] = {
       &shape_MNKL,
       &cta_tiler,

--- a/mlx/backend/cuda/quantized/qmm/qmm_naive.cu
+++ b/mlx/backend/cuda/quantized/qmm/qmm_naive.cu
@@ -141,7 +141,7 @@ void qmm_naive(
   dim3 num_blocks{uint32_t(ceil_div(m, size<0>(cta_tiler))),
                   uint32_t(ceil_div(n, size<1>(cta_tiler))),
                   uint32_t(l)};
-  dim3 block_dims(static_cast<uint32_t>(num_threads));
+  dim3 block_dims{uint32_t(num_threads)};
   void* args[] = {
       &shape_MNKL,
       &cta_tiler,

--- a/mlx/backend/cuda/quantized/qmm/qmm_sm80.cu
+++ b/mlx/backend/cuda/quantized/qmm/qmm_sm80.cu
@@ -138,7 +138,7 @@ void qmm_sm80(
   dim3 num_blocks{uint32_t(ceil_div(m, size<0>(cta_tiler))),
                   uint32_t(ceil_div(n, size<1>(cta_tiler))),
                   uint32_t(l)};
-  dim3 block_dims{num_threads};
+  dim3 block_dims(static_cast<uint32_t>(num_threads));
   void* args[] = {
       &shape_MNKL, &cta_tiler,
       &A, &dA,

--- a/mlx/backend/cuda/quantized/qmm/qmm_sm80.cu
+++ b/mlx/backend/cuda/quantized/qmm/qmm_sm80.cu
@@ -138,7 +138,7 @@ void qmm_sm80(
   dim3 num_blocks{uint32_t(ceil_div(m, size<0>(cta_tiler))),
                   uint32_t(ceil_div(n, size<1>(cta_tiler))),
                   uint32_t(l)};
-  dim3 block_dims(static_cast<uint32_t>(num_threads));
+  dim3 block_dims{uint32_t(num_threads)};
   void* args[] = {
       &shape_MNKL, &cta_tiler,
       &A, &dA,


### PR DESCRIPTION

## Proposed changes

Current build fails on windows with
  error C2398: Element '1': conversion from 'cute::C<128>' to 'unsigned int' requires a narrowing conversion

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
