### PR TITLE
Correct p-norm computation in triplet_loss

### DIFF
--- a/python/mlx/nn/layers/normalization.py
+++ b/python/mlx/nn/layers/normalization.py
@@ -73,7 +73,7 @@ class LayerNorm(Module):
 
     .. math::
 
-        y = \frac{x - E[x]}{\sqrt{Var[x]} + \epsilon} \gamma + \beta,
+        y = \frac{x - E[x]}{\sqrt{Var[x] + \epsilon}} \gamma + \beta,
 
     where :math:`\gamma` and :math:`\beta` are learned per feature dimension
     parameters initialized at 1 and 0 respectively.
@@ -150,7 +150,7 @@ class GroupNorm(Module):
 
     .. math::
 
-        y = \frac{x - E[x]}{\sqrt{Var[x]} + \epsilon} \gamma + \beta,
+        y = \frac{x - E[x]}{\sqrt{Var[x] + \epsilon}} \gamma + \beta,
 
     where :math:`\gamma` and :math:`\beta` are learned per feature dimension
     parameters initialized at 1 and 0 respectively. However, the mean and
@@ -244,7 +244,7 @@ class BatchNorm(Module):
 
     .. math::
 
-        y = \frac{x - E[x]}{\sqrt{Var[x]} + \epsilon} \gamma + \beta,
+        y = \frac{x - E[x]}{\sqrt{Var[x] + \epsilon}} \gamma + \beta,
 
     where :math:`\gamma` and :math:`\beta` are learned per feature dimension
     parameters initialized at 1 and 0 respectively.

--- a/python/mlx/nn/losses.py
+++ b/python/mlx/nn/losses.py
@@ -408,7 +408,8 @@ def triplet_loss(
         axis (int, optional): The distribution axis. Default: ``-1``.
         p (int, optional): The norm degree for pairwise distance. Default: ``2``.
         margin (float, optional): Margin for the triplet loss. Defaults to ``1.0``.
-        eps (float, optional): Small positive constant to prevent numerical instability. Defaults to ``1e-6``.
+        eps (float, optional): Small positive constant added to the p-norm sum
+          before taking the ``1 / p`` power. Defaults to ``1e-6``.
         reduction (str, optional): Specifies the reduction to apply to the output:
           ``'none'`` | ``'mean'`` | ``'sum'``. Default: ``'none'``.
 
@@ -416,12 +417,13 @@ def triplet_loss(
         array: Computed triplet loss. If reduction is "none", returns a tensor of the same shape as input;
                   if reduction is "mean" or "sum", returns a scalar tensor.
     """
-    loss = mx.maximum(
-        mx.sqrt(mx.power(anchors - positives, p).sum(axis) + eps)
-        - mx.sqrt(mx.power(anchors - negatives, p).sum(axis) + eps)
-        + margin,
-        0,
+    pos_dist = mx.power(
+        mx.power(mx.abs(anchors - positives), p).sum(axis) + eps, 1.0 / p
     )
+    neg_dist = mx.power(
+        mx.power(mx.abs(anchors - negatives), p).sum(axis) + eps, 1.0 / p
+    )
+    loss = mx.maximum(pos_dist - neg_dist + margin, 0)
     return _reduce(loss, reduction)
 
 

--- a/python/tests/test_losses.py
+++ b/python/tests/test_losses.py
@@ -360,6 +360,23 @@ class TestLosses(mlx_tests.MLXTestCase):
         expected_sum = mx.sum(expected_none)
         self.assertTrue(mx.allclose(losses_sum, expected_sum))
 
+        # Test with non-default 'p' norm degrees
+        anchors = mx.array([[0.0, 0.0]])
+        positives = mx.array([[2.0, 0.0]])
+        negatives = mx.array([[0.0, 3.0]])
+
+        losses_p1 = nn.losses.triplet_loss(
+            anchors, positives, negatives, p=1, reduction="none"
+        )
+        expected_p1 = mx.array([0.0])
+        self.assertTrue(mx.allclose(losses_p1, expected_p1))
+
+        losses_p3 = nn.losses.triplet_loss(
+            anchors, positives, negatives, p=3, reduction="none"
+        )
+        expected_p3 = mx.array([0.0])
+        self.assertTrue(mx.allclose(losses_p3, expected_p3))
+
     def test_hinge_loss(self):
         inputs = mx.ones((2, 4))
         targets = mx.zeros((2, 4))


### PR DESCRIPTION
## Description

`nn.losses.triplet_loss` exposes a configurable norm degree through the `p` argument and documents the distance term as a p-norm:

```python
||A - P||_p
```

However, the current distance computation is:

```python
mx.sqrt(mx.power(anchors - positives, p).sum(axis) + eps)
```

which only matches the documented p-norm when `p=2`. For other values of `p`, it can produce incorrect results and even `NaN` values.

This change updates the distance computation to use the standard p-norm:

```python
(sum(abs(x - y) ** p) + eps) ** (1 / p)
```

which matches both the function documentation and MLX's `linalg.norm` behavior.

On a sidenote, I also noticed that the LayerNorm, GroupNorm, and BatchNorm docstrings in `normalization.py` had `epsilon` outside the square root (`\sqrt{Var[x]} + \epsilon`) which doesn't match the standard normalization formula, so I changed it to (`\sqrt{Var[x] + \epsilon}`) instead.

## Changes

* Corrected the p-norm computation in `nn.losses.triplet_loss`
* Added test coverage for non-default `p` values

## Testing

```bash
python -m unittest python.tests.test_losses.TestLosses.test_triplet_loss
```

cc @zcbenz 