### PR TITLE
Add missing break in bool_ switch case that would result in falling through to the uint8_t case

### DIFF
--- a/mlx/backend/cpu/binary.cpp
+++ b/mlx/backend/cpu/binary.cpp
@@ -54,6 +54,7 @@ void DivMod::eval_cpu(
     switch (out_a.dtype()) {
       case bool_:
         binary_op<bool>(a, b, out_a, out_b, integral_op, bopt);
+        break;
       case uint8:
         binary_op<uint8_t>(a, b, out_a, out_b, integral_op, bopt);
         break;


### PR DESCRIPTION
## Proposed changes

Add a missing break to the switch case statement. Uncovered by a clang warning when compiling

```
binary.cpp:57:7: warning: unannotated fall-through between switch labels [-Wimplicit-fallthrough]
   57 |       case uint8:
      |       ^
```

## Checklist

Put an `x` in the boxes that apply.

- [X] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [X] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)