### PR TITLE
[metal] disable heap allocation for small buffers

### DIFF
--- a/mlx/backend/metal/allocator.cpp
+++ b/mlx/backend/metal/allocator.cpp
@@ -144,12 +144,10 @@ Buffer MetalAllocator::malloc(size_t size) {
       throw std::runtime_error(msg.str());
     }
     lk.unlock();
-    if (size < small_size_ && heap_) {
-      buf = heap_->newBuffer(size, resource_options);
-    }
-    if (!buf) {
-      buf = device_->newBuffer(size, resource_options);
-    }
+    // [PATCH elejometa] Heap allocation disabled — Metal heaps reuse memory
+    // immediately while GPU commands still reference it, causing crashes
+    // with ResourceHazardTrackingModeUntracked.
+    buf = device_->newBuffer(size, resource_options);
     if (!buf) {
       std::ostringstream msg;
       msg << "[malloc] Unable to allocate " << size << " bytes.";


### PR DESCRIPTION
Metal heaps with ResourceHazardTrackingModeUntracked reuse memory as soon as a heap-allocated buffer is "freed" via reference count drop, even while the GPU may still be executing commands that reference it. This shows up as intermittent garbage in tensor results or hard crashes from MTLBuffer access-after-free.

The cheap fix: always go through device_->newBuffer() which gives a fresh allocation tracked by the resource pool. Performance impact on inference is negligible (allocator is already locked critical section); the win is correctness.

Carry-on patch for elejometa/speech-server. Upstream PR not (yet) filed — this branch is the source of truth for our mlx-swift fork's submodule.

## Proposed changes

Please include a description of the problem or feature this PR is addressing. If there is a corresponding issue, include the issue #.

## Checklist

Put an `x` in the boxes that apply.

- [ ] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
