### PR TITLE
Validate inputs in GroupNorm and InstanceNorm

### DIFF
--- a/python/mlx/nn/layers/normalization.py
+++ b/python/mlx/nn/layers/normalization.py
@@ -56,6 +56,11 @@ class InstanceNorm(Module):
         return f"{self.dims}, eps={self.eps}, affine={'weight' in self}"
 
     def __call__(self, x: mx.array) -> mx.array:
+        if x.ndim < 3:
+            raise ValueError(
+                f"InstanceNorm expects inputs with at least 3 dimensions"
+                f" (N, ..., C) but the input has {x.ndim} dimensions."
+            )
         reduction_axes = tuple(range(1, x.ndim - 1))
         # Compute stats
         mean = mx.mean(x, axis=reduction_axes, keepdims=True)
@@ -182,6 +187,19 @@ class GroupNorm(Module):
         pytorch_compatible: bool = False,
     ):
         super().__init__()
+        if num_groups <= 0:
+            raise ValueError(
+                f"The number of groups ({num_groups}) must be a positive integer."
+            )
+        if dims <= 0:
+            raise ValueError(
+                f"The number of features ({dims}) must be a positive integer."
+            )
+        if dims % num_groups != 0:
+            raise ValueError(
+                f"The number of features ({dims}) must be evenly divisible"
+                f" by the number of groups ({num_groups})."
+            )
         if affine:
             self.bias = mx.zeros((dims,))
             self.weight = mx.ones((dims,))

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -409,6 +409,16 @@ class TestLayers(mlx_tests.MLXTestCase):
         self.assertTrue(np.allclose(means, 3 * np.ones_like(means), atol=1e-6))
         self.assertTrue(np.allclose(var, 4 * np.ones_like(var), atol=1e-6))
 
+        # Raise for invalid num_groups / dims
+        with self.assertRaises(ValueError):
+            nn.GroupNorm(num_groups=4, dims=6)
+        with self.assertRaises(ValueError):
+            nn.GroupNorm(num_groups=0, dims=8)
+        with self.assertRaises(ValueError):
+            nn.GroupNorm(num_groups=-1, dims=8)
+        with self.assertRaises(ValueError):
+            nn.GroupNorm(num_groups=4, dims=0)
+
     def test_instance_norm(self):
         # Test InstanceNorm1d
         x = mx.array(
@@ -626,6 +636,9 @@ class TestLayers(mlx_tests.MLXTestCase):
         self.assertTrue(np.allclose(y, expected_y, atol=1e-5))
         # Test repr
         self.assertTrue(str(inorm) == "InstanceNorm(3, eps=1e-05, affine=False)")
+        # Raise for inputs without spatial dimensions
+        with self.assertRaises(ValueError):
+            nn.InstanceNorm(dims=8)(mx.zeros((4, 8)))
 
     def test_batch_norm(self):
         mx.random.seed(42)


### PR DESCRIPTION
## Proposed changes

Two cases where the norm layers accept bad inputs and return meaningless results instead of raising:

1. `InstanceNorm` on an input with no spatial dimensions returns all zeros. For a `(N, C)` or `(C,)` input the reduction axes tuple is empty, so `mx.mean` returns the input itself and `mx.var` returns 0, and the normalized output is exactly zero everywhere:

```python
import mlx.core as mx
import mlx.nn as nn

nn.InstanceNorm(dims=8)(mx.random.normal((4, 8)))
# all zeros, no error
```

2. `GroupNorm` does not check that `num_groups` divides `dims`. With say `num_groups=4, dims=6` the reshape can still succeed depending on the spatial size, and the groups end up mixing channel and spatial positions, so the statistics are garbage. The `pytorch_compatible=True` path floor-divides the group size and silently drops the intended grouping too. PyTorch raises for this at construction.

Both now raise a `ValueError`, same idea as #3615 did for `SinusoidalPositionalEncoding`. Added tests to the existing group norm and instance norm tests.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)