### PR TITLE
Fix activation docstring math in log_softmax and gelu_approx

### DIFF
--- a/python/mlx/nn/layers/activations.py
+++ b/python/mlx/nn/layers/activations.py
@@ -66,7 +66,7 @@ def leaky_relu(x, negative_slope=0.01):
 def log_softmax(x, axis=-1):
     r"""Applies the Log Softmax function.
 
-    Applies :math:`x + \log \sum_i e^{x_i}` element wise.
+    Applies :math:`x - \log \sum_i e^{x_i}` element wise.
     """
     return x - mx.logsumexp(x, axis=axis, keepdims=True)
 
@@ -176,7 +176,7 @@ def gelu_approx(x):
 
     .. math::
 
-        x = 0.5 * x * \left(1 + \text{Tanh}\left((\sqrt{2 / \pi} * \left(x + 0.044715 * x^3\right)\right)\right)
+        x = 0.5 * x * \left(1 + \text{Tanh}\left(\sqrt{2 / \pi} * \left(x + 0.044715 * x^3\right)\right)\right)
 
     """
     return 0.5 * x * (1 + mx.tanh(math.sqrt(2 / math.pi) * (x + 0.044715 * x**3)))
@@ -552,7 +552,7 @@ class GELU(Module):
     However, if ``approx`` is set to 'precise' or 'fast' it applies
 
     .. math::
-        \textrm{GELUApprox}(x) &= 0.5 * x * \left(1 + \text{Tanh}\left((\sqrt{2 / \pi} * \left(x + 0.044715 * x^3\right)\right)\right) \\
+        \textrm{GELUApprox}(x) &= 0.5 * x * \left(1 + \text{Tanh}\left(\sqrt{2 / \pi} * \left(x + 0.044715 * x^3\right)\right)\right) \\
         \textrm{GELUFast}(x) &= x * \sigma\left(1.702 * x\right)
 
     respectively.


### PR DESCRIPTION
A couple of the activation docstrings in `mlx.nn` have incorrect math.

`log_softmax` documents the formula as $x + \log \sum_i e^{x_i}$, but the implementation subtracts the log-sum-exp (`x - mx.logsumexp(...)`). The documented sign is wrong. This corrects it to $x - \log \sum_i e^{x_i}$, which matches both the code and the definition of $\log(\text{softmax}(x))$.

`gelu_approx` has an extra opening parenthesis immediately after `\text{Tanh}` in its math block, so the LaTeX delimiters do not balance (three `\left(` against three `\right)` plus one stray bare `(`) and the expression renders incorrectly. The same block is duplicated in the `GELU` class docstring. Removing the stray parenthesis makes the grouping match the implementation `0.5 * x * (1 + tanh(sqrt(2 / pi) * (x + 0.044715 * x**3)))`.

These are documentation-only changes, so there is no effect on runtime behavior. I verified the corrected `log_softmax` formula against `log(softmax(x))` numerically, confirmed the GELU LaTeX now balances and matches the code, and ran `black`/`isort` plus the activation tests in `python/tests/test_nn.py`.