### PR TITLE
Fix flaky test_siblings_without_eval

### DIFF
--- a/.github/actions/build-macos-release/action.yml
+++ b/.github/actions/build-macos-release/action.yml
@@ -56,7 +56,7 @@ runs:
       shell: bash
       run: |
         echo "::group::Test local packages"
-        uv pip install numpy torch psutil
+        uv pip install numpy torch
         uv pip install dist/mlx_metal-*-macosx_26_0_arm64.whl
         uv pip install dist/mlx-*-macosx_26_0_arm64.whl
         python -m unittest discover -v python/tests

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -1,6 +1,5 @@
 # Copyright © 2023-2024 Apple Inc.
 
-import gc
 import operator
 import os
 import pickle
@@ -14,7 +13,6 @@ from itertools import permutations
 import mlx.core as mx
 import mlx_tests
 import numpy as np
-import psutil
 
 try:
     import tensorflow as tf
@@ -2278,29 +2276,6 @@ class TestArray(mlx_tests.MLXTestCase):
         for _ in range(100_000):
             x = mx.sin(x)
         mx.eval(x)
-
-    @unittest.skipIf(platform.system() == "Windows", "Memory info not accurate")
-    def test_siblings_without_eval(self):
-        def get_mem():
-            process = psutil.Process(os.getpid())
-            return process.memory_info().rss
-
-        key = mx.array([1, 2])
-
-        def t():
-            a, b = mx.split(key, 2)
-            a = mx.reshape(a, [])
-            b = mx.reshape(b, [])
-            return b
-
-        mx.synchronize()
-        t()
-        gc.collect()
-        expected = get_mem()
-        for _ in range(100):
-            t()
-        used = get_mem()
-        self.assertEqual(expected, used)
 
     def test_scalar_integer_conversion_overflow(self):
         y = mx.array(2000000000, dtype=mx.int32)

--- a/setup.py
+++ b/setup.py
@@ -234,7 +234,6 @@ if __name__ == "__main__":
             "ml_dtypes",
             "numpy>=2",
             "pre-commit",
-            "psutil>=7.2",
             "torch>=2.9",
             "typing_extensions",
         ],

--- a/tests/array_tests.cpp
+++ b/tests/array_tests.cpp
@@ -671,3 +671,22 @@ TEST_CASE("test negative indexing for shape/strides") {
   CHECK_THROWS_AS(a.shape(2), std::out_of_range);
   CHECK_THROWS_AS(a.strides(2), std::out_of_range);
 }
+
+// https://github.com/ml-explore/mlx/pull/1590
+TEST_CASE("test siblings circular references without eval") {
+  std::weak_ptr<array::Data> tracker;
+  auto fun = [&]() {
+    array key({1, 2});
+    auto splits = split(key, 2);
+    {
+      // Set fake data as a tracker for ArrayDesc's lifetime.
+      splits[0].set_data(allocator::malloc(0));
+      tracker = splits[0].data_shared_ptr();
+    }
+    auto a = reshape(splits[0], {});
+    auto b = reshape(splits[1], {});
+    return b;
+  };
+  fun();
+  CHECK(tracker.expired());
+}


### PR DESCRIPTION
Instead of measuring the RAM used by the process, which is very unreliable, change the test to directly verify we are not leaking `ArrayDesc` references.