### PR TITLE
ci: Show stack trace on crash

### DIFF
--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -27,7 +27,7 @@ runs:
         echo "::group::Install common dependencies"
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends \
-            zip \
+            gdb zip \
             libblas-dev liblapack-dev liblapacke-dev \
             openmpi-bin openmpi-common libopenmpi-dev
         echo "::endgroup::"

--- a/.github/actions/test-linux/action.yml
+++ b/.github/actions/test-linux/action.yml
@@ -67,3 +67,15 @@ runs:
         echo "::group::CPP tests - GPU"
         ./build/tests/tests -sfe="*linalg_tests.cpp"
         echo "::endgroup::"
+
+    - name: Show stack trace on crash
+      if: failure()
+      shell: bash
+      run: |
+        echo "::group::Show stack trace on crash"
+        set +e
+        sleep 10
+        if coredumpctl list; then
+          coredumpctl debug --debugger-arguments="-batch -ex 'thread apply all bt'"
+        fi
+        echo "::endgroup::"


### PR DESCRIPTION
When test fails, check if there is coredump generated, and use gdb to print symbolicated stack trace when there is there is one.

A test run:
https://github.com/ml-explore/mlx/actions/runs/25771334892/job/75695094341

<img width="1580" height="1196" alt="Screenshot 2026-05-13 at 10 05 40" src="https://github.com/user-attachments/assets/10791141-2c80-4921-a7fb-415123bc638f" />
