### PR TITLE
Handle invalid dimensions in SinusoidalPositionalEncoding

### DIFF
--- a/python/mlx/nn/layers/positional_encoding.py
+++ b/python/mlx/nn/layers/positional_encoding.py
@@ -85,7 +85,19 @@ class SinusoidalPositionalEncoding(Module):
     ):
         super().__init__()
 
-        one_zero = 1 - mx.arange(0, dims // 2) / (dims // 2 - 1)
+        # Sinusoidal embeddings are constructed from sin/cos pairs, so the
+        # embedding dimension must be positive and even.
+        if dims <= 0 or dims % 2 != 0:
+            raise ValueError(
+                f"[SinusoidalPositionalEncoding] dims must be positive and even but got {dims}."
+            )
+
+        # Avoid division by zero when dims == 2 (one frequency pair).
+        if dims == 2:
+            one_zero = mx.array([1.0])
+        else:
+            one_zero = 1 - mx.arange(0, dims // 2) / (dims // 2 - 1)
+
         min_freq = math.log(min_freq)
         max_freq = math.log(max_freq)
 

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -932,6 +932,17 @@ class TestLayers(mlx_tests.MLXTestCase):
             mx.abs(similarities[mx.arange(10), mx.arange(10)] - 1).max(), 1e-5
         )
 
+        # dims=2 should be supported (single sin/cos frequency pair)
+        m = nn.SinusoidalPositionalEncoding(2)
+        y = m(x)
+        self.assertEqual(y.shape, (10, 2))
+
+        # Odd and non-positive dimensions are invalid
+        for dims in [0, 1, 3]:
+            with self.subTest(dims=dims):
+                with self.assertRaises(ValueError):
+                    nn.SinusoidalPositionalEncoding(dims)
+
     def test_sigmoid(self):
         x = mx.array([1.0, 0.0, -1.0])
         y1 = mx.sigmoid(x)


### PR DESCRIPTION
## Description

`nn.SinusoidalPositionalEncoding` currently assumes that `dims` is positive and even, but this requirement is not enforced.

The implementation constructs sinusoidal embeddings from sine/cosine frequency pairs using:

```python
one_zero = 1 - mx.arange(0, dims // 2) / (dims // 2 - 1)
```

This works for the existing tested case (`dims=16`), but some edge cases are not handled correctly.

For example, if a user constructs:

```python
nn.SinusoidalPositionalEncoding(3)
```

the implementation produces only 2 embedding dimensions instead of the requested 3. Similarly, `dims=2` results in a division by zero while computing the values used to generate the sinusoidal frequencies, and non-positive values are not rejected explicitly.

This change validates that `dims` is a positive even integer and handles the `dims=2` case separately to avoid the division by zero.

## Tests

Added coverage for:

* `dims=2`
* Invalid dimensions: `0`, `1`, and `3`

cc @zcbenz 