### PR TITLE
docs: expose missing Python APIs

### DIFF
--- a/docs/src/python/distributed.rst
+++ b/docs/src/python/distributed.rst
@@ -15,8 +15,11 @@ made available.
     Group
     is_available
     init
+    all_max
+    all_min
     all_sum
     all_gather
     send
     recv
     recv_like
+    sum_scatter

--- a/docs/src/python/fast.rst
+++ b/docs/src/python/fast.rst
@@ -14,3 +14,4 @@ Fast
   scaled_dot_product_attention
   metal_kernel
   cuda_kernel
+  precompiled_cuda_kernel

--- a/docs/src/python/nn/init.rst
+++ b/docs/src/python/nn/init.rst
@@ -43,3 +43,5 @@ distribution, you can do:
    glorot_uniform
    he_normal
    he_uniform
+   sparse
+   orthogonal

--- a/docs/src/python/nn/layers.rst
+++ b/docs/src/python/nn/layers.rst
@@ -15,6 +15,7 @@ Layers
    AvgPool2d
    AvgPool3d
    BatchNorm
+   Bilinear
    CELU
    Conv1d
    Conv2d
@@ -34,6 +35,7 @@ Layers
    HardShrink
    HardTanh
    Hardswish
+   Identity
    InstanceNorm
    LayerNorm
    LeakyReLU
@@ -47,6 +49,7 @@ Layers
    Mish
    MultiHeadAttention
    PReLU
+   QQLinear
    QuantizedAllToShardedLinear
    QuantizedEmbedding
    QuantizedLinear
@@ -71,4 +74,8 @@ Layers
    Step
    Tanh
    Transformer
+   TransformerDecoder
+   TransformerDecoderLayer
+   TransformerEncoder
+   TransformerEncoderLayer
    Upsample

--- a/docs/src/python/ops.rst
+++ b/docs/src/python/ops.rst
@@ -27,19 +27,24 @@ Operations
    argpartition
    argsort
    array_equal
+   asarray
    as_strided
    atleast_1d
    atleast_2d
    atleast_3d
+   bartlett
    bitwise_and
    bitwise_invert
    bitwise_or
    bitwise_xor
+   blackman
    block_masked_mm
    broadcast_arrays
+   broadcast_shapes
    broadcast_to
    ceil
    clip
+   concat
    concatenate
    contiguous
    conj
@@ -59,6 +64,7 @@ Operations
    cumprod
    cumsum
    degrees
+   depends
    dequantize
    diag
    diagonal
@@ -77,11 +83,14 @@ Operations
    floor
    floor_divide
    full
+   from_fp8
    gather_mm
    gather_qmm
    greater
    greater_equal
    hadamard_transform
+   hamming
+   hanning
    identity
    imag
    inner
@@ -126,11 +135,13 @@ Operations
    outer
    partition
    pad
+   permute_dims
    power
    prod
    put_along_axis
    quantize
    quantized_matmul
+   qqmm
    radians
    real
    reciprocal
@@ -152,6 +163,7 @@ Operations
    sinh
    slice
    slice_update
+   segmented_mm
    softmax
    sort
    split
@@ -171,6 +183,7 @@ Operations
    tensordot
    tile
    topk
+   to_fp8
    trace
    transpose
    tri

--- a/docs/src/python/tree_utils.rst
+++ b/docs/src/python/tree_utils.rst
@@ -21,3 +21,4 @@ return python trees will be using the default python ``dict``, ``list`` and
    tree_map
    tree_map_with_path
    tree_reduce
+   tree_merge


### PR DESCRIPTION
## Proposed changes

Expose missing Python API entries in the Sphinx autosummary documentation.

This adds docs entries for existing public APIs in:
- `mlx.core`
- `mlx.core.distributed`
- `mlx.core.fast`
- `mlx.nn.init`
- `mlx.nn`
- `mlx.utils`

Deprecated `mlx.core.metal` memory aliases are intentionally not added because they redirect users to the top-level memory APIs.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
