### PR TITLE
Fix signed-integer overflow (UB) in roll and tile shape arithmetic

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -1349,7 +1349,8 @@ array tile(
     }
     expand_shape.push_back(shape[i]);
     broad_shape.push_back(shape[i]);
-    final_shape.push_back(reps[i] * shape[i]);
+    final_shape.push_back(
+        safe_cast(static_cast<int64_t>(reps[i]) * shape[i], "tile"));
   }
 
   auto x = reshape(arr, std::move(expand_shape), s);
@@ -6350,7 +6351,10 @@ array roll(
     if (size == 0) {
       continue; // skip rolling this axis if it has size 0
     }
-    auto split_index = (sh < 0) ? (-sh) % size : size - sh % size;
+    // Promote to 64-bit so negating a shift of INT_MIN does not overflow.
+    int64_t sh64 = sh;
+    auto split_index = static_cast<ShapeElem>(
+        (sh64 < 0) ? (-sh64) % size : size - sh64 % size);
 
     auto parts = split(result, Shape{split_index}, ax, s);
     std::swap(parts[0], parts[1]);
@@ -6369,11 +6373,11 @@ array roll(const array& a, int shift, StreamOrDevice s /* = {} */) {
 }
 
 array roll(const array& a, const Shape& shift, StreamOrDevice s /* = {} */) {
-  int total_shift = 0;
-  for (auto& s : shift) {
-    total_shift += s;
+  int64_t total_shift = 0;
+  for (auto& sh : shift) {
+    total_shift += sh;
   }
-  return roll(a, total_shift, s);
+  return roll(a, safe_cast(total_shift, "roll"), s);
 }
 
 array roll(const array& a, int shift, int axis, StreamOrDevice s /* = {} */) {
@@ -6394,11 +6398,12 @@ array roll(
     const Shape& shift,
     int axis,
     StreamOrDevice s /* = {} */) {
-  int total_shift = 0;
-  for (auto& s : shift) {
-    total_shift += s;
+  int64_t total_shift = 0;
+  for (auto& sh : shift) {
+    total_shift += sh;
   }
-  return roll(a, Shape{total_shift}, std::vector<int>{axis}, s);
+  return roll(
+      a, Shape{safe_cast(total_shift, "roll")}, std::vector<int>{axis}, s);
 }
 
 array real(const array& a, StreamOrDevice s /* = {} */) {

--- a/tests/ops_tests.cpp
+++ b/tests/ops_tests.cpp
@@ -4284,3 +4284,24 @@ TEST_CASE("test max min with nan") {
   CHECK(array_equal(max_result, expected, true).item<bool>());
   CHECK(array_equal(min_result, expected, true).item<bool>());
 }
+
+TEST_CASE("roll and tile shape overflow") {
+  // Shape arithmetic must not overflow (signed-int UB) for large but otherwise
+  // valid int32 inputs; out-of-range results are rejected gracefully.
+  // https://github.com/ml-explore/mlx/issues/3601
+
+  // tile: reps * dim exceeding int32 raises instead of overflowing.
+  CHECK_THROWS_AS(tile(zeros({2}), {2147483647}), std::overflow_error);
+
+  // roll: a shift sum exceeding int32 raises instead of overflowing.
+  CHECK_THROWS_AS(
+      roll(zeros({4}), Shape{2147483647, 2147483647}), std::overflow_error);
+  CHECK_THROWS_AS(
+      roll(zeros({4}), Shape{2147483647, 2147483647}, 0), std::overflow_error);
+
+  // roll: a shift of INT_MIN must not negate-overflow. INT_MIN mod 4 == 0, so
+  // rolling a size-4 axis by INT_MIN is the identity.
+  auto x = array({1, 2, 3, 4});
+  auto rolled = roll(x, -2147483647 - 1);
+  CHECK(array_equal(rolled, x).item<bool>());
+}


### PR DESCRIPTION
## Summary
Fixes #3601. Several shape ops computed sizes/shifts in 32-bit `int` without overflow checks, so large-or-degenerate but otherwise valid (`int32`-range) inputs triggered C++ signed-integer overflow (UB), reachable from the safe public API. UBSan-confirmed sites on current `main`:

- `tile`: `reps[i] * shape[i]` overflows `int` (`ops.cpp:1352`).
- `roll`: negating a shift of `INT_MIN` in `(-sh) % size` (`ops.cpp:6353`).
- `roll`: summing shifts into an `int total_shift` accumulator (both the `Shape`-shift and `Shape`-shift + `axis` overloads).

The `flatten` / `Flatten::output_shape` product path the issue also mentions is already 64-bit-safe on `main`, so it is not touched here.

## Fix
Compute these in `int64_t` and narrow with the existing `safe_cast` helper, which raises a graceful `std::overflow_error` for out-of-`int32` results instead of overflowing. `roll`'s `INT_MIN` negation is performed in 64-bit so it no longer overflows.

## Verification
Built CPU-only with `-DUSE_UBSAN=ON`:
- Before: UBSan reports `signed integer overflow` / `negation of -2147483648 cannot be represented` at the sites above.
- After: UBSan is silent on all three; the overflowing cases raise `std::overflow_error`, and `roll` by `INT_MIN` returns the correct (identity) result for a size-4 axis.
- Full C++ test suite passes (237 cases / 3190 assertions), no regressions.

Added `TEST_CASE("roll and tile shape overflow")`.
