### PR TITLE
Raise on arange with step == 0 instead of undefined behavior

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -168,6 +168,10 @@ array arange(
     throw std::invalid_argument("[arange] Cannot compute length.");
   }
 
+  if (step == 0) {
+    throw std::invalid_argument("[arange] step must be nonzero.");
+  }
+
   // Check if start and stop specify a valid range because if not, we have to
   // return an empty array
   if (std::isinf(step) &&

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -1433,6 +1433,13 @@ class TestOps(mlx_tests.MLXTestCase):
         expected = [0, 1, 2]
         self.assertListEqual(a.tolist(), expected)
 
+        # A zero step has no defined length; it must raise rather than divide by
+        # zero and cast the resulting nan/inf to int (undefined behavior).
+        with self.assertRaises(ValueError):
+            mx.arange(2, 2, 0)
+        with self.assertRaises(ValueError):
+            mx.arange(0, 5, 0)
+
     def test_arange_inferred_dtype(self):
         a = mx.arange(5)
         self.assertEqual(a.dtype, mx.int32)


### PR DESCRIPTION
## Proposed changes

`arange` validates `start`, `stop`, and `step` for NaN and infinity, but never checks for `step == 0`. With a zero step the length computation divides by zero:

```cpp
double real_size = std::ceil((stop - start) / step);   // (stop-start)/0
...
int size = std::max(static_cast<int>(real_size), 0);   // static_cast<int>(nan/inf)
```

`(stop - start) / 0` is `nan` when `stop == start` and `±inf` otherwise; casting either to `int` is undefined behavior. UBSan reports it at this cast for `mx.arange(2, 2, 0)`:

```
mlx/ops.cpp: runtime error: nan is outside the range of representable values of type 'int'
```

This is reachable straight from the public Python API (`mx.arange(2, 2, 0)`); NumPy raises `ZeroDivisionError` for the equivalent call. This adds an explicit guard that throws `[arange] step must be nonzero.` before the division, matching the style of the existing NaN/inf checks.

Verified against a UBSan build: before the change `arange(2, 2, 0)` triggers the cast UB; after it throws cleanly and valid `arange` calls are unaffected. Added a regression test in `python/tests/test_ops.py`.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective
