### PR TITLE
Remove reference to groups in Conv3D extra_repr

### DIFF
--- a/python/mlx/nn/layers/convolution.py
+++ b/python/mlx/nn/layers/convolution.py
@@ -219,7 +219,7 @@ class Conv3d(Module):
 
     def _extra_repr(self):
         return (
-            f"{self.weight.shape[-1] * self.groups}, {self.weight.shape[0]}, "
+            f"{self.weight.shape[-1]}, {self.weight.shape[0]}, "
             f"kernel_size={self.weight.shape[1:4]}, stride={self.stride}, "
             f"padding={self.padding}, dilation={self.dilation}, "
             f"bias={'bias' in self}"


### PR DESCRIPTION
## Proposed changes

Conv3D does not have a `groups` property. This removes the reference to the invalid prop to resolve errors when printing the object. 

## Checklist

Put an `x` in the boxes that apply.

- [X] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
