### PR TITLE
[Metal] Reject tensor-scale nvfp4 in qqmm

### DIFF
--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -1614,6 +1614,17 @@ void QQMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
 
   auto mode = quantization_mode_to_string(mode_);
   bool w_quantized = (inputs[1].dtype() == uint32);
+  // Tensor-scale nvfp4 (global_scale_x / global_scale_w) is packed into
+  // inputs by ops.cpp but no Metal qqmm kernel currently consumes the
+  // global scales. Reject the request rather than silently dropping them
+  // in the gemv path below.
+  int base_size = w_quantized ? 3 : 2;
+  if (mode_ == QuantizationMode::Nvfp4 &&
+      static_cast<int>(inputs.size()) > base_size) {
+    throw std::runtime_error(
+        "[QQMatmul] Global scale (tensor-scale nvfp4) is not supported "
+        "on the Metal backend.");
+  }
   if (w_quantized && inputs[0].shape(-2) == 1) {
     out.set_data(allocator::malloc(out.nbytes()));
 

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -205,6 +205,32 @@ class TestQuantized(mlx_tests.MLXTestCase):
                     self.assertEqual(y_q.shape, y_hat.shape)
                     self.assertLess((y_q - y_hat).abs().max(), 1e-3)
 
+    def test_qqmm_metal_global_scale_rejected(self):
+        # Tensor-scale nvfp4 (global_scale_x / global_scale_w) is not
+        # implemented in the Metal qqmm kernels. mx.qqmm must reject the
+        # request on Metal rather than silently dropping the global scales
+        # in the gemv path and producing incorrect results.
+        if not mx.metal.is_available():
+            return
+
+        w = mx.random.normal(shape=(64, 64))
+        w_q, scales = mx.quantize(w, mode="nvfp4")
+        x = mx.random.normal(shape=(1, 64))
+        gx = mx.array(1.0, dtype=mx.float32)
+        gw = mx.array(1.0, dtype=mx.float32)
+
+        with self.assertRaises(RuntimeError):
+            y = mx.qqmm(
+                x,
+                w_q,
+                scales,
+                mode="nvfp4",
+                global_scale_x=gx,
+                global_scale_w=gw,
+                stream=mx.gpu,
+            )
+            mx.eval(y)
+
     def test_qmm(self):
         key = mx.random.key(0)
         k1, k2 = mx.random.split(key)


### PR DESCRIPTION
## Summary

`QQMatmul::eval_gpu` on Metal silently dropped `global_scale_x` / `global_scale_w` in its gemv special case (pre-quantized `w`, `x.shape(-2) == 1`), producing numerically incorrect results when tensor-scale nvfp4 weights were in use. The general case already throws `[QQMatmul] NYI for the general case`. `qqmm()` was missed when tensor-scale nvfp4 landed in #3022.

This change adds a backend-level guard at the top of `QQMatmul::eval_gpu` in `mlx/backend/metal/quantized.cpp`: when `mode_ == Nvfp4` and extra inputs beyond `(x, w[, scales_w])` are present (i.e. global scales were packed by `ops.cpp`), it throws `std::runtime_error` (Python `RuntimeError`) — matching the local throw style used by the existing NYI path and keeping the device-specific check out of the backend-agnostic `ops.cpp`. CUDA is unaffected.

Per-group nvfp4 (no `global_scale`) on Metal continues to work — that path is exercised by the existing `test_qqmv` and is unchanged.

Fixes #3550.

## Test plan

- [x] Added `test_qqmm_metal_global_scale_rejected` in `python/tests/test_quantized.py`, asserts `RuntimeError` when `mx.qqmm` is evaluated on Metal with both global scales set. Verified the test fails on `main` (silently runs to completion) and passes with this fix.
- [x] Full `python/tests/test_quantized.py` (29 tests) still passes locally on Apple Silicon, including `test_qqmv` which exercises the gemv branch being guarded.