### PR TITLE
Roll back compile cache entry when the first trace throws

### DIFF
--- a/mlx/compile.cpp
+++ b/mlx/compile.cpp
@@ -1124,43 +1124,36 @@ ArrayFnWithExtra compile(
 
     // No matching cache entry existed, so compile
     if (entry.empty) {
-      // Mark the entry as not empty since we are about to fill it. If any of
-      // the steps below throw, roll the flag back so the half-filled entry is
-      // not mistaken for a usable one on a later call with matching inputs.
-      entry.empty = false;
-      try {
-        // Set the constants
-        entry.constants = std::move(constants);
-        // Trace to build the graph
-        std::tie(entry.inputs, entry.outputs, entry.extra) =
-            compile_trace(fun, inputs, shapeless);
+      // Set the constants
+      entry.constants = std::move(constants);
+      // Trace to build the graph
+      std::tie(entry.inputs, entry.outputs, entry.extra) =
+          compile_trace(fun, inputs, shapeless);
 
-        // DFS the graph and get a tape, and a map of array id to (parent,
-        // position in parent inputs)
-        std::unordered_map<uintptr_t, std::vector<std::pair<array, int>>>
-            parents_map;
-        std::tie(entry.tape, parents_map) =
-            compile_dfs(entry.inputs, entry.outputs, inputs);
+      // DFS the graph and get a tape, and a map of array id to (parent,
+      // position in parent inputs)
+      std::unordered_map<uintptr_t, std::vector<std::pair<array, int>>>
+          parents_map;
+      std::tie(entry.tape, parents_map) =
+          compile_dfs(entry.inputs, entry.outputs, inputs);
 
-        // Simplify the tape
-        auto mode = compile_mode().load();
-        if (mode != CompileMode::no_simplify) {
-          compile_simplify(
-              entry.tape, parents_map, entry.outputs, /* passes */ 3);
-        }
-
-        // Kernel fusion to generate Compiled primitives. The tape and
-        // new outputs must be updated accordingly
-        if (mode != CompileMode::no_fuse) {
-          compile_fuse(entry.tape, parents_map, entry.inputs, entry.outputs);
-        }
-      } catch (...) {
-        // Tracing failed, so the entry was never actually filled. Mark it
-        // empty again so a retry re-traces cleanly instead of replacing
-        // against an empty tape and silently returning empty outputs.
-        entry.empty = true;
-        throw;
+      // Simplify the tape
+      auto mode = compile_mode().load();
+      if (mode != CompileMode::no_simplify) {
+        compile_simplify(
+            entry.tape, parents_map, entry.outputs, /* passes */ 3);
       }
+
+      // Kernel fusion to generate Compiled primitives. The tape and
+      // new outputs must be updated accordingly
+      if (mode != CompileMode::no_fuse) {
+        compile_fuse(entry.tape, parents_map, entry.inputs, entry.outputs);
+      }
+
+      // Mark the entry as filled only after every step above completed, so
+      // a throwing first trace leaves the entry empty and a later call
+      // re-traces cleanly instead of hitting a half-filled entry
+      entry.empty = false;
     }
 
     // At this point we must have a tape, now replace the placeholders

--- a/mlx/compile.cpp
+++ b/mlx/compile.cpp
@@ -1124,32 +1124,42 @@ ArrayFnWithExtra compile(
 
     // No matching cache entry existed, so compile
     if (entry.empty) {
-      // Mark the entry as not empty since we are about to fill it
+      // Mark the entry as not empty since we are about to fill it. If any of
+      // the steps below throw, roll the flag back so the half-filled entry is
+      // not mistaken for a usable one on a later call with matching inputs.
       entry.empty = false;
-      // Set the constants
-      entry.constants = std::move(constants);
-      // Trace to build the graph
-      std::tie(entry.inputs, entry.outputs, entry.extra) =
-          compile_trace(fun, inputs, shapeless);
+      try {
+        // Set the constants
+        entry.constants = std::move(constants);
+        // Trace to build the graph
+        std::tie(entry.inputs, entry.outputs, entry.extra) =
+            compile_trace(fun, inputs, shapeless);
 
-      // DFS the graph and get a tape, and a map of array id to (parent,
-      // position in parent inputs)
-      std::unordered_map<uintptr_t, std::vector<std::pair<array, int>>>
-          parents_map;
-      std::tie(entry.tape, parents_map) =
-          compile_dfs(entry.inputs, entry.outputs, inputs);
+        // DFS the graph and get a tape, and a map of array id to (parent,
+        // position in parent inputs)
+        std::unordered_map<uintptr_t, std::vector<std::pair<array, int>>>
+            parents_map;
+        std::tie(entry.tape, parents_map) =
+            compile_dfs(entry.inputs, entry.outputs, inputs);
 
-      // Simplify the tape
-      auto mode = compile_mode().load();
-      if (mode != CompileMode::no_simplify) {
-        compile_simplify(
-            entry.tape, parents_map, entry.outputs, /* passes */ 3);
-      }
+        // Simplify the tape
+        auto mode = compile_mode().load();
+        if (mode != CompileMode::no_simplify) {
+          compile_simplify(
+              entry.tape, parents_map, entry.outputs, /* passes */ 3);
+        }
 
-      // Kernel fusion to generate Compiled primitives. The tape and
-      // new outputs must be updated accordingly
-      if (mode != CompileMode::no_fuse) {
-        compile_fuse(entry.tape, parents_map, entry.inputs, entry.outputs);
+        // Kernel fusion to generate Compiled primitives. The tape and
+        // new outputs must be updated accordingly
+        if (mode != CompileMode::no_fuse) {
+          compile_fuse(entry.tape, parents_map, entry.inputs, entry.outputs);
+        }
+      } catch (...) {
+        // Tracing failed, so the entry was never actually filled. Mark it
+        // empty again so a retry re-traces cleanly instead of replacing
+        // against an empty tape and silently returning empty outputs.
+        entry.empty = true;
+        throw;
       }
     }
 

--- a/tests/compile_tests.cpp
+++ b/tests/compile_tests.cpp
@@ -816,3 +816,31 @@ TEST_CASE("test compile random bits") {
   auto out = compile(fun)({in})[0];
   CHECK(array_equal(out, expected).item<bool>());
 }
+
+TEST_CASE("test compile throwing first trace does not poison cache") {
+  // A nullary function whose first trace raises. Without rolling the cache
+  // entry back, the second call with matching (empty) inputs would hit a
+  // half-filled entry, skip tracing, and silently return empty outputs.
+  bool should_throw = true;
+  auto fun = [&should_throw](const std::vector<array>& inputs) {
+    if (should_throw) {
+      throw std::runtime_error("trace failure");
+    }
+    return std::vector<array>{array(1.0f) + array(2.0f)};
+  };
+
+  auto cfun = compile(fun);
+
+  // First call: the trace raises and must propagate.
+  CHECK_THROWS_AS(cfun({}), std::runtime_error);
+
+  // Second call: still raising. It must re-trace and raise again rather than
+  // return an empty result from a poisoned cache entry.
+  CHECK_THROWS_AS(cfun({}), std::runtime_error);
+
+  // Once the function stops raising, a retry must trace cleanly and succeed.
+  should_throw = false;
+  auto out = cfun({});
+  REQUIRE_EQ(out.size(), 1);
+  CHECK_EQ(out[0].item<float>(), 3.0f);
+}


### PR DESCRIPTION
## Proposed changes

Fixes #3624.

The per-call lambda built by `compile()` marks a cache entry non-empty before it traces it:

```cpp
if (entry.empty) {
  entry.empty = false;                 // marked filled BEFORE the trace
  entry.constants = std::move(constants);
  std::tie(entry.inputs, entry.outputs, entry.extra) =
      compile_trace(fun, inputs, shapeless);   // may throw
  ...
}
```

If `compile_trace` (or the subsequent dfs, simplify, or fuse steps) throws on the first trace, the entry is left with `empty == false` but no `inputs`, `outputs`, or tape. A later call with matching inputs then `find()`s that entry, sees it is not empty, skips tracing, and `compile_replace`s against an empty tape, returning empty outputs as a spurious success instead of re-tracing or re-raising. A nullary compiled function is the sharpest case since its inputs always match.

This moves `entry.empty = false` to after the trace, dfs, simplify, and fuse steps complete, so a throwing first trace leaves the entry empty and a later call re-traces cleanly while a failure stays a failure. This is the approach @zcbenz endorsed on the issue. A retry reassigns `constants`, `inputs`, `outputs`, and the tape when it re-enters the fill path, so the partially assigned fields from the failed attempt are overwritten.

## Testing

Added a C++ regression test in `tests/compile_tests.cpp` that compiles a nullary function which raises on its first invocation, then calls it twice. Without the fix the second call returns 0 outputs instead of raising. With the fix both calls raise, and once the function stops raising a retry traces cleanly and returns the correct result.

Verified on macOS (CPU-only build): the new test fails on `main` (second call did not throw, `out.size()` was 0) and passes with the fix. The full compile suite (23 cases, 111 assertions) is green. Both touched files pass clang-format.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
