### PR TITLE
Fix doubled-word typos in docstrings

### DIFF
--- a/python/mlx/nn/layers/distributed.py
+++ b/python/mlx/nn/layers/distributed.py
@@ -199,7 +199,7 @@ class AllToShardedLinear(Module):
     Args:
         input_dims (int): The dimensionality of the input features
         output_dims (int): The dimensionality of the output features
-        bias (bool, optional): If set to ``False`` the the layer will not use a
+        bias (bool, optional): If set to ``False`` the layer will not use a
             bias. Default is ``True``.
         group (mx.distributed.Group, optional): The sharding will happen across
             this group. If not set then the global group is used. Default is
@@ -283,7 +283,7 @@ class ShardedToAllLinear(Module):
     Args:
         input_dims (int): The dimensionality of the input features
         output_dims (int): The dimensionality of the output features
-        bias (bool, optional): If set to ``False`` the the layer will not use a
+        bias (bool, optional): If set to ``False`` the layer will not use a
             bias. Default is ``True``.
         group (mx.distributed.Group, optional): The sharding will happen across
             this group. If not set then the global group is used. Default is

--- a/python/mlx/nn/losses.py
+++ b/python/mlx/nn/losses.py
@@ -272,7 +272,7 @@ def gaussian_nll_loss(
         \ \epsilon\right)\right) + \frac{\left(\text{inputs} - \text{targets} \right)^2}
         {\max\left(\text{vars}, \ \epsilon \right)}\right) + \text{const.}
 
-    where ``inputs`` are the predicted means and ``vars`` are the the
+    where ``inputs`` are the predicted means and ``vars`` are the
     predicted variances.
 
     Args:

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -837,7 +837,7 @@ void init_ops(nb::module_& m) {
         This is a numerically stable log-add-exp of two arrays with numpy-style
         broadcasting semantics. Either or both input arrays can also be scalars.
 
-        The computation is is a numerically stable version of ``log(exp(a) + exp(b))``.
+        The computation is a numerically stable version of ``log(exp(a) + exp(b))``.
 
         Args:
             a (array): Input array or scalar.

--- a/python/src/transforms.cpp
+++ b/python/src/transforms.cpp
@@ -1517,7 +1517,7 @@ void init_transforms(nb::module_& m) {
 
         Returns:
             Callable: A compiled function which has the same input arguments
-            as ``fun`` and returns the the same output(s).
+            as ``fun`` and returns the same output(s).
       )pbdoc");
   m.def(
       "disable_compile",


### PR DESCRIPTION
## Summary

Five trivial doubled-word typos in user-visible docstrings:

| File | Line | Fix |
|---|---|---|
| `python/mlx/nn/losses.py` | 275 | `gaussian_nll_loss` docstring: "are the the predicted variances" → "are the predicted variances" |
| `python/mlx/nn/layers/distributed.py` | 202, 286 | `AllToShardedLinear` / `ShardedToAllLinear` bias arg: "If set to ``False`` the the layer will not use a bias" → "the layer will not use a bias" |
| `python/src/ops.cpp` | 840 | `logaddexp` docstring: "The computation is is a numerically stable version" → "The computation is a numerically stable version" |
| `python/src/transforms.cpp` | 1520 | `compile()` return-value docstring: "returns the the same output(s)" → "returns the same output(s)" |

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('python/mlx/nn/losses.py').read()); ast.parse(open('python/mlx/nn/layers/distributed.py').read())"` — both files still parse.
- [x] `grep -rEn '\b(the the|of of|is is|to to|and and|that that|in in|a a)\b' --include='*.py' --include='*.cpp' --include='*.h' python/` — no remaining hits in user-visible code.

## Scope

Docstring text only. No code, behavior, or API affected.