### PR TITLE
Fix use-after-free when a custom Metal kernel is called with different dtypes in one graph

### DIFF
--- a/docs/src/dev/custom_metal_kernels.rst
+++ b/docs/src/dev/custom_metal_kernels.rst
@@ -62,7 +62,7 @@ The full function signature will be generated using:
     so we add ``device float16_t* out``.
 * Template parameters passed using ``template``
     In the above, ``template=[("T", mx.float32)]`` adds a template of ``template <typename T>`` to the function
-    and instantiates the template with ``custom_kernel_myexp_float<float>``.
+    and instantiates the template with ``custom_kernel_myexp_float_float16_float16<float>``.
     Template parameters can be ``mx.core.Dtype``, ``int`` or ``bool``.
 * Metal attributes used in ``source`` such as ``[[thread_position_in_grid]]``
     These will be added as function arguments.
@@ -73,7 +73,7 @@ Putting this all together, the generated function signature for ``myexp`` is as 
 .. code-block:: cpp
 
   template <typename T>
-  [[kernel]] void custom_kernel_myexp_float(
+  [[kernel]] void custom_kernel_myexp_float_float16_float16(
     const device float16_t* inp [[buffer(0)]],
     device float16_t* out [[buffer(1)]],
     uint3 thread_position_in_grid [[thread_position_in_grid]]) {
@@ -84,7 +84,7 @@ Putting this all together, the generated function signature for ``myexp`` is as 
 
   }
 
-  template [[host_name("custom_kernel_myexp_float")]] [[kernel]] decltype(custom_kernel_myexp_float<float>) custom_kernel_myexp_float<float>;
+  template [[host_name("custom_kernel_myexp_float_float16_float16")]] [[kernel]] decltype(custom_kernel_myexp_float_float16_float16<float>) custom_kernel_myexp_float_float16_float16<float>;
 
 Note: ``grid`` and ``threadgroup`` are parameters to the Metal `dispatchThreads
 <https://developer.apple.com/documentation/metal/mtlcomputecommandencoder/2866532-dispatchthreads>`_

--- a/mlx/backend/metal/custom_kernel.cpp
+++ b/mlx/backend/metal/custom_kernel.cpp
@@ -22,6 +22,9 @@ static CustomKernelCache& cache() {
   return cache_;
 };
 
+// Inputs with fewer elements are passed in the constant address space
+constexpr int max_constant_array_size = 8;
+
 std::string write_signature(
     std::string func_name,
     const std::string& header,
@@ -66,7 +69,6 @@ std::string write_signature(
   kernel_source += "(\n";
 
   int index = 0;
-  constexpr int max_constant_array_size = 8;
   // Add inputs
   for (int i = 0; i < inputs.size(); ++i) {
     const auto& name = input_names[i];
@@ -272,6 +274,26 @@ CustomKernelFunction metal_kernel(
       template_hash.pop_back();
       kernel_name += "_";
       kernel_name += template_hash;
+    }
+
+    // The generated source depends on the dtypes of the inputs and outputs
+    // and on how each input is passed (see `write_signature`). Include them
+    // in the kernel name so that a given name always maps to the same
+    // source. Otherwise calling the same kernel with e.g. a different input
+    // dtype would evict the previous pipeline state from the cache while it
+    // may still be in use by an uncommitted command buffer.
+    for (const auto& arr : inputs) {
+      kernel_name += "_";
+      kernel_name += type_to_name(arr);
+      if (arr.ndim() == 0) {
+        kernel_name += "s";
+      } else if (arr.size() < max_constant_array_size) {
+        kernel_name += "c";
+      }
+    }
+    for (const auto& dtype : output_dtypes) {
+      kernel_name += "_";
+      kernel_name += type_to_name(dtype);
     }
 
     std::string kernel_source = write_signature(

--- a/python/tests/test_fast.py
+++ b/python/tests/test_fast.py
@@ -1011,6 +1011,36 @@ class TestFast(mlx_tests.MLXTestCase):
         out = call_kernel(a, source)
         self.assertTrue(mx.array_equal(out, mx.ones_like(out)))
 
+    @unittest.skipIf(not mx.metal.is_available(), "Metal is not available")
+    def test_custom_kernel_mixed_dtypes(self):
+        # Calling the same kernel with different input dtypes in a single
+        # graph should not invalidate pipeline states that are still in use
+        # by an uncommitted command buffer
+        kernel = mx.fast.metal_kernel(
+            name="mixed_dtypes",
+            input_names=["inp"],
+            output_names=["out"],
+            source="""
+                uint elem = thread_position_in_grid.x;
+                out[elem] = inp[elem] + inp[elem];
+            """,
+        )
+
+        def call_kernel(a: mx.array):
+            return kernel(
+                inputs=[a],
+                grid=(a.size, 1, 1),
+                threadgroup=(a.size, 1, 1),
+                output_shapes=[a.shape],
+                output_dtypes=[a.dtype],
+                stream=mx.gpu,
+            )[0]
+
+        a = mx.full((32,), 1.5, dtype=mx.float16)
+        b = mx.full((32,), 2.5, dtype=mx.float32)
+        out = call_kernel(a).astype(mx.float32) + call_kernel(b)
+        self.assertTrue(mx.allclose(out, mx.full((32,), 8.0)))
+
 
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner()


### PR DESCRIPTION
## Proposed changes

Fixes #3347.

Calling the same `mx.fast.metal_kernel` with different input dtypes inside one lazy graph regenerates different source under the same kernel name, and the cache eviction (`clear_library`) releases a pipeline state that an uncommitted command buffer still references (mechanism detailed in #3347). This implements the approach @zcbenz suggested on #3434: put the input dtypes in the generated kernel name, so a given name always maps to exactly one source and dtype variants coexist in the cache instead of evicting each other.

Dtypes turn out not to be the only per-call fact `write_signature` bakes into the source: the address space choice (`constant` for inputs with `size() < 8`) and pass-by-reference for 0-dim inputs vary per call too. The generated name now encodes all of it — each input's dtype with a `c`/`s` suffix for those two cases, plus the output dtypes — and `max_constant_array_size` is hoisted to file scope so the naming and `write_signature` can't drift. The `clear_library` path is kept for genuinely different user sources reusing one name (covered by the existing `test_custom_kernel_caching`).

Added a regression test (`test_custom_kernel_mixed_dtypes`) that composes float16 and float32 invocations of one kernel in a single graph; with `METAL_DEVICE_WRAPPER_TYPE=1` as CI sets, the unfixed code aborts on it with the `command buffer references deallocated object` assertion. Also updated the generated-name example in the custom Metal kernels docs (names now look like `custom_kernel_myexp_float_float16_float16`).

With the fix, `test_fast.py` (24 tests) and `test_export_import.py` (16 tests) pass under Metal API validation.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
