### PR TITLE
Correct grammatical typo in label smoothing ValueError

### DIFF
--- a/python/mlx/nn/losses.py
+++ b/python/mlx/nn/losses.py
@@ -65,7 +65,7 @@ def cross_entropy(
         array([0.348587, 0.348587], dtype=float32)
     """
     if label_smoothing < 0 or label_smoothing >= 1:
-        raise ValueError(f"Label smoothing must in [0, 1), got {label_smoothing}.")
+        raise ValueError(f"Label smoothing must be in [0, 1), got {label_smoothing}.")
 
     # Whether targets are class indices or probabilities
     targets_as_probs = targets.ndim == logits.ndim


### PR DESCRIPTION
## Proposed changes

This PR fixes a minor grammatical typo in the ValueError message raised when the label_smoothing parameter in cross_entropy is out of the valid [0, 1) range.

**Before:** "Label smoothing must in [0, 1), got {label_smoothing}."
**After:** "Label smoothing must be in [0, 1), got {label_smoothing}."

While simple, error messages are a primary interface for developers using MLX. Grammatically correct and clear error messages:

1. Enhance Developer Experience (DX): Prevent momentary cognitive overhead or confusion when a user is diagnosing parameter issues during training configuration.
2. Polished API Presentation: Keep the library's developer-facing interface clean and professional.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
