### PR TITLE
Fix int16 overflow in NAX qmm edge-tile bounds

### DIFF
--- a/mlx/backend/metal/kernels/fp_quantized_nax.h
+++ b/mlx/backend/metal/kernels/fp_quantized_nax.h
@@ -260,10 +260,10 @@ METAL_FUNC void fp_qmm_t_impl(
   constexpr bool transpose_a = false;
   constexpr bool transpose_b = true;
 
-  const short sgp_sm = min(SM, short(M - (y_row + tm)));
+  const short sgp_sm = min(int(SM), M - (y_row + tm));
   const bool is_unaligned_sm = (sgp_sm != SM);
 
-  const short sgp_sn = aligned_N ? SN : min(SN, short(N - (y_col + tn)));
+  const short sgp_sn = aligned_N ? SN : min(int(SN), N - (y_col + tn));
 
   const short tgp_bn = aligned_N ? BN : min(BN, int(N - (y_col)));
   const bool is_unaligned_bn = aligned_N ? false : (tgp_bn != BN);
@@ -864,10 +864,8 @@ template <
   const short tm = SM * (simd_group_id / WN);
   const short tn = SN * (simd_group_id % WN);
 
-  const short sgp_sm =
-      align_M ? SM : min(SM, short(max(0, (M - (y_row + tm)))));
-  const short sgp_sn =
-      align_N ? SN : min(SN, short(max(0, (N - (y_col + tn)))));
+  const short sgp_sm = align_M ? SM : min(int(SM), max(0, (M - (y_row + tm))));
+  const short sgp_sn = align_N ? SN : min(int(SN), max(0, (N - (y_col + tn))));
 
   const bool is_unaligned_sm = align_M ? false : (sgp_sm != SM);
   const bool is_unaligned_bn = align_N ? false : (tgp_bn != BN);

--- a/mlx/backend/metal/kernels/quantized_nax.h
+++ b/mlx/backend/metal/kernels/quantized_nax.h
@@ -1000,10 +1000,10 @@ METAL_FUNC void qmm_t_nax_tgp_impl(
   constexpr bool transpose_a = false;
   constexpr bool transpose_b = true;
 
-  const short sgp_sm = min(SM, short(M - (y_row + tm)));
+  const short sgp_sm = min(int(SM), M - (y_row + tm));
   const bool is_unaligned_sm = (sgp_sm != SM);
 
-  const short sgp_sn = aligned_N ? SN : min(SN, short(N - (y_col + tn)));
+  const short sgp_sn = aligned_N ? SN : min(int(SN), N - (y_col + tn));
 
   const short tgp_bn = aligned_N ? BN : min(BN, int(N - (y_col)));
   const bool is_unaligned_bn = aligned_N ? false : (tgp_bn != BN);

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -268,6 +268,38 @@ class TestQuantized(mlx_tests.MLXTestCase):
                 tol = 1e-3 if dtype == mx.float32 else 1.5e-3
                 self.assertLess((y_q - y_hat).abs().max(), tol)
 
+    def test_qmm_large_dims(self):
+        # Regression test for an int16 overflow in the NAX qmm kernels:
+        # the per-simdgroup edge sizes were computed as
+        # min(SN, short(N - (y_col + tn))), which wraps for distances
+        # over 32767 and made store_safe skip a contiguous band of output
+        # columns [N - 65536, N - 32768) whenever the M-tile was partial.
+        key = mx.random.key(0)
+        k1, k2 = mx.random.split(key)
+        dtype = mx.float16 if (mx.default_device() == mx.gpu) else mx.float32
+        group_size, bits = 64, 4
+        K = 128
+        tests = [
+            (16, 32840),  # unaligned N > 2**15, M < 32: partial M-tile
+            (33, 32840),  # unaligned N > 2**15, M % 32 != 0
+            (33000, 64),  # M > 2**15: row distance overflows (aligned N)
+        ]
+        for M, N in tests:
+            with self.subTest(shape=(M, N, K)):
+                x = mx.random.normal(shape=(M, K), key=k1) / K**0.5
+                w = mx.random.normal(shape=(N, K), key=k2) / K**0.5
+                x = x.astype(dtype)
+                w = w.astype(dtype)
+                w_q, scales, biases = mx.quantize(w, group_size, bits)
+                w_hat = mx.dequantize(w_q, scales, biases, group_size, bits)
+                y_q = mx.quantized_matmul(
+                    x, w_q, scales, biases, True, group_size, bits
+                )
+                y_hat = x @ w_hat.T
+                self.assertEqual(y_q.shape, y_hat.shape)
+                tol = 1e-3 if dtype == mx.float32 else 1.5e-3
+                self.assertLess((y_q - y_hat).abs().max(), tol)
+
     def test_qmm_vjp(self):
         key = mx.random.key(0)
         k1, k2 = mx.random.split(key)


### PR DESCRIPTION
## Proposed changes

`qmm_t_nax_tgp_impl` and the `fp_` variants compute per-simdgroup edge sizes with:

```cpp
const short sgp_sn = aligned_N ? SN : min(SN, short(N - (y_col + tn)));
```

The short() cast wraps for distances greater than 32767. On M-series devices using the NAX path, this can leave output regions unwritten or corrupted for large unaligned dimensions. For example, transposed quantized matmul with unaligned N > 2^15 leaves a column band unwritten when the M-tile is partial (M % 32 != 0). Symmetrically, large M can corrupt leading rows even when N is aligned.

Fix: compute the min in int, matching the dense NAX GEMM kernels in steel_gemm_fused_nax.h and the adjacent tgp_bn calculation.

## Real-world impact

MiniCPM3-4B has vocab size 73448 (% 64 = 40). On an M5, 10-31 token prompt processing hits the affected qmm path for lm_head, so token ids in the corrupted output band can receive wrong logits and lead to wrong generations. This was hit in vllm-project/vllm-metal; standalone mlx_lm prompt processing is equally affected. Many models avoid this because common vocab sizes are multiples of 64.

Repro on main, Apple M5 Max:

``` python
import mlx.core as mx
mx.random.seed(0)

K, N, M = 2560, 73448, 16
w = mx.random.normal((N, K)).astype(mx.float16)
wq, s, b = mx.quantize(w, group_size=64, bits=4)
w_fp = mx.dequantize(wq, s, b, group_size=64, bits=4).astype(mx.float32)

x = mx.random.normal((M, K)).astype(mx.bfloat16)
y = mx.quantized_matmul(x, wq, s, b, transpose=True, group_size=64, bits=4)

print(mx.abs(y.astype(mx.float32) - x.astype(mx.float32) @ w_fp.T).max())
# main: ~13
# fixed: quantization-level error
```

The corrupted column band matches the int16 wrap points: first bad column 7912 = N - 65536, and the bad range ends before the first tile where N - base <= 32767. Rows <= 9 use qmv, and M multiples of 32 use a different store path, matching the observed unaffected cases.

## Tests

Added test_qmm_large_dims covering:

- (M=16, N=32840)
- (M=33, N=32840)
- (M=33000, N=64)

All three fail on main on an M5 and pass with this fix. The rest of test_quantized.py has no new pass/fail changes on my machine.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)