### PR TITLE
Fused SDPA full-attention for head_dim=192/256 (revival of #3293)

### DIFF
--- a/mlx/backend/metal/kernels/scaled_dot_product_attention.metal
+++ b/mlx/backend/metal/kernels/scaled_dot_product_attention.metal
@@ -32,10 +32,12 @@ using namespace metal;
   instantiate_sdpa_vector(type, 64, 64)          \
   instantiate_sdpa_vector(type, 96, 96)          \
   instantiate_sdpa_vector(type, 128, 128)        \
+  instantiate_sdpa_vector(type, 192, 192)        \
   instantiate_sdpa_vector(type, 256, 256)        \
   instantiate_sdpa_vector_aggregation(type, 64)  \
   instantiate_sdpa_vector_aggregation(type, 96)  \
   instantiate_sdpa_vector_aggregation(type, 128) \
+  instantiate_sdpa_vector_aggregation(type, 192) \
   instantiate_sdpa_vector_aggregation(type, 256)
 
 instantiate_sdpa_vector_heads(float)

--- a/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention.metal
+++ b/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention.metal
@@ -12,6 +12,7 @@
   attention, dtype, bq, bk, bd, wm, wn, mtype, float)
 
 #define instantiate_attn_shapes_helper(iname, itype, mname, mtype)  \
+    instantiate_attn(iname, itype, 32, 16, 256, 4, 1, mname, mtype) \
     instantiate_attn(iname, itype, 32, 16, 128, 4, 1, mname, mtype) \
     instantiate_attn(iname, itype, 32, 32,  80, 4, 1, mname, mtype) \
     instantiate_attn(iname, itype, 32, 32,  64, 4, 1, mname, mtype)

--- a/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention.metal
+++ b/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention.metal
@@ -13,6 +13,7 @@
 
 #define instantiate_attn_shapes_helper(iname, itype, mname, mtype)  \
     instantiate_attn(iname, itype, 32, 16, 256, 4, 1, mname, mtype) \
+    instantiate_attn(iname, itype, 32, 16, 192, 4, 1, mname, mtype) \
     instantiate_attn(iname, itype, 32, 16, 128, 4, 1, mname, mtype) \
     instantiate_attn(iname, itype, 32, 32,  80, 4, 1, mname, mtype) \
     instantiate_attn(iname, itype, 32, 32,  64, 4, 1, mname, mtype)

--- a/mlx/backend/metal/scaled_dot_product_attention.cpp
+++ b/mlx/backend/metal/scaled_dot_product_attention.cpp
@@ -623,7 +623,8 @@ bool ScaledDotProductAttention::use_fallback(
       (query_head_dim == 64 || query_head_dim == 96 || query_head_dim == 128 ||
        query_head_dim == 256);
   const bool sdpa_full_supported_head_dim = query_head_dim == value_head_dim &&
-      (query_head_dim == 64 || query_head_dim == 80 || query_head_dim == 128);
+      (query_head_dim == 64 || query_head_dim == 80 || query_head_dim == 128 ||
+       query_head_dim == 256);
 
   const bool sdpa_full_supported_mask = !has_mask || has_arr_mask ||
       (query_sequence_length <= key_sequence_length && do_causal);

--- a/mlx/backend/metal/scaled_dot_product_attention.cpp
+++ b/mlx/backend/metal/scaled_dot_product_attention.cpp
@@ -621,15 +621,17 @@ bool ScaledDotProductAttention::use_fallback(
   const bool sdpa_vector_supported_head_dim =
       query_head_dim == value_head_dim &&
       (query_head_dim == 64 || query_head_dim == 96 || query_head_dim == 128 ||
-       query_head_dim == 256);
-  // For head_dim=256, the fused full-attention kernel is ~30% slower than
-  // unfused. Only route to fused when kL is large enough that unfused would
-  // exceed Metal buffer limits (the fused kernel tiles K/V so it scales).
-  const bool sdpa_full_256_ok =
-      query_head_dim == 256 && key_sequence_length > 16384;
+       query_head_dim == 192 || query_head_dim == 256);
+  // For head_dim >= 192, the fused full-attention kernel is slower than
+  // unfused for short sequences. Only route to fused when kL is large enough
+  // that the unfused path would exceed Metal buffer limits (the fused kernel
+  // tiles K/V so it scales to arbitrary sequence lengths).
+  const bool sdpa_full_large_hd_ok =
+      (query_head_dim == 192 || query_head_dim == 256) &&
+      key_sequence_length > 16384;
   const bool sdpa_full_supported_head_dim = query_head_dim == value_head_dim &&
       (query_head_dim == 64 || query_head_dim == 80 || query_head_dim == 128 ||
-       sdpa_full_256_ok);
+       sdpa_full_large_hd_ok);
 
   const bool sdpa_full_supported_mask = !has_mask || has_arr_mask ||
       (query_sequence_length <= key_sequence_length && do_causal);

--- a/mlx/backend/metal/scaled_dot_product_attention.cpp
+++ b/mlx/backend/metal/scaled_dot_product_attention.cpp
@@ -622,9 +622,14 @@ bool ScaledDotProductAttention::use_fallback(
       query_head_dim == value_head_dim &&
       (query_head_dim == 64 || query_head_dim == 96 || query_head_dim == 128 ||
        query_head_dim == 256);
+  // For head_dim=256, the fused full-attention kernel is ~30% slower than
+  // unfused. Only route to fused when kL is large enough that unfused would
+  // exceed Metal buffer limits (the fused kernel tiles K/V so it scales).
+  const bool sdpa_full_256_ok =
+      query_head_dim == 256 && key_sequence_length > 16384;
   const bool sdpa_full_supported_head_dim = query_head_dim == value_head_dim &&
       (query_head_dim == 64 || query_head_dim == 80 || query_head_dim == 128 ||
-       query_head_dim == 256);
+       sdpa_full_256_ok);
 
   const bool sdpa_full_supported_mask = !has_mask || has_arr_mask ||
       (query_sequence_length <= key_sequence_length && do_causal);

--- a/mlx/backend/metal/scaled_dot_product_attention.cpp
+++ b/mlx/backend/metal/scaled_dot_product_attention.cpp
@@ -174,7 +174,10 @@ void sdpa_full_self_attention_metal(
     bool do_causal_,
     const std::optional<array>& mask,
     const std::optional<array>& sinks) {
-  if (metal::is_nax_available() && q.shape(3) != 80 &&
+  // head_dim >= 192 only reaches the fused path for long sequences (see
+  // use_fallback); the NAX kernel family has no bd=192/256 instantiations,
+  // so route those shapes to the legacy steel kernel which does.
+  if (metal::is_nax_available() && q.shape(3) != 80 && q.shape(3) < 192 &&
       (env::enable_tf32() || q.dtype() != float32)) {
     return sdpa_full_self_attention_nax(
         /* const Stream& s = */ s,

--- a/python/tests/test_fast_sdpa.py
+++ b/python/tests/test_fast_sdpa.py
@@ -117,6 +117,27 @@ def mlx_primitives_sdpa(q, k, v, scale, mask=None):
 
 
 class TestFastSDPA(mlx_tests.MLXTestCase):
+    def test_sdpa_large_head_dim_full_attention(self):
+        qL = 9
+        kL = 16385
+
+        for D in [192, 256]:
+            with self.subTest(head_dim=D):
+                q, k, v, scale, _ = prepare_inputs(
+                    1, qL, kL, D, 1, 1, None, False, mx.float16
+                )
+                ref = mlx_primitives_sdpa(q, k, v, scale)
+                out = mx.fast.scaled_dot_product_attention(q, k, v, scale=scale)
+                self.assertTrue(mx.allclose(ref, out, atol=1e-3, rtol=1e-3))
+
+    def test_sdpa_vector_head_dim_192(self):
+        q, k, v, scale, _ = prepare_inputs(
+            1, 1, 257, 192, 1, 1, None, False, mx.float16
+        )
+        ref = mlx_primitives_sdpa(q, k, v, scale)
+        out = mx.fast.scaled_dot_product_attention(q, k, v, scale=scale)
+        self.assertTrue(mx.allclose(ref, out, atol=1e-3, rtol=1e-3))
+
     def test_sdpa_vector_kv_transposed_head_seq(self):
         D = 64
         Nq = 4


### PR DESCRIPTION
## Proposed changes

Revival of #3293: add head_dim=192/256 instantiations to the fused
`steel_attention` full-attention kernel and route prefill SDPA to them when
`kL > 16384`. Below that dispatch threshold the unfused path remains selected
for lower latency while its score-shaped transient is still considered
acceptable.

Decode's `sdpa_vector` path already supported head_dim=256. This PR also adds
the missing head_dim=192 vector and vector-aggregation instantiations, while
closing the full-attention/prefill dispatch gap for both 192 and 256.

The three original commits by @Thump604 are preserved with their authorship.
Additional commits port the original work to the code structure at submission
time and add focused regression coverage:

- add the missing `bd=192` steel instantiation already targeted by routing
- exclude head_dim >= 192 from the NAX branch, whose kernel family has no
  192/256 instantiations
- exercise the 192/256 full-attention route above the dispatch threshold and
  the newly instantiated head_dim=192 vector route

## Scope correction

The original version of this PR description incorrectly used Gemma 4 26B as
end-to-end evidence for this change. That attribution was wrong.

Gemma 4 26B/31B use `global_head_dim=512` in the full-attention layers that
see the long context. Their head_dim=256 layers are sliding-window layers with
bounded `kL`, so the new 192/256 large-`kL` route in this PR is not selected
for their long-context attention. A stock `mlx-lm` A/B subsequently showed
identical Gemma peak memory and prompt throughput between vanilla MLX and this
branch.

The previously reported Gemma 156K -> 184K admission increase came from a
serving-side estimator change in oMLX, not from this kernel. The fallback score
tensor was also previously described as fp32; for the measured bf16 Gemma
workload the materialized array is bf16, with fp32 softmax accumulation.

Therefore this PR should be evaluated for models whose actual long-context
full-attention head dimension is 192 or 256. Gemma 4 26B/31B are not evidence
for or against that kernel.

Detailed correction and the stock `mlx-lm` measurements:
https://github.com/ml-explore/mlx/issues/3658#issuecomment-4698010439

## Kernel microbenchmarks

Synthetic GQA shape, not labeled as a Gemma model shape:

`n_q=16, n_kv=8, head_dim=256, fp16`, M4 Max 36 GB. Peak memory includes
inputs.

| qL | kL | inputs | fused peak | unfused peak | max abs err |
|---:|---:|---:|---:|---:|---:|
| 1024 | 32768 | 264M | **272M** | 1,824M | 0.0 |
| 2048 | 65536 | 528M | **544M** | 5,696M | 0.0 |
| 2048 | 131072 | 1,040M | **1,056M** | 11,328M | 0.0 |

For this shape, fused overhead above the input allocation stays approximately
8-16 MB, while the unfused score-shaped transient grows linearly with `kL`.
The fused path is slower per kernel above the current dispatch threshold:
approximately 0.74-0.79x the unfused throughput on this machine. The threshold
preserves the lower-latency unfused route for shorter contexts. Error values
in the table are shown at the benchmark's printed precision.

## Stock mlx-lm validation

After a maintainer request, the comparison was rerun through
`python -m mlx_lm.benchmark`, without oMLX or a serving scheduler.

### Gemma 4 26B

Gemma 4 26B UD-MLX 3-bit and 4-bit were tested from 32K through 131K. Peak
memory was identical between the two builds to the benchmark's 0.001 GB
precision, and prompt throughput matched within 0.1%. Static dispatch analysis
confirms both builds use the same unfused fallback for the long-context
head_dim=512 global layers.

### Qwen3.6 35B

An independent stock `mlx-lm` smoke by @Thump604 showed the expected
memory/speed tradeoff on a genuine head_dim=256 workload:

| context | main prompt_tps | PR prompt_tps | main peak GB | PR peak GB |
|---:|---:|---:|---:|---:|
| 32K | 1005.743 | 871.489 | 41.316 | **39.882** |
| 64K | 802.929 | 624.513 | 44.201 | **40.068** |

The 131K PR run aborted with an interactivity-impacting command-buffer error,
so that row is unresolved and is not presented as a valid A/B result.

These stock benchmark arms were not a strict single-commit comparison because
the tested builds were separated by other main-branch commits. The static
dispatch change and focused route tests establish what this PR changes; the
stock benchmarks are supporting workload evidence.

Independent validation:
https://github.com/ml-explore/mlx/issues/3658#issuecomment-4697602644

## Validation

- focused route tests added in `python/tests/test_fast_sdpa.py`:
  - head_dim 192/256 full attention with `qL=9`, `kL=16385`
  - head_dim 192 vector attention
- current `python/tests/test_fast_sdpa.py`: 18 tests run, 1 skipped
- `python/tests/test_fast.py`: 23 passed before the focused tests were added;
  the kernel source is unchanged by the test-only follow-up commit
- head_dim=256 fp16 fused/unfused microbenchmark errors were reported as
  `0.0000` at the benchmark's printed precision
- pre-commit hooks passed on all files changed by this PR
- original #3293 work was also tested on M2 Ultra and M3 Ultra
- stock `mlx-lm` correction run: Gemma 4 26B 3-bit/4-bit, 32K-131K

## Tradeoff

This is intentionally not a blanket performance optimization. For the tested
head_dim=256 prefill shapes, the fused kernel trades prompt throughput for a
bounded-memory attention path. The dispatch threshold keeps the unfused path
where it is faster and reserves the fused path for long-`kL` workloads where
the growing score transient is the limiting factor.

Credit: the kernel work and original routing are @Thump604's (#3293). This PR
preserves those commits and authorship, ports the work to the submission-time
code structure, and adds the small completeness fixes and regression tests
described above.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
  - pre-commit hooks were run successfully on every file changed by this PR
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (not applicable; no public API or user documentation changed)
