### PR TITLE
Fix data race in tracing state by making it thread-local

### DIFF
--- a/mlx/transforms.cpp
+++ b/mlx/transforms.cpp
@@ -63,13 +63,15 @@ class Synchronizer : public Primitive {
 // These are used to implement the in_tracing() function the returns true if we
 // are currently under a function transformation and the retain_graph()
 // function which returns true if we are forced to retain the graph during
-// evaluation.
+// evaluation. They are thread_local since a trace belongs to the thread that
+// runs it, so that concurrent transforms on different threads do not race on
+// shared tracing state.
 std::vector<std::pair<char, char>>& detail::InTracing::trace_stack() {
-  static std::vector<std::pair<char, char>> trace_stack_;
+  static thread_local std::vector<std::pair<char, char>> trace_stack_;
   return trace_stack_;
 }
-int detail::InTracing::grad_counter{0};
-int detail::RetainGraph::tracing_counter{0};
+thread_local int detail::InTracing::grad_counter{0};
+thread_local int detail::RetainGraph::tracing_counter{0};
 
 array eval_impl(std::vector<array> outputs, bool async) {
   std::deque<array> tape;

--- a/mlx/transforms_impl.h
+++ b/mlx/transforms_impl.h
@@ -44,7 +44,7 @@ struct InTracing {
   }
 
  private:
-  static int grad_counter;
+  static thread_local int grad_counter;
   static std::vector<std::pair<char, char>>& trace_stack();
 };
 
@@ -61,7 +61,7 @@ struct RetainGraph {
   }
 
  private:
-  static int tracing_counter;
+  static thread_local int tracing_counter;
 };
 
 /** Return true if we are currently performing a function transformation in

--- a/python/tests/test_threads.py
+++ b/python/tests/test_threads.py
@@ -47,6 +47,66 @@ class TestThreads(mlx_tests.MLXTestCase):
         t2.join()
         self.assertFalse(any(raised))
 
+    def test_concurrent_transforms(self):
+        # Running function transformations from multiple threads concurrently
+        # must not crash or corrupt results. The tracing state used to mark
+        # "we are inside a transformation" is per-thread, so independent traces
+        # on different threads do not interfere.
+        x = mx.array([1.0, 2.0, 3.0])
+        n_iters = 2000
+
+        # Single-threaded references.
+        expected_grad = mx.grad(lambda a: (a * a).sum())(x).tolist()
+        expected_compile = mx.compile(lambda a: a * a + 1)(x).tolist()
+        xb = mx.broadcast_to(x, (8, 3))
+        expected_vmap = mx.vmap(lambda a: a * a)(xb).tolist()
+
+        errors = []
+
+        def grad_worker():
+            try:
+                g = mx.grad(lambda a: (a * a).sum())
+                for _ in range(n_iters):
+                    r = g(x)
+                    mx.eval(r)
+                    if r.tolist() != expected_grad:
+                        errors.append(("grad", r.tolist()))
+                        return
+            except Exception as e:
+                errors.append(("grad", repr(e)))
+
+        def compile_worker():
+            try:
+                f = mx.compile(lambda a: a * a + 1)
+                for _ in range(n_iters):
+                    r = f(x)
+                    mx.eval(r)
+                    if r.tolist() != expected_compile:
+                        errors.append(("compile", r.tolist()))
+                        return
+            except Exception as e:
+                errors.append(("compile", repr(e)))
+
+        def vmap_worker():
+            try:
+                h = mx.vmap(lambda a: a * a)
+                for _ in range(n_iters):
+                    r = h(xb)
+                    mx.eval(r)
+                    if r.tolist() != expected_vmap:
+                        errors.append(("vmap", r.tolist()))
+                        return
+            except Exception as e:
+                errors.append(("vmap", repr(e)))
+
+        workers = [grad_worker, compile_worker, vmap_worker]
+        threads = [threading.Thread(target=workers[i % 3]) for i in range(9)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertEqual(errors, [])
+
 
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner()


### PR DESCRIPTION
Fixes #3620

## Summary
The state that marks "we are inside a function transformation" — `InTracing::trace_stack_`, `InTracing::grad_counter` and `RetainGraph::tracing_counter` — is held in process-global statics. They are mutated by every `grad`/`jvp`/`vjp`/`vmap`/`compile` trace, so running transforms concurrently from multiple threads races on this shared state (undefined behaviour). This makes the tracing state `thread_local`.

## Problem
`mlx/transforms.cpp` stores the tracing flags as plain statics, pushed/popped and incremented by the `InTracing`/`RetainGraph` RAII guards on every transform. Two threads entering transforms at the same time read/write the same vector and counters without synchronisation:

```python
import threading, mlx.core as mx

def tracer():
    f = mx.compile(lambda x: x * x + 1)
    for _ in range(100000):
        mx.eval(f(mx.array([1.0, 2.0, 3.0])))

def grader():
    g = mx.grad(lambda x: (x * x).sum())
    for _ in range(100000):
        mx.eval(g(mx.array([1.0, 2.0, 3.0])))

t1 = threading.Thread(target=tracer)
t2 = threading.Thread(target=grader)
t1.start(); t2.start(); t1.join(); t2.join()
```

Built with ThreadSanitizer this reports data races on `InTracing::trace_stack()::trace_stack_`, `InTracing::grad_counter` and `RetainGraph::tracing_counter`.

## Fix
Make the tracing/retain state `thread_local`. A trace belongs to the thread that runs it: these flags are only consulted during graph construction (via `array::is_tracer()`), on the same thread that holds the `InTracing`/`RetainGraph` guard — by the time the resulting arrays are evaluated the guards are already destroyed, so eval-time behaviour is unchanged. Per-thread state therefore removes the race and preserves semantics, at zero cost for single-threaded use.

## Test
- Verified with ThreadSanitizer (CPU build, `-DUSE_TSAN=ON`) that the concurrent-transforms repro races before the change and that the three tracing-state races are gone afterwards.
- Added `test_concurrent_transforms` to `python/tests/test_threads.py`, which runs `grad`/`compile`/`vmap` from multiple threads and checks results against a single-threaded reference. `test_autograd`, `test_compile` and `test_vmap` continue to pass.
