### PR TITLE
Fix complex VJPs for log and exp

### DIFF
--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -1992,7 +1992,7 @@ std::vector<array> Exp::vjp(
     const std::vector<array>& cotangents,
     const std::vector<int>& argnums,
     const std::vector<array>& outputs) {
-  return {multiply(cotangents[0], outputs[0], stream())};
+  return {multiply(cotangents[0], conjugate(outputs[0], stream()), stream())};
 }
 
 std::vector<array> Exp::jvp(
@@ -2713,7 +2713,15 @@ std::vector<array> Log::vjp(
     const std::vector<array>& cotangents,
     const std::vector<int>& argnums,
     const std::vector<array>&) {
-  return jvp(primals, cotangents, argnums);
+  //   return jvp(primals, cotangents, argnums);
+  assert(primals.size() == 1);
+  assert(argnums.size() == 1);
+  auto out = divide(cotangents[0], conjugate(primals[0], stream()), stream());
+  if (base_ != Base::e) {
+    auto scale = 1 / std::log(base_ == Base::ten ? 10.0f : 2.0f);
+    out = multiply(array(scale, out.dtype()), out, stream());
+  }
+  return {out};
 }
 
 std::vector<array> Log::jvp(

--- a/python/tests/test_autograd.py
+++ b/python/tests/test_autograd.py
@@ -987,6 +987,45 @@ class TestAutograd(mlx_tests.MLXTestCase):
 
         self.assertTrue(mx.array_equal(mx.stack(vjps_multiply), vjps[0]))
 
+    def test_complex_exp_vjp(self):
+        primal = mx.random.normal((3, 4, 5), dtype=mx.complex64)
+        cotangent = mx.random.normal(
+            (
+                3,
+                4,
+                5,
+            ),
+            dtype=mx.complex64,
+        )
+
+        _, vjps = mx.vjp(mx.exp, [primal], [cotangent])
+
+        expected = cotangent * mx.conj(mx.exp(primal))
+
+        # Check against hand-computed vjps
+        self.assertTrue(mx.allclose(vjps[0], expected))
+
+    def test_complex_log_vjp(self):
+        primal = mx.random.normal((3, 4, 5), dtype=mx.complex64)
+        cotangent = mx.random.normal(
+            (
+                3,
+                4,
+                5,
+            ),
+            dtype=mx.complex64,
+        )
+
+        # guard against values too close to the origin
+        primal = mx.where(abs(primal) < 1e-3, 1e-3, primal)
+
+        _, vjps = mx.vjp(mx.log, [primal], [cotangent])
+
+        expected = cotangent * mx.conj(1 / primal)
+
+        # Check against hand-computed vjps
+        self.assertTrue(mx.allclose(vjps[0], expected))
+
 
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner()


### PR DESCRIPTION
## Fix complex VJPs for log and exp

This is the same as #3433, just with the `exp` and `log` functions now. Specifically, the VJP implementations for these primitives were lacking a conjugation which is necessary for correctness under the Wirtinger convention used by MLX. The change to `Log::vjp` looks more extensive since the previous implementation re-uses `Log::jvp`, but I have effectively copied over and modified the body of `Log::jvp`, so the actual change is just the addition of the conjugation

I have added tests to verify correctness, and I ran pre-commit already. No documentation changes should be necessary, as this is just a correctness fix.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
