### PR TITLE
Synchronize no-GPU cache eviction with CPU streams

### DIFF
--- a/mlx/backend/no_gpu/allocator.cpp
+++ b/mlx/backend/no_gpu/allocator.cpp
@@ -6,6 +6,7 @@
 #include "mlx/allocator.h"
 #include "mlx/backend/common/buffer_cache.h"
 #include "mlx/memory.h"
+#include "mlx/stream.h"
 
 #ifdef __APPLE__
 #include "mlx/backend/no_gpu/apple_memory.h"
@@ -18,6 +19,18 @@ size_t get_memory_size() {
 #endif
 
 namespace mlx::core {
+
+namespace {
+
+void synchronize_cpu_streams() {
+  for (const auto& s : get_streams()) {
+    if (s.device == Device::cpu) {
+      synchronize(s);
+    }
+  }
+}
+
+} // namespace
 
 namespace allocator {
 
@@ -114,10 +127,12 @@ size_t CommonAllocator::size(Buffer buffer) const {
 }
 
 size_t CommonAllocator::get_cache_memory() const {
+  std::unique_lock lk(mutex_);
   return buffer_cache_.cache_size();
 }
 
 size_t CommonAllocator::set_cache_limit(size_t limit) {
+  synchronize_cpu_streams();
   std::unique_lock lk(mutex_);
   std::swap(cache_limit_, limit);
   if (buffer_cache_.cache_size() > cache_limit_) {
@@ -128,6 +143,13 @@ size_t CommonAllocator::set_cache_limit(size_t limit) {
 }
 
 void CommonAllocator::clear_cache() {
+  {
+    std::unique_lock lk(mutex_);
+    if (buffer_cache_.cache_size() == 0) {
+      return;
+    }
+  }
+  synchronize_cpu_streams();
   std::unique_lock lk(mutex_);
   buffer_cache_.clear();
 }

--- a/tests/allocator_tests.cpp
+++ b/tests/allocator_tests.cpp
@@ -1,11 +1,18 @@
-// Copyright © 2023 Apple Inc.
+// Copyright © 2023-2026 Apple Inc.
 
+#include <chrono>
+#include <future>
+#include <memory>
 #include <stdexcept>
+#include <thread>
 
 #include "doctest/doctest.h"
 
 #include "mlx/allocator.h"
+#include "mlx/device.h"
 #include "mlx/memory.h"
+#include "mlx/scheduler.h"
+#include "mlx/stream.h"
 
 using namespace mlx::core;
 
@@ -56,5 +63,58 @@ TEST_CASE("test cached allocation keeps capacity") {
   CHECK_GE(get_cache_memory(), cached);
 
   clear_cache();
+  set_cache_limit(old_limit);
+}
+
+TEST_CASE("test clear cache synchronizes cpu streams") {
+  if (is_available(Device{Device::gpu})) {
+    return;
+  }
+
+  auto old_limit = set_cache_limit(1 << 20);
+  clear_cache();
+
+  auto cached = allocator::malloc(8192);
+  allocator::free(cached);
+  CHECK_GE(get_cache_memory(), 8192);
+
+  auto task_started = std::make_shared<std::promise<void>>();
+  auto task_started_future = task_started->get_future();
+  auto release_task = std::make_shared<std::promise<void>>();
+  auto release_task_future = release_task->get_future().share();
+  auto task_finished = std::make_shared<std::promise<void>>();
+  auto task_finished_future = task_finished->get_future();
+  auto clear_finished = std::make_shared<std::promise<void>>();
+  auto clear_finished_future = clear_finished->get_future();
+
+  auto stream = new_stream(Device{Device::cpu});
+  scheduler::enqueue(
+      stream, [task_started, release_task_future, task_finished] {
+        task_started->set_value();
+        release_task_future.wait();
+        task_finished->set_value();
+      });
+
+  task_started_future.wait();
+
+  std::thread clear_thread([clear_finished] {
+    clear_cache();
+    clear_finished->set_value();
+  });
+
+  CHECK_EQ(
+      clear_finished_future.wait_for(std::chrono::milliseconds(50)),
+      std::future_status::timeout);
+
+  release_task->set_value();
+
+  CHECK_EQ(
+      task_finished_future.wait_for(std::chrono::seconds(10)),
+      std::future_status::ready);
+  CHECK_EQ(
+      clear_finished_future.wait_for(std::chrono::seconds(10)),
+      std::future_status::ready);
+  clear_thread.join();
+
   set_cache_limit(old_limit);
 }


### PR DESCRIPTION
## Proposed changes

Follow up to #3554 - while testing variations on my AVX2 branch I found this bug on that change.

The no-GPU CPU allocator cache could release cached buffers while asynchronous CPU work was still queued on a non-default stream. mlx-lm generation can hit this by queuing the next token on a CPU stream and calling clear_cache between yielded tokens, which can leave queued work referencing freed cached memory.

Synchronize CPU streams before evicting cached buffers from clear_cache or set_cache_limit, and protect get_cache_memory with the allocator mutex. Add a regression test that verifies clear_cache waits for queued CPU stream work before returning.


## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
