### PR TITLE
Expose from_dlpack on __array_namespace__()

### DIFF
--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -1796,6 +1796,48 @@ void init_ops(nb::module_& m) {
             ValueError: If ``copy`` is ``False``.
       )pbdoc");
   m.def(
+      "from_dlpack",
+      [](const nb::object& x,
+         const nb::object& device,
+         std::optional<bool> copy) {
+        if (!device.is_none()) {
+          throw std::invalid_argument(
+              "[from_dlpack] device keyword is not supported.");
+        }
+        if (copy.has_value() && !*copy) {
+          throw std::invalid_argument(
+              "[from_dlpack] copy=False is not supported.");
+        }
+        return create_array(x, std::nullopt);
+      },
+      nb::arg(),
+      nb::kw_only(),
+      "device"_a = nb::none(),
+      "copy"_a = nb::none(),
+      nb::sig(
+          "def from_dlpack(x: DLPackCompatible, /, *, device: Optional[Any] = None, copy: Optional[bool] = None) -> array"),
+      R"pbdoc(
+        Construct an mlx array from a DLPack-compatible object.
+
+        The input must implement the ``__dlpack__`` and ``__dlpack_device__``
+        methods as described in the
+        `Python array API <https://data-apis.org/array-api/latest/API_specification/generated/array_api.from_dlpack.html>`_.
+
+        Args:
+            x: Input DLPack-compatible object.
+            device: Must be ``None``. Specifying a target device is not
+              supported.
+            copy (bool, optional): Must be ``True`` or unspecified. ``False``
+              is not supported, since MLX has no in-place operations and
+              cannot return a non-copying view.
+
+        Returns:
+            array: An mlx array constructed from the input.
+
+        Raises:
+            ValueError: If ``device`` is not ``None`` or ``copy`` is ``False``.
+      )pbdoc");
+  m.def(
       "zeros_like",
       &mx::zeros_like,
       nb::arg(),

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -2175,6 +2175,22 @@ class TestArray(mlx_tests.MLXTestCase):
         arr_pass = xp.asarray(existing)
         self.assertEqual(arr_pass.tolist(), [4, 5, 6])
 
+    def test_array_namespace_from_dlpack(self):
+        xp = mx.array(1.0).__array_namespace__()
+        self.assertTrue(hasattr(xp, "from_dlpack"))
+
+        existing = mx.array([1, 2, 3])
+        arr = xp.from_dlpack(existing)
+        self.assertIsInstance(arr, mx.array)
+        self.assertEqual(arr.tolist(), [1, 2, 3])
+
+        # device and copy=False are not supported
+        with self.assertRaises(ValueError):
+            xp.from_dlpack(existing, copy=False)
+
+        with self.assertRaises(ValueError):
+            xp.from_dlpack(existing, device="cpu")
+
     def test_asarray_copy(self):
         existing = mx.array([1, 2, 3])
 


### PR DESCRIPTION
### Proposed changes

#3484 reports that `from_dlpack` and `asarray(copy=)` are missing from the array-api namespace returned by `array.__array_namespace__()`. PR #3510 wired in `asarray(copy=)` but explicitly deferred `from_dlpack` until #3495 reworked DLPack consumption. #3495 has since landed, so this PR finishes the job.

Adds a top-level `mx.from_dlpack(x, *, device=None, copy=None)` that delegates to the existing array-construction path. Because `__array_namespace__()` returns the `mlx.core` module, no extra wiring is needed — the new function is picked up automatically by `xp.from_dlpack(...)`. `device` and `copy=False` raise `ValueError`, mirroring the array-api guarantees that MLX can honor today (MLX has no device targeting for DLPack imports and no zero-copy view).

Repro from the issue now works:

```python
>>> import mlx.core as mx
>>> mx.array([[0, 1], [2, 3]]).__array_namespace__().from_dlpack
<built-in method from_dlpack of ...>
```

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

Fixes #3484.