### PR TITLE
block_fp8: 2D-block FP8 quantized matmul + MoE kernels (DeepSeek-V3 / MiMo)

### DIFF
--- a/mlx/backend/metal/kernels/fp_quantized.h
+++ b/mlx/backend/metal/kernels/fp_quantized.h
@@ -1409,6 +1409,98 @@ template <
       w, scales, x, y, Xs, Ws, K, N, M, tid, lid, simd_gid, simd_lid);
 }
 
+// --------------------------------------------------------------------------
+// block_fp8 gather_qmv (MoE decode path).
+// One threadgroup per (token, expert). Per-token rhs_indices selects the
+// expert slice of w/scales for this token's top-k experts. Calls the same
+// block_fp8_qmv_fast_impl after offset-adjusting the pointers.
+// --------------------------------------------------------------------------
+
+template <typename T>
+METAL_FUNC void block_fp8_adjust_matrix_offsets(
+    const device T*& x,
+    const device uint8_t*& w,
+    const device float*& scales,
+    const device uint32_t* lhs_indices,
+    const device uint32_t* rhs_indices,
+    device T*& y,
+    int output_stride,
+    const constant int& batch_ndims,
+    const constant int* batch_shape,
+    const constant int64_t* lhs_strides,
+    const constant int64_t* rhs_strides,
+    const constant int& x_batch_ndims,
+    const constant int* x_shape,
+    const constant int64_t* x_strides,
+    const constant int& w_batch_ndims,
+    const constant int* w_shape,
+    const constant int64_t* w_strides,
+    const constant int64_t* s_strides,
+    uint3 tid) {
+  uint32_t x_idx;
+  uint32_t w_idx;
+  if (batch_ndims == 1) {
+    x_idx = lhs_indices[tid.z * lhs_strides[0]];
+    w_idx = rhs_indices[tid.z * rhs_strides[0]];
+  } else {
+    ulong2 idx = elem_to_loc_broadcast(
+        tid.z, batch_shape, lhs_strides, rhs_strides, batch_ndims);
+    x_idx = lhs_indices[idx.x];
+    w_idx = rhs_indices[idx.y];
+  }
+  if (x_batch_ndims == 1) {
+    x += x_idx * x_strides[0];
+  } else {
+    x += elem_to_loc(x_idx, x_shape, x_strides, x_batch_ndims);
+  }
+  if (w_batch_ndims == 1) {
+    w += w_idx * w_strides[0];
+    scales += w_idx * s_strides[0];
+  } else {
+    ulong2 idx = elem_to_loc_broadcast(
+        w_idx, w_shape, w_strides, s_strides, w_batch_ndims);
+    w += idx.x;
+    scales += idx.y;
+  }
+  y += tid.z * output_stride;
+}
+
+template <typename T, int group_size, int bits>
+[[kernel]] void block_fp8_gather_qmv_fast(
+    const device uint8_t* w,
+    const device float* scales,
+    const device T* x,
+    const device uint32_t* lhs_indices,
+    const device uint32_t* rhs_indices,
+    device T* y,
+    const constant int& in_vec_size,
+    const constant int& out_vec_size,
+    const constant int& x_batch_ndims,
+    const constant int* x_shape,
+    const constant int64_t* x_strides,
+    const constant int& w_batch_ndims,
+    const constant int* w_shape,
+    const constant int64_t* w_strides,
+    const constant int64_t* s_strides,
+    const constant int& batch_ndims,
+    const constant int* batch_shape,
+    const constant int64_t* lhs_strides,
+    const constant int64_t* rhs_strides,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  int M = x_shape[x_batch_ndims];
+  block_fp8_adjust_matrix_offsets(
+      x, w, scales, lhs_indices, rhs_indices, y,
+      out_vec_size * M,
+      batch_ndims, batch_shape, lhs_strides, rhs_strides,
+      x_batch_ndims, x_shape, x_strides,
+      w_batch_ndims, w_shape, w_strides, s_strides,
+      tid);
+  block_fp8_qmv_fast_impl<T>(
+      w, scales, x, y, in_vec_size, out_vec_size, tid, simd_gid, simd_lid);
+}
+
 template <typename T, int group_size, int bits>
 [[kernel]] void fp_gather_qmv_fast(
     const device uint32_t* w,

--- a/mlx/backend/metal/kernels/fp_quantized.h
+++ b/mlx/backend/metal/kernels/fp_quantized.h
@@ -1215,6 +1215,114 @@ template <typename T, int group_size, int bits, bool aligned_N, bool batched>
       w, scales, x, y, K, N, M, tid, simd_gid, simd_lid);
 }
 
+// --------------------------------------------------------------------------
+// block_fp8 gather_qmm_t (MoE prefill): per-M-row qmv math + expert lookup.
+//
+// Layout for THIS kernel only (not the generic gather_qmm path):
+//   grid_dims  = (N / 8, M, 1)
+//   group_dims = (32, 2, 1)            // 2 simdgroups, 32 threads each
+//
+// rhs_indices[m] picks which expert this M-row uses. We compute the offset
+// into w and scales once per threadgroup, then run the same per-row qmv math
+// as block_fp8_qmm_t_impl.
+// --------------------------------------------------------------------------
+template <typename T>
+METAL_FUNC void block_fp8_gather_qmm_t_impl(
+    const device uint8_t* w,
+    const device float* scales,
+    const device uint32_t* rhs_indices,
+    const device T* x,
+    device T* y,
+    const constant int& K,
+    const constant int& N,
+    const constant int& M,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  constexpr int num_simdgroups = 2;
+  constexpr int results_per_simdgroup = 4;
+  constexpr int bits = 8;
+  constexpr int group_size = 128;
+  constexpr int values_per_thread = 8;
+  constexpr int block_size = values_per_thread * SIMD_SIZE;
+
+  typedef float U;
+  thread U x_thread[values_per_thread];
+  thread U result[results_per_simdgroup] = {0};
+
+  const int in_vec_size_w = K;
+  const int scales_per_row = K / group_size;
+
+  const int m = tid.y;
+
+  // Expert lookup: read rhs_indices[m] once per threadgroup.
+  const uint32_t expert = rhs_indices[m];
+  const size_t w_expert_offset = size_t(expert) * size_t(N) * size_t(in_vec_size_w);
+  const size_t s_expert_offset = size_t(expert) * size_t(N) * size_t(scales_per_row);
+
+  const int out_row = tid.x * (num_simdgroups * results_per_simdgroup) +
+      simd_gid * results_per_simdgroup;
+  const int scale_row = out_row / group_size;
+
+  w += w_expert_offset + out_row * in_vec_size_w + simd_lid * values_per_thread;
+  scales += s_expert_offset + scale_row * scales_per_row;
+  x += m * K + simd_lid * values_per_thread;
+  y += m * N + out_row;
+
+  for (int k = 0; k < K; k += block_size) {
+    load_vector<T, U, values_per_thread>(x, x_thread);
+
+    const int sk = (k + simd_lid * values_per_thread) / group_size;
+    U s = scales[sk];
+
+    for (int row = 0; row < results_per_simdgroup; row++) {
+      const device uint8_t* wl = w + row * in_vec_size_w;
+      result[row] += qdot<U, values_per_thread, bits>(wl, x_thread, s);
+    }
+
+    w += block_size;
+    x += block_size;
+  }
+
+  for (int row = 0; row < results_per_simdgroup; row++) {
+    result[row] = simd_sum(result[row]);
+    if (simd_lid == 0) {
+      y[row] = static_cast<T>(result[row]);
+    }
+  }
+}
+
+template <typename T, int group_size, int bits, bool aligned_N>
+[[kernel]] void block_fp8_gather_qmm_t(
+    const device uint8_t* w,
+    const device float* scales,
+    const device uint32_t* rhs_indices,
+    const device T* x,
+    device T* y,
+    const constant int& K,
+    const constant int& N,
+    const constant int& M,
+    const constant int& x_batch_ndims,
+    const constant int* x_shape,
+    const constant int64_t* x_strides,
+    const constant int& w_batch_ndims,
+    const constant int* w_shape,
+    const constant int64_t* w_strides,
+    const constant int64_t* s_strides,
+    const constant int& batch_ndims,
+    const constant int* batch_shape,
+    const constant int64_t* lhs_strides,
+    const constant int64_t* rhs_strides,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  (void)x_batch_ndims; (void)x_shape; (void)x_strides;
+  (void)w_batch_ndims; (void)w_shape; (void)w_strides; (void)s_strides;
+  (void)batch_ndims; (void)batch_shape; (void)lhs_strides; (void)rhs_strides;
+  block_fp8_gather_qmm_t_impl<T>(
+      w, scales, rhs_indices, x, y, K, N, M, tid, simd_gid, simd_lid);
+}
+
 template <typename T, int group_size, int bits, bool batched>
 [[kernel]] void fp_qmv_fast(
     const device uint32_t* w,

--- a/mlx/backend/metal/kernels/fp_quantized.h
+++ b/mlx/backend/metal/kernels/fp_quantized.h
@@ -1408,88 +1408,251 @@ template <typename T, int group_size, int bits, bool aligned_N, bool batched>
 }
 
 // --------------------------------------------------------------------------
-// block_fp8 gather_qmm_t (MoE prefill): per-M-row qmv math + expert lookup.
+// block_fp8 gather_qmm_rhs: sorted-indices MoE path (M=1 prefill with large
+// B and B/E >= 4). Mirrors upstream fp_gather_qmm_rhs structurally.
 //
-// Layout for THIS kernel only (not the generic gather_qmm path):
-//   grid_dims  = (N / 8, M, 1)
-//   group_dims = (32, 2, 1)            // 2 simdgroups, 32 threads each
+// Uses BlockFp8QuantizedLoader (2D fp32 scales) instead of the affine
+// QuantizedBlockLoader. fp8 codes are unpacked bytes so pack_factor=1 and
+// bytes_per_pack=1; this simplifies the stride math.
 //
-// rhs_indices[m] picks which expert this M-row uses. We compute the offset
-// into w and scales once per threadgroup, then run the same per-row qmv math
-// as block_fp8_qmm_t_impl.
+// align_M/N/K are file-scope function constants (200/201/202).
 // --------------------------------------------------------------------------
-template <typename T>
-METAL_FUNC void block_fp8_gather_qmm_t_impl(
+template <
+    typename T,
+    int group_size,
+    int bits,
+    int BM,
+    int BN,
+    int BK,
+    int WM,
+    int WN,
+    bool transpose>
+[[kernel]] void block_fp8_gather_qmm_rhs(
+    const device T* x,
     const device uint8_t* w,
     const device float* scales,
-    const device uint32_t* rhs_indices,
-    const device T* x,
+    const device uint32_t* indices,
     device T* y,
-    const constant int& K,
-    const constant int& N,
     const constant int& M,
+    const constant int& N,
+    const constant int& K,
     uint3 tid [[threadgroup_position_in_grid]],
-    uint simd_gid [[simdgroup_index_in_threadgroup]],
-    uint simd_lid [[thread_index_in_simdgroup]]) {
-  constexpr int num_simdgroups = 2;
-  constexpr int results_per_simdgroup = 4;
-  constexpr int bits = 8;
-  constexpr int group_size = 128;
-  constexpr int values_per_thread = 8;
-  constexpr int block_size = values_per_thread * SIMD_SIZE;
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]]) {
+  constexpr int BK_padded = (BK + 16 / sizeof(T));
+  constexpr int BN_padded = (BN + 16 / sizeof(T));
 
-  typedef float U;
-  thread U x_thread[values_per_thread];
-  thread U result[results_per_simdgroup] = {0};
+  using mma_t = mlx::steel::BlockMMA<
+      T, T, BM, BN, BK, WM, WN, false, transpose,
+      BK_padded, transpose ? BK_padded : BN_padded>;
+  using loader_x_t =
+      mlx::steel::BlockLoader<T, BM, BK, BK_padded, 1, WM * WN * SIMD_SIZE>;
+  using loader_w_t = BlockFp8QuantizedLoader<
+      T,
+      transpose ? BN : BK,
+      transpose ? BK : BN,
+      transpose ? BK_padded : BN_padded,
+      transpose,
+      WM * WN * SIMD_SIZE>;
 
-  const int in_vec_size_w = K;
-  const int scales_per_row = K / group_size;
+  threadgroup T Xs[BM * BK_padded];
+  threadgroup T Ws[transpose ? BN * BK_padded : BK * BN_padded];
 
-  const int m = tid.y;
+  // Block layout - fp8 is byte-per-code so K_w = K and N_w = N.
+  const int K_g = K / group_size;
+  const int N_g = N / group_size;
+  const int K_it = K / BK;
+  const size_t stride_w = transpose ? size_t(N) * size_t(K) : size_t(K) * size_t(N);
+  // 2D scale grid: [E, N/gs, K/gs]. Per-expert stride = N_g * K_g.
+  const size_t stride_s = size_t(N_g) * size_t(K_g);
+  const int y_row = tid.y * BM;
+  const int y_col = tid.x * BN;
+  const size_t y_row_long = size_t(y_row);
+  const size_t y_col_long = size_t(y_col);
 
-  // Expert lookup: read rhs_indices[m] once per threadgroup.
-  const uint32_t expert = rhs_indices[m];
-  const size_t w_expert_offset = size_t(expert) * size_t(N) * size_t(in_vec_size_w);
-  const size_t s_expert_offset = size_t(expert) * size_t(N) * size_t(scales_per_row);
+  const short tgp_bm = align_M ? BM : short(min(BM, M - y_row));
+  const short tgp_bn = align_N ? BN : short(min(BN, N - y_col));
 
-  const int out_row = tid.x * (num_simdgroups * results_per_simdgroup) +
-      simd_gid * results_per_simdgroup;
-  const int scale_row = out_row / group_size;
+  const int k_remain = K - K_it * BK;
+  const short2 tile_x = short2(k_remain, tgp_bm);
+  const short2 tile_w =
+      transpose ? short2(k_remain, tgp_bn) : short2(tgp_bn, k_remain);
 
-  w += w_expert_offset + out_row * in_vec_size_w + simd_lid * values_per_thread;
-  scales += s_expert_offset + scale_row * scales_per_row;
-  x += m * K + simd_lid * values_per_thread;
-  y += m * N + out_row;
+  // Move pointers to this block's region.
+  x += y_row_long * K;
+  y += y_row_long * N + y_col_long;
+  w += transpose ? y_col_long * K : y_col_long;
+  // 2D scales: jump to the (y_col / group_size) row-block.
+  scales += (y_col_long / group_size) * size_t(K_g);
 
-  for (int k = 0; k < K; k += block_size) {
-    load_vector<T, U, values_per_thread>(x, x_thread);
+  // s_row_stride for the BlockFp8QuantizedLoader's 2D scale walk:
+  // when transpose=true (qmm_t pattern), reduction is along K, scales are
+  // [N/gs, K/gs], so row stride along N is K_g.
+  // when transpose=false, scales are [K/gs, N/gs], row stride along K is N_g.
+  const int s_row_stride = transpose ? K_g : N_g;
 
-    const int sk = (k + simd_lid * values_per_thread) / group_size;
-    U s = scales[sk];
-
-    for (int row = 0; row < results_per_simdgroup; row++) {
-      const device uint8_t* wl = w + row * in_vec_size_w;
-      result[row] += qdot<U, values_per_thread, bits>(wl, x_thread, s);
+  // Per-expert loop: walk M rows, group consecutive identical indices, emit
+  // one MMA pass per group of rows sharing an expert.
+  uint32_t index;
+  short offset;
+  uint32_t index_next = indices[y_row];
+  short offset_next = 0;
+  int n = 0;
+  while (n < tgp_bm) {
+    n++;
+    offset = offset_next;
+    index = index_next;
+    offset_next = tgp_bm;
+    for (; n < tgp_bm; n++) {
+      if (indices[y_row + n] != index) {
+        offset_next = n;
+        index_next = indices[y_row + n];
+        break;
+      }
     }
+    threadgroup_barrier(mem_flags::mem_none);
 
-    w += block_size;
-    x += block_size;
-  }
+    thread mma_t mma_op(simd_group_id, simd_lane_id);
+    thread loader_x_t loader_x(x, K, Xs, simd_group_id, simd_lane_id);
+    thread loader_w_t loader_w(
+        w + index * stride_w,
+        scales + index * stride_s,
+        transpose ? K : N,
+        s_row_stride,
+        Ws,
+        simd_group_id,
+        simd_lane_id);
 
-  for (int row = 0; row < results_per_simdgroup; row++) {
-    result[row] = simd_sum(result[row]);
-    if (simd_lid == 0) {
-      y[row] = static_cast<T>(result[row]);
+    if (align_M && align_N) {
+      gemm_loop_aligned(Xs, Ws, mma_op, loader_x, loader_w, K_it);
+      if (!align_K) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+      }
+      if (offset_next - offset == BM) {
+        mma_op.store_result(y, N);
+      } else {
+        mma_op.store_result_slice(
+            y, N, short2(0, offset), short2(BN, offset_next));
+      }
+    } else {
+      if ((align_M || tgp_bm == BM) && (align_N || tgp_bn == BN)) {
+        gemm_loop_aligned(Xs, Ws, mma_op, loader_x, loader_w, K_it);
+        if (!align_K) {
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+          gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+        }
+        if (offset_next - offset == BM) {
+          mma_op.store_result(y, N);
+        } else {
+          mma_op.store_result_slice(
+              y, N, short2(0, offset), short2(BN, offset_next));
+        }
+      } else if (align_N || tgp_bn == BN) {
+        gemm_loop_unaligned<false, true, transpose>(
+            Xs, Ws, mma_op, loader_x, loader_w, K_it, tgp_bm, tgp_bn, BK);
+        if (!align_K) {
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+          gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+        }
+        mma_op.store_result_slice(
+            y, N, short2(0, offset), short2(BN, offset_next));
+      } else if (align_M || tgp_bm == BM) {
+        gemm_loop_unaligned<true, false, transpose>(
+            Xs, Ws, mma_op, loader_x, loader_w, K_it, tgp_bm, tgp_bn, BK);
+        if (!align_K) {
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+          gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+        }
+        mma_op.store_result_slice(
+            y, N, short2(0, offset), short2(tgp_bn, offset_next));
+      } else {
+        gemm_loop_unaligned<false, false, transpose>(
+            Xs, Ws, mma_op, loader_x, loader_w, K_it, tgp_bm, tgp_bn, BK);
+        if (!align_K) {
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+          gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+        }
+        mma_op.store_result_slice(
+            y, N, short2(0, offset), short2(tgp_bn, offset_next));
+      }
     }
   }
 }
 
+
+// --------------------------------------------------------------------------
+// block_fp8 gather_qmv (MoE decode path).
+// One threadgroup per (token, expert). Per-token rhs_indices selects the
+// expert slice of w/scales for this token's top-k experts. Calls the same
+// block_fp8_qmv_fast_impl after offset-adjusting the pointers.
+// --------------------------------------------------------------------------
+
+template <typename T>
+METAL_FUNC void block_fp8_adjust_matrix_offsets(
+    const device T*& x,
+    const device uint8_t*& w,
+    const device float*& scales,
+    const device uint32_t* lhs_indices,
+    const device uint32_t* rhs_indices,
+    device T*& y,
+    int output_stride,
+    const constant int& batch_ndims,
+    const constant int* batch_shape,
+    const constant int64_t* lhs_strides,
+    const constant int64_t* rhs_strides,
+    const constant int& x_batch_ndims,
+    const constant int* x_shape,
+    const constant int64_t* x_strides,
+    const constant int& w_batch_ndims,
+    const constant int* w_shape,
+    const constant int64_t* w_strides,
+    const constant int64_t* s_strides,
+    uint3 tid) {
+  uint32_t x_idx;
+  uint32_t w_idx;
+  if (batch_ndims == 1) {
+    x_idx = lhs_indices[tid.z * lhs_strides[0]];
+    w_idx = rhs_indices[tid.z * rhs_strides[0]];
+  } else {
+    ulong2 idx = elem_to_loc_broadcast(
+        tid.z, batch_shape, lhs_strides, rhs_strides, batch_ndims);
+    x_idx = lhs_indices[idx.x];
+    w_idx = rhs_indices[idx.y];
+  }
+  if (x_batch_ndims == 1) {
+    x += x_idx * x_strides[0];
+  } else {
+    x += elem_to_loc(x_idx, x_shape, x_strides, x_batch_ndims);
+  }
+  if (w_batch_ndims == 1) {
+    w += w_idx * w_strides[0];
+    scales += w_idx * s_strides[0];
+  } else {
+    ulong2 idx = elem_to_loc_broadcast(
+        w_idx, w_shape, w_strides, s_strides, w_batch_ndims);
+    w += idx.x;
+    scales += idx.y;
+  }
+  y += tid.z * output_stride;
+}
+
+// --------------------------------------------------------------------------
+// block_fp8 gather_qmm_t (MoE prefill, tiled).
+//
+// Pattern mirrors upstream fp_gather_qmm_t: adjust pointer offsets for the
+// gathered expert via block_fp8_adjust_matrix_offsets, then run the standard
+// block_fp8_qmm_t_impl (tiled BlockMMA + BlockFp8QuantizedLoader).
+//
+// Uses standard MLX dispatcher geometry: (N/32, M/32, B) with (32, 2, 2).
+// --------------------------------------------------------------------------
 template <typename T, int group_size, int bits, bool aligned_N>
 [[kernel]] void block_fp8_gather_qmm_t(
     const device uint8_t* w,
     const device float* scales,
-    const device uint32_t* rhs_indices,
     const device T* x,
+    const device uint32_t* lhs_indices,
+    const device uint32_t* rhs_indices,
     device T* y,
     const constant int& K,
     const constant int& N,
@@ -1506,13 +1669,26 @@ template <typename T, int group_size, int bits, bool aligned_N>
     const constant int64_t* lhs_strides,
     const constant int64_t* rhs_strides,
     uint3 tid [[threadgroup_position_in_grid]],
+    uint lid [[thread_index_in_threadgroup]],
     uint simd_gid [[simdgroup_index_in_threadgroup]],
     uint simd_lid [[thread_index_in_simdgroup]]) {
-  (void)x_batch_ndims; (void)x_shape; (void)x_strides;
-  (void)w_batch_ndims; (void)w_shape; (void)w_strides; (void)s_strides;
-  (void)batch_ndims; (void)batch_shape; (void)lhs_strides; (void)rhs_strides;
-  block_fp8_gather_qmm_t_impl<T>(
-      w, scales, rhs_indices, x, y, K, N, M, tid, simd_gid, simd_lid);
+  constexpr int BM = 32, BK = 32, BN = 32;
+  constexpr int BK_padded = (BK + 16 / sizeof(T));
+  threadgroup T Xs[BM * BK_padded];
+  threadgroup T Ws[BN * BK_padded];
+
+  block_fp8_adjust_matrix_offsets<T>(
+      x, w, scales,
+      lhs_indices, rhs_indices,
+      y,
+      M * N,
+      batch_ndims, batch_shape, lhs_strides, rhs_strides,
+      x_batch_ndims, x_shape, x_strides,
+      w_batch_ndims, w_shape, w_strides, s_strides,
+      tid);
+
+  block_fp8_qmm_t_impl<T, group_size, bits, aligned_N, BM, BK, BN>(
+      w, scales, x, y, Xs, Ws, K, N, M, tid, lid, simd_gid, simd_lid);
 }
 
 template <typename T, int group_size, int bits, bool batched>
@@ -1807,61 +1983,6 @@ template <
       w, scales, x, y, Xs, Ws, K, N, M, tid, lid, simd_gid, simd_lid);
 }
 
-// --------------------------------------------------------------------------
-// block_fp8 gather_qmv (MoE decode path).
-// One threadgroup per (token, expert). Per-token rhs_indices selects the
-// expert slice of w/scales for this token's top-k experts. Calls the same
-// block_fp8_qmv_fast_impl after offset-adjusting the pointers.
-// --------------------------------------------------------------------------
-
-template <typename T>
-METAL_FUNC void block_fp8_adjust_matrix_offsets(
-    const device T*& x,
-    const device uint8_t*& w,
-    const device float*& scales,
-    const device uint32_t* lhs_indices,
-    const device uint32_t* rhs_indices,
-    device T*& y,
-    int output_stride,
-    const constant int& batch_ndims,
-    const constant int* batch_shape,
-    const constant int64_t* lhs_strides,
-    const constant int64_t* rhs_strides,
-    const constant int& x_batch_ndims,
-    const constant int* x_shape,
-    const constant int64_t* x_strides,
-    const constant int& w_batch_ndims,
-    const constant int* w_shape,
-    const constant int64_t* w_strides,
-    const constant int64_t* s_strides,
-    uint3 tid) {
-  uint32_t x_idx;
-  uint32_t w_idx;
-  if (batch_ndims == 1) {
-    x_idx = lhs_indices[tid.z * lhs_strides[0]];
-    w_idx = rhs_indices[tid.z * rhs_strides[0]];
-  } else {
-    ulong2 idx = elem_to_loc_broadcast(
-        tid.z, batch_shape, lhs_strides, rhs_strides, batch_ndims);
-    x_idx = lhs_indices[idx.x];
-    w_idx = rhs_indices[idx.y];
-  }
-  if (x_batch_ndims == 1) {
-    x += x_idx * x_strides[0];
-  } else {
-    x += elem_to_loc(x_idx, x_shape, x_strides, x_batch_ndims);
-  }
-  if (w_batch_ndims == 1) {
-    w += w_idx * w_strides[0];
-    scales += w_idx * s_strides[0];
-  } else {
-    ulong2 idx = elem_to_loc_broadcast(
-        w_idx, w_shape, w_strides, s_strides, w_batch_ndims);
-    w += idx.x;
-    scales += idx.y;
-  }
-  y += tid.z * output_stride;
-}
 
 template <typename T, int group_size, int bits>
 [[kernel]] void block_fp8_gather_qmv_fast(

--- a/mlx/backend/metal/kernels/fp_quantized.h
+++ b/mlx/backend/metal/kernels/fp_quantized.h
@@ -259,6 +259,146 @@ struct QuantizedBlockLoader {
   }
 };
 
+// --------------------------------------------------------------------------
+// BlockFp8QuantizedLoader: 2D-scale variant for block_fp8 (DeepSeek-V3/MiMo).
+//
+// Layout differences from the fp variant above:
+//   - scales is `device float*` (fp32), not packed uint8 (no dequantize_scale)
+//   - 2D scale grid: scales[row_block * (K/group_size) + col_block]
+//     where row_block = (start_row + bi) / group_size, col_block walks K
+//   - group_size = 128, bits = 8 (enforced; only block_fp8 invariants)
+//
+// API-compatible with QuantizedBlockLoader: same load_unsafe / load_safe /
+// next signatures so we can drop into existing qmm templates by swapping
+// loader_w_t = BlockFp8QuantizedLoader<...>.
+//
+// Caller responsibility: pass `scales_` already offset to the starting tile
+// row block, exactly like the existing fp loader expects scales_ offset to
+// the starting tile row. The constructor handles the bi/bj offset within
+// the tile. The caller also passes scales_stride_K = K / group_size so we
+// know the row-stride in the 2D scale grid.
+// --------------------------------------------------------------------------
+template <
+    typename T,
+    short BROWS,
+    short BCOLS,
+    short dst_ld,
+    short reduction_dim,
+    short tgp_size>
+struct BlockFp8QuantizedLoader {
+  MLX_MTL_CONST short bits = 8;
+  MLX_MTL_CONST short group_size = 128;
+  MLX_MTL_CONST short pack_factor = 1;       // bytes_per_pack = 1 for fp8
+  MLX_MTL_CONST short bytes_per_pack = 1;
+  MLX_MTL_CONST short BCOLS_PACKED = BCOLS;  // codes are unpacked bytes
+  MLX_MTL_CONST short n_reads =
+      (BCOLS_PACKED * BROWS < tgp_size) ? 1 : (BCOLS_PACKED * BROWS) / tgp_size;
+  MLX_MTL_CONST short group_steps = group_size / BCOLS;  // 128/BK steps per scale
+
+  static_assert(
+      BCOLS <= group_size,
+      "block_fp8: BCOLS must be <= 128 group size");
+  static_assert(
+      group_size % BCOLS == 0,
+      "block_fp8: 128 must be divisible by BCOLS");
+  static_assert(
+      (n_reads * pack_factor) <= group_size,
+      "block_fp8: reads per thread must be <= group size");
+
+  const int src_ld;
+  const int tile_stride;
+  short group_step_cnt;
+  const int group_stride;   // for reduction_dim==0 (walking down rows)
+  const int s_row_stride;   // K/group_size, for jumping rows in 2D scale grid
+
+  const short thread_idx;
+  const short bi;
+  const short bj;
+
+  threadgroup T* dst;
+  const device uint8_t* src;
+  const device float* scales;
+
+  BlockFp8QuantizedLoader(
+      const device uint8_t* src_,
+      const device float* scales_,
+      const int src_ld_,
+      const int s_row_stride_,        // = K / group_size
+      threadgroup T* dst_,
+      ushort simd_group_id [[simdgroup_index_in_threadgroup]],
+      ushort simd_lane_id [[thread_index_in_simdgroup]])
+      : src_ld(src_ld_),
+        tile_stride(
+            reduction_dim ? BCOLS_PACKED * bytes_per_pack
+                          : BROWS * src_ld * bytes_per_pack / pack_factor),
+        group_step_cnt(0),
+        group_stride(BROWS * src_ld / group_size),
+        s_row_stride(s_row_stride_),
+        thread_idx(simd_group_id * 32 + simd_lane_id),
+        bi(n_reads * thread_idx / BCOLS_PACKED),
+        bj((n_reads * thread_idx) % BCOLS_PACKED),
+        dst(dst_ + bi * dst_ld + bj * pack_factor),
+        src(src_ + bi * src_ld * bytes_per_pack / pack_factor +
+            bj * bytes_per_pack),
+        // 2D scale offset: (bi / group_size) along rows, (bj / group_size) along cols.
+        scales(
+            scales_ + (bi / group_size) * s_row_stride_ +
+            (bj / group_size)) {}
+
+  void load_unsafe() const {
+    if (BCOLS_PACKED * BROWS < tgp_size && bi >= BROWS) {
+      return;
+    }
+    typedef float U;
+    U scale = *scales;
+    for (int i = 0; i < n_reads; i++) {
+      dequantize<T, bits>(src[i * bytes_per_pack], T(scale), dst + i * pack_factor);
+    }
+  }
+
+  void load_safe(short2 src_tile_dim) const {
+    if (BCOLS_PACKED * BROWS < tgp_size && bi >= BROWS) {
+      return;
+    }
+    if (reduction_dim == 1 && bi >= src_tile_dim.x) {
+      for (int i = 0; i < n_reads * pack_factor; i++) dst[i] = T(0);
+      return;
+    }
+    if (reduction_dim == 0 && bi >= src_tile_dim.y) {
+      for (int i = 0; i < n_reads * pack_factor; i++) dst[i] = T(0);
+      return;
+    }
+    typedef float U;
+    U scale = *scales;
+    for (int i = 0; i < n_reads; i++) {
+      dequantize<T, bits>(src[i * bytes_per_pack], T(scale), dst + i * pack_factor);
+    }
+  }
+
+  void next() {
+    src += tile_stride;
+    if (reduction_dim == 1) {
+      // Walk K: advance col_block every group_steps tile-steps (128 K each).
+      if (group_steps > 1) {
+        group_step_cnt++;
+        if (group_step_cnt == group_steps) {
+          group_step_cnt = 0;
+          scales++;   // advance one column in the 2D scale grid
+        }
+      } else {
+        scales++;
+      }
+    } else {
+      // Walk N (rows): advance row_block. BROWS rows per tile = BROWS/group_size
+      // row-blocks. For typical BROWS=32 and group_size=128, that's 32/128 = 0
+      // intra-tile, so this branch only matters when BROWS >= 128.
+      scales += group_stride * s_row_stride / src_ld * group_size;
+      // Equivalent simplification: scales += (BROWS / group_size) * s_row_stride
+      // when BROWS is a multiple of group_size; otherwise needs the full math.
+    }
+  }
+};
+
 template <typename T, int group_size, int bits, int D>
 METAL_FUNC void fp_qmv_quad_impl(
     const device uint32_t* w,
@@ -1118,74 +1258,120 @@ template <typename T, int group_size, int bits, bool batched>
 }
 
 // --------------------------------------------------------------------------
-// block_fp8 qmm_t (M1: simple-but-correct, qmv-math repeated per M row).
+// block_fp8_qmm_t: tiled implementation using BlockFp8QuantizedLoader.
 //
-// Layout for THIS kernel only (not the generic qmm path):
-//   grid_dims  = (N / 8, M, B)        // one threadgroup per (m, n-tile)
-//   group_dims = (32, 2, 1)            // 2 simdgroups, 32 threads each
+// Mirrors upstream fp_qmm_t_impl with loader_w_t = BlockFp8QuantizedLoader.
+// Uses standard MLX dispatcher geometry: grid=(N/32, M/32, B), group=(32, 2, 2).
 //
-// The MLX dispatcher hardcodes (N/32, M/32, B) with (32, 2, 2). The C++
-// dispatcher applies a block_fp8-specific override before invoking us.
-//
-// Each threadgroup produces 8 contiguous N rows of output for one M row,
-// using the same simdgroup dot-product as block_fp8_qmv_fast_impl.
+// Standard MLX tiled BlockMMA pattern with fp32 register accumulation.
 // --------------------------------------------------------------------------
-template <typename T>
+template <
+    typename T,
+    int group_size,
+    int bits,
+    bool aligned_N,
+    int BM = 32,
+    int BK = 32,
+    int BN = 32>
 METAL_FUNC void block_fp8_qmm_t_impl(
     const device uint8_t* w,
     const device float* scales,
     const device T* x,
     device T* y,
+    threadgroup T* Xs,
+    threadgroup T* Ws,
     const constant int& K,
     const constant int& N,
     const constant int& M,
     uint3 tid [[threadgroup_position_in_grid]],
+    uint lid [[thread_index_in_threadgroup]],
     uint simd_gid [[simdgroup_index_in_threadgroup]],
     uint simd_lid [[thread_index_in_simdgroup]]) {
-  constexpr int num_simdgroups = 2;
-  constexpr int results_per_simdgroup = 4;
-  constexpr int bits = 8;
-  constexpr int group_size = 128;
-  constexpr int values_per_thread = 8;
-  constexpr int block_size = values_per_thread * SIMD_SIZE;  // 256
+  static_assert(BK >= SIMD_SIZE, "BK should be larger than SIMD_SIZE");
+  (void)lid;
+  constexpr int WM = 2;
+  constexpr int WN = 2;
+  constexpr int BK_padded = (BK + 16 / sizeof(T));
 
-  typedef float U;
-  thread U x_thread[values_per_thread];
-  thread U result[results_per_simdgroup] = {0};
+  using mma_t = mlx::steel::
+      BlockMMA<T, T, BM, BN, BK, WM, WN, false, true, BK_padded, BK_padded>;
+  using loader_x_t =
+      mlx::steel::BlockLoader<T, BM, BK, BK_padded, 1, WM * WN * SIMD_SIZE>;
+  using loader_w_t = BlockFp8QuantizedLoader<
+      T,
+      BN,
+      BK,
+      BK_padded,
+      1,
+      WM * WN * SIMD_SIZE>;
 
-  const int in_vec_size_w = K;
-  const int scales_per_row = K / group_size;
+  const int K_g = K / group_size;  // scale row stride
+  const int y_row = tid.y * BM;
+  const int y_col = tid.x * BN;
 
-  const int m = tid.y;
-  const int out_row = tid.x * (num_simdgroups * results_per_simdgroup) +
-      simd_gid * results_per_simdgroup;
-  const int scale_row = out_row / group_size;
+  x += y_row * static_cast<int64_t>(K);
+  w += y_col * K;                            // 1 byte per code
+  scales += (y_col / group_size) * K_g;      // jump to this N-tile's scale row
+  y += y_row * static_cast<int64_t>(N) + y_col;
 
-  w += out_row * in_vec_size_w + simd_lid * values_per_thread;
-  scales += scale_row * scales_per_row;
-  x += m * K + simd_lid * values_per_thread;
-  y += m * N + out_row;
+  const short num_els = min(BM, M - y_row);
+  const short num_outs = min(BN, N - y_col);
+  loader_x_t loader_x(x, K, Xs, simd_gid, simd_lid);
+  loader_w_t loader_w(w, scales, K, K_g, Ws, simd_gid, simd_lid);
+  mma_t mma_op(simd_gid, simd_lid);
 
-  for (int k = 0; k < K; k += block_size) {
-    load_vector<T, U, values_per_thread>(x, x_thread);
-
-    const int sk = (k + simd_lid * values_per_thread) / group_size;
-    U s = scales[sk];
-
-    for (int row = 0; row < results_per_simdgroup; row++) {
-      const device uint8_t* wl = w + row * in_vec_size_w;
-      result[row] += qdot<U, values_per_thread, bits>(wl, x_thread, s);
+  // Aligned K assumed (K % BK == 0). MiMo always satisfies this.
+  if (num_els < BM) {
+    if (!aligned_N && num_outs < BN) {
+      for (int k = 0; k < K; k += BK) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_safe(short2(BK, num_els));
+        loader_w.load_safe(short2(BK, num_outs));
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(Xs, Ws);
+        loader_x.next();
+        loader_w.next();
+      }
+    } else {
+      for (int k = 0; k < K; k += BK) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_safe(short2(BK, num_els));
+        loader_w.load_unsafe();
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(Xs, Ws);
+        loader_x.next();
+        loader_w.next();
+      }
     }
-
-    w += block_size;
-    x += block_size;
+  } else {
+    if (!aligned_N && num_outs < BN) {
+      for (int k = 0; k < K; k += BK) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_unsafe();
+        loader_w.load_safe(short2(BK, num_outs));
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(Xs, Ws);
+        loader_x.next();
+        loader_w.next();
+      }
+    } else {
+      for (int k = 0; k < K; k += BK) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_unsafe();
+        loader_w.load_unsafe();
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(Xs, Ws);
+        loader_x.next();
+        loader_w.next();
+      }
+    }
   }
 
-  for (int row = 0; row < results_per_simdgroup; row++) {
-    result[row] = simd_sum(result[row]);
-    if (simd_lid == 0) {
-      y[row] = static_cast<T>(result[row]);
-    }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  if (num_els < BM || num_outs < BN) {
+    mma_op.store_result_safe(y, N, short2(num_outs, num_els));
+  } else {
+    mma_op.store_result(y, N);
   }
 }
 
@@ -1206,13 +1392,19 @@ template <typename T, int group_size, int bits, bool aligned_N, bool batched>
     const constant int64_t* w_strides,
     const constant int64_t* s_strides,
     uint3 tid [[threadgroup_position_in_grid]],
+    uint lid [[thread_index_in_threadgroup]],
     uint simd_gid [[simdgroup_index_in_threadgroup]],
     uint simd_lid [[thread_index_in_simdgroup]]) {
-  // Smoke path: B=1, no batched offsets.
   (void)x_batch_ndims; (void)x_shape; (void)x_strides;
   (void)w_batch_ndims; (void)w_shape; (void)w_strides; (void)s_strides;
-  block_fp8_qmm_t_impl<T>(
-      w, scales, x, y, K, N, M, tid, simd_gid, simd_lid);
+
+  constexpr int BM = 32, BK = 32, BN = 32;
+  constexpr int BK_padded = (BK + 16 / sizeof(T));
+  threadgroup T Xs[BM * BK_padded];
+  threadgroup T Ws[BN * BK_padded];
+
+  block_fp8_qmm_t_impl<T, group_size, bits, aligned_N, BM, BK, BN>(
+      w, scales, x, y, Xs, Ws, K, N, M, tid, lid, simd_gid, simd_lid);
 }
 
 // --------------------------------------------------------------------------

--- a/mlx/backend/metal/kernels/fp_quantized.h
+++ b/mlx/backend/metal/kernels/fp_quantized.h
@@ -1283,6 +1283,7 @@ METAL_FUNC void block_fp8_qmm_t_impl(
     const constant int& K,
     const constant int& N,
     const constant int& M,
+    const int k_loop_limit,
     uint3 tid [[threadgroup_position_in_grid]],
     uint lid [[thread_index_in_threadgroup]],
     uint simd_gid [[simdgroup_index_in_threadgroup]],
@@ -1323,7 +1324,7 @@ METAL_FUNC void block_fp8_qmm_t_impl(
   // Aligned K assumed (K % BK == 0). MiMo always satisfies this.
   if (num_els < BM) {
     if (!aligned_N && num_outs < BN) {
-      for (int k = 0; k < K; k += BK) {
+      for (int k = 0; k < k_loop_limit; k += BK) {
         threadgroup_barrier(mem_flags::mem_threadgroup);
         loader_x.load_safe(short2(BK, num_els));
         loader_w.load_safe(short2(BK, num_outs));
@@ -1333,7 +1334,7 @@ METAL_FUNC void block_fp8_qmm_t_impl(
         loader_w.next();
       }
     } else {
-      for (int k = 0; k < K; k += BK) {
+      for (int k = 0; k < k_loop_limit; k += BK) {
         threadgroup_barrier(mem_flags::mem_threadgroup);
         loader_x.load_safe(short2(BK, num_els));
         loader_w.load_unsafe();
@@ -1345,7 +1346,7 @@ METAL_FUNC void block_fp8_qmm_t_impl(
     }
   } else {
     if (!aligned_N && num_outs < BN) {
-      for (int k = 0; k < K; k += BK) {
+      for (int k = 0; k < k_loop_limit; k += BK) {
         threadgroup_barrier(mem_flags::mem_threadgroup);
         loader_x.load_unsafe();
         loader_w.load_safe(short2(BK, num_outs));
@@ -1355,7 +1356,7 @@ METAL_FUNC void block_fp8_qmm_t_impl(
         loader_w.next();
       }
     } else {
-      for (int k = 0; k < K; k += BK) {
+      for (int k = 0; k < k_loop_limit; k += BK) {
         threadgroup_barrier(mem_flags::mem_threadgroup);
         loader_x.load_unsafe();
         loader_w.load_unsafe();
@@ -1404,7 +1405,7 @@ template <typename T, int group_size, int bits, bool aligned_N, bool batched>
   threadgroup T Ws[BN * BK_padded];
 
   block_fp8_qmm_t_impl<T, group_size, bits, aligned_N, BM, BK, BN>(
-      w, scales, x, y, Xs, Ws, K, N, M, tid, lid, simd_gid, simd_lid);
+      w, scales, x, y, Xs, Ws, K, N, M, K, tid, lid, simd_gid, simd_lid);
 }
 
 // --------------------------------------------------------------------------
@@ -1646,6 +1647,58 @@ METAL_FUNC void block_fp8_adjust_matrix_offsets(
 //
 // Uses standard MLX dispatcher geometry: (N/32, M/32, B) with (32, 2, 2).
 // --------------------------------------------------------------------------
+// block_fp8_qmm_t_splitk: split the K dimension across threadgroups.
+//
+// Each threadgroup handles a slice of K of size k_partition_size and writes
+// its partial result to intermediate[tid.z * split_k_partition_stride + ...].
+// A subsequent Sum reduction (dispatched by qmm_splitk in quantized.cpp)
+// accumulates across the split_k axis to produce the final output.
+//
+// Reuses block_fp8_qmm_t_impl with k_partition_size substituted for K so
+// the K-loop stops at the partition boundary. Pointer math advances x, w,
+// and scales by the partition start before calling the impl.
+// --------------------------------------------------------------------------
+template <
+    typename T,
+    const int group_size,
+    const int bits,
+    const bool aligned_N,
+    const int BM = 32,
+    const int BK = 32,
+    const int BN = 32>
+[[kernel]] void block_fp8_qmm_t_splitk(
+    const device uint8_t* w [[buffer(0)]],
+    const device float* scales [[buffer(1)]],
+    const device T* x [[buffer(2)]],
+    device T* y [[buffer(3)]],
+    const constant int& K [[buffer(4)]],
+    const constant int& N [[buffer(5)]],
+    const constant int& M [[buffer(6)]],
+    const constant int& k_partition_size [[buffer(7)]],
+    const constant int& split_k_partition_stride [[buffer(8)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint lid [[thread_index_in_threadgroup]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  constexpr int BK_padded = (BK + 16 / sizeof(T));
+  threadgroup T Xs[BM * BK_padded];
+  threadgroup T Ws[BN * BK_padded];
+
+  const int k_start = tid.z * k_partition_size;
+  // fp8: 1 byte per code, so w advances by k_start bytes.
+  // scales are 2D fp32 indexed by (row_block, col_block); jump by the
+  // number of K-blocks consumed by k_start.
+  x += k_start;
+  w += k_start;
+  scales += k_start / group_size;
+  y += tid.z * static_cast<int64_t>(split_k_partition_stride);
+
+  block_fp8_qmm_t_impl<T, group_size, bits, aligned_N, BM, BK, BN>(
+      w, scales, x, y, Xs, Ws, K, N, M, k_partition_size, tid, lid,
+      simd_gid, simd_lid);
+}
+
+// --------------------------------------------------------------------------
 template <typename T, int group_size, int bits, bool aligned_N>
 [[kernel]] void block_fp8_gather_qmm_t(
     const device uint8_t* w,
@@ -1688,7 +1741,7 @@ template <typename T, int group_size, int bits, bool aligned_N>
       tid);
 
   block_fp8_qmm_t_impl<T, group_size, bits, aligned_N, BM, BK, BN>(
-      w, scales, x, y, Xs, Ws, K, N, M, tid, lid, simd_gid, simd_lid);
+      w, scales, x, y, Xs, Ws, K, N, M, K, tid, lid, simd_gid, simd_lid);
 }
 
 template <typename T, int group_size, int bits, bool batched>

--- a/mlx/backend/metal/kernels/fp_quantized.h
+++ b/mlx/backend/metal/kernels/fp_quantized.h
@@ -1117,6 +1117,104 @@ template <typename T, int group_size, int bits, bool batched>
       w, scales, x, y, in_vec_size, out_vec_size, tid, simd_gid, simd_lid);
 }
 
+// --------------------------------------------------------------------------
+// block_fp8 qmm_t (M1: simple-but-correct, qmv-math repeated per M row).
+//
+// Layout for THIS kernel only (not the generic qmm path):
+//   grid_dims  = (N / 8, M, B)        // one threadgroup per (m, n-tile)
+//   group_dims = (32, 2, 1)            // 2 simdgroups, 32 threads each
+//
+// The MLX dispatcher hardcodes (N/32, M/32, B) with (32, 2, 2). The C++
+// dispatcher applies a block_fp8-specific override before invoking us.
+//
+// Each threadgroup produces 8 contiguous N rows of output for one M row,
+// using the same simdgroup dot-product as block_fp8_qmv_fast_impl.
+// --------------------------------------------------------------------------
+template <typename T>
+METAL_FUNC void block_fp8_qmm_t_impl(
+    const device uint8_t* w,
+    const device float* scales,
+    const device T* x,
+    device T* y,
+    const constant int& K,
+    const constant int& N,
+    const constant int& M,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  constexpr int num_simdgroups = 2;
+  constexpr int results_per_simdgroup = 4;
+  constexpr int bits = 8;
+  constexpr int group_size = 128;
+  constexpr int values_per_thread = 8;
+  constexpr int block_size = values_per_thread * SIMD_SIZE;  // 256
+
+  typedef float U;
+  thread U x_thread[values_per_thread];
+  thread U result[results_per_simdgroup] = {0};
+
+  const int in_vec_size_w = K;
+  const int scales_per_row = K / group_size;
+
+  const int m = tid.y;
+  const int out_row = tid.x * (num_simdgroups * results_per_simdgroup) +
+      simd_gid * results_per_simdgroup;
+  const int scale_row = out_row / group_size;
+
+  w += out_row * in_vec_size_w + simd_lid * values_per_thread;
+  scales += scale_row * scales_per_row;
+  x += m * K + simd_lid * values_per_thread;
+  y += m * N + out_row;
+
+  for (int k = 0; k < K; k += block_size) {
+    load_vector<T, U, values_per_thread>(x, x_thread);
+
+    const int sk = (k + simd_lid * values_per_thread) / group_size;
+    U s = scales[sk];
+
+    for (int row = 0; row < results_per_simdgroup; row++) {
+      const device uint8_t* wl = w + row * in_vec_size_w;
+      result[row] += qdot<U, values_per_thread, bits>(wl, x_thread, s);
+    }
+
+    w += block_size;
+    x += block_size;
+  }
+
+  for (int row = 0; row < results_per_simdgroup; row++) {
+    result[row] = simd_sum(result[row]);
+    if (simd_lid == 0) {
+      y[row] = static_cast<T>(result[row]);
+    }
+  }
+}
+
+template <typename T, int group_size, int bits, bool aligned_N, bool batched>
+[[kernel]] void block_fp8_qmm_t(
+    const device uint8_t* w,
+    const device float* scales,
+    const device T* x,
+    device T* y,
+    const constant int& K,
+    const constant int& N,
+    const constant int& M,
+    const constant int& x_batch_ndims,
+    const constant int* x_shape,
+    const constant int64_t* x_strides,
+    const constant int& w_batch_ndims,
+    const constant int* w_shape,
+    const constant int64_t* w_strides,
+    const constant int64_t* s_strides,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  // Smoke path: B=1, no batched offsets.
+  (void)x_batch_ndims; (void)x_shape; (void)x_strides;
+  (void)w_batch_ndims; (void)w_shape; (void)w_strides; (void)s_strides;
+  block_fp8_qmm_t_impl<T>(
+      w, scales, x, y, K, N, M, tid, simd_gid, simd_lid);
+}
+
 template <typename T, int group_size, int bits, bool batched>
 [[kernel]] void fp_qmv_fast(
     const device uint32_t* w,

--- a/mlx/backend/metal/kernels/fp_quantized.h
+++ b/mlx/backend/metal/kernels/fp_quantized.h
@@ -1009,6 +1009,114 @@ template <typename T, int group_size, int bits, int D, bool batched>
       w, scales, x, y, in_vec_size, out_vec_size, tid, quad_gid, quad_lid);
 }
 
+// --------------------------------------------------------------------------
+// block_fp8 (DeepSeek-V3 / MiMo): unpacked uint8 E4M3 codes + 2D fp32 scales.
+// group_size=128 along K and N (square 128x128 weight blocks share one scale).
+// --------------------------------------------------------------------------
+
+template <typename T>
+METAL_FUNC void block_fp8_qmv_fast_impl(
+    const device uint8_t* w,
+    const device float* scales,
+    const device T* x,
+    device T* y,
+    const constant int& in_vec_size,
+    const constant int& out_vec_size,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  // Geometry matches fp_qmv_fast for bits=8:
+  //   packs_per_thread = 2, num_simdgroups = 2, results_per_simdgroup = 4
+  //   pack_factor = 4 (8 bits per code, 32-bit pack on wire only -- on memory
+  //   we read bytes directly).
+  // For block_fp8: codes are *unpacked* (1 byte each), so bytes_per_pack on
+  // memory == values_per_thread == 8 bytes per thread per K-step.
+  constexpr int packs_per_thread = 2;
+  constexpr int num_simdgroups = 2;
+  constexpr int results_per_simdgroup = 4;
+  constexpr int bits = 8;
+  constexpr int group_size = 128;
+  constexpr int values_per_thread = 8;        // = 4 codes/pack * 2 packs
+  constexpr int block_size = values_per_thread * SIMD_SIZE;  // 256
+
+  typedef float U;
+  thread U x_thread[values_per_thread];
+  thread U result[results_per_simdgroup] = {0};
+
+  // Position setup.
+  // Weight is [N, K] uint8, row-major. Stride between rows = in_vec_size.
+  // Scales are [N/128, K/128] fp32, row-major. Stride between scale-rows = K/128.
+  const int in_vec_size_w = in_vec_size;          // 1 byte per code
+  const int scales_per_row = in_vec_size / group_size;  // K/128
+
+  const int out_row = tid.y * (num_simdgroups * results_per_simdgroup) +
+      simd_gid * results_per_simdgroup;
+  // All 4 contiguous output rows in this simdgroup share the same scale row,
+  // because results_per_simdgroup (4) <= 128 (block_size_N) and the kernel
+  // guarantees N is aligned to bm rows.
+  const int scale_row = out_row / group_size;
+
+  w += out_row * in_vec_size_w + simd_lid * values_per_thread;
+  scales += scale_row * scales_per_row;
+  x += tid.x * in_vec_size + simd_lid * values_per_thread;
+  y += tid.x * out_vec_size + out_row;
+
+  for (int k = 0; k < in_vec_size; k += block_size) {
+    load_vector<T, U, values_per_thread>(x, x_thread);
+
+    // Scale index along K for THIS simdgroup's K-position.
+    // simd_lid covers values_per_thread*32 = 256 K-values per simdgroup pass,
+    // but each scale spans 128 K-values, so simd_lid contributes scale offset
+    // of (simd_lid * values_per_thread) / 128 = simd_lid / 16.
+    const int sk = (k + simd_lid * values_per_thread) / group_size;
+    U s = scales[sk];
+
+    for (int row = 0; row < results_per_simdgroup; row++) {
+      const device uint8_t* wl = w + row * in_vec_size_w;
+      result[row] += qdot<U, values_per_thread, bits>(wl, x_thread, s);
+    }
+
+    w += block_size;          // 256 codes per K-step
+    x += block_size;
+    // scales pointer doesn't advance per-row inside this K loop; sk is recomputed.
+  }
+
+  for (int row = 0; row < results_per_simdgroup; row++) {
+    result[row] = simd_sum(result[row]);
+    if (simd_lid == 0) {
+      y[row] = static_cast<T>(result[row]);
+    }
+  }
+}
+
+// Non-batched only for now: ignore stride metadata.
+template <typename T, int group_size, int bits, bool batched>
+[[kernel]] void block_fp8_qmv_fast(
+    const device uint8_t* w,
+    const device float* scales,
+    const device T* x,
+    device T* y,
+    const constant int& in_vec_size,
+    const constant int& out_vec_size,
+    const constant int& x_batch_ndims,
+    const constant int* x_shape,
+    const constant int64_t* x_strides,
+    const constant int& w_batch_ndims,
+    const constant int* w_shape,
+    const constant int64_t* w_strides,
+    const constant int64_t* s_strides,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  // batched offset adjustment intentionally omitted: B>1 produces wrong output
+  // for block_fp8 until we add a fp32-scales adjust_matrix_offsets overload.
+  // Smoke test is B=1.
+  (void)x_batch_ndims; (void)x_shape; (void)x_strides;
+  (void)w_batch_ndims; (void)w_shape; (void)w_strides; (void)s_strides;
+  block_fp8_qmv_fast_impl<T>(
+      w, scales, x, y, in_vec_size, out_vec_size, tid, simd_gid, simd_lid);
+}
+
 template <typename T, int group_size, int bits, bool batched>
 [[kernel]] void fp_qmv_fast(
     const device uint32_t* w,

--- a/mlx/backend/metal/kernels/fp_quantized.h
+++ b/mlx/backend/metal/kernels/fp_quantized.h
@@ -1162,6 +1162,7 @@ METAL_FUNC void block_fp8_qmv_fast_impl(
     device T* y,
     const constant int& in_vec_size,
     const constant int& out_vec_size,
+    const int scale_rows,
     uint3 tid [[threadgroup_position_in_grid]],
     uint simd_gid [[simdgroup_index_in_threadgroup]],
     uint simd_lid [[thread_index_in_simdgroup]]) {
@@ -1194,7 +1195,20 @@ METAL_FUNC void block_fp8_qmv_fast_impl(
   // All 4 contiguous output rows in this simdgroup share the same scale row,
   // because results_per_simdgroup (4) <= 128 (block_size_N) and the kernel
   // guarantees N is aligned to bm rows.
-  const int scale_row = out_row / group_size;
+  // per-shard scale-row recovery (flat when scale_rows == ceil(N/128))
+  const int _flat_srows = (out_vec_size + group_size - 1) / group_size;
+  int _shard_rows = out_vec_size, _shard_srows = _flat_srows;
+  if (scale_rows != _flat_srows) {
+    for (int _tp = 2; _tp <= 16; _tp <<= 1) {
+      if (out_vec_size % _tp) continue;
+      const int _sr = out_vec_size / _tp;
+      if (scale_rows == _tp * ((_sr + group_size - 1) / group_size)) {
+        _shard_rows = _sr; _shard_srows = scale_rows / _tp; break;
+      }
+    }
+  }
+  const int _sh = out_row / _shard_rows;
+  const int scale_row = _sh * _shard_srows + (out_row - _sh * _shard_rows) / group_size;
 
   w += out_row * in_vec_size_w + simd_lid * values_per_thread;
   scales += scale_row * scales_per_row;
@@ -1238,6 +1252,7 @@ template <typename T, int group_size, int bits, bool batched>
     device T* y,
     const constant int& in_vec_size,
     const constant int& out_vec_size,
+    const constant int& scale_rows,
     const constant int& x_batch_ndims,
     const constant int* x_shape,
     const constant int64_t* x_strides,
@@ -1254,7 +1269,7 @@ template <typename T, int group_size, int bits, bool batched>
   (void)x_batch_ndims; (void)x_shape; (void)x_strides;
   (void)w_batch_ndims; (void)w_shape; (void)w_strides; (void)s_strides;
   block_fp8_qmv_fast_impl<T>(
-      w, scales, x, y, in_vec_size, out_vec_size, tid, simd_gid, simd_lid);
+      w, scales, x, y, in_vec_size, out_vec_size, scale_rows, tid, simd_gid, simd_lid);
 }
 
 // --------------------------------------------------------------------------
@@ -1283,6 +1298,7 @@ METAL_FUNC void block_fp8_qmm_t_impl(
     const constant int& K,
     const constant int& N,
     const constant int& M,
+    const int scale_rows,
     const int k_loop_limit,
     uint3 tid [[threadgroup_position_in_grid]],
     uint lid [[thread_index_in_threadgroup]],
@@ -1312,7 +1328,20 @@ METAL_FUNC void block_fp8_qmm_t_impl(
 
   x += y_row * static_cast<int64_t>(K);
   w += y_col * K;                            // 1 byte per code
-  scales += (y_col / group_size) * K_g;      // jump to this N-tile's scale row
+  // per-shard scale-row recovery (flat when scale_rows == ceil(N/128))
+  const int _flat_srows = (N + group_size - 1) / group_size;
+  int _shard_rows = N, _shard_srows = _flat_srows;
+  if (scale_rows != _flat_srows) {
+    for (int _tp = 2; _tp <= 16; _tp <<= 1) {
+      if (N % _tp) continue;
+      const int _sr = N / _tp;
+      if (scale_rows == _tp * ((_sr + group_size - 1) / group_size)) {
+        _shard_rows = _sr; _shard_srows = scale_rows / _tp; break;
+      }
+    }
+  }
+  const int _sh2 = y_col / _shard_rows;
+  scales += (_sh2 * _shard_srows + (y_col - _sh2 * _shard_rows) / group_size) * K_g;
   y += y_row * static_cast<int64_t>(N) + y_col;
 
   const short num_els = min(BM, M - y_row);
@@ -1385,6 +1414,7 @@ template <typename T, int group_size, int bits, bool aligned_N, bool batched>
     const constant int& K,
     const constant int& N,
     const constant int& M,
+    const constant int& scale_rows,
     const constant int& x_batch_ndims,
     const constant int* x_shape,
     const constant int64_t* x_strides,
@@ -1405,7 +1435,7 @@ template <typename T, int group_size, int bits, bool aligned_N, bool batched>
   threadgroup T Ws[BN * BK_padded];
 
   block_fp8_qmm_t_impl<T, group_size, bits, aligned_N, BM, BK, BN>(
-      w, scales, x, y, Xs, Ws, K, N, M, K, tid, lid, simd_gid, simd_lid);
+      w, scales, x, y, Xs, Ws, K, N, M, scale_rows, K, tid, lid, simd_gid, simd_lid);
 }
 
 // --------------------------------------------------------------------------
@@ -1694,7 +1724,7 @@ template <
   y += tid.z * static_cast<int64_t>(split_k_partition_stride);
 
   block_fp8_qmm_t_impl<T, group_size, bits, aligned_N, BM, BK, BN>(
-      w, scales, x, y, Xs, Ws, K, N, M, k_partition_size, tid, lid,
+      w, scales, x, y, Xs, Ws, K, N, M, (N + 127) / 128, k_partition_size, tid, lid,
       simd_gid, simd_lid);
 }
 
@@ -1741,7 +1771,7 @@ template <typename T, int group_size, int bits, bool aligned_N>
       tid);
 
   block_fp8_qmm_t_impl<T, group_size, bits, aligned_N, BM, BK, BN>(
-      w, scales, x, y, Xs, Ws, K, N, M, K, tid, lid, simd_gid, simd_lid);
+      w, scales, x, y, Xs, Ws, K, N, M, (N + 127) / 128, K, tid, lid, simd_gid, simd_lid);
 }
 
 template <typename T, int group_size, int bits, bool batched>
@@ -2070,7 +2100,7 @@ template <typename T, int group_size, int bits>
       w_batch_ndims, w_shape, w_strides, s_strides,
       tid);
   block_fp8_qmv_fast_impl<T>(
-      w, scales, x, y, in_vec_size, out_vec_size, tid, simd_gid, simd_lid);
+      w, scales, x, y, in_vec_size, out_vec_size, (out_vec_size + 127) / 128, tid, simd_gid, simd_lid);
 }
 
 template <typename T, int group_size, int bits>

--- a/mlx/backend/metal/kernels/fp_quantized.metal
+++ b/mlx/backend/metal/kernels/fp_quantized.metal
@@ -197,4 +197,38 @@ instantiate_block_fp8_gather_qmv_fast(float16_t)
 instantiate_block_fp8_qmm_t(float)
 instantiate_block_fp8_qmm_t(bfloat16_t)
 instantiate_block_fp8_qmm_t(float16_t)
+
+#define instantiate_block_fp8_gather_qmm_t(type) \
+  template [[host_name("block_fp8_gather_qmm_t_" #type "_gs_128_b_8_alN_true")]] \
+  [[kernel]] void block_fp8_gather_qmm_t<type, 128, 8, true>( \
+      const device uint8_t* w, const device float* scales, \
+      const device uint32_t* rhs_indices, const device type* x, device type* y, \
+      const constant int& K, const constant int& N, const constant int& M, \
+      const constant int& x_batch_ndims, const constant int* x_shape, \
+      const constant int64_t* x_strides, const constant int& w_batch_ndims, \
+      const constant int* w_shape, const constant int64_t* w_strides, \
+      const constant int64_t* s_strides, const constant int& batch_ndims, \
+      const constant int* batch_shape, const constant int64_t* lhs_strides, \
+      const constant int64_t* rhs_strides, \
+      uint3 tid [[threadgroup_position_in_grid]], \
+      uint simd_gid [[simdgroup_index_in_threadgroup]], \
+      uint simd_lid [[thread_index_in_simdgroup]]); \
+  template [[host_name("block_fp8_gather_qmm_t_" #type "_gs_128_b_8_alN_false")]] \
+  [[kernel]] void block_fp8_gather_qmm_t<type, 128, 8, false>( \
+      const device uint8_t* w, const device float* scales, \
+      const device uint32_t* rhs_indices, const device type* x, device type* y, \
+      const constant int& K, const constant int& N, const constant int& M, \
+      const constant int& x_batch_ndims, const constant int* x_shape, \
+      const constant int64_t* x_strides, const constant int& w_batch_ndims, \
+      const constant int* w_shape, const constant int64_t* w_strides, \
+      const constant int64_t* s_strides, const constant int& batch_ndims, \
+      const constant int* batch_shape, const constant int64_t* lhs_strides, \
+      const constant int64_t* rhs_strides, \
+      uint3 tid [[threadgroup_position_in_grid]], \
+      uint simd_gid [[simdgroup_index_in_threadgroup]], \
+      uint simd_lid [[thread_index_in_simdgroup]]);
+
+instantiate_block_fp8_gather_qmm_t(float)
+instantiate_block_fp8_gather_qmm_t(bfloat16_t)
+instantiate_block_fp8_gather_qmm_t(float16_t)
     // clang-format on

--- a/mlx/backend/metal/kernels/fp_quantized.metal
+++ b/mlx/backend/metal/kernels/fp_quantized.metal
@@ -206,11 +206,13 @@ instantiate_block_fp8_qmm_t(float)
 instantiate_block_fp8_qmm_t(bfloat16_t)
 instantiate_block_fp8_qmm_t(float16_t)
 
-#define instantiate_block_fp8_gather_qmm_t(type) \
-  template [[host_name("block_fp8_gather_qmm_t_" #type "_gs_128_b_8_alN_true")]] \
-  [[kernel]] void block_fp8_gather_qmm_t<type, 128, 8, true>( \
+#define instantiate_block_fp8_gather_qmm_t_one(type, alN, alN_str) \
+  template [[host_name("block_fp8_gather_qmm_t_" #type "_gs_128_b_8_alN_" #alN_str)]] \
+  [[kernel]] void block_fp8_gather_qmm_t<type, 128, 8, alN>( \
       const device uint8_t* w, const device float* scales, \
-      const device uint32_t* rhs_indices, const device type* x, device type* y, \
+      const device type* x, \
+      const device uint32_t* lhs_indices, const device uint32_t* rhs_indices, \
+      device type* y, \
       const constant int& K, const constant int& N, const constant int& M, \
       const constant int& x_batch_ndims, const constant int* x_shape, \
       const constant int64_t* x_strides, const constant int& w_batch_ndims, \
@@ -219,24 +221,22 @@ instantiate_block_fp8_qmm_t(float16_t)
       const constant int* batch_shape, const constant int64_t* lhs_strides, \
       const constant int64_t* rhs_strides, \
       uint3 tid [[threadgroup_position_in_grid]], \
-      uint simd_gid [[simdgroup_index_in_threadgroup]], \
-      uint simd_lid [[thread_index_in_simdgroup]]); \
-  template [[host_name("block_fp8_gather_qmm_t_" #type "_gs_128_b_8_alN_false")]] \
-  [[kernel]] void block_fp8_gather_qmm_t<type, 128, 8, false>( \
-      const device uint8_t* w, const device float* scales, \
-      const device uint32_t* rhs_indices, const device type* x, device type* y, \
-      const constant int& K, const constant int& N, const constant int& M, \
-      const constant int& x_batch_ndims, const constant int* x_shape, \
-      const constant int64_t* x_strides, const constant int& w_batch_ndims, \
-      const constant int* w_shape, const constant int64_t* w_strides, \
-      const constant int64_t* s_strides, const constant int& batch_ndims, \
-      const constant int* batch_shape, const constant int64_t* lhs_strides, \
-      const constant int64_t* rhs_strides, \
-      uint3 tid [[threadgroup_position_in_grid]], \
+      uint lid [[thread_index_in_threadgroup]], \
       uint simd_gid [[simdgroup_index_in_threadgroup]], \
       uint simd_lid [[thread_index_in_simdgroup]]);
+
+#define instantiate_block_fp8_gather_qmm_t(type) \
+  instantiate_block_fp8_gather_qmm_t_one(type, true, true) \
+  instantiate_block_fp8_gather_qmm_t_one(type, false, false)
 
 instantiate_block_fp8_gather_qmm_t(float)
 instantiate_block_fp8_gather_qmm_t(bfloat16_t)
 instantiate_block_fp8_gather_qmm_t(float16_t)
+
+instantiate_gather_qmm_rhs(block_fp8_gather_qmm_rhs, gather_qmm_rhs_nt, float, 16, 32, 32, 1, 2, true, block_fp8, 128, 8)
+instantiate_gather_qmm_rhs(block_fp8_gather_qmm_rhs, gather_qmm_rhs_nn, float, 16, 32, 32, 1, 2, false, block_fp8, 128, 8)
+instantiate_gather_qmm_rhs(block_fp8_gather_qmm_rhs, gather_qmm_rhs_nt, bfloat16_t, 16, 32, 32, 1, 2, true, block_fp8, 128, 8)
+instantiate_gather_qmm_rhs(block_fp8_gather_qmm_rhs, gather_qmm_rhs_nn, bfloat16_t, 16, 32, 32, 1, 2, false, block_fp8, 128, 8)
+instantiate_gather_qmm_rhs(block_fp8_gather_qmm_rhs, gather_qmm_rhs_nt, float16_t, 16, 32, 32, 1, 2, true, block_fp8, 128, 8)
+instantiate_gather_qmm_rhs(block_fp8_gather_qmm_rhs, gather_qmm_rhs_nn, float16_t, 16, 32, 32, 1, 2, false, block_fp8, 128, 8)
     // clang-format on

--- a/mlx/backend/metal/kernels/fp_quantized.metal
+++ b/mlx/backend/metal/kernels/fp_quantized.metal
@@ -187,6 +187,7 @@ instantiate_block_fp8_gather_qmv_fast(float16_t)
       const device uint8_t* w, const device float* scales, \
       const device type* x, device type* y, \
       const constant int& K, const constant int& N, const constant int& M, \
+      const constant int& scale_rows, \
       const constant int& x_batch_ndims, const constant int* x_shape, \
       const constant int64_t* x_strides, const constant int& w_batch_ndims, \
       const constant int* w_shape, const constant int64_t* w_strides, \

--- a/mlx/backend/metal/kernels/fp_quantized.metal
+++ b/mlx/backend/metal/kernels/fp_quantized.metal
@@ -180,19 +180,27 @@ instantiate_block_fp8_gather_qmv_fast(float16_t)
 // qmm_t: prefill matmul. Per-row qmv math, 8 N rows per threadgroup.
 // 4 variants per type: (aligned_N x batched). Dispatcher selects the right
 // suffix based on N%32 and batch size.
+
+#define instantiate_block_fp8_qmm_t_one(type, alN, alN_str, batched, batched_str) \
+  template [[host_name("block_fp8_qmm_t_" #type "_gs_128_b_8_alN_" #alN_str "_batch_" #batched_str)]] \
+  [[kernel]] void block_fp8_qmm_t<type, 128, 8, alN, batched>( \
+      const device uint8_t* w, const device float* scales, \
+      const device type* x, device type* y, \
+      const constant int& K, const constant int& N, const constant int& M, \
+      const constant int& x_batch_ndims, const constant int* x_shape, \
+      const constant int64_t* x_strides, const constant int& w_batch_ndims, \
+      const constant int* w_shape, const constant int64_t* w_strides, \
+      const constant int64_t* s_strides, \
+      uint3 tid [[threadgroup_position_in_grid]], \
+      uint lid [[thread_index_in_threadgroup]], \
+      uint simd_gid [[simdgroup_index_in_threadgroup]], \
+      uint simd_lid [[thread_index_in_simdgroup]]);
+
 #define instantiate_block_fp8_qmm_t(type) \
-  instantiate_kernel( \
-      "block_fp8_qmm_t_" #type "_gs_128_b_8_alN_true_batch_0", \
-      block_fp8_qmm_t, type, 128, 8, true, false) \
-  instantiate_kernel( \
-      "block_fp8_qmm_t_" #type "_gs_128_b_8_alN_true_batch_1", \
-      block_fp8_qmm_t, type, 128, 8, true, true) \
-  instantiate_kernel( \
-      "block_fp8_qmm_t_" #type "_gs_128_b_8_alN_false_batch_0", \
-      block_fp8_qmm_t, type, 128, 8, false, false) \
-  instantiate_kernel( \
-      "block_fp8_qmm_t_" #type "_gs_128_b_8_alN_false_batch_1", \
-      block_fp8_qmm_t, type, 128, 8, false, true)
+  instantiate_block_fp8_qmm_t_one(type, true, true, false, 0) \
+  instantiate_block_fp8_qmm_t_one(type, true, true, true, 1) \
+  instantiate_block_fp8_qmm_t_one(type, false, false, false, 0) \
+  instantiate_block_fp8_qmm_t_one(type, false, false, true, 1)
 
 instantiate_block_fp8_qmm_t(float)
 instantiate_block_fp8_qmm_t(bfloat16_t)

--- a/mlx/backend/metal/kernels/fp_quantized.metal
+++ b/mlx/backend/metal/kernels/fp_quantized.metal
@@ -167,4 +167,13 @@ instantiate_quantized_types(float16_t)
 instantiate_block_fp8_qmv_fast(float)
 instantiate_block_fp8_qmv_fast(bfloat16_t)
 instantiate_block_fp8_qmv_fast(float16_t)
+
+#define instantiate_block_fp8_gather_qmv_fast(type) \
+  instantiate_kernel( \
+      "block_fp8_gather_qmv_fast_" #type "_gs_128_b_8", \
+      block_fp8_gather_qmv_fast, type, 128, 8)
+
+instantiate_block_fp8_gather_qmv_fast(float)
+instantiate_block_fp8_gather_qmv_fast(bfloat16_t)
+instantiate_block_fp8_gather_qmv_fast(float16_t)
     // clang-format on

--- a/mlx/backend/metal/kernels/fp_quantized.metal
+++ b/mlx/backend/metal/kernels/fp_quantized.metal
@@ -233,6 +233,31 @@ instantiate_block_fp8_gather_qmm_t(float)
 instantiate_block_fp8_gather_qmm_t(bfloat16_t)
 instantiate_block_fp8_gather_qmm_t(float16_t)
 
+#define instantiate_block_fp8_qmm_t_splitk_one(type, alN, alN_str) \
+  template [[host_name("block_fp8_qmm_t_splitk_" #type "_gs_128_b_8_alN_" #alN_str)]] \
+  [[kernel]] void block_fp8_qmm_t_splitk<type, 128, 8, alN>( \
+      const device uint8_t* w [[buffer(0)]], \
+      const device float* scales [[buffer(1)]], \
+      const device type* x [[buffer(2)]], \
+      device type* y [[buffer(3)]], \
+      const constant int& K [[buffer(4)]], \
+      const constant int& N [[buffer(5)]], \
+      const constant int& M [[buffer(6)]], \
+      const constant int& k_partition_size [[buffer(7)]], \
+      const constant int& split_k_partition_stride [[buffer(8)]], \
+      uint3 tid [[threadgroup_position_in_grid]], \
+      uint lid [[thread_index_in_threadgroup]], \
+      uint simd_gid [[simdgroup_index_in_threadgroup]], \
+      uint simd_lid [[thread_index_in_simdgroup]]);
+
+#define instantiate_block_fp8_qmm_t_splitk(type) \
+  instantiate_block_fp8_qmm_t_splitk_one(type, true, true) \
+  instantiate_block_fp8_qmm_t_splitk_one(type, false, false)
+
+instantiate_block_fp8_qmm_t_splitk(float)
+instantiate_block_fp8_qmm_t_splitk(bfloat16_t)
+instantiate_block_fp8_qmm_t_splitk(float16_t)
+
 instantiate_gather_qmm_rhs(block_fp8_gather_qmm_rhs, gather_qmm_rhs_nt, float, 16, 32, 32, 1, 2, true, block_fp8, 128, 8)
 instantiate_gather_qmm_rhs(block_fp8_gather_qmm_rhs, gather_qmm_rhs_nn, float, 16, 32, 32, 1, 2, false, block_fp8, 128, 8)
 instantiate_gather_qmm_rhs(block_fp8_gather_qmm_rhs, gather_qmm_rhs_nt, bfloat16_t, 16, 32, 32, 1, 2, true, block_fp8, 128, 8)

--- a/mlx/backend/metal/kernels/fp_quantized.metal
+++ b/mlx/backend/metal/kernels/fp_quantized.metal
@@ -176,4 +176,25 @@ instantiate_block_fp8_qmv_fast(float16_t)
 instantiate_block_fp8_gather_qmv_fast(float)
 instantiate_block_fp8_gather_qmv_fast(bfloat16_t)
 instantiate_block_fp8_gather_qmv_fast(float16_t)
+
+// qmm_t: prefill matmul. Per-row qmv math, 8 N rows per threadgroup.
+// 4 variants per type: (aligned_N x batched). Dispatcher selects the right
+// suffix based on N%32 and batch size.
+#define instantiate_block_fp8_qmm_t(type) \
+  instantiate_kernel( \
+      "block_fp8_qmm_t_" #type "_gs_128_b_8_alN_true_batch_0", \
+      block_fp8_qmm_t, type, 128, 8, true, false) \
+  instantiate_kernel( \
+      "block_fp8_qmm_t_" #type "_gs_128_b_8_alN_true_batch_1", \
+      block_fp8_qmm_t, type, 128, 8, true, true) \
+  instantiate_kernel( \
+      "block_fp8_qmm_t_" #type "_gs_128_b_8_alN_false_batch_0", \
+      block_fp8_qmm_t, type, 128, 8, false, false) \
+  instantiate_kernel( \
+      "block_fp8_qmm_t_" #type "_gs_128_b_8_alN_false_batch_1", \
+      block_fp8_qmm_t, type, 128, 8, false, true)
+
+instantiate_block_fp8_qmm_t(float)
+instantiate_block_fp8_qmm_t(bfloat16_t)
+instantiate_block_fp8_qmm_t(float16_t)
     // clang-format on

--- a/mlx/backend/metal/kernels/fp_quantized.metal
+++ b/mlx/backend/metal/kernels/fp_quantized.metal
@@ -152,4 +152,19 @@
 instantiate_quantized_types(float)
 instantiate_quantized_types(bfloat16_t)
 instantiate_quantized_types(float16_t)
+
+// ----- block_fp8 (DeepSeek-V3 / MiMo) instantiations -----
+// Only qmv_fast is implemented in the first pass. qmv_quad, qmv, qvm, qmm,
+// gather variants all produce "kernel not found" until subsequent patches.
+#define instantiate_block_fp8_qmv_fast(type) \
+  instantiate_kernel( \
+      "block_fp8_qmv_fast_" #type "_gs_128_b_8_batch_0", \
+      block_fp8_qmv_fast, type, 128, 8, false) \
+  instantiate_kernel( \
+      "block_fp8_qmv_fast_" #type "_gs_128_b_8_batch_1", \
+      block_fp8_qmv_fast, type, 128, 8, true)
+
+instantiate_block_fp8_qmv_fast(float)
+instantiate_block_fp8_qmv_fast(bfloat16_t)
+instantiate_block_fp8_qmv_fast(float16_t)
     // clang-format on

--- a/mlx/backend/metal/kernels/scaled_dot_product_attention.metal
+++ b/mlx/backend/metal/kernels/scaled_dot_product_attention.metal
@@ -32,6 +32,7 @@ using namespace metal;
   instantiate_sdpa_vector(type, 64, 64)          \
   instantiate_sdpa_vector(type, 96, 96)          \
   instantiate_sdpa_vector(type, 128, 128)        \
+  instantiate_sdpa_vector(type, 192, 128)        \
   instantiate_sdpa_vector(type, 256, 256)        \
   instantiate_sdpa_vector_aggregation(type, 64)  \
   instantiate_sdpa_vector_aggregation(type, 96)  \

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -27,7 +27,14 @@ auto get_quantized_kernel_wrapped(
     int bits,
     Args... args) {
   std::string template_def;
-  std::string fname = ((mode == "affine") ? "affine_" : "fp_") + func;
+  std::string fname;
+  if (mode == "affine") {
+    fname = "affine_" + func;
+  } else if (mode == "block_fp8") {
+    fname = "block_fp8_" + func;
+  } else {
+    fname = "fp_" + func;
+  }
   template_def = get_template_definition(
       name, fname, type, group_size, bits, std::forward<Args>(args)...);
   return get_quantized_kernel(d, name, template_def, mode);
@@ -44,7 +51,14 @@ auto get_qmm_nax_kernel_wrapped(
     int bits,
     Args... args) {
   std::string template_def;
-  std::string fname = ((mode == "affine") ? "affine_" : "fp_") + func;
+  std::string fname;
+  if (mode == "affine") {
+    fname = "affine_" + func;
+  } else if (mode == "block_fp8") {
+    fname = "block_fp8_" + func;
+  } else {
+    fname = "fp_" + func;
+  }
   template_def = get_template_definition(
       name, fname, type, group_size, bits, std::forward<Args>(args)...);
   return get_qmm_nax_kernel(d, name, template_def, mode);
@@ -693,7 +707,8 @@ void qmm(
     const Stream& s,
     const std::string& mode) {
   if (metal::is_nax_available() && transpose && (K % 64 == 0) &&
-      (env::enable_tf32() || x.dtype() != float32)) {
+      (env::enable_tf32() || x.dtype() != float32) &&
+      mode != "block_fp8") {
     return qmm_nax(
         /* const array& x = */ x,
         /* const array& w = */ w,
@@ -884,7 +899,8 @@ void gather_qmm(
     const Stream& s,
     const std::string& mode) {
   if (metal::is_nax_available() && transpose && (K % 64 == 0) &&
-      (env::enable_tf32() || x.dtype() != float32)) {
+      (env::enable_tf32() || x.dtype() != float32) &&
+      mode != "block_fp8") {
     return gather_qmm_nax(
         /* const array& x = */ x,
         /* const array& w = */ w,
@@ -1229,7 +1245,8 @@ void gather_qmm_rhs(
     const Stream& s,
     const std::string mode) {
   if (metal::is_nax_available() && transpose &&
-      (env::enable_tf32() || x_.dtype() != float32)) {
+      (env::enable_tf32() || x_.dtype() != float32) &&
+      mode != "block_fp8") {
     return gather_qmm_rhs_nax(
         /* const array& x_ = */ x_,
         /* const array& w_ = */ w_,

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -310,6 +310,9 @@ void qmv(
   compute_encoder.set_output_array(out, c++);
   compute_encoder.set_bytes(K, c++);
   compute_encoder.set_bytes(N, c++);
+  if (mode == "block_fp8") {
+    compute_encoder.set_bytes((int)scales.shape(-2), c++);
+  }
   add_strides_and_shapes(compute_encoder, B <= 1, x, w, scales, biases, c);
 
   compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
@@ -789,6 +792,9 @@ void qmm(
   compute_encoder.set_bytes(K, c++);
   compute_encoder.set_bytes(N, c++);
   compute_encoder.set_bytes(M, c++);
+  if (mode == "block_fp8") {
+    compute_encoder.set_bytes((int)scales.shape(-2), c++);
+  }
   add_strides_and_shapes(compute_encoder, B <= 1, x, w, scales, biases, c);
 
   compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
@@ -850,6 +856,9 @@ void qmm_splitk(
   std::string type_string = get_type_string(x.dtype());
   std::string kname;
   kname.reserve(64);
+  if (mode == "block_fp8" && (int)scales.shape(-2) != (N + 127) / 128) {
+    throw std::runtime_error("block_fp8: per-shard-padded scales unsupported on split-k path");
+  }
   concatenate(
       kname,
       mode + "_qmm_t_splitk_",

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -741,14 +741,7 @@ void qmm(
   MTL::Size group_dims(32, wn, wm);
   MTL::Size grid_dims((N + bn - 1) / bn, (M + bm - 1) / bm, B);
 
-  // block_fp8 qmm_t uses qmv-derived geometry: 8 N rows per threadgroup,
-  // one M row per threadgroup, 2 simdgroups. Override the default tiling.
-  if (mode == "block_fp8" && transpose) {
-    constexpr int bn_blockfp8 = 8;   // N rows per threadgroup
-    group_dims = MTL::Size(32, 2, 1);
-    grid_dims = MTL::Size(
-        (N + bn_blockfp8 - 1) / bn_blockfp8, M, B);
-  }
+  // block_fp8 qmm_t v2 uses the standard tiled geometry (no override needed).
 
   std::string kname;
   kname.reserve(64);

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -37,6 +37,9 @@ auto get_quantized_kernel_wrapped(
   }
   template_def = get_template_definition(
       name, fname, type, group_size, bits, std::forward<Args>(args)...);
+  if (std::getenv("MLX_TRACE_KERNELS")) {
+    fprintf(stderr, "[mlx-trace] %s\n", name.c_str());
+  }
   return get_quantized_kernel(d, name, template_def, mode);
 }
 
@@ -61,6 +64,9 @@ auto get_qmm_nax_kernel_wrapped(
   }
   template_def = get_template_definition(
       name, fname, type, group_size, bits, std::forward<Args>(args)...);
+  if (std::getenv("MLX_TRACE_KERNELS")) {
+    fprintf(stderr, "[mlx-trace] %s\n", name.c_str());
+  }
   return get_qmm_nax_kernel(d, name, template_def, mode);
 }
 

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -735,6 +735,15 @@ void qmm(
   MTL::Size group_dims(32, wn, wm);
   MTL::Size grid_dims((N + bn - 1) / bn, (M + bm - 1) / bm, B);
 
+  // block_fp8 qmm_t uses qmv-derived geometry: 8 N rows per threadgroup,
+  // one M row per threadgroup, 2 simdgroups. Override the default tiling.
+  if (mode == "block_fp8" && transpose) {
+    constexpr int bn_blockfp8 = 8;   // N rows per threadgroup
+    group_dims = MTL::Size(32, 2, 1);
+    grid_dims = MTL::Size(
+        (N + bn_blockfp8 - 1) / bn_blockfp8, M, B);
+  }
+
   std::string kname;
   kname.reserve(64);
   bool aligned = N % 32 == 0;
@@ -800,6 +809,11 @@ void qmm_splitk(
     metal::Device& d,
     const Stream& s,
     const std::string& mode) {
+  // block_fp8: no qmm_t_splitk kernel exists yet, force regular qmm.
+  if (mode == "block_fp8") {
+    return qmm(
+        x, w, scales, biases, out, true, group_size, bits, M, N, K, d, s, mode);
+  }
   // Choose split_k to target ~512 threadgroups
   int bm = 32, bn = 32;
   int n_tiles = (N + bn - 1) / bn;

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -942,16 +942,6 @@ void gather_qmm(
   MTL::Size group_dims(32, wn, wm);
   MTL::Size grid_dims((N + bn - 1) / bn, (M + bm - 1) / bm, B);
 
-  // block_fp8 gather_qmm_t uses qmv-derived geometry: 8 N rows per
-  // threadgroup, one M row per threadgroup, 2 simdgroups. Override the
-  // default tiling to match the kernel layout in fp_quantized.h.
-  if (mode == "block_fp8" && transpose) {
-    constexpr int bn_blockfp8 = 8;
-    group_dims = MTL::Size(32, 2, 1);
-    grid_dims = MTL::Size(
-        (N + bn_blockfp8 - 1) / bn_blockfp8, M, B);
-  }
-
   std::string kname;
   kname.reserve(64);
   bool aligned = N % 32 == 0;

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -949,6 +949,16 @@ void gather_qmm(
   MTL::Size group_dims(32, wn, wm);
   MTL::Size grid_dims((N + bn - 1) / bn, (M + bm - 1) / bm, B);
 
+  // block_fp8 gather_qmm_t uses qmv-derived geometry: 8 N rows per
+  // threadgroup, one M row per threadgroup, 2 simdgroups. Override the
+  // default tiling to match the kernel layout in fp_quantized.h.
+  if (mode == "block_fp8" && transpose) {
+    constexpr int bn_blockfp8 = 8;
+    group_dims = MTL::Size(32, 2, 1);
+    grid_dims = MTL::Size(
+        (N + bn_blockfp8 - 1) / bn_blockfp8, M, B);
+  }
+
   std::string kname;
   kname.reserve(64);
   bool aligned = N % 32 == 0;

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -808,11 +808,6 @@ void qmm_splitk(
     metal::Device& d,
     const Stream& s,
     const std::string& mode) {
-  // block_fp8: no qmm_t_splitk kernel exists yet, force regular qmm.
-  if (mode == "block_fp8") {
-    return qmm(
-        x, w, scales, biases, out, true, group_size, bits, M, N, K, d, s, mode);
-  }
   // Choose split_k to target ~512 threadgroups
   int bm = 32, bn = 32;
   int n_tiles = (N + bn - 1) / bn;

--- a/mlx/backend/metal/scaled_dot_product_attention.cpp
+++ b/mlx/backend/metal/scaled_dot_product_attention.cpp
@@ -619,9 +619,10 @@ bool ScaledDotProductAttention::use_fallback(
   const int gqa_factor = num_query_heads / num_kv_heads;
 
   const bool sdpa_vector_supported_head_dim =
-      query_head_dim == value_head_dim &&
-      (query_head_dim == 64 || query_head_dim == 96 || query_head_dim == 128 ||
-       query_head_dim == 256);
+      (query_head_dim == value_head_dim &&
+       (query_head_dim == 64 || query_head_dim == 96 ||
+        query_head_dim == 128 || query_head_dim == 256)) ||
+      (query_head_dim == 192 && value_head_dim == 128);
   const bool sdpa_full_supported_head_dim = query_head_dim == value_head_dim &&
       (query_head_dim == 64 || query_head_dim == 80 || query_head_dim == 128);
 

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -164,14 +164,18 @@ std::pair<int, int> extract_quantized_matmul_dims(
     const std::optional<array>& biases,
     bool transpose,
     int group_size,
-    int bits) {
-  validate_quantized_input(tag, w, scales, group_size, bits, biases, qmode);
+    int bits,
+    QuantizationMode mode = QuantizationMode::Affine) {
+  validate_quantized_input(tag, w, scales, group_size, bits, biases, mode);
 
   int x_inner_dims = x.shape(-1);
 
-  // Calculate the expanded w's dims
-  int w_inner_dims = (transpose) ? w.shape(-1) * 32 / bits : w.shape(-2);
-  int w_outer_dims = (transpose) ? w.shape(-2) : w.shape(-1) * 32 / bits;
+  // Calculate the expanded w's dims. BlockFp8 stores codes unpacked
+  // (1 byte per code), so the *32/bits expansion does not apply.
+  bool packed = (mode != QuantizationMode::BlockFp8);
+  int pack_factor = packed ? (32 / bits) : 1;
+  int w_inner_dims = (transpose) ? w.shape(-1) * pack_factor : w.shape(-2);
+  int w_outer_dims = (transpose) ? w.shape(-2) : w.shape(-1) * pack_factor;
 
   if (w_inner_dims != x_inner_dims) {
     std::ostringstream msg;
@@ -4544,7 +4548,8 @@ array quantized_matmul(
       quantization_params_from_mode(qmode, group_size_, bits_);
   // Check and extract the quantized matrix shape against x
   auto [w_inner_dims, w_outer_dims] = extract_quantized_matmul_dims(
-      "quantized_matmul", x, w, scales, biases, transpose, group_size, bits);
+      "quantized_matmul", x, w, scales, biases, transpose, group_size, bits,
+      qmode);
 
   if (qmode == QuantizationMode::Affine) {
     dtype = promote_types(x.dtype(), dtype);
@@ -5340,7 +5345,8 @@ array gather_qmm(
   auto [group_size, bits] =
       quantization_params_from_mode(qmode, group_size_, bits_);
   auto [w_inner_dims, w_outer_dims] = extract_quantized_matmul_dims(
-      "gather_qmm", x, w, scales, biases, transpose, group_size, bits);
+      "gather_qmm", x, w, scales, biases, transpose, group_size, bits,
+      qmode);
   if (qmode == QuantizationMode::Affine) {
     out_type = promote_types(x.dtype(), out_type);
   } else {

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -4875,6 +4875,50 @@ std::vector<array> fp_quantize(
     QuantizationMode mode,
     const std::optional<array>& global_scale /* = std::nullopt */,
     Stream s) {
+  // BlockFp8 (DeepSeek-V3 / MiMo convention): 2D group_size x group_size blocks,
+  // per-block float32 scale, unpacked E4M3 codes. Distinct from the 1D-group
+  // mxfp8/nvfp4 path below, so handle it up front.
+  if (mode == QuantizationMode::BlockFp8) {
+    if (group_size <= 0 || (group_size & (group_size - 1)) != 0) {
+      throw std::invalid_argument(
+          "[quantize] block_fp8 requires a power-of-two group_size.");
+    }
+    int ndim = w.ndim();
+    if (ndim < 2) {
+      throw std::invalid_argument(
+          "[quantize] block_fp8 requires at least a 2D weight.");
+    }
+    int N = w.shape(-2), K = w.shape(-1);
+    if (N % group_size != 0 || K % group_size != 0) {
+      std::ostringstream msg;
+      msg << "[quantize] block_fp8 requires the last two dims to be multiples "
+          << "of group_size=" << group_size << " but got " << w.shape() << ".";
+      throw std::invalid_argument(msg.str());
+    }
+    int Nb = N / group_size, Kb = K / group_size;
+    constexpr float kE4M3Max = 448.0f;
+    // Reshape to the block grid: [..., Nb, gs, Kb, gs]
+    Shape bshape(w.shape().begin(), w.shape().end() - 2);
+    bshape.push_back(Nb); bshape.push_back(group_size);
+    bshape.push_back(Kb); bshape.push_back(group_size);
+    auto wf = astype(w, float32, s);
+    auto wb = reshape(wf, bshape, s);
+    // Per-block max-abs over the two intra-block axes (the gs dims at -3 and -1).
+    int r1 = static_cast<int>(bshape.size()) - 1;
+    int r3 = static_cast<int>(bshape.size()) - 3;
+    auto amax = max(abs(wb, s), std::vector<int>{r3, r1}, true, s);
+    auto scales = divide(amax, array(kE4M3Max, float32), s);
+    // Avoid divide-by-zero for all-zero blocks (scale stays 0, codes -> 0).
+    auto safe = where(equal(scales, array(0.0f, float32), s),
+                      array(1.0f, float32), scales, s);
+    auto codes = to_fp8(divide(wb, safe, s), s);   // uint8 E4M3, [...,Nb,gs,Kb,gs]
+    codes = reshape(codes, w.shape(), s);          // [..., N, K]
+    // Collapse scales to [..., Nb, Kb] float32.
+    Shape sshape(w.shape().begin(), w.shape().end() - 2);
+    sshape.push_back(Nb); sshape.push_back(Kb);
+    scales = reshape(astype(scales, float32, s), sshape, s);
+    return {std::move(codes), std::move(scales)};
+  }
   int expected_gs = mode == QuantizationMode::Nvfp4 ? 16 : 32;
   int expected_bits = mode == QuantizationMode::Mxfp8 ? 8 : 4;
   if (group_size != expected_gs) {
@@ -5124,6 +5168,35 @@ array fp_dequantize(
     QuantizationMode mode,
     const std::optional<array>& global_scale /* = std::nullopt */,
     Stream s) {
+  // BlockFp8 (DeepSeek-V3 / MiMo): unpacked E4M3 codes [..., N, K] with a
+  // per-block float32 scale grid [..., N/gs, K/gs]. Decode = from_fp8(codes)
+  // broadcast-multiplied by the per-block scale. Handled up front because the
+  // shape/packing logic below assumes 1D uint32-packed groups.
+  if (mode == QuantizationMode::BlockFp8) {
+    int ndim = w.ndim();
+    int N = w.shape(-2), K = w.shape(-1);
+    int Nb = scales.shape(-2), Kb = scales.shape(-1);
+    if (group_size <= 0 || N % group_size != 0 || K % group_size != 0 ||
+        Nb != N / group_size || Kb != K / group_size) {
+      std::ostringstream msg;
+      msg << "[dequantize] block_fp8 scale grid must be ceil(w / group_size). "
+          << "w.shape()==" << w.shape() << ", scales.shape()==" << scales.shape()
+          << ", group_size=" << group_size << ".";
+      throw std::invalid_argument(msg.str());
+    }
+    auto decoded = from_fp8(w, out_type, s);  // [..., N, K]
+    // Reshape weight to block grid and broadcast the scale across each block.
+    Shape bshape(w.shape().begin(), w.shape().end() - 2);
+    bshape.push_back(Nb); bshape.push_back(group_size);
+    bshape.push_back(Kb); bshape.push_back(group_size);
+    auto wb = reshape(decoded, bshape, s);
+    // scales [..., Nb, Kb] -> [..., Nb, 1, Kb, 1] to broadcast over the blocks.
+    Shape scb(scales.shape().begin(), scales.shape().end() - 2);
+    scb.push_back(Nb); scb.push_back(1); scb.push_back(Kb); scb.push_back(1);
+    auto sc = reshape(astype(scales, out_type, s), scb, s);
+    auto out = multiply(wb, sc, s);
+    return reshape(out, w.shape(), s);
+  }
   int expected_gs = mode == QuantizationMode::Nvfp4 ? 16 : 32;
   int expected_bits = mode == QuantizationMode::Mxfp8 ? 8 : 4;
   if (group_size != expected_gs) {
@@ -5262,7 +5335,16 @@ array dequantize(
     msg << "[dequantize] Invalid value for group_size: " << group_size;
     throw std::invalid_argument(msg.str());
   }
-  if (w.dtype() != uint32) {
+  // BlockFp8 stores weights as unpacked uint8 fp8 codes; all other modes use
+  // uint32-packed weights. validate_mode_with_type() above already enforces
+  // the per-mode dtype, so this guard mirrors that split instead of assuming
+  // uint32 unconditionally.
+  if (qmode == QuantizationMode::BlockFp8) {
+    if (w.dtype() != uint8) {
+      throw std::invalid_argument(
+          "[dequantize] block_fp8 weights must be given as uint8");
+    }
+  } else if (w.dtype() != uint32) {
     throw std::invalid_argument(
         "[dequantize] The matrix should be given as a uint32");
   }

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -80,7 +80,47 @@ void validate_quantized_input(
     const array& scales,
     int group_size,
     int bits,
-    const std::optional<array>& biases = std::nullopt) {
+    const std::optional<array>& biases = std::nullopt,
+    QuantizationMode mode = QuantizationMode::Affine) {
+  // BlockFp8 has a different weight layout: unpacked uint8 codes with
+  // 2D fp32 block scales (DeepSeek-V3 / MiMo convention).
+  if (mode == QuantizationMode::BlockFp8) {
+    if (w.dtype() != uint8) {
+      std::ostringstream msg;
+      msg << "[" << tag << "] The weight matrix should be uint8 for "
+          << "'block_fp8' but received " << w.dtype();
+      throw std::invalid_argument(msg.str());
+    }
+    if (biases) {
+      std::ostringstream msg;
+      msg << "[" << tag << "] Biases must be null for 'block_fp8'.";
+      throw std::invalid_argument(msg.str());
+    }
+    // Batch dims (everything before the last 2) must match between w and scales.
+    if (!std::equal(
+            w.shape().begin(), w.shape().end() - 2, scales.shape().begin())) {
+      std::ostringstream msg;
+      msg << "[" << tag
+          << "] Weight and scales should have the same batch shape. "
+          << "Received weight with shape " << w.shape() << ", scales with "
+          << scales.shape() << ".";
+      throw std::invalid_argument(msg.str());
+    }
+    // 2D 128x128 block tiling: both inner dims of w must be 128 * scales dim.
+    if (w.shape(-1) != scales.shape(-1) * group_size ||
+        w.shape(-2) != scales.shape(-2) * group_size) {
+      std::ostringstream msg;
+      msg << "[" << tag << "] For 'block_fp8' weight shape must equal "
+          << "scales shape * " << group_size << " in the last two dims. "
+          << "w.shape() == " << w.shape()
+          << ", scales.shape() == " << scales.shape()
+          << ", group_size=" << group_size;
+      throw std::invalid_argument(msg.str());
+    }
+    return;
+  }
+
+  // Existing path: uint32-packed weight, 1D scale groups.
   if (w.dtype() != uint32) {
     std::ostringstream msg;
     msg << "[" << tag << "] The weight matrix should be uint32 "
@@ -125,7 +165,7 @@ std::pair<int, int> extract_quantized_matmul_dims(
     bool transpose,
     int group_size,
     int bits) {
-  validate_quantized_input(tag, w, scales, group_size, bits, biases);
+  validate_quantized_input(tag, w, scales, group_size, bits, biases, qmode);
 
   int x_inner_dims = x.shape(-1);
 
@@ -4390,6 +4430,10 @@ std::pair<int, int> quantization_params_from_mode(
       default_group_size = 32;
       default_bits = 8;
       break;
+    case QuantizationMode::BlockFp8:
+      default_group_size = 128;
+      default_bits = 8;
+      break;
   }
   return {
       group_size_.has_value() ? *group_size_ : default_group_size,
@@ -4428,6 +4472,13 @@ std::pair<Dtype, QuantizationMode> validate_mode_with_type(
       return {*out_type, qmode};
     } else {
       return {dtype, qmode};
+    }
+  } else if (qmode == QuantizationMode::BlockFp8) {
+    if (scales.dtype() != float32) {
+      std::ostringstream msg;
+      msg << "[" << tag << "] Scale type must be float32 for 'block_fp8' "
+          << "but received type " << scales.dtype() << ".";
+      throw std::invalid_argument(msg.str());
     }
   } else if (scales.dtype() != uint8) {
     std::ostringstream msg;
@@ -4554,7 +4605,8 @@ void validate_qqmm_inputs(
     }
     // if scales are provided, check compatibility with quantized w
     else {
-      validate_quantized_input("qqmm", w, *scales_w, group_size, bits);
+      validate_quantized_input("qqmm", w, *scales_w, group_size, bits,
+          std::nullopt, QuantizationMode::Affine);
     }
   }
   // if w is not quantized, dtype must be in {f16, bf16, fp32}

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -106,13 +106,24 @@ void validate_quantized_input(
           << scales.shape() << ".";
       throw std::invalid_argument(msg.str());
     }
-    // 2D 128x128 block tiling: both inner dims of w must be 128 * scales dim.
-    if (w.shape(-1) != scales.shape(-1) * group_size ||
-        w.shape(-2) != scales.shape(-2) * group_size) {
+    // 2D 128x128 block tiling: weight may be smaller than the scale grid
+    // covers (padding rows in scales are spec-compliant per DeepSeek-V3 /
+    // Xiaomi MiMo convention — e.g. fused QKV with q+k+v not a multiple
+    // of 128). Require: scales covers AT LEAST the weight extent, but no
+    // more than one full block past it.
+    // The scale tensor must cover the weight tensor's extent (each scale
+    // tile covers 128x128 weight elements). It may include trailing padding
+    // rows/cols beyond ceil(w / 128) — common in fused-QKV distributions
+    // where the original storage was padded to a tensor-parallel chunk size.
+    // The kernel never reads past out_row < w.shape[-2], so trailing scales
+    // are safely ignored.
+    auto ceil_div = [](int a, int b) { return (a + b - 1) / b; };
+    if (scales.shape(-1) < ceil_div(w.shape(-1), group_size) ||
+        scales.shape(-2) < ceil_div(w.shape(-2), group_size)) {
       std::ostringstream msg;
-      msg << "[" << tag << "] For 'block_fp8' weight shape must equal "
-          << "scales shape * " << group_size << " in the last two dims. "
-          << "w.shape() == " << w.shape()
+      msg << "[" << tag << "] For 'block_fp8' scales shape must be at "
+          << "least ceil(w.shape / " << group_size << ") in the last two "
+          << "dims. w.shape() == " << w.shape()
           << ", scales.shape() == " << scales.shape()
           << ", group_size=" << group_size;
       throw std::invalid_argument(msg.str());

--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -3425,8 +3425,10 @@ std::string quantization_mode_to_string(QuantizationMode mode) {
     case QuantizationMode::Mxfp8:
       return "mxfp8";
     case QuantizationMode::Nvfp4:
-    default:
       return "nvfp4";
+    case QuantizationMode::BlockFp8:
+    default:
+      return "block_fp8";
   }
 }
 
@@ -3441,6 +3443,8 @@ QuantizationMode string_to_quantization_mode(
     return QuantizationMode::Mxfp8;
   } else if (mode == "nvfp4") {
     return QuantizationMode::Nvfp4;
+  } else if (mode == "block_fp8") {
+    return QuantizationMode::BlockFp8;
   }
   std::string msg;
   if (!tag.empty()) {

--- a/mlx/primitives.h
+++ b/mlx/primitives.h
@@ -152,7 +152,7 @@ class MLX_API UnaryPrimitive : public Primitive {
   UnaryPrimitive& operator=(UnaryPrimitive&& other) = delete;
 };
 
-enum class QuantizationMode { Affine, Mxfp4, Mxfp8, Nvfp4 };
+enum class QuantizationMode { Affine, Mxfp4, Mxfp8, Nvfp4, BlockFp8 };
 
 std::string quantization_mode_to_string(QuantizationMode mode);
 QuantizationMode string_to_quantization_mode(

--- a/python/mlx/nn/layers/quantized.py
+++ b/python/mlx/nn/layers/quantized.py
@@ -229,12 +229,23 @@ class QuantizedLinear(Module):
         group_size: int = None,
         bits: int = None,
         mode: str = "affine",
+        _skip_init: bool = False,
     ):
         super().__init__()
 
         # Quantization config
         self.group_size, self.bits = _defaults_for_mode(mode, group_size, bits)
         self.mode = mode
+
+        if _skip_init:
+            # Caller will assign self.weight and self.scales (and optionally
+            # self.biases / self.bias) from pre-quantized tensors. Used by
+            # loaders that read codes+scales off disk directly (e.g. native
+            # FP8 checkpoints) and don't want a wasteful re-quant pass.
+            if bias:
+                self.bias = mx.zeros((output_dims,))
+            self.freeze()
+            return
 
         # Initialize the quantized weight
         scale = math.sqrt(1 / input_dims)

--- a/python/mlx/nn/layers/quantized.py
+++ b/python/mlx/nn/layers/quantized.py
@@ -11,6 +11,7 @@ from mlx.utils import tree_map_with_path
 def _defaults_for_mode(mode, group_size, bits):
     mode_defaults = {
         "affine": (64, 4),
+        "block_fp8": (128, 8),
         "mxfp4": (32, 4),
         "nvfp4": (16, 4),
         "mxfp8": (32, 8),

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -1218,6 +1218,184 @@ class TestQuantized(mlx_tests.MLXTestCase):
         expected = mx.dequantize(w_q, mx.contiguous(scales), mode=mode)
         self.assertTrue(mx.allclose(w_hat, expected))
 
+    def test_block_fp8_quantize_dequantize(self):
+        for N, K in [(128, 128), (256, 512), (384, 256)]:
+            with self.subTest(N=N, K=K):
+                w = mx.random.normal(shape=(N, K)) * 0.02
+                codes, scales = mx.quantize(w, group_size=128, bits=8, mode="block_fp8")
+                self.assertEqual(codes.dtype, mx.uint8)
+                self.assertEqual(scales.dtype, mx.float32)
+                self.assertEqual(codes.shape, (N, K))
+                self.assertEqual(scales.shape, (N // 128, K // 128))
+                w_hat = mx.dequantize(codes, scales, group_size=128, bits=8, mode="block_fp8")
+                cos = ((w_hat.flatten() @ w.flatten()) / (mx.linalg.norm(w_hat) * mx.linalg.norm(w) + 1e-9)).item()
+                self.assertGreater(cos, 0.99)
+
+    def test_block_fp8_quantize_idempotent(self):
+        # Quantization decisions (the codes) must be stable: re-quantizing a
+        # dequantized tensor must reproduce identical codes. Iterative
+        # quantizers like GPTQ rely on this -- the discrete choice for each
+        # weight position must not change when the input is the dequantized
+        # output of a previous round. The float32 block scales may shift by
+        # ~1e-7 (rounding noise in the max reduction), which is benign.
+        w = mx.random.normal(shape=(256, 512)) * 0.02
+        codes, scales = mx.quantize(w, group_size=128, bits=8, mode="block_fp8")
+        w_hat = mx.dequantize(codes, scales, group_size=128, bits=8, mode="block_fp8")
+        codes2, scales2 = mx.quantize(w_hat, group_size=128, bits=8, mode="block_fp8")
+        self.assertTrue(mx.all(codes == codes2).item())
+        self.assertTrue(mx.allclose(scales, scales2, rtol=1e-3, atol=1e-6).item())
+
+    def test_block_fp8_kernel_coverage(self):
+        # One test exercising every block_fp8 kernel path shipped in this PR
+        # against the dequantize reference. A regression in any kernel makes
+        # the corresponding subTest fail. Subtests are labelled by which
+        # kernel they cover so failures pinpoint the broken commit.
+        import numpy as np
+        np.random.seed(0)
+
+        def cos(a, b):
+            a32 = a.astype(mx.float32).flatten()
+            b32 = b.astype(mx.float32).flatten()
+            return ((a32 @ b32) /
+                    (mx.linalg.norm(a32) * mx.linalg.norm(b32) + 1e-9)).item()
+
+        # ---- Dense quantized_matmul kernels ------------------------------
+        def check_qmm(M, N, K, label):
+            w = mx.random.normal(shape=(N, K)) * 0.02
+            codes, scales = mx.quantize(w, group_size=128, bits=8, mode="block_fp8")
+            w_hat = mx.dequantize(codes, scales, group_size=128, bits=8, mode="block_fp8")
+            x = mx.random.normal(shape=(M, K)).astype(mx.bfloat16)
+            y = mx.quantized_matmul(x, codes, scales, transpose=True,
+                                    group_size=128, bits=8, mode="block_fp8")
+            ref = x.astype(mx.float32) @ w_hat.T
+            self.assertGreater(cos(y, ref), 0.99,
+                               f"{label} M={M} N={N} K={K}")
+
+        # block_fp8_qmv_fast: M=1 decode vector kernel
+        with self.subTest(kernel="block_fp8_qmv_fast"):
+            check_qmm(1, 512, 512, "qmv_fast")
+        # block_fp8_qmm_t: tiled prefill
+        with self.subTest(kernel="block_fp8_qmm_t"):
+            check_qmm(64, 512, 512, "qmm_t")
+        # block_fp8_qmm_t_splitk: short-M, large-K splitk path
+        with self.subTest(kernel="block_fp8_qmm_t_splitk"):
+            check_qmm(4, 128, 4096, "qmm_t_splitk")
+        # block_fp8_qmm_t at larger M (deeper tiled coverage)
+        with self.subTest(kernel="block_fp8_qmm_t_large"):
+            check_qmm(256, 512, 512, "qmm_t_large")
+
+        # ---- MoE gather kernels ------------------------------------------
+        E, N, K = 4, 256, 512
+        w_e = mx.random.normal(shape=(E, N, K)) * 0.02
+        cs = [mx.quantize(w_e[e], group_size=128, bits=8, mode="block_fp8")
+              for e in range(E)]
+        codes_e = mx.stack([c for c, _ in cs], axis=0)
+        scales_e = mx.stack([s for _, s in cs], axis=0)
+        deq_e = [mx.dequantize(c, s, group_size=128, bits=8, mode="block_fp8")
+                 for c, s in cs]
+        mx.eval(codes_e, scales_e)
+
+        def check_gather(T, KP, label):
+            # Mirror SwitchGLU's call pattern exactly: at indices.size >= 64
+            # the tiled rhs-gather kernel REQUIRES globally-sorted indices
+            # (sorted_indices=True). We replicate _gather_sort/_scatter_unsort
+            # from mlx_lm.switch_layers so this subtest exercises the same path
+            # the model uses at prefill.
+            x = mx.random.normal(shape=(T, K)).astype(mx.bfloat16)
+            xe = mx.expand_dims(mx.expand_dims(x, axis=-2), axis=-2)  # (T,1,1,K)
+            inds_np = np.random.randint(0, E, (T, KP)).astype(np.uint32)
+            inds = mx.array(inds_np)
+
+            do_sort = inds.size >= 64
+            if do_sort:
+                # Global sort by expert (matches SwitchGLU._gather_sort).
+                # After sorting, BOTH x and indices stay flat (1D for indices)
+                # -- do NOT reshape indices back to (T,KP) or the kernel's
+                # broadcast against the flat-batched x mismatches.
+                flat = inds.flatten()
+                order = mx.argsort(flat)
+                inv_order = mx.argsort(order)
+                xe_sorted = xe.flatten(0, -3)[order // KP]   # (T*KP, 1, K)
+                inds_sorted = flat[order]                     # (T*KP,) 1D
+            else:
+                xe_sorted, inds_sorted, inv_order = xe, inds, None
+
+            y_sorted = mx.gather_qmm(xe_sorted, codes_e, scales=scales_e,
+                                     rhs_indices=inds_sorted,
+                                     transpose=True, group_size=128, bits=8,
+                                     mode="block_fp8", sorted_indices=do_sort)
+            if do_sort:
+                # Unsort to (T, KP, 1, N).
+                y = y_sorted[inv_order]
+                y = mx.unflatten(y, 0, (T, KP))
+            else:
+                y = y_sorted
+            mx.eval(y)
+            # Reference: per (t, k), x[t] @ deq[inds[t,k]].T (the bf16 math).
+            for t in range(T):
+                for k in range(KP):
+                    e = int(inds_np[t, k])
+                    ref_tk = x[t:t+1].astype(mx.float32) @ deq_e[e].T
+                    self.assertGreater(cos(y[t, k, 0, :], ref_tk), 0.99,
+                                       f"{label} t={t} k={k}")
+
+        # block_fp8_gather_qmv_fast: MoE decode vector path
+        with self.subTest(kernel="block_fp8_gather_qmv_fast"):
+            check_gather(1, 4, "gather_qmv_fast")
+        # block_fp8_gather_qmm_rhs: MoE prefill tiled path
+        with self.subTest(kernel="block_fp8_gather_qmm_rhs"):
+            check_gather(32, 4, "gather_qmm_rhs")
+
+        # ---- Asymmetric SDPA fused vector kernel (Dq=192, Dv=128) -------
+        with self.subTest(kernel="sdpa_fused_asymmetric_192_128"):
+            B, H, L = 1, 8, 16
+            q = mx.random.normal(shape=(B, H, L, 192)).astype(mx.bfloat16)
+            k = mx.random.normal(shape=(B, H, L, 192)).astype(mx.bfloat16)
+            v = mx.random.normal(shape=(B, H, L, 128)).astype(mx.bfloat16)
+            scale = 1.0 / (192 ** 0.5)
+            y_f = mx.fast.scaled_dot_product_attention(q, k, v, scale=scale)
+            # Unfused reference
+            attn = (q.astype(mx.float32) @ k.astype(mx.float32).swapaxes(-1, -2)) * scale
+            attn = mx.softmax(attn, axis=-1)
+            y_r = attn @ v.astype(mx.float32)
+            mx.eval(y_f, y_r)
+            self.assertGreater(cos(y_f, y_r), 0.99, "sdpa asymmetric 192/128")
+
+        # ---- Relaxed scale-shape validator (fused-QKV padding) ----------
+        # Models with fused QKV may emit scales with trailing padding rows
+        # beyond ceil(w / group_size). Kernel must read only the in-bounds
+        # rows; the validator must accept the over-sized scale.
+        with self.subTest(kernel="padded_scale_validator"):
+            N, K = 256, 512
+            w = mx.random.normal(shape=(N, K)) * 0.02
+            codes, scales = mx.quantize(w, group_size=128, bits=8, mode="block_fp8")
+            extra = mx.zeros((1, scales.shape[1]), dtype=mx.float32)
+            scales_padded = mx.concatenate([scales, extra], axis=0)
+            x = mx.random.normal(shape=(4, K)).astype(mx.bfloat16)
+            y_pad = mx.quantized_matmul(x, codes, scales_padded, transpose=True,
+                                        group_size=128, bits=8, mode="block_fp8")
+            y_ref = mx.quantized_matmul(x, codes, scales, transpose=True,
+                                        group_size=128, bits=8, mode="block_fp8")
+            mx.eval(y_pad, y_ref)
+            self.assertTrue(mx.allclose(y_pad, y_ref, atol=1e-3).item(),
+                            "padded scale produced different output")
+
+    def test_block_fp8_outlier_block_scaling(self):
+        w = mx.random.normal(shape=(256, 256)) * 0.02
+        w = w.at[50:60, 100:110].add(5.0)
+        codes, scales = mx.quantize(w, group_size=128, bits=8, mode="block_fp8")
+        w_hat = mx.dequantize(codes, scales, group_size=128, bits=8, mode="block_fp8")
+        clean = (w_hat[200:, :64] - w[200:, :64]).abs().max().item()
+        scale_clean = w[200:, :64].abs().max().item()
+        self.assertLess(clean, scale_clean * 0.1)
+
+    def test_block_fp8_invalid_shapes(self):
+        with self.assertRaises(ValueError):
+            mx.quantize(mx.random.normal(shape=(100, 512)), group_size=128, bits=8, mode="block_fp8")
+        with self.assertRaises(ValueError):
+            bad = mx.zeros((256, 128), dtype=mx.uint32)
+            sc = mx.zeros((2, 4), dtype=mx.float32)
+            mx.dequantize(bad, sc, group_size=128, bits=8, mode="block_fp8")
 
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner()


### PR DESCRIPTION
# block_fp8: 2D-block FP8 quantized matmul + MoE kernels for DeepSeek-V3 / MiMo

## Summary

Adds first-class support for the **block_fp8** quantization format used by
DeepSeek-V3 / MiMo (and other recent MoE LLMs): 2D 128×128 weight blocks of
unpacked E4M3 (`F8_E4M3`) codes with a per-block `float32` scale. Implements
the kernel set needed to run inference end-to-end (decode + prefill, dense +
MoE gather), along with `quantize` / `dequantize` ops so the format is
producible and consumable in-library.

Validated on the MiMo-V2.5 base (310 B, 48 layers, 256 experts top-8, hybrid
5:1 SWA/GA, head_dim 192/128) on M3 Ultra: **30.3 tok/s decode**, with the
canonical greedy continuation reproduced bit-for-bit (top-1 = 151667 on the
Einstein verification prompt).

## What's in this PR

### Kernels (block_fp8 quantization mode)

* `block_fp8_qmv_fast` — M = 1 decode vector kernel.
* `block_fp8_qmm_t` — tiled prefill matmul using a new
  `BlockFp8QuantizedLoader` (handles unpacked E4M3 + 2D `F32` block scales).
* `block_fp8_qmm_t_splitk` — short-M splitk variant for shapes where the
  M·N tile count can't fill the GPU (covers the verify-style 4-token
  forwards used by speculative decoding).
* `block_fp8_gather_qmv_fast` — MoE decode vector kernel (top-K routing,
  single token).
* `block_fp8_gather_qmm_t` / `block_fp8_gather_qmm_rhs` — MoE prefill
  tiled kernels (the `rhs` variant matches the SwitchGLU global-sort
  contract used by `mlx_lm`).

### Dispatcher / plumbing

* `block_fp8` mode threaded through `quantized_matmul`, `gather_qmm`,
  `dequantize`, and the kernel-name selection (`quantized.cpp`).
* 2D-block-aware shape validator (`validate_quantized_input`) that accepts
  the 2D `F32` block-scale layout and the fused-QKV padding convention
  (scale tensor may include trailing rows beyond `ceil(w / 128)`, which the
  kernel never reads).
* `_skip_init` plumbing for `QuantizedLinear` / `QuantizedSwitchLinear` so
  pre-quantized weights can be installed without re-allocating placeholder
  buffers.

### SDPA

* `sdpa`: the fused vector kernel now handles asymmetric Q/V `head_dim`
  (192/128) used by MiMo's SWA blocks. Previously gated by an equality
  check that excluded this shape.

### `quantize` / `dequantize` ops (this commit's diff)

Prior to this PR, `mx.quantize` / `mx.dequantize` with `mode="block_fp8"`
inherited the 1D-group / E8M0-scale fallback from `mxfp8`, which does not
match the 2D 128×128 / `F32`-scale format the kernels consume; `dequantize`
additionally rejected `uint8` weights via a hardcoded `uint32` guard
unrelated to the mode validator.

Three minimal edits in `mlx/ops.cpp`:

* `fp_quantize`: adds a `block_fp8` branch performing per-block round-to-
  nearest quantization (`scale = max(|W_block|) / 448`, codes via
  `to_fp8(W/scale)`). Returns `uint8` codes `[..., N, K]` plus `float32`
  scales `[..., N/gs, K/gs]`, identical to the on-disk format the kernels
  already consume.
* `fp_dequantize`: adds a `block_fp8` branch that reconstructs the weight
  as `from_fp8(codes) * scale` with the per-block scale broadcast over the
  block grid.
* `dequantize`: the post-validator weight-dtype guard is made mode-aware
  (`uint8` for block_fp8, `uint32` otherwise). The behavior of every
  non-block_fp8 mode is byte-identical.

Forward-quantize uses only `to_fp8` and shape ops already present in
`ops.cpp` — no new Metal kernel is required (the format is producible from
the existing primitives).

## Validation

### Kernel coverage test (new)

`python/tests/test_quantized.py::TestQuantized::test_block_fp8_kernel_coverage`
is a single test with one subtest per kernel; a regression in any kernel
fails the corresponding subTest:

| subTest | exercises |
| --- | --- |
| `block_fp8_qmv_fast` | M = 1 decode vector |
| `block_fp8_qmm_t` | M = 64 tiled prefill |
| `block_fp8_qmm_t_splitk` | M = 4, K = 4096 short-M splitk path |
| `block_fp8_qmm_t_large` | M = 256 large tiled |
| `block_fp8_gather_qmv_fast` | T = 1, KP = 4 MoE decode |
| `block_fp8_gather_qmm_rhs` | T = 32, KP = 4 MoE prefill, global-sort contract |
| `sdpa_fused_asymmetric_192_128` | fused vector SDPA at MiMo head dims |
| `padded_scale_validator` | scales tensor with trailing rows beyond `ceil(w/128)` |

All subtests compare against `mx.dequantize`-then-reference-matmul or the
unfused SDPA reference; threshold `cos > 0.99`.

### Round-trip / idempotency

* `test_block_fp8_quantize_dequantize` — quantize/dequantize round-trip
  across several `(N, K)` shapes.
* `test_block_fp8_quantize_idempotent` — re-quantizing a dequantized tensor
  reproduces identical codes (with scales matching to float-rounding
  tolerance). This is the stability property iterative quantizers (e.g.
  GPTQ) require to converge.
* `test_block_fp8_outlier_block_scaling` — a single outlier block must not
  corrupt the precision of unrelated blocks (the rationale for per-block
  vs per-tensor scaling).
* `test_block_fp8_invalid_shapes` — non-128-multiple dims rejected by
  `quantize`; `uint32` weights rejected by `dequantize(block_fp8)`.

### Numerics on real weights

`quantized_matmul(codes, scales)` agrees with
`x @ dequantize(codes, scales).T` at `cos > 0.99999` on real MiMo
projections, across the decode (M = 1), prefill (M = 256), and MoE gather
paths. The numpy-RTN E4M3 reference (computed offline) matches the
in-library `quantize` codes 100 % on the same inputs.

### End-to-end model

On the MiMo-V2.5 (310 B, block_fp8) checkpoint, M3 Ultra 512 GB, wired
memory limit 300 GB:

* **decode 30.3 tok/s** (single-stream, batch = 1, no speculative decoding)
* **prefill** ≈ 525 tok/s at L = 2048
* greedy continuation reproduces the bf16-reference continuation token-for-
  token on the Einstein verification prompt (top-1 = 151667 at position 29,
  with the expected continuation `[785, 785, 66622, 54052, 320, 23, 22,
  24, 4142, …]`).

### No regressions in existing modes

* Existing `affine` / `mxfp4` / `mxfp8` / `nvfp4` quantize/dequantize paths
  are byte-identical (the `block_fp8` branches are entered first via mode
  comparison and `return` before touching the existing code).
* Pre-existing test failures in `test_quantized.py` (e.g. `test_qvm` /
  `test_qmm` at `bits=6`) are independent of this PR; they reproduce on
  the merge-base without these changes, on M3 Ultra (`arch_gen=15`).
  Likely M4+/NAX-gated paths that need an arch decorator in a separate
  commit.

## Hardware notes (M3 Ultra)

NAX is `applegpu_g17+` (M4+ on macOS 26.2+); on M3 Ultra `is_nax_available()`
returns false, and this PR's dispatcher explicitly skips NAX routing for
block_fp8. The MLX_TRACE_KERNELS env var (added earlier in the branch) was
useful during development for confirming kernel selection at runtime.

