### PR TITLE
Fix axis param in nll_loss

### DIFF
--- a/python/mlx/nn/losses.py
+++ b/python/mlx/nn/losses.py
@@ -249,7 +249,9 @@ def nll_loss(
     Returns:
         array: The computed NLL loss.
     """
-    loss = -mx.take_along_axis(inputs, targets[..., None], axis).squeeze(-1)
+    loss = -mx.take_along_axis(inputs, mx.expand_dims(targets, axis), axis).squeeze(
+        axis
+    )
 
     return _reduce(loss, reduction)
 

--- a/python/tests/test_losses.py
+++ b/python/tests/test_losses.py
@@ -270,6 +270,26 @@ class TestLosses(mlx_tests.MLXTestCase):
         expected_sum = mx.sum(expected_none)
         self.assertEqual(losses_sum, expected_sum)
 
+        # Test a different axis
+        logits = mx.log(mx.softmax(mx.random.normal((4, 8)), axis=-1))
+        targets = mx.array([1, 2, 3, 0])
+        loss = nn.losses.nll_loss(logits.T, targets, axis=0)
+        expected = nn.losses.nll_loss(logits, targets, axis=-1)
+        self.assertTrue(mx.allclose(loss, expected))
+
+        # Test a middle axis on a higher rank input
+        logits = mx.log(mx.softmax(mx.random.normal((2, 5, 3)), axis=1))
+        targets = mx.array([[1, 4, 0], [2, 3, 1]])
+        loss = nn.losses.nll_loss(logits, targets, axis=1)
+        logits_np = np.array(logits)
+        targets_np = np.array(targets)
+        expected = np.zeros((2, 3))
+        for b in range(2):
+            for k in range(3):
+                expected[b, k] = -logits_np[b, targets_np[b, k], k]
+        self.assertEqual(loss.shape, (2, 3))
+        self.assertTrue(np.allclose(np.array(loss), expected))
+
     def test_gaussian_nll_loss(self):
         inputs = mx.array([[0.1, 0.2], [0.3, 0.4]])
         targets = mx.array([[0.2, 0.1], [0.1, 0.2]])


### PR DESCRIPTION
## Proposed changes

`nll_loss` ignores its `axis` argument. The gather happens along `axis` but the targets get expanded at the last dim and the result squeezed at the last dim, so anything other than the default axis either fails with a confusing squeeze error, or returns wrong values with no error at all if the trailing dim happens to be 1:

```python
import mlx.core as mx
import mlx.nn as nn

logp = mx.log(mx.softmax(mx.random.normal((3, 4)), axis=0))
nn.losses.nll_loss(logp, mx.array([0, 2, 1, 2]), axis=0)
# ValueError: [squeeze] Cannot squeeze axis -1 with size 4 which is not equal to 1.
```

cross_entropy had the same problem and was fixed in #2641, but nll_loss kept the old pattern. This applies the same fix and adds a test along the lines of the one from that PR. Checked the result against numpy take_along_axis for axis 0, a middle axis on a 3d input, and the default axis.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)