### PR TITLE
Return zero VJPs for scatter indices

### DIFF
--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -4391,8 +4391,9 @@ std::vector<array> Scatter::vjp(
         }
       }
     } else {
-      throw std::invalid_argument(
-          "[scatter] Cannot calculate VJP with respect to indices.");
+      // Grads w.r.t. indices are zero
+      vjps.push_back(
+          zeros(primals[num].shape(), primals[num].dtype(), stream()));
     }
   }
   return vjps;
@@ -4503,8 +4504,9 @@ std::vector<array> ScatterAxis::vjp(
     } else if (num == 2) {
       vjps.push_back(take_along_axis(cotangents[0], indices, axis_, stream()));
     } else {
-      throw std::invalid_argument(
-          "[scatter_axis] Cannot calculate VJP with respect to indices.");
+      // Grads w.r.t. indices are zero
+      vjps.push_back(
+          zeros(primals[num].shape(), primals[num].dtype(), stream()));
     }
   }
   return vjps;

--- a/python/tests/test_autograd.py
+++ b/python/tests/test_autograd.py
@@ -367,6 +367,46 @@ class TestAutograd(mlx_tests.MLXTestCase):
         self.assertTrue(mx.allclose(vjps[0], mx.array([4.0, 0.0, 6.0, 0.0])))
         self.assertTrue(mx.allclose(vjps[1], mx.array([5.0, 7.0])))
 
+    def test_scatter_index_vjp(self):
+        # The gradient with respect to scatter indices is zero, consistent
+        # with gather. Previously this raised. See #1439.
+        def fun(src, idx, updates):
+            return src.at[idx].add(updates)
+
+        src = mx.array([1.0, 2.0, 3.0, 4.0])
+        idx = mx.array([1, 3])
+        updates = mx.array([1.0, 2.0])
+        cotan = mx.array([4.0, 5.0, 6.0, 7.0])
+        _, vjps = mx.vjp(fun, [src, idx, updates], [cotan])
+        mx.eval(vjps)
+        self.assertTrue(mx.array_equal(vjps[1], mx.zeros(idx.shape, dtype=idx.dtype)))
+        self.assertEqual(vjps[1].dtype, idx.dtype)
+
+        # Also cover the original failure mode: differentiable values produce
+        # indices that are then used by scatter.
+        def fun_derived_index(cost, src, updates):
+            idx = mx.argmin(cost, axis=0)
+            return src.at[idx].add(updates)
+
+        cost = mx.array([[4.0, 1.0], [2.0, 3.0], [0.0, 5.0]])
+        _, vjps = mx.vjp(fun_derived_index, [cost, src, updates], [cotan])
+        mx.eval(vjps)
+        self.assertTrue(mx.array_equal(vjps[0], mx.zeros_like(cost)))
+
+        # scatter_axis (put_along_axis) shares the same rule.
+        def fun_axis(a, idx, values):
+            return mx.put_along_axis(a, idx, values, axis=0)
+
+        a = mx.zeros((5, 1))
+        idx2 = mx.array([[0], [3]])
+        values = mx.ones((2, 1))
+        cotan2 = mx.full((5, 1), 2.0)
+        _, vjps2 = mx.vjp(fun_axis, [a, idx2, values], [cotan2])
+        mx.eval(vjps2)
+        self.assertTrue(
+            mx.array_equal(vjps2[1], mx.zeros(idx2.shape, dtype=idx2.dtype))
+        )
+
     def test_slice_update_max_vjp(self):
         def fun(src, updates):
             x = src.at[1:3].maximum(updates)


### PR DESCRIPTION
## Summary
- Return zero VJPs for scatter and scatter_axis index inputs.
- Match gather behavior and fix gradients when scatter indices come from differentiable values.
- Add autograd coverage for direct and derived scatter indices.

Closes #1439.

## Tests
- /opt/homebrew/bin/black --check python/tests/test_autograd.py
- clang-format --dry-run --Werror mlx/primitives.cpp
- git diff --check
- PYTHONPATH=/Users/ldy/Desktop/project/mt/opencode/mlx/python:/Users/ldy/Desktop/project/mt/opencode/mlx/python/tests python3.11 -m unittest python.tests.test_autograd.TestAutograd.test_scatter_index_vjp
- PYTHONPATH=/Users/ldy/Desktop/project/mt/opencode/mlx/python:/Users/ldy/Desktop/project/mt/opencode/mlx/python/tests python3.11 -m unittest python.tests.test_autograd