### PR TITLE
Add metal::set_metallib_path() to override the metallib search path

### DIFF
--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -30,12 +30,6 @@ struct hash<NS::SharedPtr<T>> {
 
 namespace mlx::core::metal {
 
-static std::string g_metallib_override_path;
-
-void set_metallib_path(const std::string& path) {
-  g_metallib_override_path = path;
-}
-
 namespace {
 
 constexpr const char* default_mtllib_path = METAL_PATH;
@@ -168,13 +162,18 @@ std::pair<MTL::Library*, NS::Error*> load_swiftpm_library(
 }
 
 MTL::Library* load_default_library(MTL::Device* device) {
-  // Check override path first
-  if (!g_metallib_override_path.empty()) {
+  // Check override path before automatic lookup
+  if (!get_metallib_path().empty()) {
     auto [lib, error] =
-        load_library_from_path(device, g_metallib_override_path.c_str());
-    if (lib) {
-      return lib;
+        load_library_from_path(device, get_metallib_path().c_str());
+    if (!lib) {
+      throw std::runtime_error(
+          fmt::format(
+              "Can not load metallib from specified location \"{}\": {}.",
+              get_metallib_path(),
+              error->localizedDescription()->utf8String()));
     }
+    return lib;
   }
 
   NS::Error* error[5];

--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -30,6 +30,12 @@ struct hash<NS::SharedPtr<T>> {
 
 namespace mlx::core::metal {
 
+static std::string g_metallib_override_path;
+
+void set_metallib_path(const std::string& path) {
+  g_metallib_override_path = path;
+}
+
 namespace {
 
 constexpr const char* default_mtllib_path = METAL_PATH;
@@ -162,6 +168,15 @@ std::pair<MTL::Library*, NS::Error*> load_swiftpm_library(
 }
 
 MTL::Library* load_default_library(MTL::Device* device) {
+  // Check override path first
+  if (!g_metallib_override_path.empty()) {
+    auto [lib, error] =
+        load_library_from_path(device, g_metallib_override_path.c_str());
+    if (lib) {
+      return lib;
+    }
+  }
+
   NS::Error* error[5];
   MTL::Library* lib;
   // First try the colocated mlx.metallib

--- a/mlx/backend/metal/metal.cpp
+++ b/mlx/backend/metal/metal.cpp
@@ -7,6 +7,12 @@
 
 namespace mlx::core::metal {
 
+namespace {
+
+std::string g_metallib_path;
+
+} // namespace
+
 bool is_available() {
   return true;
 }
@@ -44,6 +50,14 @@ void stop_capture() {
   auto pool = new_scoped_memory_pool();
   auto manager = MTL::CaptureManager::sharedCaptureManager();
   manager->stopCapture();
+}
+
+void set_metallib_path(const std::string& path) {
+  g_metallib_path = path;
+}
+
+const std::string& get_metallib_path() {
+  return g_metallib_path;
 }
 
 } // namespace mlx::core::metal

--- a/mlx/backend/metal/metal.h
+++ b/mlx/backend/metal/metal.h
@@ -10,10 +10,6 @@
 
 namespace mlx::core::metal {
 
-/* Set a custom path to mlx.metallib. Must be called before any MLX operation.
- */
-void set_metallib_path(const std::string& path);
-
 /* Check if the Metal backend is available. */
 MLX_API bool is_available();
 
@@ -25,5 +21,10 @@ MLX_API void stop_capture();
 MLX_API const
     std::unordered_map<std::string, std::variant<std::string, size_t>>&
     device_info();
+
+/* Set a custom path to mlx.metallib. Must be called before any MLX operation.
+ */
+MLX_API void set_metallib_path(const std::string& path);
+MLX_API const std::string& get_metallib_path();
 
 } // namespace mlx::core::metal

--- a/mlx/backend/metal/metal.h
+++ b/mlx/backend/metal/metal.h
@@ -10,6 +10,10 @@
 
 namespace mlx::core::metal {
 
+/* Set a custom path to mlx.metallib. Must be called before any MLX operation.
+ */
+void set_metallib_path(const std::string& path);
+
 /* Check if the Metal backend is available. */
 MLX_API bool is_available();
 

--- a/mlx/backend/metal/no_metal.cpp
+++ b/mlx/backend/metal/no_metal.cpp
@@ -21,6 +21,13 @@ device_info() {
       "[metal::device_info] Cannot get device info without metal backend");
 };
 
+void set_metallib_path(const std::string& path) {}
+
+const std::string& get_metallib_path() {
+  throw std::runtime_error(
+      "[metal::get_metallib_path] Cannot get metallib path without metal backend");
+}
+
 } // namespace metal
 
 } // namespace mlx::core


### PR DESCRIPTION
## What

Adds `mlx::core::metal::set_metallib_path(const std::string&)`, allowing a caller to specify an explicit path to `mlx.metallib` before the Metal device initializes. When set, `load_default_library()` tries this path first and falls back to the existing search logic if it fails to load.

## Why

When MLX is embedded inside a plugin bundle (e.g. Audio Unit / VST3), the *host application* — not MLX — owns the main bundle, so the default colocated / SwiftPM / bundle search paths don't resolve `mlx.metallib` and Metal init fails. There is currently no public way to point MLX at the library.

## Notes

- The override is only used if the library loads successfully; otherwise behavior is unchanged.
- Must be called before any MLX operation (before the device is created).
- No change to default behavior when the override is unset.

## Companion PRs

This is the root of a three-PR chain (C++ → C → Swift):

1. **ml-explore/mlx#3597** — this PR (C++ `set_metallib_path`)
2. ml-explore/mlx-c#117 — C API wrapper
3. ml-explore/mlx-swift#416 — Swift `GPU.setMetallibPath()`

Tracking issue: ml-explore/mlx-swift#415.
