### PR TITLE
Fix typos in backend code comments

### DIFF
--- a/mlx/backend/cuda/allocator.cpp
+++ b/mlx/backend/cuda/allocator.cpp
@@ -318,7 +318,7 @@ void CudaAllocator::move_to_unified_memory(
   buf.device = -1;
 }
 
-// This must be called with mutex_ aquired
+// This must be called with mutex_ acquired
 void CudaAllocator::free_cuda_buffer(CudaBuffer* buf) {
   if (scalar_pool_.in_pool(buf)) {
     scalar_pool_.free(buf);

--- a/mlx/backend/cuda/eval.cpp
+++ b/mlx/backend/cuda/eval.cpp
@@ -13,7 +13,7 @@
 namespace mlx::core::gpu {
 
 void init() {
-  // Force initalization of CUDA, so CUDA runtime get destroyed last.
+  // Force initialization of CUDA, so CUDA runtime get destroyed last.
   cudaFree(nullptr);
   // Make sure CUDA event pool get destroyed after device and stream.
   mlx::core::cu::CudaEvent::init_pool();

--- a/mlx/backend/metal/kernels/fft.h
+++ b/mlx/backend/metal/kernels/fft.h
@@ -229,7 +229,7 @@ template <int tg_mem_size, typename in_T, typename out_T>
     uint3 grid [[threads_per_grid]]) {
   // Use Rader's algorithm to compute fast FFTs
   // when a prime factor `p` of `n` is greater than 13 but
-  // has `p - 1` Stockham decomposable into to prime factors <= 13.
+  // has `p - 1` Stockham decomposable into prime factors <= 13.
   //
   // E.g. n = 102
   //        = 2 * 3 * 17


### PR DESCRIPTION
Three small comment typos in the backend that I noticed while reading the code. None affect behavior.

In `mlx/backend/metal/kernels/fft.h` the Rader's algorithm comment said "decomposable into to prime factors", which should be "decomposable into prime factors". In `mlx/backend/cuda/eval.cpp` and `mlx/backend/cuda/allocator.cpp` the words "initalization" and "aquired" are misspellings of "initialization" and "acquired" respectively; both spellings are used correctly elsewhere in the repo.

Comment text only, no code or behavior changes.