### PR TITLE
Fix JVPs of power, divmod, and slice_update with partly traced inputs

### DIFF
--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -1806,7 +1806,9 @@ std::vector<array> DivMod::jvp(
     const std::vector<array>& primals,
     const std::vector<array>& tangents,
     const std::vector<int>& argnums) {
-  return {zeros_like(primals[0], stream())};
+  // One tangent per output; inputs are pre-broadcast and pre-promoted
+  auto zero = zeros_like(primals[0], stream());
+  return {zero, zero};
 }
 
 std::pair<std::vector<array>, std::vector<int>> DivMod::vmap(
@@ -3409,12 +3411,12 @@ std::vector<array> Power::jvp(
     const std::vector<array>& tangents,
     const std::vector<int>& argnums) {
   auto output = power(primals[0], primals[1], stream());
-  auto grads = vjp(primals, tangents, argnums, {output});
-  if (argnums.size() > 1) {
-    return {add(grads[0], grads[1], stream())};
-  } else {
-    return grads;
+  auto jvp = vjp(primals, {tangents[0]}, {argnums[0]}, {output})[0];
+  for (int i = 1; i < argnums.size(); ++i) {
+    jvp = add(
+        jvp, vjp(primals, {tangents[i]}, {argnums[i]}, {output})[0], stream());
   }
+  return {jvp};
 }
 
 std::pair<std::vector<array>, std::vector<int>> Power::vmap(
@@ -5215,8 +5217,20 @@ std::vector<array> DynamicSliceUpdate::vjp(
 std::vector<array> DynamicSliceUpdate::jvp(
     const std::vector<array>& primals,
     const std::vector<array>& tangents,
-    const std::vector<int>&) {
-  return {slice_update(tangents[0], tangents[1], primals[2], axes_, stream())};
+    const std::vector<int>& argnums) {
+  array tan_src = zeros_like(primals[0], stream());
+  array tan_upd = zeros_like(primals[1], stream());
+  for (int i = 0; i < argnums.size(); ++i) {
+    if (argnums[i] == 0) {
+      tan_src = tangents[i];
+    } else if (argnums[i] == 1) {
+      tan_upd = tangents[i];
+    } else {
+      throw std::invalid_argument(
+          "[DynamicSliceUpdate::jvp] Not supported for start indices");
+    }
+  }
+  return {slice_update(tan_src, tan_upd, primals[2], axes_, stream())};
 }
 
 bool DynamicSliceUpdate::is_equivalent(const Primitive& other) const {

--- a/python/tests/test_autograd.py
+++ b/python/tests/test_autograd.py
@@ -1,6 +1,7 @@
 # Copyright © 2023 Apple Inc.
 
 import gc
+import math
 import unittest
 
 import mlx.core as mx
@@ -69,6 +70,50 @@ class TestAutograd(mlx_tests.MLXTestCase):
         self.assertEqual(out[0].item(), 4.0 * 1.0)
         self.assertEqual(out[1].item(), 2.0 * 1.0 + 6.0 * 3.0)
         self.assertEqual(out[2].item(), 4.0 * 3.0)
+
+    def test_jvp_with_partly_traced_inputs(self):
+        # power: each traced input must use its own tangent (issue #3634)
+        fun = lambda a, b: a**b
+        primals = [mx.array(2.0), mx.array(3.0)]
+        dyda = 12.0  # d/da a^b = b * a^(b - 1)
+        dydb = math.log(2.0) * 8.0  # d/db a^b = ln(a) * a^b
+        _, (j,) = mx.jvp(fun, primals, [mx.array(1.0), mx.array(0.0)])
+        self.assertAlmostEqual(j.item(), dyda, places=4)
+        _, (j,) = mx.jvp(fun, primals, [mx.array(0.0), mx.array(1.0)])
+        self.assertAlmostEqual(j.item(), dydb, places=4)
+        _, (j,) = mx.jvp(fun, primals, [mx.array(1.0), mx.array(1.0)])
+        self.assertAlmostEqual(j.item(), dyda + dydb, places=4)
+        fun = lambda a: a ** mx.array(3.0)
+        _, (j,) = mx.jvp(fun, [mx.array(2.0)], [mx.array(1.0)])
+        self.assertAlmostEqual(j.item(), dyda, places=4)
+        fun = lambda b: mx.array(2.0) ** b
+        _, (j,) = mx.jvp(fun, [mx.array(3.0)], [mx.array(1.0)])
+        self.assertAlmostEqual(j.item(), dydb, places=4)
+
+        # divmod: one tangent per output, and consuming the second output
+        # used to crash (issue #3634)
+        def fun(x):
+            q, r = mx.divmod(x, mx.array(3.0))
+            return q, -r
+
+        _, (dq, dr) = mx.jvp(fun, [mx.array(7.0)], [mx.array(1.0)])
+        self.assertEqual(dq.item(), 0.0)
+        self.assertEqual(dr.item(), 0.0)
+
+        # slice_update with dynamic start indices and a subset of traced
+        # inputs (issue #3634)
+        src = mx.zeros(4)
+        upd = mx.ones(2)
+        start = mx.array([1])
+        fun = lambda u: mx.slice_update(src, u, start, axes=[0])
+        _, (j,) = mx.jvp(fun, [upd], [mx.ones(2)])
+        self.assertEqual(j.tolist(), [0.0, 1.0, 1.0, 0.0])
+        fun = lambda s: mx.slice_update(s, upd, start, axes=[0])
+        _, (j,) = mx.jvp(fun, [src], [mx.ones(4)])
+        self.assertEqual(j.tolist(), [1.0, 0.0, 0.0, 1.0])
+        fun = lambda s, u: mx.slice_update(s, u, start, axes=[0])
+        _, (j,) = mx.jvp(fun, [src, upd], [mx.ones(4), mx.full(2, 2.0)])
+        self.assertEqual(j.tolist(), [1.0, 2.0, 2.0, 1.0])
 
     def test_grad(self):
         fun = lambda x: x * x


### PR DESCRIPTION
Fixes #3634

Same class as #3627/#3629 (fixed by #3633): 

`Primitive::jvp` implementations that break the packed-tangents convention (`tangents[i]` is the tangent of input `argnums[i]`; a jvp returns one tangent per output).

| jvp | bug | fix |
|---|---|---|
| `Power` | delegated to `vjp`, which scales every partial by `cotangents[0]`, so with both inputs traced both partials used the first input's tangent and the second tangent was ignored | one `vjp` call per traced input with its own tangent as the cotangent, summed |
| `DivMod` | returned one tangent for a two-output primitive, so the second output never entered the tangent map and its consumer was invoked with empty `argnums`/`tangents` — segfault | return one zero tangent per output (divmod stays non-differentiable, matching its vjp) |
| `DynamicSliceUpdate` | ignored `argnums` and read `tangents[0]`/`tangents[1]` unconditionally — OOB segfault with one traced input, mispaired tangents for `argnums = {0, 2}` | untraced inputs get zero tangents; traced start indices throw, matching the vjp |

**Before**

```python
_, (j,) = mx.jvp(lambda a, b: a**b, [mx.array(2.0), mx.array(3.0)],
                 [mx.array(0.0), mx.array(1.0)])
# j = 0.0, silently wrong (vjp and finite differences give ln(2)·8 ≈ 5.5452)
```

The divmod and slice_update repros in #3634 segfaulted.

**After**

`j = 5.5452`, jvp matches vjp and finite differences, and all repros pass.

Added a regression test covering tangent pairing for power, per-output tangents for divmod (including a consumer of the second output), and dynamic slice_update with each subset of traced inputs. Each case fails on unfixed main (wrong value for power, segfault for the other two).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
