### PR TITLE
Fix threaded compile cache cleanup

### DIFF
--- a/python/src/transforms.cpp
+++ b/python/src/transforms.cpp
@@ -421,7 +421,6 @@ void ensure_compile_cache_cleanup() {
     mx::detail::compile_clear_cache();
     return ThreadCleanup{};
   }();
-  (void)clear_cache;
 }
 
 struct PyCompiledFun {
@@ -1481,8 +1480,6 @@ void init_transforms(nb::module_& m) {
          const nb::object& inputs,
          const nb::object& outputs,
          bool shapeless) {
-        ensure_compile_cache_cleanup();
-
         return mlx_func(
             nb::cpp_function(PyCompiledFun{fun, inputs, outputs, shapeless}),
             fun,

--- a/python/src/transforms.cpp
+++ b/python/src/transforms.cpp
@@ -406,6 +406,24 @@ auto py_vmap(
   };
 }
 
+void ensure_compile_cache_cleanup() {
+  // Make sure each thread using mx.compile would clear its compile cache
+  // before python interpreter exits.
+  struct ThreadCleanup {
+    ~ThreadCleanup() {
+      if (!mx::detail::compile_cache_empty()) {
+        nb::gil_scoped_acquire gil;
+        mx::detail::compile_clear_cache();
+      }
+    }
+  };
+  static thread_local auto clear_cache = []() {
+    mx::detail::compile_clear_cache();
+    return ThreadCleanup{};
+  }();
+  (void)clear_cache;
+}
+
 struct PyCompiledFun {
   nb::callable fun;
   std::uintptr_t fun_id;
@@ -447,6 +465,8 @@ struct PyCompiledFun {
   };
 
   nb::object call_impl(const nb::args& args, const nb::kwargs& kwargs) {
+    ensure_compile_cache_cleanup();
+
     // Flat array inputs
     std::vector<mx::array> inputs;
 
@@ -1461,23 +1481,7 @@ void init_transforms(nb::module_& m) {
          const nb::object& inputs,
          const nb::object& outputs,
          bool shapeless) {
-        // Make sure each thread using mx.compile would clear its compile cache
-        // before python interpreter exits.
-        struct ThreadCleanup {
-          ~ThreadCleanup() {
-            if (!mx::detail::compile_cache_empty()) {
-              nb::gil_scoped_acquire gil;
-              mx::detail::compile_clear_cache();
-            }
-          }
-        };
-        static thread_local auto clear_cache = []() {
-          // Ensure it is created
-          mx::detail::compile_clear_cache();
-
-          // Ensure it will be cleaned up
-          return ThreadCleanup{};
-        }();
+        ensure_compile_cache_cleanup();
 
         return mlx_func(
             nb::cpp_function(PyCompiledFun{fun, inputs, outputs, shapeless}),

--- a/python/tests/test_compile.py
+++ b/python/tests/test_compile.py
@@ -4,6 +4,7 @@ import gc
 import inspect
 import io
 import math
+import threading
 from functools import partial, wraps
 from io import StringIO
 
@@ -43,6 +44,33 @@ class TestCompile(mlx_tests.MLXTestCase):
         out = compiled_fn(x, y)
         self.assertEqual(out.dtype, mx.int32)
         self.assertTrue(mx.array_equal(out, mx.array([2, 4])))
+
+    def test_compile_tuple_output_in_thread(self):
+        @mx.compile
+        def fun(x):
+            return x + 1, x * 2
+
+        results = []
+        errors = []
+
+        def worker():
+            try:
+                x = mx.array([1.0])
+                y, z = fun(x)
+                mx.eval(y, z)
+                results.append((y.item(), z.item()))
+            except Exception as e:
+                errors.append(e)
+
+        for _ in range(3):
+            thread = threading.Thread(target=worker)
+            thread.start()
+            thread.join()
+            gc.collect()
+
+        if errors:
+            raise errors[0]
+        self.assertEqual(results, [(2.0, 2.0)] * 3)
 
     def test_compile_grad(self):
         def loss_fn(x):


### PR DESCRIPTION
When mx.compile is used as a decorator but the compiled function is first invoked on another thread, the invocation thread’s compiler cache could keep Python output metadata until unsafe thread teardown. This change makes sure we register cache cleanup in the invoking thread too.

Resolves https://github.com/ml-explore/mlx/issues/3619

## Checklist

Put an `x` in the boxes that apply.

- [X] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [X] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have updated the necessary documentation (if needed)
