### PR TITLE
Cache JIT-compiled CUDA kernels

### DIFF
--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -41,6 +41,15 @@ runs:
         # ccache-action bug: running "apt-get update" fails on large arm runner.
         update-package-index: false
 
+    - name: Cache JIT-compiled CUDA kernels
+      if: ${{ startsWith(inputs.toolkit, 'cuda') }}
+      uses: actions/cache@v5
+      with:
+        path: /tmp/mlx-ptx-cache
+        key: >-
+          ptx-${{ runner.os }}-${{ runner.arch }}-${{ inputs.toolkit }}-
+          ${{ hashFiles('mlx/backend/cuda/**') }}
+
     - uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}

--- a/.github/actions/test-linux/action.yml
+++ b/.github/actions/test-linux/action.yml
@@ -44,6 +44,7 @@ runs:
       shell: bash
       env:
         DEVICE: gpu
+        MLX_PTX_CACHE_DIR: /tmp/mlx-ptx-cache
       run: |
         echo "::group::Python tests - GPU"
         python -m tests discover python/tests -v


### PR DESCRIPTION
This reduces test run time to 7m, it is a must when we start JIT-compiling CUTLASS/CuTe kernels which would spend over an hour on running tests in CI.

The cache key is the hash of all files under `mlx/backend/cuda`, which is not 100% bullet-proof but should be robust enough to dodge most cache invalidation problems.