### PR TITLE
Fix gather_qmm NAX kernel name mismatch

### DIFF
--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -596,7 +596,9 @@ void gather_qmm_nax(
   int wn = 2;
   int bm = 64;
   int bn = 64;
-  int bk = 32;
+  // The gather qmm NAX kernels are instantiated with BK = 64 only; any
+  // other value here makes the kernel name lookup fail.
+  int bk = 64;
   MTL::Size group_dims(32, wn, wm);
   MTL::Size grid_dims((N + bn - 1) / bn, (M + bm - 1) / bm, B);
 

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -992,6 +992,43 @@ class TestQuantized(mlx_tests.MLXTestCase):
         g2 = mx.grad(f_test)(x, qw, s, b, lhs_indices, rhs_indices)
         self.assertTrue(mx.allclose(g1, g2, atol=1e-4))
 
+    def test_gather_qmm_matrix_path(self):
+        # Regression test for matrix-size gather_qmm with half precision
+        # inputs: on NAX devices the kernel name was built with bk = 32
+        # while the kernels are only instantiated with bk = 64, so the
+        # kernel lookup failed with "Unable to load kernel".
+        key = mx.random.key(0)
+        k1, k2 = mx.random.split(key)
+        dtype = mx.bfloat16 if (mx.default_device() == mx.gpu) else mx.float32
+        E, M, N, K = 4, 64, 512, 512
+        lhs_indices = mx.array([0, 1, 2], dtype=mx.uint32)
+        rhs_indices = mx.array([0, 2, 3], dtype=mx.uint32)
+        for mode in ["affine", "mxfp4"]:
+            with self.subTest(mode=mode):
+                x = (mx.random.normal(shape=(3, M, K), key=k1) / K**0.5).astype(dtype)
+                # Keep w in the same dtype so affine scales do not promote
+                # the matmul to float32 (which would skip the NAX route).
+                w = mx.random.normal(shape=(E, N, K), key=k2).astype(dtype)
+                w_q, *wargs = mx.quantize(w, mode=mode)
+                w_hat = mx.dequantize(w_q, *wargs, mode=mode)
+                y_q = mx.gather_qmm(
+                    x,
+                    w_q,
+                    *wargs,
+                    lhs_indices=lhs_indices,
+                    rhs_indices=rhs_indices,
+                    transpose=True,
+                    mode=mode,
+                )
+                y_hat = mx.stack(
+                    [
+                        x[i].astype(mx.float32) @ w_hat[int(rhs_indices[i])].T
+                        for i in range(3)
+                    ]
+                ).astype(dtype)
+                self.assertEqual(y_q.shape, y_hat.shape)
+                self.assertLess((y_q - y_hat).abs().max(), 1e-1)
+
     def test_gather_qmm_sorted(self):
         def quantize(w, transpose=True, group_size=None, mode="affine"):
             if mode == "affine":


### PR DESCRIPTION
## Proposed changes

`gather_qmm_nax` builds the NAX kernel name with `bk = 32`, but the gather qmm NAX kernels are only instantiated with `_bk64_` names. On NAX devices this makes the matrix-size `gather_qmm` path (taken for half-precision inputs, or float32 with tf32 enabled) fail during kernel lookup with an `Unable to load kernel ..._bk32...` error.

This changes the `gather_qmm_nax` kernel-name construction to use `bk = 64`, matching the existing instantiations. In this path `bk` is only part of the kernel name; the dispatch geometry is unchanged.

The PR also adds a regression test for matrix-size half-precision `gather_qmm` covering both `affine` and `mxfp4`, checked against a float32 reference.

Tested with:

```bash
DEVICE=gpu .venv/bin/pytest -q python/tests/test_quantized.py::TestQuantized::test_gather_qmm_matrix_path
```

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
