### PR TITLE
Fix JVPs of select, arctan2, masked_scatter, and bitwise ops

### DIFF
--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -551,14 +551,18 @@ std::vector<array> ArcTan2::jvp(
   const array& x1 = primals[0];
   const array& x2 = primals[1];
 
-  auto jvp_fun = [&](int i) {
-    return argnums[i] == 0 ? multiply(x2, tangents[i], s)
-                           : negative(multiply(x1, tangents[i], s), s);
-  };
-  auto numerator = jvp_fun(0);
-  if (argnums.size() > 1) {
-    numerator = add(numerator, jvp_fun(1), s);
-  }
+  auto numerator = [&](){
+    if (argnums.size() == 2) {
+      return subtract(
+          multiply(x2, tangents[0], s),
+          multiply(x1, tangents[1], s),
+          s);
+    } else if (argnums[0] == 0) {
+      return multiply(x2, tangents[0], s);
+    } else {
+      return negative(multiply(x1, tangents[1], s), s);
+    }
+  }();
   return {divide(numerator, add(square(x1, s), square(x2, s), s), s)};
 }
 

--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -518,7 +518,7 @@ std::vector<array> ArcTan2::vjp(
     const std::vector<int>& argnums,
     const std::vector<array>&) {
   assert(primals.size() == 2);
-  assert(argnums.size() == 2);
+  assert(cotangents.size() == 1);
 
   const auto& s = stream();
   const array& x1 = primals[0];

--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -545,18 +545,21 @@ std::vector<array> ArcTan2::jvp(
     const std::vector<array>& tangents,
     const std::vector<int>& argnums) {
   assert(primals.size() == 2);
-  assert(argnums.size() == 2);
+  assert(tangents.size() == argnums.size());
 
   const auto& s = stream();
   const array& x1 = primals[0];
   const array& x2 = primals[1];
-  const array& dx1 = tangents[0];
-  const array& dx2 = tangents[1];
 
-  return {divide(
-      subtract(multiply(x2, dx1, s), multiply(x1, dx2, s), s),
-      add(square(x1, s), square(x2, s), s),
-      s)};
+  auto jvp_fun = [&](int i) {
+    return argnums[i] == 0 ? multiply(x2, tangents[i], s)
+                           : negative(multiply(x1, tangents[i], s), s);
+  };
+  auto numerator = jvp_fun(0);
+  if (argnums.size() > 1) {
+    numerator = add(numerator, jvp_fun(1), s);
+  }
+  return {divide(numerator, add(square(x1, s), square(x2, s), s), s)};
 }
 
 std::pair<std::vector<array>, std::vector<int>> ArcTan2::vmap(
@@ -794,11 +797,8 @@ std::vector<array> BitwiseBinary::jvp(
     const std::vector<array>& tangents,
     const std::vector<int>& argnums) {
   assert(primals.size() == 2);
-  std::vector<array> vjps = {zeros_like(tangents[0], stream())};
-  if (argnums.size() > 1) {
-    vjps.push_back(vjps.back());
-  }
-  return vjps;
+  auto shape = broadcast_shapes(primals[0].shape(), primals[1].shape());
+  return {zeros(shape, tangents[0].dtype(), stream())};
 }
 
 std::vector<array> BitwiseBinary::vjp(
@@ -806,7 +806,11 @@ std::vector<array> BitwiseBinary::vjp(
     const std::vector<array>& cotangents,
     const std::vector<int>& argnums,
     const std::vector<array>&) {
-  return jvp(primals, cotangents, argnums);
+  std::vector<array> vjps;
+  for (auto arg : argnums) {
+    vjps.push_back(zeros_like(primals[arg], stream()));
+  }
+  return vjps;
 }
 
 std::vector<array>
@@ -3146,30 +3150,30 @@ std::vector<array> Select::jvp(
     const std::vector<array>& tangents,
     const std::vector<int>& argnums) {
   assert(primals.size() == 3);
-  assert(tangents.size() == 3);
+  assert(tangents.size() == argnums.size());
 
   auto jvp_fun = [&](int i) {
     int arg = argnums[i];
 
     if (arg == 0) {
-      return zeros_like(primals[0], stream());
+      return zeros_like(primals[1], stream());
     } else if (arg == 1) {
       return multiply(
-          astype(primals[0], tangents[1].dtype(), stream()),
-          tangents[1],
+          astype(primals[0], tangents[i].dtype(), stream()),
+          tangents[i],
           stream());
     } else {
       return multiply(
           astype(
-              logical_not(primals[0], stream()), tangents[2].dtype(), stream()),
-          tangents[2],
+              logical_not(primals[0], stream()), tangents[i].dtype(), stream()),
+          tangents[i],
           stream());
     }
   };
 
-  array jvp = jvp_fun(argnums[0]);
+  array jvp = jvp_fun(0);
   for (int i = 1; i < argnums.size(); i++) {
-    jvp = add(jvp, jvp_fun(argnums[i]));
+    jvp = add(jvp, jvp_fun(i));
   }
   return {jvp};
 }
@@ -4654,15 +4658,16 @@ std::vector<array> MaskedScatter::jvp(
   }
 
   array out = zeros_like(dst, s);
-  for (int arg : argnums) {
+  for (int i = 0; i < argnums.size(); ++i) {
+    int arg = argnums[i];
     if (arg == 0) {
-      out = where(mask_b, out, tangents[0], s);
+      out = where(mask_b, out, tangents[i], s);
     } else if (arg == 2) {
       out = array(
           out.shape(),
           out.dtype(),
           std::make_shared<MaskedScatter>(s),
-          {out, mask, tangents[1]});
+          {out, mask, tangents[i]});
     } else {
       throw std::invalid_argument("[masked_scatter] invalid arg index in JVP");
     }

--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -551,12 +551,10 @@ std::vector<array> ArcTan2::jvp(
   const array& x1 = primals[0];
   const array& x2 = primals[1];
 
-  auto numerator = [&](){
+  auto numerator = [&]() {
     if (argnums.size() == 2) {
       return subtract(
-          multiply(x2, tangents[0], s),
-          multiply(x1, tangents[1], s),
-          s);
+          multiply(x2, tangents[0], s), multiply(x1, tangents[1], s), s);
     } else if (argnums[0] == 0) {
       return multiply(x2, tangents[0], s);
     } else {

--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -558,7 +558,7 @@ std::vector<array> ArcTan2::jvp(
     } else if (argnums[0] == 0) {
       return multiply(x2, tangents[0], s);
     } else {
-      return negative(multiply(x1, tangents[1], s), s);
+      return negative(multiply(x1, tangents[0], s), s);
     }
   }();
   return {divide(numerator, add(square(x1, s), square(x2, s), s), s)};

--- a/mlx/transforms.cpp
+++ b/mlx/transforms.cpp
@@ -634,6 +634,8 @@ std::pair<std::vector<array>, std::vector<array>> jvp(
 
     auto jvps = a.primitive().jvp(a.inputs(), tangents, argnums);
     auto outputs = a.outputs();
+    // A primitive's jvp returns one tangent per output
+    assert(jvps.size() <= outputs.size());
     for (int i = 0; i < jvps.size(); ++i) {
       tan_map.insert({outputs[i].id(), jvps[i]});
     }

--- a/python/tests/test_autograd.py
+++ b/python/tests/test_autograd.py
@@ -48,6 +48,72 @@ class TestAutograd(mlx_tests.MLXTestCase):
             _, tangents = mx.jvp(lambda x, _op=op: _op(x, 0.0), [x], [t])
             self.assertEqual(tangents[0].dtype, mx.float32)
 
+    def test_jvp_with_constant_inputs(self):
+        # JVPs of primitives with only a subset of inputs traced used to
+        # index tangents out of bounds and silently return wrong tangents
+        # (issue #3627)
+
+        # d/dt (t + 1)^2 = 2 at t = 0
+        cases = [
+            lambda t: mx.where((t + 1) ** 2 > -1, (t + 1) ** 2, 999.0),
+            lambda t: mx.where((t + 1) ** 2 < -1, 999.0, (t + 1) ** 2),
+            lambda t: mx.where(mx.array(True), (t + 1) ** 2, 999.0),
+            lambda t: mx.where(mx.array(False), 999.0, (t + 1) ** 2),
+        ]
+        for fun in cases:
+            _, (dout,) = mx.jvp(fun, [mx.array(0.0)], [mx.array(1.0)])
+            self.assertEqual(dout.item(), 2.0)
+
+        # The tangent of a where with only the condition traced is zero
+        # with the output's dtype
+        _, (dout,) = mx.jvp(
+            lambda c: mx.where(c > 0, 2.0, 3.0), [mx.array(1.0)], [mx.array(1.0)]
+        )
+        self.assertEqual(dout.item(), 0.0)
+        self.assertEqual(dout.dtype, mx.float32)
+
+        # d/dy atan2(y, x) = x / (x^2 + y^2)
+        _, (dout,) = mx.jvp(
+            lambda y: mx.arctan2(y, mx.array(2.0)), [mx.array(1.0)], [mx.array(1.0)]
+        )
+        self.assertAlmostEqual(dout.item(), 0.4, places=6)
+
+        # d/dx atan2(y, x) = -y / (x^2 + y^2)
+        _, (dout,) = mx.jvp(
+            lambda x: mx.arctan2(mx.array(2.0), x), [mx.array(1.0)], [mx.array(1.0)]
+        )
+        self.assertAlmostEqual(dout.item(), -0.4, places=6)
+
+        # masked_scatter with a constant destination
+        mask = mx.array([True, False, True, False])
+
+        def masked_set(src):
+            dst = mx.zeros(4)
+            dst[mask] = src
+            return dst
+
+        _, (dout,) = mx.jvp(masked_set, [mx.ones(2)], [mx.ones(2)])
+        self.assertTrue(mx.array_equal(dout, mx.array([1.0, 0.0, 1.0, 0.0])))
+
+    def test_jvp_through_bitwise_ops(self):
+        # JVPs of bitwise ops returned one tangent per traced input instead
+        # of one per output which corrupted the tangents of downstream
+        # outputs (issue #3629)
+        def fun(x):
+            b = (x == 0) & (x > -1)
+            return x + b.astype(mx.float32)
+
+        x = mx.array([0.0, 1.0, 2.0])
+        _, (dout,) = mx.jvp(fun, [x], [mx.ones_like(x)])
+        self.assertTrue(mx.array_equal(dout, mx.ones_like(x)))
+
+        def fun(x):
+            b = (x == 0) | (x > 1)
+            return x * b.astype(mx.float32)
+
+        _, (dout,) = mx.jvp(fun, [x], [mx.ones_like(x)])
+        self.assertTrue(mx.array_equal(dout, mx.array([1.0, 0.0, 1.0])))
+
     def test_vjp(self):
         fun = lambda x: 2 * x
         out, dout = mx.vjp(fun, [mx.array(1.0)], [mx.array(2.0)])

--- a/python/tests/test_autograd.py
+++ b/python/tests/test_autograd.py
@@ -64,6 +64,14 @@ class TestAutograd(mlx_tests.MLXTestCase):
             _, (dout,) = mx.jvp(fun, [mx.array(0.0)], [mx.array(1.0)])
             self.assertEqual(dout.item(), 2.0)
 
+        # Constant condition with both branches traced
+        _, (dout,) = mx.jvp(
+            lambda a, b: mx.where(mx.array([True, False]), a, b),
+            [mx.zeros(2), mx.zeros(2)],
+            [mx.array([1.0, 2.0]), mx.array([3.0, 4.0])],
+        )
+        self.assertTrue(mx.array_equal(dout, mx.array([1.0, 4.0])))
+
         # The tangent of a where with only the condition traced is zero
         # with the output's dtype
         _, (dout,) = mx.jvp(
@@ -98,7 +106,9 @@ class TestAutograd(mlx_tests.MLXTestCase):
     def test_jvp_through_bitwise_ops(self):
         # JVPs of bitwise ops returned one tangent per traced input instead
         # of one per output which corrupted the tangents of downstream
-        # outputs (issue #3629)
+        # outputs (issue #3629). The corruption is out-of-bounds UB that can
+        # go unnoticed in release builds; the assert in the jvp transform
+        # catches it deterministically in debug builds.
         def fun(x):
             b = (x == 0) & (x > -1)
             return x + b.astype(mx.float32)


### PR DESCRIPTION
Fixes #3627 AND #3629

The jvp transform passes tangents packed: `tangents[i]` is the tangent of input `argnums[i]`, and a jvp returns one tangent per output. Four jvps broke this contract and read out of bounds when only some of their inputs were traced.

| jvp | bug | fix |
|---|---|---|
| `Select` | helper called with `argnums[i]` instead of `i`, so it read `argnums[argnums[i]]` and `tangents[1]`/`tangents[2]` | index by position, use `tangents[i]`; condition tangent gets the output dtype |
| `ArcTan2` | always read `tangents[1]`, OOB for `atan2(traced, constant)` | accumulate one term per traced input |
| `MaskedScatter` | read `tangents[1]` for the update even when it was the only traced input | use `tangents[i]` |
| `BitwiseBinary` | returned one tangent per traced input (vjp semantics), so the transform indexed `outputs[1]` OOB and corrupted the tangent map | return one zero tangent per output; vjp written out instead of delegating to jvp |

**Before**

```python
_, (dout,) = mx.jvp(lambda t: mx.where(t < -1.0, 999.0, t * t), [mx.array(3.0)], [mx.array(1.0)])
# dout = 0.0, silently wrong (vjp and finite differences give 6.0)
```

The repro in #3629 crashed 10/10 runs with segfaults and non-deterministic shape errors.

**After**

`dout = 6.0`, jvp matches vjp and finite differences, and the repro passes 10/10 runs.

Added a regression test per case and a debug assert in the jvp transform that a primitive returns at most one tangent per output. Also fixed the stale `argnums.size() == 2` assert in `ArcTan2::vjp` (one-sided grads aborted debug builds) and added a `where` test with a constant condition and both branches traced.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
