### PR TITLE
Fix singleton lifetime issues at process exit

### DIFF
--- a/mlx/backend/cpu/compiled.cpp
+++ b/mlx/backend/cpu/compiled.cpp
@@ -41,8 +41,11 @@ struct CompilerCache {
 };
 
 static CompilerCache& cache() {
-  static CompilerCache cache_;
-  return cache_;
+  // Leak - see Scheduler singleton comment in scheduler.cpp.
+  // DLib destructors call dlclose() which unmaps JIT .so files;
+  // StreamThreads may still be executing that code at exit.
+  static CompilerCache* cache_ = new CompilerCache;
+  return *cache_;
 };
 
 // GPU compile is always available if the GPU is available and since we are in

--- a/mlx/io/load.cpp
+++ b/mlx/io/load.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023-2024 Apple Inc.
+// Copyright © 2023-2026 Apple Inc.
 #include <algorithm>
 #include <cstring>
 #include <fstream>
@@ -335,13 +335,15 @@ array load(std::string file, StreamOrDevice s) {
 namespace io {
 
 ThreadPool& thread_pool() {
-  static ThreadPool pool_{4};
-  return pool_;
+  // Leak - see Scheduler singleton comment in scheduler.cpp.
+  static ThreadPool* pool_ = new ThreadPool{4};
+  return *pool_;
 }
 
 ThreadPool& ParallelFileReader::thread_pool() {
-  static ThreadPool thread_pool{4};
-  return thread_pool;
+  // Leak - see Scheduler singleton comment in scheduler.cpp.
+  static ThreadPool* thread_pool = new ThreadPool{4};
+  return *thread_pool;
 }
 
 void ParallelFileReader::read(char* data, size_t n) {

--- a/mlx/scheduler.cpp
+++ b/mlx/scheduler.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Apple Inc.
+// Copyright © 2023-2026 Apple Inc.
 
 #include "mlx/scheduler.h"
 #include "mlx/backend/cpu/eval.h"
@@ -58,7 +58,11 @@ void Scheduler::enqueue(Stream s, std::function<void()> task) {
   st->enqueue(std::move(task));
 }
 
-/** A singleton scheduler to manage devices, streams, and task execution. */
+// Leak the scheduler singleton on all platforms. During static destruction,
+// worker threads may still be executing JIT-compiled code that has been
+// unmapped, causing SIGSEGV (macOS/Linux) or join() deadlocks (Windows/MSVC
+// CRT).
+// The OS reclaims all resources at process exit anyway.
 Scheduler& scheduler() {
   // Intentionally leaked to avoid the "static destruction order fiasco":
   // background threads (e.g. command buffer completion handlers) may

--- a/mlx/scheduler.cpp
+++ b/mlx/scheduler.cpp
@@ -64,10 +64,6 @@ void Scheduler::enqueue(Stream s, std::function<void()> task) {
 // CRT).
 // The OS reclaims all resources at process exit anyway.
 Scheduler& scheduler() {
-  // Intentionally leaked to avoid the "static destruction order fiasco":
-  // background threads (e.g. command buffer completion handlers) may
-  // reference this singleton after other static objects are destroyed
-  // during process teardown.
   static Scheduler* scheduler = new Scheduler;
   return *scheduler;
 }


### PR DESCRIPTION
## Proposed changes

Split out from #3019

Leak the IO ThreadPool singletons and CPU CompilerCache using the same process-lifetime pattern already used by the Scheduler singleton.

The CompilerCache owns dlopen handles for JIT shared libraries. Destroying it during static teardown can dlclose generated code while stream worker threads may still be winding down. The IO loader thread pools have the same shutdown-order risk on Windows CRT teardown. These objects are process-lifetime infrastructure, and the OS reclaims their resources at exit.

Changes:
- Leak CompilerCache so JIT libraries remain mapped through process exit
- Leak IO ThreadPool singletons to avoid teardown-order races
- Clarify the Scheduler singleton comment that documents this pattern

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
