### PR TITLE
Fix Adafactor factored update for params with more than 2 dims

### DIFF
--- a/python/mlx/optimizers/optimizers.py
+++ b/python/mlx/optimizers/optimizers.py
@@ -797,9 +797,7 @@ class Adafactor(Optimizer):
             exp_avg_sq_row / mx.mean(exp_avg_sq_row, axis=-1, keepdims=True)
         )
         c_factor = mx.rsqrt(exp_avg_sq_col)
-        return mx.matmul(
-            mx.expand_dims(r_factor, axis=-1), mx.expand_dims(c_factor, axis=0)
-        )
+        return mx.expand_dims(r_factor, axis=-1) * mx.expand_dims(c_factor, axis=-2)
 
     def apply_single(self, gradient: mx.array, parameter: mx.array, state: dict):
         """Performs the Adafactor parameter and state update."""

--- a/python/tests/test_optimizers.py
+++ b/python/tests/test_optimizers.py
@@ -286,6 +286,27 @@ class TestOptimizers(mlx_tests.MLXTestCase):
             self.assertEqual(xp["x"].shape, x.shape)
         self.assertEqual(optimizer.state["step"], 2)
 
+        # Parameters with more than 2 dimensions also use the factored update
+        x = mx.zeros((2, 3, 4))
+        params = {"x": x}
+        grad = {"x": mx.ones_like(x)}
+        optimizer = opt.Adafactor()
+        for _ in range(2):
+            xp = optimizer.apply_gradients(grad, params)
+            self.assertEqual(xp["x"].shape, x.shape)
+            self.assertTrue(mx.isfinite(xp["x"]).all())
+            params = xp
+
+        # The factored estimate is a per-batch separable outer product
+        row = mx.array([[1.0, 4.0, 9.0], [16.0, 25.0, 36.0]])
+        col = mx.array([[1.0, 4.0, 9.0, 16.0], [25.0, 36.0, 49.0, 64.0]])
+        got = np.array(opt.Adafactor()._approximate_exp_moving_avg(row, col))
+        row_np, col_np = np.array(row), np.array(col)
+        r = 1.0 / np.sqrt(row_np / row_np.mean(axis=-1, keepdims=True))
+        c = 1.0 / np.sqrt(col_np)
+        expected = r[..., :, None] * c[..., None, :]
+        self.assertTrue(np.allclose(got, expected))
+
     def test_muon(self):
         params = {
             "first": [mx.zeros((10, 5)), mx.zeros((1,))],


### PR DESCRIPTION
## Proposed changes

Adafactor crashes on any parameter with more than 2 dimensions, for example a conv weight or a stacked weight:

```python
import mlx.core as mx
import mlx.optimizers as optim

p = {"w": mx.ones((2, 3, 4))}
g = {"w": mx.full((2, 3, 4), 0.1)}
optim.Adafactor().apply_gradients(g, p)
# ValueError: [matmul] Last dimension of first input with shape (2,3,1) must match
# second to last dimension of second input with shape (1,2,4).
```

`init_single` creates factored state for anything with ndim >= 2, but `_approximate_exp_moving_avg` recombines the factors with a matmul of `expand_dims(r, -1)` and `expand_dims(c, 0)`, which only works for 2d. The reference implementation (huggingface Adafactor `_approx_sq_grad`) uses `unsqueeze(-1)` and `unsqueeze(-2)` with an elementwise multiply, which is the same thing for 2d and also handles leading batch dims. This switches to that form.

Checked the 2d path against the huggingface implementation before and after (max diff 1.9e-9, unchanged) and the 3d path now matches it too (max diff 3.7e-9). Added a 3d case to the existing test.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)