### PR TITLE
Fix Select::jvp tangent indexing (silent zero JVP through mx.where)

### DIFF
--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -3146,8 +3146,9 @@ std::vector<array> Select::jvp(
     const std::vector<array>& tangents,
     const std::vector<int>& argnums) {
   assert(primals.size() == 3);
-  assert(tangents.size() == 3);
+  assert(tangents.size() == argnums.size());
 
+  // tangents[i] is the tangent for argnums[i] (compact, positional).
   auto jvp_fun = [&](int i) {
     int arg = argnums[i];
 
@@ -3155,21 +3156,21 @@ std::vector<array> Select::jvp(
       return zeros_like(primals[0], stream());
     } else if (arg == 1) {
       return multiply(
-          astype(primals[0], tangents[1].dtype(), stream()),
-          tangents[1],
+          astype(primals[0], tangents[i].dtype(), stream()),
+          tangents[i],
           stream());
     } else {
       return multiply(
           astype(
-              logical_not(primals[0], stream()), tangents[2].dtype(), stream()),
-          tangents[2],
+              logical_not(primals[0], stream()), tangents[i].dtype(), stream()),
+          tangents[i],
           stream());
     }
   };
 
-  array jvp = jvp_fun(argnums[0]);
-  for (int i = 1; i < argnums.size(); i++) {
-    jvp = add(jvp, jvp_fun(argnums[i]));
+  array jvp = jvp_fun(0);
+  for (int i = 1; i < static_cast<int>(argnums.size()); i++) {
+    jvp = add(jvp, jvp_fun(i));
   }
   return {jvp};
 }

--- a/python/tests/test_autograd.py
+++ b/python/tests/test_autograd.py
@@ -30,6 +30,56 @@ class TestAutograd(mlx_tests.MLXTestCase):
         self.assertEqual(out[0].item(), 4.0 * 1.0 + 2.0 * 3.0)
         self.assertEqual(out[1].item(), 4.0 * 1.0 + 6.0 * 3.0)
 
+    def test_jvp_where_tangent_indexing(self):
+        # Regression test for Select::jvp tangent mis-indexing (issue #3627).
+        # When the constant is in the TRUE branch and the traced value is in
+        # the FALSE branch, JVP must return the false-branch tangent, not zero.
+        theta = mx.array(0.0)
+        v = mx.array(1.0)
+        cot = mx.array(1.0)
+
+        # Variant A: traced in TRUE, constant in FALSE — must give +2
+        def fA(x):
+            y = (x + 1.0) ** 2
+            return mx.where(y > -1.0, y, mx.array(999.0))
+
+        _, jvA = mx.jvp(fA, [theta], [v])
+        mx.eval(jvA[0])
+        self.assertAlmostEqual(jvA[0].item(), 2.0, places=5)
+
+        # Variant B: constant in TRUE, traced in FALSE — was returning 0 (bug)
+        def fB(x):
+            y = (x + 1.0) ** 2
+            return mx.where(y < -1.0, mx.array(999.0), y)
+
+        _, jvB = mx.jvp(fB, [theta], [v])
+        mx.eval(jvB[0])
+        self.assertAlmostEqual(jvB[0].item(), 2.0, places=5)
+
+        # Variant C: both branches traced — must give same result as VJP
+        def fC(x):
+            y = (x + 1.0) ** 2
+            z = x + 2.0
+            return mx.where(y > -1.0, y, z)
+
+        _, (vjC,) = mx.vjp(fC, [theta], [cot])
+        _, (jvC,) = mx.jvp(fC, [theta], [v])
+        mx.eval(vjC, jvC)
+        self.assertAlmostEqual(jvC.item(), vjC.item(), places=5)
+
+        # Variant D: JVP through where with only the FALSE branch traced,
+        # using a batched (non-scalar) input to exercise shape handling
+        def fD(x):
+            y = x**2
+            return mx.where(y < 0.0, mx.zeros_like(y), y)
+
+        x_batch = mx.array([-2.0, 0.0, 3.0])
+        v_batch = mx.ones_like(x_batch)
+        _, (jvD,) = mx.jvp(fD, [x_batch], [v_batch])
+        mx.eval(jvD)
+        expected = mx.array([-4.0, 0.0, 6.0])
+        self.assertTrue(mx.allclose(jvD, expected).item())
+
     def test_jvp_comparison_tangent_dtype(self):
         # Comparison op JVP tangents should preserve the input tangent's
         # dtype (e.g. float32), not return bool. Using bool tangents causes


### PR DESCRIPTION
## Summary

Fixes #3627.

`mx.jvp` silently returned zero when differentiating through `mx.where(cond, constant, traced_value)` — when the constant is in the true branch and the traced value is in the false branch.

## Root Cause

`Select::jvp` in `mlx/primitives.cpp` had three related indexing errors.

The JVP driver in `transforms.cpp` builds a **compact** tangent vector: `tangents[i]` is the tangent for `argnums[i]`, not for argument number `i`. Every other primitive JVP follows this positional convention. `Select::jvp` did not:

1. **Wrong assertion** — `assert(tangents.size() == 3)` assumed a full-length vector; corrected to `assert(tangents.size() == argnums.size())`.

2. **Wrong call sites** — `jvp_fun(argnums[0])` and `jvp_fun(argnums[i])` passed argument numbers (1 or 2) as the positional index `i`. Inside the lambda, `int arg = argnums[i]` then accessed `argnums` out-of-bounds (UB in release mode). In practice the OOB read returned 0, hitting the `arg == 0` branch and returning `zeros_like`. Corrected to `jvp_fun(0)` / `jvp_fun(i)`.

3. **Wrong tangent access** — `tangents[1]` and `tangents[2]` were hard-coded absolute argument indices instead of `tangents[i]`. Corrected to `tangents[i]`.

## Tests

Added `test_jvp_where_tangent_indexing` in `test_autograd.py` covering all four variants:

| Variant | Description | Before | After |
|---|---|---|---|
| A | `where(cond, traced, const)` | correct | correct |
| B | `where(cond, const, traced)` | returned 0 (bug) | returns 2.0 |
| C | `where(cond, traced, traced)` | correct | correct |
| D | batched false-branch-only input | broken | correct |