### PR TITLE
Fix CPU gather transposing column-contiguous slices

### DIFF
--- a/mlx/backend/cpu/indexing.cpp
+++ b/mlx/backend/cpu/indexing.cpp
@@ -66,43 +66,26 @@ void gather(
     array& out,
     const std::vector<int>& axes,
     const Shape& slice_sizes) {
-  // If the array is row contiguous then we can do a contiguous copy given
-  // two conditions on the slice size:
-  // - Any number of leading ones in the slice sizes are allowed
-  // - All other slice sizes match the corresponding dimension except the
-  //   first non-singleton slice size
-  // If the array is col contiguous then the reverse is the case:
-  // - Any number of trailing ones in the slice sizes are allowed
-  // - All other slice sizes match the corresponding dimension except the
-  //   first non-singleton slice size from the end
-
-  bool can_copy = false;
-  if (src.flags().row_contiguous) {
-    can_copy = true;
-
-    // Ignore leading 1s
-    int i = 0;
-    for (; i < slice_sizes.size() && slice_sizes[i] == 1; ++i)
-      ;
-
-    // Check the remaining
-    i++;
-    for (; i < src.ndim() && can_copy; ++i) {
-      can_copy = (src.shape(i) == slice_sizes[i]);
+  // Each gathered slice is written into the (row-contiguous) output as a
+  // sequential block. We can therefore replace the per-element strided read
+  // with a single contiguous copy only when the slice is itself laid out
+  // contiguously in row-major order within the source. That holds exactly when
+  // every non-singleton slice dimension has a source stride equal to the
+  // product of the slice sizes of the dimensions inside it. Size-1 dimensions
+  // are skipped since their stride is irrelevant.
+  //
+  // Checking the strides directly (rather than relying on the row/col
+  // contiguous flags) is important: a column-contiguous source is contiguous
+  // in memory but in column-major order, so copying a multi-dimensional slice
+  // as a raw block would transpose it.
+  bool can_copy = true;
+  int64_t expected_stride = 1;
+  for (int i = src.ndim() - 1; i >= 0 && can_copy; --i) {
+    if (slice_sizes[i] == 1) {
+      continue;
     }
-  } else if (src.flags().col_contiguous) {
-    can_copy = true;
-
-    // Ignore trailing 1s
-    int i = slice_sizes.size() - 1;
-    for (; i >= 0 && slice_sizes[i] == 1; --i)
-      ;
-
-    // Skip the next slice size and check the remaining
-    i--;
-    for (; i >= 0 && can_copy; --i) {
-      can_copy = (src.shape(i) == slice_sizes[i]);
-    }
+    can_copy = (src.strides()[i] == expected_stride);
+    expected_stride *= slice_sizes[i];
   }
   size_t slice_size = 1;
   for (auto s : slice_sizes) {

--- a/mlx/backend/cpu/indexing.cpp
+++ b/mlx/backend/cpu/indexing.cpp
@@ -69,15 +69,7 @@ void gather(
   // Each gathered slice is written into the (row-contiguous) output as a
   // sequential block. We can therefore replace the per-element strided read
   // with a single contiguous copy only when the slice is itself laid out
-  // contiguously in row-major order within the source. That holds exactly when
-  // every non-singleton slice dimension has a source stride equal to the
-  // product of the slice sizes of the dimensions inside it. Size-1 dimensions
-  // are skipped since their stride is irrelevant.
-  //
-  // Checking the strides directly (rather than relying on the row/col
-  // contiguous flags) is important: a column-contiguous source is contiguous
-  // in memory but in column-major order, so copying a multi-dimensional slice
-  // as a raw block would transpose it.
+  // contiguously in row-major order within the source.
   bool can_copy = true;
   int64_t expected_stride = 1;
   for (int i = src.ndim() - 1; i >= 0 && can_copy; --i) {

--- a/tests/ops_tests.cpp
+++ b/tests/ops_tests.cpp
@@ -2264,6 +2264,42 @@ TEST_CASE("test take") {
   CHECK_THROWS(take(a, zeros({2, 3, 2}), 0));
 }
 
+TEST_CASE("test gather contiguity") {
+  // Regression test for a CPU-backend bug where the gather "fast copy" path
+  // copied a multi-dimensional slice from a column-contiguous source as a raw
+  // (column-major) memory block, producing a transposed/wrong-stride result.
+  // The bug only showed up on the CPU backend and is exercised by:
+  //  - chained takes through a size-1 axis (which produce a col-contiguous
+  //    intermediate), and
+  //  - a direct take from a transposed (col-contiguous) source.
+
+  // Chained gather through size-1 axes (issue repro).
+  {
+    auto u = reshape(array({1.0f, 2.0f}), {2, 1, 1});
+    auto g = take(u, array({0, 1}, int32), 0, Device::cpu);
+    g = take(g, array({0, 0, 0}, int32), 1, Device::cpu);
+    g = take(g, array({0, 0, 0}, int32), 2, Device::cpu);
+    CHECK_EQ(g.shape(), Shape{2, 3, 3});
+    // Each batch must be uniform: batch 0 -> 1.0, batch 1 -> 2.0.
+    auto expected = array(
+        {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f,
+         2.0f, 2.0f, 2.0f, 2.0f, 2.0f, 2.0f, 2.0f, 2.0f, 2.0f},
+        {2, 3, 3});
+    CHECK(array_equal(g, expected).item<bool>());
+  }
+
+  // Direct take from a column-contiguous source with a multi-dim slice.
+  {
+    auto base = astype(reshape(arange(24), {4, 3, 2}), int32);
+    auto a = transpose(base, {2, 1, 0}); // [2, 3, 4], col-contiguous
+    auto t = take(a, array({0, 1}, int32), 2, Device::cpu);
+    CHECK_EQ(t.shape(), Shape{2, 3, 2});
+    auto expected = array(
+        {0, 6, 2, 8, 4, 10, 1, 7, 3, 9, 5, 11}, {2, 3, 2}, int32);
+    CHECK(array_equal(t, expected).item<bool>());
+  }
+}
+
 TEST_CASE("test take along axis") {
   // No zero dim arrays
   auto a = array(1);

--- a/tests/ops_tests.cpp
+++ b/tests/ops_tests.cpp
@@ -2282,8 +2282,24 @@ TEST_CASE("test gather contiguity") {
     CHECK_EQ(g.shape(), Shape{2, 3, 3});
     // Each batch must be uniform: batch 0 -> 1.0, batch 1 -> 2.0.
     auto expected = array(
-        {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f,
-         2.0f, 2.0f, 2.0f, 2.0f, 2.0f, 2.0f, 2.0f, 2.0f, 2.0f},
+        {1.0f,
+         1.0f,
+         1.0f,
+         1.0f,
+         1.0f,
+         1.0f,
+         1.0f,
+         1.0f,
+         1.0f,
+         2.0f,
+         2.0f,
+         2.0f,
+         2.0f,
+         2.0f,
+         2.0f,
+         2.0f,
+         2.0f,
+         2.0f},
         {2, 3, 3});
     CHECK(array_equal(g, expected).item<bool>());
   }
@@ -2294,8 +2310,8 @@ TEST_CASE("test gather contiguity") {
     auto a = transpose(base, {2, 1, 0}); // [2, 3, 4], col-contiguous
     auto t = take(a, array({0, 1}, int32), 2, Device::cpu);
     CHECK_EQ(t.shape(), Shape{2, 3, 2});
-    auto expected = array(
-        {0, 6, 2, 8, 4, 10, 1, 7, 3, 9, 5, 11}, {2, 3, 2}, int32);
+    auto expected =
+        array({0, 6, 2, 8, 4, 10, 1, 7, 3, 9, 5, 11}, {2, 3, 2}, int32);
     CHECK(array_equal(t, expected).item<bool>());
   }
 }


### PR DESCRIPTION
## Summary

`mx.take` (gather) on the **CPU** backend returns a transposed / wrong-stride result when the source is **column-contiguous** and the gathered slice spans more than one non-singleton dimension. The GPU backend is correct.

The `gather` "fast copy" path in `mlx/backend/cpu/indexing.cpp` decided whether each gathered slice could be copied as a single contiguous block based on the source's `row_contiguous` / `col_contiguous` flags. The gather output is always written in **row-major** order, but a **column-contiguous** source is contiguous in memory in **column-major** order — so copying a multi-dimensional slice as a raw block transposes it.

This surfaces via:
- **chained `take`** through size-1 axes, which produces a column-contiguous intermediate, and
- a **direct `take`** from a transposed (column-contiguous) source.

## Repro

```python
import mlx.core as mx
import numpy as np

# 1) chained take through size-1 axes
with mx.stream(mx.cpu):
    u = mx.array([1.0, 2.0], dtype=mx.float32).reshape(2, 1, 1)
    g = mx.take(u, mx.array([0, 1], dtype=mx.int32), axis=0)
    g = mx.take(g, mx.array([0, 0, 0], dtype=mx.int32), axis=1)
    g = mx.take(g, mx.array([0, 0, 0], dtype=mx.int32), axis=2)
    mx.eval(g)

# 2) direct take from a transposed (col-contiguous) source
with mx.stream(mx.cpu):
    a = mx.transpose(mx.arange(24).reshape(4, 3, 2), (2, 1, 0))  # [2,3,4] col-contiguous
    t = mx.take(a, mx.array([0, 1], dtype=mx.int32), axis=2)
    mx.eval(t)
```

**Before this fix** (disagrees with NumPy / the GPU backend):

```
chained take  mlx  : [1 1 1 2 2 2 1 1 1 2 2 2 1 1 1 2 2 2]
              numpy: [1 1 1 1 1 1 1 1 1 2 2 2 2 2 2 2 2 2]
col take      mlx  : [0 6 1 7 2 8 3 9 4 10 5 11]
              numpy: [0 6 2 8 4 10 1 7 3 9 5 11]
```

**After this fix** both match NumPy.

Originally found while differential-testing a CPU reference against the GPU/MPS path; a downstream consumer reaches this through a `dynamic_update_slice` lowering that expands to a chained-`take` + mask + `where`.

## Fix

Replace the flag-based heuristic with a direct check that the slice is genuinely **row-major contiguous within the source**: each non-singleton slice dimension's source stride must equal the product of the slice sizes of the dimensions inside it (size-1 dimensions are skipped, since their stride is irrelevant). This is the exact precondition for the contiguous `std::copy`; everything else falls back to the strided iterator. The check is also strictly more correct than the previous row-contiguous branch.

## Testing

- Added a `test gather contiguity` C++ regression case (`tests/ops_tests.cpp`) covering both scenarios, forced onto the CPU device.
- Full C++ test suite passes (253 cases / 3445 assertions).
- Verified end-to-end through the Python wrapper: the repro above matches NumPy with the fix and mismatches without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
