### PR TITLE
Use unittest discovery for Linux GPU Python tests

### DIFF
--- a/.github/actions/test-linux/action.yml
+++ b/.github/actions/test-linux/action.yml
@@ -46,7 +46,7 @@ runs:
         DEVICE: gpu
       run: |
         echo "::group::Python tests - GPU"
-        python -m tests discover python/tests -v
+        python -m unittest discover python/tests -v
         echo "::endgroup::"
 
     - name: Run CPP tests - CPU


### PR DESCRIPTION
## Summary
- Use `unittest` discovery for the Linux GPU Python test step.
- Align the GPU command with the Linux CPU, Windows, macOS, docs, and local testing instructions.

## Context
The existing Linux GPU command uses `python -m tests discover python/tests -v`. Recent upstream Build and Test runs show the x86_64 CUDA jobs are passing on `main`, so this is not a confirmed CI-breaking bug. The command likely works because the editable install/import path makes `python/tests/__main__.py` importable as `tests.__main__`.

Using `python -m unittest discover python/tests -v` is more explicit and matches the other Python test paths.

## Validation
- `git diff --check HEAD~1..HEAD`
- Checked recent upstream Build and Test run `26150207039`; Linux CUDA x86_64 jobs completed successfully

Related #3569