### PR TITLE
feat(fast): add sliding-window SDPA kernel path

### DIFF
--- a/mlx/backend/cuda/scaled_dot_product_attention.cpp
+++ b/mlx/backend/cuda/scaled_dot_product_attention.cpp
@@ -558,7 +558,11 @@ bool ScaledDotProductAttention::use_fallback(
     bool do_causal,
     bool is_training,
     bool output_logsumexp,
+    int window_size,
     Stream s) {
+  if (window_size > 0) {
+    return true;
+  }
   if (s.device == Device::cpu) {
     return true;
   }

--- a/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention.h
+++ b/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention.h
@@ -238,7 +238,7 @@ template <
   int kb_start = 0;
   int kb_min_causal = params->NK;
 
-  if (do_causal) {
+  if (do_causal || has_window) {
     int q_max = (tid.x + 1) * BQ + params->qL_off;
     kb_lim = (q_max + BK - 1) / BK;
     kb_lim = min(params->NK, kb_lim);
@@ -315,8 +315,8 @@ template <
       }
     }
 
-    // Mask out if causal
-    if (do_causal && kb >= kb_min_causal) {
+    // Mask out if causal or past the right edge of the sliding window.
+    if ((do_causal || has_window) && kb >= kb_min_causal) {
       using stile_t = decltype(Stile);
       using selem_t = typename stile_t::elem_type;
       constexpr auto neg_inf = Limits<selem_t>::finite_min;

--- a/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention.h
+++ b/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention.h
@@ -14,6 +14,7 @@ constant bool align_K [[function_constant(201)]];
 constant bool has_mask [[function_constant(300)]];
 constant bool do_causal [[function_constant(301)]];
 constant bool has_sinks [[function_constant(302)]];
+constant bool has_window [[function_constant(303)]];
 
 struct MaxOp {
   template <typename T>
@@ -234,6 +235,7 @@ template <
   }
 
   int kb_lim = params->NK;
+  int kb_start = 0;
   int kb_min_causal = params->NK;
 
   if (do_causal) {
@@ -246,8 +248,19 @@ template <
     kb_min_causal = (q_min / BK);
   }
 
+  if (has_window) {
+    int q_min = tid.x * BQ + params->qL_off;
+    int k_min = q_min - params->window_size + 1;
+    if (k_min > 0) {
+      kb_start = k_min / BK;
+      if (kb_start > kb_lim) {
+        kb_start = kb_lim;
+      }
+    }
+  }
+
   // Loop over KV seq length
-  for (int kb = 0; kb < kb_lim; kb++) {
+  for (int kb = kb_start; kb < kb_lim; kb++) {
     // Load K block and apply scale
     threadgroup_barrier(mem_flags::mem_threadgroup);
     if (!align_K && kb == (params->NK_aligned)) {
@@ -318,6 +331,28 @@ template <
           STEEL_PRAGMA_UNROLL
           for (short jj = 0; jj < stile_t::MMAFrag_t::kElemCols; jj++) {
             if (row_pos < (col_pos + jj)) {
+              Stile.frag_at(i, j)[jj] = neg_inf;
+            }
+          }
+        }
+      }
+    }
+
+    if (has_window && kb < (kb_start + ((BQ + BK - 1) / BK))) {
+      using stile_t = decltype(Stile);
+      using selem_t = typename stile_t::elem_type;
+      constexpr auto neg_inf = Limits<selem_t>::finite_min;
+
+      STEEL_PRAGMA_UNROLL
+      for (short i = 0; i < stile_t::kTileRows; i++) {
+        const int row_pos =
+            tid.x * BQ + params->qL_off + tm + sm + (i * stile_t::kFragRows);
+        STEEL_PRAGMA_UNROLL
+        for (short j = 0; j < stile_t::kTileCols; j++) {
+          const int col_pos = kb * BK + sn + (j * stile_t::kFragCols);
+          STEEL_PRAGMA_UNROLL
+          for (short jj = 0; jj < stile_t::MMAFrag_t::kElemCols; jj++) {
+            if (row_pos - (col_pos + jj) >= params->window_size) {
               Stile.frag_at(i, j)[jj] = neg_inf;
             }
           }

--- a/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention_nax.h
+++ b/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention_nax.h
@@ -178,7 +178,7 @@ template <
   int kb_start = 0;
   int kb_min_causal = params->NK;
 
-  if (do_causal) {
+  if (do_causal || has_window) {
     int q_max = (tid.x + 1) * BQ + params->qL_off;
     kb_lim = (q_max + BK - 1) / BK;
     kb_lim = min(params->NK, kb_lim);
@@ -288,8 +288,8 @@ template <
       }
     }
 
-    // Mask out if causal
-    if (do_causal && kb >= kb_min_causal) {
+    // Mask out if causal or past the right edge of the sliding window.
+    if ((do_causal || has_window) && kb >= kb_min_causal) {
       constexpr auto neg_inf = Limits<AccumType>::finite_min;
 
       const int base_row = tid.x * BQ + params->qL_off + tm;

--- a/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention_nax.h
+++ b/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention_nax.h
@@ -17,6 +17,7 @@ constant bool align_K [[function_constant(201)]];
 constant bool has_mask [[function_constant(300)]];
 constant bool do_causal [[function_constant(301)]];
 constant bool has_sinks [[function_constant(302)]];
+constant bool has_window [[function_constant(303)]];
 
 template <typename T>
 struct TransformScale {
@@ -174,6 +175,7 @@ template <
   }
 
   int kb_lim = params->NK;
+  int kb_start = 0;
   int kb_min_causal = params->NK;
 
   if (do_causal) {
@@ -186,6 +188,17 @@ template <
     kb_min_causal = (q_min / BK);
   }
 
+  if (has_window) {
+    int q_min = tid.x * BQ + params->qL_off;
+    int k_min = q_min - params->window_size + 1;
+    if (k_min > 0) {
+      kb_start = k_min / BK;
+      if (kb_start > kb_lim) {
+        kb_start = kb_lim;
+      }
+    }
+  }
+
   const bool is_last_bq = int(tid.x) == (params->NQ_aligned);
   // const bool is_last_tq = int(simd_group_id) >= (params->qL_rem / UQ);
   const bool is_last_q = is_last_bq;
@@ -194,7 +207,7 @@ template <
   const short lim_rows_k = params->kL_rem;
 
   // Loop over KV seq length
-  for (int kb = 0; kb < kb_lim; kb++) {
+  for (int kb = kb_start; kb < kb_lim; kb++) {
     const int is_last_k = (kb == (params->NK_aligned));
 
     // Do S = Q @ K.T
@@ -297,6 +310,33 @@ template <
               const auto c = base_col + ik * kU + jj + sn;
               const auto loc = ii * stile_t::kFragThrCols + jj;
               fg[loc] = (r < c) ? neg_inf : fg[loc];
+            }
+          }
+        }
+      }
+    }
+
+    if (has_window && kb < (kb_start + ((BQ + BK - 1) / BK))) {
+      constexpr auto neg_inf = Limits<AccumType>::finite_min;
+
+      const int base_row = tid.x * BQ + params->qL_off + tm;
+      const int base_col = kb * BK;
+
+      STEEL_PRAGMA_UNROLL
+      for (short iq = 0; iq < TQ; iq++) {
+        STEEL_PRAGMA_UNROLL
+        for (short ik = 0; ik < TK; ik++) {
+          thread auto& fg = Stile.frag_at(iq, ik);
+
+          STEEL_PRAGMA_UNROLL
+          for (short ii = 0; ii < stile_t::kFragThrRows; ii++) {
+            STEEL_PRAGMA_UNROLL
+            for (short jj = 0; jj < stile_t::kFragThrCols; jj++) {
+              const auto r =
+                  base_row + iq * kU + ii * stile_t::kFragRowsJump + sm;
+              const auto c = base_col + ik * kU + jj + sn;
+              const auto loc = ii * stile_t::kFragThrCols + jj;
+              fg[loc] = ((r - c) >= params->window_size) ? neg_inf : fg[loc];
             }
           }
         }

--- a/mlx/backend/metal/kernels/steel/attn/params.h
+++ b/mlx/backend/metal/kernels/steel/attn/params.h
@@ -30,6 +30,8 @@ struct AttnParams {
   int kL_rem; ///< Remainder in last key/value block
   int qL_off; ///< Offset in query sequence start
 
+  int window_size; ///< Sliding window size (0 = no window)
+
   int64_t Q_strides[3]; ///< Query  strides (B, H, L, D = 1)
   int64_t K_strides[3]; ///< Key    strides (B, H, L, D = 1)
   int64_t V_strides[3]; ///< Value  strides (B, H, L, D = 1)

--- a/mlx/backend/metal/kernels/steel/attn/params.h
+++ b/mlx/backend/metal/kernels/steel/attn/params.h
@@ -30,7 +30,7 @@ struct AttnParams {
   int kL_rem; ///< Remainder in last key/value block
   int qL_off; ///< Offset in query sequence start
 
-  int window_size; ///< Sliding window size (0 = no window)
+  int window_size; ///< Sliding window size (-1 or 0 = no window)
 
   int64_t Q_strides[3]; ///< Query  strides (B, H, L, D = 1)
   int64_t K_strides[3]; ///< Key    strides (B, H, L, D = 1)

--- a/mlx/backend/metal/scaled_dot_product_attention.cpp
+++ b/mlx/backend/metal/scaled_dot_product_attention.cpp
@@ -24,6 +24,7 @@ void sdpa_full_self_attention_nax(
     const float scale,
     array& o,
     bool do_causal_,
+    int window_size_,
     const std::optional<array>& mask,
     const std::optional<array>& sinks) {
   using namespace mlx::steel;
@@ -48,13 +49,15 @@ void sdpa_full_self_attention_nax(
   const bool has_mask = mask.has_value();
   const bool do_causal = do_causal_;
   const bool has_sinks = sinks.has_value();
+  const bool has_window = window_size_ > 0;
 
   metal::MTLFCList func_consts = {
       {&align_Q, MTL::DataType::DataTypeBool, 200},
       {&align_K, MTL::DataType::DataTypeBool, 201},
       {&has_mask, MTL::DataType::DataTypeBool, 300},
       {&do_causal, MTL::DataType::DataTypeBool, 301},
-      {&has_sinks, MTL::DataType::DataTypeBool, 302}};
+      {&has_sinks, MTL::DataType::DataTypeBool, 302},
+      {&has_window, MTL::DataType::DataTypeBool, 303}};
 
   std::string base_name;
   concatenate(
@@ -87,7 +90,9 @@ void sdpa_full_self_attention_nax(
       "_do_causal_",
       (do_causal ? 't' : 'n'),
       "_has_sinks_",
-      (has_sinks ? 't' : 'n'));
+      (has_sinks ? 't' : 'n'),
+      "_has_window_",
+      (has_window ? 't' : 'n'));
 
   auto& compute_encoder = metal::get_command_encoder(s);
 
@@ -133,6 +138,8 @@ void sdpa_full_self_attention_nax(
       /* int kL_rem = */ (kL - NK_aligned * bk),
       /* int qL_off = */ (kL - qL),
 
+      /* int window_size = */ window_size_,
+
       /* int64_t Q_strides[3] = */ {q.strides(0), q.strides(1), q.strides(2)},
       /* int64_t K_strides[3] = */ {k.strides(0), k.strides(1), k.strides(2)},
       /* int64_t V_strides[3] = */ {v.strides(0), v.strides(1), v.strides(2)},
@@ -172,6 +179,7 @@ void sdpa_full_self_attention_metal(
     const float scale,
     array& o,
     bool do_causal_,
+    int window_size_,
     const std::optional<array>& mask,
     const std::optional<array>& sinks) {
   if (metal::is_nax_available() && q.shape(3) != 80 &&
@@ -185,6 +193,7 @@ void sdpa_full_self_attention_metal(
         /* const float scale = */ scale,
         /* array& o = */ o,
         /* bool do_causal_ = */ do_causal_,
+        /* int window_size_ = */ window_size_,
         /* const std::optional<array>& mask = */ mask,
         /* const std::optional<array>& sinks = */ sinks);
   }
@@ -211,13 +220,15 @@ void sdpa_full_self_attention_metal(
   const bool has_mask = mask.has_value();
   const bool do_causal = do_causal_;
   const bool has_sinks = sinks.has_value();
+  const bool has_window = window_size_ > 0;
 
   metal::MTLFCList func_consts = {
       {&align_Q, MTL::DataType::DataTypeBool, 200},
       {&align_K, MTL::DataType::DataTypeBool, 201},
       {&has_mask, MTL::DataType::DataTypeBool, 300},
       {&do_causal, MTL::DataType::DataTypeBool, 301},
-      {&has_sinks, MTL::DataType::DataTypeBool, 302}};
+      {&has_sinks, MTL::DataType::DataTypeBool, 302},
+      {&has_window, MTL::DataType::DataTypeBool, 303}};
 
   std::string base_name;
   concatenate(
@@ -250,7 +261,9 @@ void sdpa_full_self_attention_metal(
       "_do_causal_",
       (do_causal ? 't' : 'n'),
       "_has_sinks_",
-      (has_sinks ? 't' : 'n'));
+      (has_sinks ? 't' : 'n'),
+      "_has_window_",
+      (has_window ? 't' : 'n'));
 
   auto& compute_encoder = metal::get_command_encoder(s);
 
@@ -295,6 +308,8 @@ void sdpa_full_self_attention_metal(
       /* int qL_rem = */ (qL - NQ_aligned * bq),
       /* int kL_rem = */ (kL - NK_aligned * bk),
       /* int qL_off = */ (kL - qL),
+
+      /* int window_size = */ window_size_,
 
       /* int64_t Q_strides[3] = */ {q.strides(0), q.strides(1), q.strides(2)},
       /* int64_t K_strides[3] = */ {k.strides(0), k.strides(1), k.strides(2)},
@@ -597,6 +612,7 @@ bool ScaledDotProductAttention::use_fallback(
     bool do_causal,
     bool is_training,
     bool output_logsumexp,
+    int window_size,
     Stream s) {
   if (is_training) {
     // It's faster for training on Metal to use the unfused SDPA for both
@@ -623,7 +639,8 @@ bool ScaledDotProductAttention::use_fallback(
       (query_head_dim == 64 || query_head_dim == 96 || query_head_dim == 128 ||
        query_head_dim == 256);
   const bool sdpa_full_supported_head_dim = query_head_dim == value_head_dim &&
-      (query_head_dim == 64 || query_head_dim == 80 || query_head_dim == 128);
+      (query_head_dim == 64 || query_head_dim == 80 ||
+       query_head_dim == 128 || (query_head_dim == 256 && window_size > 0));
 
   const bool sdpa_full_supported_mask = !has_mask || has_arr_mask ||
       (query_sequence_length <= key_sequence_length && do_causal);
@@ -782,7 +799,7 @@ void ScaledDotProductAttention::eval_gpu(
         : std::nullopt;
 
     sdpa_full_self_attention_metal(
-        s, d, q, k, v, scale_, o, do_causal_, mask, sinks);
+        s, d, q, k, v, scale_, o, do_causal_, window_size_, mask, sinks);
   }
 
   metal::get_command_encoder(s).add_temporaries(std::move(copies));

--- a/mlx/backend/metal/scaled_dot_product_attention.cpp
+++ b/mlx/backend/metal/scaled_dot_product_attention.cpp
@@ -650,7 +650,7 @@ bool ScaledDotProductAttention::use_fallback(
 
   const bool supports_sdpa_vector = (query_sequence_length <= 8) &&
       (query_sequence_length <= key_sequence_length) &&
-      sdpa_vector_supported_head_dim &&
+      sdpa_vector_supported_head_dim && window_size <= 0 &&
       (query_sequence_length * gqa_factor) <= 32;
 
   return !(supports_sdpa_full || supports_sdpa_vector);

--- a/mlx/backend/no_gpu/primitives.cpp
+++ b/mlx/backend/no_gpu/primitives.cpp
@@ -32,6 +32,7 @@ bool fast::ScaledDotProductAttention::use_fallback(
     bool do_causal,
     bool is_training,
     bool output_logsumexp,
+    int window_size,
     Stream s) {
   return true;
 }

--- a/mlx/fast.cpp
+++ b/mlx/fast.cpp
@@ -618,6 +618,7 @@ array scaled_dot_product_attention(
     const std::string& mask_mode /* = "" */,
     std::optional<array> mask_arr /* = {} */,
     const std::optional<array>& sinks /* = {} */,
+    int window_size /* = 0 */,
     StreamOrDevice s /* = {}*/) {
   for (const auto& tensor : {queries, keys, values}) {
     if (tensor.ndim() != 4) {
@@ -660,6 +661,12 @@ array scaled_dot_product_attention(
     std::ostringstream msg;
     msg << "[scaled_dot_product_attention] the mask with shape "
         << mask_arr->shape() << " expected to have at most rank 4.";
+    throw std::invalid_argument(msg.str());
+  }
+  if (window_size < 0) {
+    std::ostringstream msg;
+    msg << "[scaled_dot_product_attention] window_size must be non-negative; "
+        << "received " << window_size << ".";
     throw std::invalid_argument(msg.str());
   }
 
@@ -718,6 +725,7 @@ array scaled_dot_product_attention(
                    n_q_heads,
                    n_kv_heads,
                    do_causal,
+                   window_size,
                    has_sinks,
                    has_arr_mask,
                    s](const std::vector<array>& inputs) {
@@ -731,19 +739,45 @@ array scaled_dot_product_attention(
       v = expand_dims(v, 2, s);
     }
     auto scores = matmul(q, swapaxes(k, -1, -2, s), s);
-    if (has_arr_mask || do_causal) {
+    if (has_arr_mask || do_causal || window_size > 0) {
       // Mask must be broadcast-compatible with [B, n_q_heads, L_q, L_kv]
       auto make_or_fetch_mask = [&]() {
+        int kL = k.shape(-2);
+        int qL = q.shape(-2);
+        int offset = kL - qL;
+        auto q_idx = arange(offset, qL + offset, s);
+        auto k_idx = arange(0, kL, s);
+        q_idx = expand_dims(q_idx, 1, s);
+        k_idx = expand_dims(k_idx, 0, s);
+
         if (do_causal) {
-          int kL = k.shape(-2);
-          int qL = q.shape(-2);
-          int offset = kL - qL;
-          auto q_idx = arange(offset, qL + offset, s);
-          auto k_idx = arange(0, kL, s);
-          q_idx = expand_dims(q_idx, 1, s);
-          k_idx = expand_dims(k_idx, 0, s);
-          return greater_equal(q_idx, k_idx, s);
+          auto causal_mask = greater_equal(q_idx, k_idx, s);
+          if (window_size > 0) {
+            auto window_mask =
+                less(q_idx, add(k_idx, array(window_size, k_idx.dtype()), s), s);
+            return logical_and(causal_mask, window_mask, s);
+          }
+          return causal_mask;
         }
+
+        if (window_size > 0) {
+          auto window_mask =
+              less(q_idx, add(k_idx, array(window_size, k_idx.dtype()), s), s);
+          if (!has_arr_mask) {
+            return window_mask;
+          }
+          auto mask = inputs[3];
+          if (mask.dtype() == bool_) {
+            return logical_and(mask, window_mask, s);
+          }
+          auto additive_window_mask = where(
+              window_mask,
+              full_like(mask, 0, mask.dtype(), s),
+              full_like(mask, finfo(mask.dtype()).min, mask.dtype(), s),
+              s);
+          return add(mask, additive_window_mask, s);
+        }
+
         return inputs[3];
       };
       auto mask = make_or_fetch_mask();
@@ -834,6 +868,7 @@ array scaled_dot_product_attention(
           do_causal,
           is_training,
           output_logsumexp,
+          window_size,
           stream)) {
     if (has_bool_mask && !ScaledDotProductAttention::supports_bool_mask()) {
       // Convert bool mask to additive mask.
@@ -846,7 +881,13 @@ array scaled_dot_product_attention(
     }
     Shape out_shape{q.shape(0), q.shape(1), q.shape(2), v.shape(-1)};
     auto primitive = std::make_shared<ScaledDotProductAttention>(
-        stream, fallback, scale, do_causal, has_sinks, output_logsumexp);
+        stream,
+        fallback,
+        scale,
+        do_causal,
+        has_sinks,
+        output_logsumexp,
+        window_size);
     if (output_logsumexp) {
       return array::make_arrays(
           {std::move(out_shape), Shape{q.shape(0), q.shape(1), q.shape(2), 1}},
@@ -912,7 +953,8 @@ bool ScaledDotProductAttention::is_equivalent(const Primitive& other) const {
       static_cast<const ScaledDotProductAttention&>(other);
   return scale_ == a_other.scale_ && do_causal_ == a_other.do_causal_ &&
       has_sinks_ == a_other.has_sinks_ &&
-      output_logsumexp_ == a_other.output_logsumexp_;
+      output_logsumexp_ == a_other.output_logsumexp_ &&
+      window_size_ == a_other.window_size_;
 }
 
 bool ScaledDotProductAttentionVJP::is_equivalent(const Primitive& other) const {

--- a/mlx/fast.cpp
+++ b/mlx/fast.cpp
@@ -618,7 +618,7 @@ array scaled_dot_product_attention(
     const std::string& mask_mode /* = "" */,
     std::optional<array> mask_arr /* = {} */,
     const std::optional<array>& sinks /* = {} */,
-    int window_size /* = 0 */,
+    int window_size /* = -1 */,
     StreamOrDevice s /* = {}*/) {
   for (const auto& tensor : {queries, keys, values}) {
     if (tensor.ndim() != 4) {
@@ -663,9 +663,9 @@ array scaled_dot_product_attention(
         << mask_arr->shape() << " expected to have at most rank 4.";
     throw std::invalid_argument(msg.str());
   }
-  if (window_size < 0) {
+  if (window_size < -1) {
     std::ostringstream msg;
-    msg << "[scaled_dot_product_attention] window_size must be non-negative; "
+    msg << "[scaled_dot_product_attention] window_size must be -1 or non-negative; "
         << "received " << window_size << ".";
     throw std::invalid_argument(msg.str());
   }
@@ -761,8 +761,10 @@ array scaled_dot_product_attention(
         }
 
         if (window_size > 0) {
-          auto window_mask =
+          auto left_bound =
               less(q_idx, add(k_idx, array(window_size, k_idx.dtype()), s), s);
+          auto right_bound = greater_equal(q_idx, k_idx, s);
+          auto window_mask = logical_and(left_bound, right_bound, s);
           if (!has_arr_mask) {
             return window_mask;
           }

--- a/mlx/fast.h
+++ b/mlx/fast.h
@@ -43,7 +43,12 @@ MLX_API array rope(
     const std::optional<array>& freqs = std::nullopt,
     StreamOrDevice s = {});
 
-/** Computes: O = softmax(Q @ K.T) @ V **/
+/** Computes: O = softmax(Q @ K.T) @ V
+ *
+ * `window_size` (>0) enables a sliding-window attention pattern: query at
+ * absolute position q only attends to keys in [max(0, q - window_size + 1), q].
+ * When 0 (default), the standard full-attention behavior is used.
+ **/
 MLX_API array scaled_dot_product_attention(
     const array& queries,
     const array& keys,
@@ -52,6 +57,7 @@ MLX_API array scaled_dot_product_attention(
     const std::string& mask_mode = "",
     std::optional<array> mask_arr = {},
     const std::optional<array>& sinks = {},
+    int window_size = 0,
     StreamOrDevice s = {});
 
 using TemplateArg = std::variant<int, bool, Dtype>;

--- a/mlx/fast.h
+++ b/mlx/fast.h
@@ -47,7 +47,7 @@ MLX_API array rope(
  *
  * `window_size` (>0) enables a sliding-window attention pattern: query at
  * absolute position q only attends to keys in [max(0, q - window_size + 1), q].
- * When 0 (default), the standard full-attention behavior is used.
+ * When -1 (default) or 0, the standard full-attention behavior is used.
  **/
 MLX_API array scaled_dot_product_attention(
     const array& queries,
@@ -57,7 +57,7 @@ MLX_API array scaled_dot_product_attention(
     const std::string& mask_mode = "",
     std::optional<array> mask_arr = {},
     const std::optional<array>& sinks = {},
-    int window_size = 0,
+    int window_size = -1,
     StreamOrDevice s = {});
 
 using TemplateArg = std::variant<int, bool, Dtype>;

--- a/mlx/fast_primitives.h
+++ b/mlx/fast_primitives.h
@@ -212,7 +212,7 @@ class ScaledDotProductAttention : public Custom {
       bool do_causal,
       bool has_sinks,
       bool output_logsumexp,
-      int window_size = 0)
+      int window_size = -1)
       : Custom(stream, std::move(fallback)),
         scale_(scale),
         do_causal_(do_causal),

--- a/mlx/fast_primitives.h
+++ b/mlx/fast_primitives.h
@@ -211,12 +211,14 @@ class ScaledDotProductAttention : public Custom {
       float scale,
       bool do_causal,
       bool has_sinks,
-      bool output_logsumexp)
+      bool output_logsumexp,
+      int window_size = 0)
       : Custom(stream, std::move(fallback)),
         scale_(scale),
         do_causal_(do_causal),
         has_sinks_(has_sinks),
-        output_logsumexp_(output_logsumexp) {}
+        output_logsumexp_(output_logsumexp),
+        window_size_(window_size) {}
 
   static bool use_fallback(
       const array& q,
@@ -227,6 +229,7 @@ class ScaledDotProductAttention : public Custom {
       bool do_causal,
       bool is_training,
       bool output_logsumexp,
+      int window_size,
       Stream s);
   static bool supports_bool_mask();
 
@@ -250,7 +253,12 @@ class ScaledDotProductAttention : public Custom {
   DEFINE_INPUT_OUTPUT_SHAPE()
   auto state() const {
     return std::make_tuple(
-        nullptr, scale_, do_causal_, has_sinks_, output_logsumexp_);
+        nullptr,
+        scale_,
+        do_causal_,
+        has_sinks_,
+        output_logsumexp_,
+        window_size_);
   }
 
  private:
@@ -258,6 +266,7 @@ class ScaledDotProductAttention : public Custom {
   bool do_causal_;
   bool has_sinks_;
   bool output_logsumexp_;
+  int window_size_;
 };
 
 class ScaledDotProductAttentionVJP : public Custom {

--- a/python/src/fast.cpp
+++ b/python/src/fast.cpp
@@ -197,6 +197,7 @@ void init_fast(nb::module_& parent_module) {
          const float scale,
          const std::variant<std::monostate, std::string, mx::array>& mask,
          const std::optional<mx::array>& sinks,
+         int window_size,
          mx::StreamOrDevice s) {
         bool has_mask = !std::holds_alternative<std::monostate>(mask);
         bool has_str_mask =
@@ -213,16 +214,32 @@ void init_fast(nb::module_& parent_module) {
               throw std::invalid_argument(msg.str());
             }
             return mx::fast::scaled_dot_product_attention(
-                queries, keys, values, scale, mask_str, std::nullopt, sinks, s);
+                queries,
+                keys,
+                values,
+                scale,
+                mask_str,
+                std::nullopt,
+                sinks,
+                window_size,
+                s);
           } else {
             auto mask_arr = std::get<mx::array>(mask);
             return mx::fast::scaled_dot_product_attention(
-                queries, keys, values, scale, "", mask_arr, sinks, s);
+                queries,
+                keys,
+                values,
+                scale,
+                "",
+                mask_arr,
+                sinks,
+                window_size,
+                s);
           }
 
         } else {
           return mx::fast::scaled_dot_product_attention(
-              queries, keys, values, scale, "", {}, sinks, s);
+              queries, keys, values, scale, "", {}, sinks, window_size, s);
         }
       },
       "q"_a,
@@ -232,9 +249,10 @@ void init_fast(nb::module_& parent_module) {
       "scale"_a,
       "mask"_a = nb::none(),
       "sinks"_a = nb::none(),
+      "window_size"_a = 0,
       "stream"_a = nb::none(),
       nb::sig(
-          "def scaled_dot_product_attention(q: array, k: array, v: array, *, scale: float,  mask: Union[None, str, array] = None, sinks: Optional[array] = None, stream: Union[None, Stream, Device] = None) -> array"),
+          "def scaled_dot_product_attention(q: array, k: array, v: array, *, scale: float,  mask: Union[None, str, array] = None, sinks: Optional[array] = None, window_size: int = 0, stream: Union[None, Stream, Device] = None) -> array"),
       R"pbdoc(
         A fast implementation of multi-head attention: ``O = softmax(Q @ K.T, dim=-1) @ V``.
 
@@ -276,6 +294,9 @@ void init_fast(nb::module_& parent_module) {
                last query aligns with the last key.
             sinks (array, optional): An optional array of attention sinks.
                Default: ``None``.
+            window_size (int, optional): A sliding-window size. When greater
+               than zero, each query attends only to keys in the last
+               ``window_size`` positions. Default: ``0``.
 
         Returns:
             array: The output array.

--- a/python/src/fast.cpp
+++ b/python/src/fast.cpp
@@ -249,10 +249,10 @@ void init_fast(nb::module_& parent_module) {
       "scale"_a,
       "mask"_a = nb::none(),
       "sinks"_a = nb::none(),
-      "window_size"_a = 0,
+      "window_size"_a = -1,
       "stream"_a = nb::none(),
       nb::sig(
-          "def scaled_dot_product_attention(q: array, k: array, v: array, *, scale: float,  mask: Union[None, str, array] = None, sinks: Optional[array] = None, window_size: int = 0, stream: Union[None, Stream, Device] = None) -> array"),
+          "def scaled_dot_product_attention(q: array, k: array, v: array, *, scale: float,  mask: Union[None, str, array] = None, sinks: Optional[array] = None, window_size: int = -1, stream: Union[None, Stream, Device] = None) -> array"),
       R"pbdoc(
         A fast implementation of multi-head attention: ``O = softmax(Q @ K.T, dim=-1) @ V``.
 
@@ -296,7 +296,8 @@ void init_fast(nb::module_& parent_module) {
                Default: ``None``.
             window_size (int, optional): A sliding-window size. When greater
                than zero, each query attends only to keys in the last
-               ``window_size`` positions. Default: ``0``.
+               ``window_size`` positions. ``-1`` means no window. Default:
+               ``-1``.
 
         Returns:
             array: The output array.

--- a/python/tests/test_fast_sdpa.py
+++ b/python/tests/test_fast_sdpa.py
@@ -603,6 +603,48 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
                 atol = 1e-5 if dtype == mx.float32 else 1e-2
                 self.assertTrue(mx.allclose(out, expected, atol=atol))
 
+    def test_sdpa_window_non_causal(self):
+        B, N, L, D = 1, 1, 5, 32
+        scale = 1 / math.sqrt(D)
+        window_size = 2
+
+        q = mx.random.normal(shape=(B, N, L, D), dtype=mx.float32)
+        k = mx.random.normal(shape=(B, N, L, D), dtype=mx.float32)
+        v = mx.random.normal(shape=(B, N, L, D), dtype=mx.float32)
+
+        q_idx = mx.expand_dims(mx.arange(L), 1)
+        k_idx = mx.expand_dims(mx.arange(L), 0)
+        mask = mx.logical_and(q_idx >= k_idx, q_idx < k_idx + window_size)
+
+        expected = mlx_ref_attn(q, k, v, scale, mask=mask)
+        out = mx.fast.scaled_dot_product_attention(
+            q, k, v, scale=scale, window_size=window_size
+        )
+
+        self.assertTrue(mx.allclose(out, expected, atol=1e-5))
+
+    def test_sdpa_window_disabled_values(self):
+        B, N, L, D = 1, 1, 5, 32
+        scale = 1 / math.sqrt(D)
+
+        q = mx.random.normal(shape=(B, N, L, D), dtype=mx.float32)
+        k = mx.random.normal(shape=(B, N, L, D), dtype=mx.float32)
+        v = mx.random.normal(shape=(B, N, L, D), dtype=mx.float32)
+
+        expected = mx.fast.scaled_dot_product_attention(
+            q, k, v, scale=scale, window_size=-1
+        )
+        out = mx.fast.scaled_dot_product_attention(
+            q, k, v, scale=scale, window_size=0
+        )
+
+        self.assertTrue(mx.allclose(out, expected, atol=1e-5))
+
+        with self.assertRaises(ValueError):
+            mx.fast.scaled_dot_product_attention(
+                q, k, v, scale=scale, window_size=-2
+            )
+
     def test_sdpa_grad(self):
         # High tolerance due to cuDNN SDPA kernel requiring tf32.
         tolerance = {"rtol": 1e-2, "atol": 1e-2}


### PR DESCRIPTION
# feat(fast::sdpa): sliding-window attention via has_window function constant + kb_start truncation

## Summary

Adds optional `window_size` parameter to `mlx::fast::scaled_dot_product_attention` enabling sliding-window attention (each Q position attends only to the last `window_size` K positions, combined with causal masking). The implementation mirrors the existing `do_causal` upper-bound (`kb_lim`) pattern with a symmetric lower-bound (`kb_start`) in the steel attention kernel, skipping K-blocks below the window's lower edge wholesale.

## Motivation

Sliding-window attention is used by Gemma 2, Gemma 3, Gemma 4, Mistral 7B, and several long-context Qwen variants. Currently mlx callers must construct an explicit `[L_q, L_kv]` bool mask Array to express the window pattern, which:

1. Materializes the mask tensor (8 KB at L=1024 → 64 MB at L=8192).
2. Forces the matmul fallback for `head_dim ∉ {64, 80, 128}` since the steel kernel's `sdpa_full_supported_head_dim` doesn't include 256/512.
3. Materializes the full `[B, H, L, L]` scores tensor in the fallback path (1 GB bf16 at L=8192, B=1, H=8) → significant DRAM pressure.

With explicit `window_size`, the steel kernel can:
- Compute valid K-block range `[kb_start, kb_lim)` per Q-tile and skip the rest entirely.
- Apply per-element left-edge mask only for the first `ceil(BQ/BK)` blocks past `kb_start` (symmetric with the existing causal upper-edge mask).
- Avoid mask Array allocation + scan entirely.

## Performance (Gemma 4 26B-A4B, M3 Max, macOS 26.3.1)

Methodology: 3 timed trials per cell, alternating ON/OFF within context to
control thermal drift, 1 untimed warmup per cell, 30s cooldown between
trials, 60s between configs, 90s between contexts. STEPS=32 decode,
WARMUP=4 (bench-internal). Window size W=1024.

**Prefill** (single-pass, sliding-window layers exercised):

| Context | Baseline (array-mask path) | Windowed kernel | Δ | K-block skip ratio |
|---------|---------------------------:|----------------:|------:|-------------------:|
| 2K | 986.5 ± 8.3 tok/s | 1039.4 ± 11.5 tok/s | **+5.4%** | 50.0% |
| 4K | 863.7 ± 7.5 tok/s |   997.6 ± 9.0 tok/s | **+15.5%** | 75.0% |
| 8K | 678.8 ± 0.6 tok/s |   914.7 ± 1.1 tok/s | **+34.8%** | 87.5% |

**Decode** (32 steps each, post-prefill autoregressive):

| Context | Baseline | Windowed | Δ |
|---------|---------:|---------:|---|
| 2K | 49.0 ± 15.5 tok/s | 49.9 ± 19.6 tok/s | neutral (small-ctx timing noise) |
| 4K | 47.1 ± 10.1 tok/s | 46.8 ± 9.7  tok/s | neutral |
| 8K | 50.9 ± 1.2  tok/s | 50.4 ± 1.5  tok/s | **neutral (tight std)** |

The prefill speedup tracks the theoretical K-block skip ratio
`floor((L − W) / L)` — at 8K, 87.5% of K-blocks below the window's lower
edge are skipped wholesale, yielding a 34.8% end-to-end prefill speedup
once the unchanged full-attention layers, MoE experts, and dense layers
are amortized in. The 8K measurement is essentially noise-free (baseline
σ = 0.6 tok/s, windowed σ = 1.1 tok/s over 3 trials), making the +34.8%
margin statistically unambiguous.

Decode is neutral at all contexts. The 2K/4K decode std is high because
total decode time at small ctx is short and timing jitter dominates per
trial; the 8K decode measurement (σ ≈ 1.3 tok/s on both arms) is the
canonical reading for decode neutrality.

Raw measurements: see "Reproducibility" section below.

## Implementation

### Kernel (`steel_attention.h` / `steel_attention_nax.h`)

```cpp
constant bool has_window [[function_constant(303)]];

// Lower-bound K-block truncation, mirrors do_causal upper-bound:
int kb_start = 0;
if (has_window) {
    int q_min = tid.x * BQ + params->qL_off;
    int k_min = q_min - params->window_size + 1;
    if (k_min > 0) kb_start = min(kb_lim, k_min / BK);
}
for (int kb = kb_start; kb < kb_lim; kb++) { ... }

// Per-element left-edge mask (only first ceil(BQ/BK) blocks past kb_start):
if (has_window && kb < kb_start + ((BQ + BK - 1) / BK)) {
    // row_pos - col_pos >= W → mask = -inf
}
```

The window check uses K-relative coordinates (`qL_off = kL - qL` equals `kv_offset - cache_first_held_pos` for both rotated and non-rotated caches), so chunked prefill with rotating sliding-window cache works automatically.

### Public API

```cpp
// mlx/fast.h
MLX_API array scaled_dot_product_attention(
    const array& queries,
    const array& keys,
    const array& values,
    const float scale,
    const std::string& mask_mode = "",
    std::optional<array> mask_arr = {},
    const std::optional<array>& sinks = {},
    int window_size = 0,    // NEW (default 0 = no window)
    StreamOrDevice s = {});
```

### use_fallback

`window_size > 0` allows BD=256 path even when `LUMEN_GEMMA4_PREFILL_FAST_BD256` env gate is not set — the window-aware kernel is faster than fallback on non-NAX hardware (87.5% K-block skip dominates over the lack of NAX tensor unit fragments).

## Backward compatibility

- Default `window_size = 0` preserves all existing behavior. Function constant `has_window = false` → kernel takes original code path with `kb_start = 0`.
- Python: `mx.fast.scaled_dot_product_attention(...)` gets a new optional `window_size` kwarg. No breakage to existing callers.
- C++: signature change is parameter addition with default, ABI-compatible at the C++ level.
- C ABI: `mlx_fast_scaled_dot_product_attention` passes `window_size=0` internally; no signature change required for C consumers.

## Test coverage

The implementation has been validated against Gemma 4 26B-A4B on M3 Max:
- Functional smoke (chat completions produce coherent output).
- Multi-trial perf A/B confirming the speedup at 2K/4K/8K.
- Chunked-prefill rotation case (chunk_size=1024, prompt_len=4096, 4 chunks) — kernel produces valid outputs via K-relative coordinate math.

Outstanding before merge (would appreciate maintainer feedback on test expectations):
- Bit-identical output vs the manually-constructed sliding mask Array path. **In our measurement bf16 accumulation order differs between kernel and array-mask path → greedy argmax can flip when top-K logits are close. Both are mathematically valid sliding attention.** Maintainers may want to add tolerance-based tests; we did not include explicit unit tests for this.
- D ∈ {64, 80, 128, 256} smoke (only D=256 directly tested; the other BD instantiations should behave the same — same kernel code, different specialization).
- NAX path verification (kernel was updated symmetrically but tested only on non-NAX M3 Max).
- VJP support — the windowed forward is supported; backward (`ScaledDotProductAttentionVJP`) was not extended. Probably needs same treatment but it's out of scope for inference-only use.

## Notes for reviewers

- The `is_equivalent` extension to compare `window_size_` is required for correctness — primitives with different windows must not be deduplicated by mlx's graph optimizer. Independent clean A/B (3 trials, alternating, 8K) confirms decode throughput is **unchanged (50.9 → 50.4 tok/s with σ ≈ 1.3 on both arms)** with windowed kernel ON. An initial -22% decode reading turned out to be measurement variance at low trial count.
- Two minor host-side helpers (`hash_name` extended with `_has_window_`, fallback lambda extended for sliding mask construction) — included for completeness.
- BD=512 instantiation was independently attempted (BQ=16, BK=8, WM=2, padQ=0 conditional) to unlock head_dim=512 full-attention paths. It builds and runs functionally but A/B showed **-25% prefill regression on M3 Max** (non-NAX) — the WM=2 / padQ=0 trade-offs vs matmul fallback's tuned gemm dispatch are net negative. Reverted, not included in this PR. May be worth revisiting once NAX-capable M5+ hardware is available.

## Files changed

```
mlx/backend/metal/kernels/steel/attn/params.h                    +2
mlx/backend/metal/kernels/steel/attn/kernels/steel_attention.h   +47
mlx/backend/metal/kernels/steel/attn/kernels/steel_attention_nax.h +46
mlx/backend/metal/scaled_dot_product_attention.cpp               +~30  (only sliding-window related)
mlx/backend/cuda/scaled_dot_product_attention.cpp                +4    (fallback for unsupported windowed path)
mlx/backend/no_gpu/primitives.cpp                                +1    (signature sync)
mlx/fast.h                                                       +9
mlx/fast.cpp                                                     +~65  (only sliding-window related)
mlx/fast_primitives.h                                            +15
python/src/fast.cpp                                              +~30  (Python kwarg binding/docs)
```
Total ~200 lines of sliding-window-only changes.

## Reproducibility

The performance numbers above were collected with the following protocol on
a quiet M3 Max (no other GPU consumers, mains power):

```
hardware:    M3 Max (40-core GPU)
os:          macOS 26.3.1
model:       Gemma 4 26B-A4B Q4 (lumen-rs native backend, mlx ~main)
window_size: 1024 (Gemma-4 sliding layers)
bench:       lumen-rs `bench_gemma4_native_e2e`
decode:      STEPS=32, WARMUP=4
arms:        windowed ON (default)   vs   windowed OFF (LUMEN_GEMMA4_SDPA_WINDOWED=0)
trials/cell: 3 (timed) + 1 (untimed warmup)
order:       alternating ON / OFF within each context (thermal-drift control)
cooldowns:   30s between trials, 60s between configs, 90s between contexts
```

Raw per-trial readings (prefill tok/s | decode tok/s):

```
ctx=2K  ON  T1: 1032.8 | 64.6     OFF T1:  998.2 | 27.2
ctx=2K  ON  T2: 1055.6 | 22.1     OFF T2:  981.6 | 58.1
ctx=2K  ON  T3: 1029.9 | 62.9     OFF T3:  979.6 | 61.7
ctx=4K  ON  T1:  991.1 | 53.4     OFF T1:  857.4 | 53.8
ctx=4K  ON  T2:  991.4 | 53.8     OFF T2:  859.6 | 54.7
ctx=4K  ON  T3: 1010.4 | 33.1     OFF T3:  874.2 | 32.8
ctx=8K  ON  T1:  915.9 | 48.2     OFF T1:  678.6 | 49.2
ctx=8K  ON  T2:  915.0 | 51.5     OFF T2:  678.1 | 51.8
ctx=8K  ON  T3:  913.2 | 51.4     OFF T3:  679.6 | 51.6
```

The 8K prefill measurement is the tightest signal in the dataset
(σ = 0.6 / 1.1 tok/s on the two arms) and is the load-bearing evidence
for the kernel's prefill speedup. The smaller-context numbers carry more
timing noise but show consistent directionality and align with the
predicted K-block skip ratio (50% / 75% / 87.5% at 2K / 4K / 8K).
