### PR TITLE
Validate segmented_mm inner dimensions

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -5895,6 +5895,14 @@ array segmented_mm(
     throw std::invalid_argument("[segmented_mm] Batched matmul not supported");
   }
 
+  if (a.shape(-1) != b.shape(-2)) {
+    std::ostringstream msg;
+    msg << "[segmented_mm] Last dimension of first input with shape "
+        << a.shape() << " must match first dimension of second input with "
+        << "shape " << b.shape() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+
   if (segments.ndim() < 1 || segments.shape().back() != 2) {
     std::ostringstream msg;
     msg << "[segmented_mm] The segments should have shape (..., 2) but "

--- a/python/tests/test_blas.py
+++ b/python/tests/test_blas.py
@@ -1342,6 +1342,12 @@ class TestBlas(mlx_tests.MLXTestCase):
             s = mx.array([[0, 5], [5, 10]]).astype(mx.uint32)
             mx.segmented_mm(a, a, s)
 
+        with self.assertRaises(ValueError):
+            a = mx.ones((2, 3))
+            b = mx.ones((4, 5))
+            s = mx.array([[0, 3]]).astype(mx.uint32)
+            mx.segmented_mm(a, b, s)
+
         a = mx.ones((10, 1000))
         s = mx.random.randint(0, 16, shape=(1000,))
         s = mx.zeros(16, dtype=s.dtype).at[s].add(1)


### PR DESCRIPTION
## Summary
- Add an inner-dimension check to `segmented_mm` before creating the primitive.
- Add a regression test for mismatched `MxK` and `KxN` inputs.

## Why
`segmented_mm` expects `a` to have shape `MxK` and `b` to have shape `KxN`, but it did not reject incompatible inner dimensions. This now matches the validation style used by neighboring matmul APIs.

## Validation
- `git diff --check HEAD~1..HEAD`
- `python3 -m py_compile python/tests/test_blas.py`

I could not run the full MLX Python test locally because this machine does not have the Metal compiler available through `xcrun -sdk macosx metal`.

Fixes #3571