### PR TITLE
Fix HDRS_LIST building when paths in header inclusion tree include spaces

### DIFF
--- a/mlx/backend/metal/make_compiled_preamble.sh
+++ b/mlx/backend/metal/make_compiled_preamble.sh
@@ -54,7 +54,10 @@ fi
 HDRS=$(echo "$HDRS" | grep -v "Xcode")
 
 # Use the header depth to sort the files in order of inclusion
-declare -a HDRS_LIST=($HDRS)
+declare -a HDRS_LIST=()
+while read -r dots path; do
+  [ -n "$dots" ] && HDRS_LIST+=("$dots" "$path")
+done <<< "$HDRS"
 declare -a HDRS_STACK=()
 declare -a HDRS_SORTED=()
 


### PR DESCRIPTION
## Proposed changes

In `mlx/backend/metal/make_compiled_preamble.sh`, doing `declare -a HDRS_LIST=($HDRS)` breaks when the header inclusion tree `$HDRS` has paths with spaces. This manifests by headers not being properly linked, and a bunch of `grep` errors during build. This PR fixes header inclusion to support paths with spaces.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
