### PR TITLE
fix(shapeless): infer dynamic dim in Unflatten::output_shapes (#2607)

### DIFF
--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -2200,7 +2200,36 @@ Shape Unflatten::output_shape(
 }
 
 std::vector<Shape> Unflatten::output_shapes(const std::vector<array>& inputs) {
-  return {Unflatten::output_shape(inputs[0], axis_, shape_)};
+  auto flat_actual = inputs[0].shape()[axis_];
+
+  // Compute the stored product so we can detect a shape mismatch in
+  // shapeless mode (e.g. when the contracted matmul batch dim changes).
+  int flat_stored = 1;
+  for (auto s : shape_) {
+    flat_stored *= s;
+  }
+
+  if (flat_actual == flat_stored) {
+    return {Unflatten::output_shape(inputs[0], axis_, shape_)};
+  }
+
+  // Shapeless mode: the flat dimension changed.  Find the rightmost dimension
+  // in shape_ whose removal leaves a divisor of flat_actual and scale it to
+  // absorb the new size.  This handles the common transformer pattern where
+  // batch dims are static but seq_len is dynamic.
+  for (int i = (int)shape_.size() - 1; i >= 0; --i) {
+    int other = flat_stored / shape_[i];
+    if (other > 0 && flat_actual % other == 0) {
+      Shape dyn_shape = shape_;
+      dyn_shape[i] = flat_actual / other;
+      return {Unflatten::output_shape(inputs[0], axis_, dyn_shape)};
+    }
+  }
+
+  throw std::invalid_argument(
+      "[Unflatten::output_shapes] Cannot infer output shape in shapeless mode: "
+      "flat size " + std::to_string(flat_actual) +
+      " is not divisible by any sub-product of the stored expansion.");
 }
 
 std::pair<std::vector<array>, std::vector<int>> FFT::vmap(

--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -2228,7 +2228,8 @@ std::vector<Shape> Unflatten::output_shapes(const std::vector<array>& inputs) {
 
   throw std::invalid_argument(
       "[Unflatten::output_shapes] Cannot infer output shape in shapeless mode: "
-      "flat size " + std::to_string(flat_actual) +
+      "flat size " +
+      std::to_string(flat_actual) +
       " is not divisible by any sub-product of the stored expansion.");
 }
 

--- a/python/tests/test_export_import.py
+++ b/python/tests/test_export_import.py
@@ -615,6 +615,53 @@ class TestExportImport(mlx_tests.MLXTestCase):
         imported = mx.import_function(path)
         self.assertTrue(mx.array_equal(imported(x, y, z)[0], fun(x, y, z)))
 
+    def test_export_matmul_shapeless_mid_dim(self):
+        # Regression test for issue #2607:
+        # shapeless export of (B, T, E) @ (E, H) must allow T to vary on import.
+        # The matmul path flattens the batch dims, does a 2-D matmul, then
+        # unflattens.  Unflatten::output_shapes must infer the new T rather
+        # than returning the trace-time value.
+        path = os.path.join(self.test_dir, "matmul_shapeless.mlxfn")
+
+        E, H = 64, 17
+        arr = mx.arange(E * H, dtype=mx.float32).reshape((E, H)) * (1.0 / (E * H))
+
+        def fn(x):
+            return mx.matmul(x, arr)
+
+        sample = mx.zeros((1, 40, E), dtype=mx.float32)
+        mx.export_function(path, fn, sample, shapeless=True)
+        imported = mx.import_function(path)
+
+        for seq_len in (40, 248, 623):
+            with self.subTest(seq_len=seq_len):
+                x = mx.arange(seq_len * E, dtype=mx.float32).reshape((1, seq_len, E))
+                expected = fn(x)
+                (y,) = imported(x)
+                self.assertEqual(y.shape, (1, seq_len, H))
+                self.assertTrue(mx.allclose(y, expected))
+
+    def test_export_matmul_shapeless_batch_and_mid_dim(self):
+        # Extend shapeless matmul test to higher-rank batched inputs (B, T, E).
+        path = os.path.join(self.test_dir, "matmul_shapeless_batch.mlxfn")
+
+        E, H = 32, 8
+        arr = mx.zeros((E, H), dtype=mx.float32)
+
+        def fn(x):
+            return mx.matmul(x, arr)
+
+        # Trace with batch=2, seq_len=10
+        sample = mx.zeros((2, 10, E), dtype=mx.float32)
+        mx.export_function(path, fn, sample, shapeless=True)
+        imported = mx.import_function(path)
+
+        for seq_len in (10, 50, 100):
+            with self.subTest(seq_len=seq_len):
+                x = mx.zeros((2, seq_len, E), dtype=mx.float32)
+                (y,) = imported(x)
+                self.assertEqual(y.shape, (2, seq_len, H))
+
 
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner()


### PR DESCRIPTION
## What

`mx.matmul(x, W)` where `x` has `ndim > 2` and `W` has `ndim ≤ 2`
is implemented in `ops.cpp` as:

```
Flatten(x, 0, -2)  →  Matmul  →  Unflatten(out, 0, orig_shape)
```

`orig_shape` is `x.shape()[:-1]` at trace time (e.g. `{1, 40}`), which
is stored verbatim as state inside the `Unflatten` primitive.

In shapeless mode `compile_replace` calls `output_shapes` on every
primitive to recompute output shapes for the actual inputs.
`Unflatten::output_shapes` returned the stored shape unchanged, so a
call with `seq_len=248` would produce `(1, 40, H)` instead of
`(1, 248, H)` — silently wrong.

## Fix

`mlx/primitives.cpp` — `Unflatten::output_shapes`:

When `inputs[0].shape()[axis_] ≠ product(shape_)`, scan `shape_`
right-to-left for the unique dimension whose removal leaves a divisor
of the actual flat size, then scale that dimension to absorb the new
size.  If no such dimension exists, raise `std::invalid_argument`.

This matches the common transformer pattern where leading batch
dimensions are static and `seq_len` is dynamic.

## Tests

Two new tests in `python/tests/test_export_import.py`:

- **`test_export_matmul_shapeless_mid_dim`** — the exact reproduction
  case from #2607 (`B=1`, varying `seq_len` ∈ {40, 248, 623}); checks
  both shape and numerical agreement with the reference function.
- **`test_export_matmul_shapeless_batch_and_mid_dim`** — higher-rank
  variant (`B=2`, varying `seq_len`); ensures the fix generalises
  beyond the single-batch case.

Fixes #2607