### PR TITLE
perf(scheduler): MLX_STREAM_QOS env var to pin StreamThread QoS class (Apple-only)

### DIFF
--- a/mlx/scheduler.h
+++ b/mlx/scheduler.h
@@ -3,11 +3,18 @@
 #pragma once
 
 #include <atomic>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <future>
 #include <queue>
 #include <shared_mutex>
 #include <thread>
 #include <unordered_map>
+
+#if defined(__APPLE__)
+#include <pthread/qos.h>
+#endif
 
 #include "mlx/api.h"
 #include "mlx/backend/gpu/eval.h"
@@ -35,6 +42,34 @@ struct StreamThread {
   }
 
   void thread_fn() {
+#if defined(__APPLE__)
+    // exo-mlx-tune: env-gated QoS pin for stream worker threads.
+    // Diagnosed via JACCL_TRACE_PROGRESS=1: rank 0 (the API/master
+    // host) sees asymmetric busy-poll stalls (17M+ poll_iters)
+    // during MTP verify all_reduces while rank 1 completes in 2
+    // poll_iters. The comm-stream worker thread is getting
+    // descheduled by the macOS scheduler — purely C++ busy-poll,
+    // no Python re-entry. Pinning the thread to a higher QoS
+    // keeps it on a P-core under contention.
+    //
+    // Off by default (safety: USER_INTERACTIVE has misbehaved on
+    // some cluster states — opt in deliberately). Set
+    // MLX_STREAM_QOS=user_initiated|user_interactive|default|utility
+    // to enable. Once-per-process getenv() — cheap.
+    static const int qos_class = [] {
+      const char* v = std::getenv("MLX_STREAM_QOS");
+      if (v == nullptr) return -1;
+      if (std::strcmp(v, "user_interactive") == 0) return (int)QOS_CLASS_USER_INTERACTIVE;
+      if (std::strcmp(v, "user_initiated") == 0) return (int)QOS_CLASS_USER_INITIATED;
+      if (std::strcmp(v, "default") == 0) return (int)QOS_CLASS_DEFAULT;
+      if (std::strcmp(v, "utility") == 0) return (int)QOS_CLASS_UTILITY;
+      if (std::strcmp(v, "off") == 0) return -1;
+      return -1;
+    }();
+    if (qos_class != -1) {
+      pthread_set_qos_class_self_np((qos_class_t)qos_class, 0);
+    }
+#endif
     while (true) {
       std::function<void()> task;
       {


### PR DESCRIPTION
**Repo:** ml-explore/mlx
**Branch:** adurham:pr/mlx-stream-qos
**Target:** ml-explore/mlx:main
**Commits:** 1 (`1540ecbc`)

---

# Title

`perf(scheduler): MLX_STREAM_QOS env var to pin StreamThread QoS class (Apple-only)`

# Body

## Summary

Add `MLX_STREAM_QOS` env var to optionally pin every `StreamThread` worker thread to a specified Apple QoS class via `pthread_set_qos_class_self_np()`.

Off by default (safe: misconfiguration could affect system scheduling). Apple-only — no-op on other platforms.

## Motivation

On a 2-node M4 Max RDMA cluster with concurrent foreground workloads, JACCL communication-stream worker threads sometimes hit asymmetric busy-poll stalls during all-reduce / all-gather. Diagnosed via `JACCL_TRACE_PROGRESS=1`:

- Rank 0's comm-stream worker: 1M-17M `poll_iters/call` (descheduled by macOS)
- Rank 1's comm-stream worker on the same call: 2 poll_iters

The C++ poll loop never re-enters Python, so the GIL isn't involved. macOS deprioritizes the worker thread because it inherits the parent's QoS class, which can drift during high system load.

Pinning to `USER_INTERACTIVE` keeps the thread on a P-core under contention. Empirically eliminates the stall asymmetry.

## Usage

```bash
MLX_STREAM_QOS=user_interactive  # max boost (recommended for latency-sensitive)
MLX_STREAM_QOS=user_initiated    # mild boost
MLX_STREAM_QOS=default           # explicit baseline
MLX_STREAM_QOS=utility           # demote (background work)
# (unset)                        # macOS default (off)
```

## Changes

- `mlx/scheduler.h`:
  - Add include for `<pthread/qos.h>` (Apple), `<cstdio>` `<cstdlib>` `<cstring>` for env parsing
  - Apply QoS pin to `StreamThread`'s `worker` thread on construction
  - Single function, ~35 lines

## Safety

- Gated on `__APPLE__` — no behavior change on Linux/Windows
- Gated on env var being set — no behavior change in default operation
- Unknown values are silently ignored (defaults preserved)
- The QoS pin is per-thread, applied only to MLX's StreamThread workers

## Test Plan

- [x] Build clean on Apple Silicon M4 Max
- [x] `MLX_STREAM_QOS=user_interactive python -c "import mlx.core as mx; mx.eval(mx.random.normal((4096,4096)) @ mx.random.normal((4096,4096)))"` — runs clean
- [x] Default (env unset): identical behavior to pre-PR
- [x] Production load: 2-node M4 Max cluster, 100K-context DeepSeek-V4 decode, `MLX_STREAM_QOS=user_interactive` over multi-hour benches — no regressions, eliminates the asymmetric stall pattern

## Notes

Linux equivalent (`sched_setattr(SCHED_DEADLINE)` or `pthread_setschedparam`) is out of scope for this PR — only `__APPLE__` path is implemented. Happy to add Linux support in a follow-up.
