### PR TITLE
[Improvement] CopyType::Vector in concatenate if axis=0 and contiguous  

### DIFF
--- a/mlx/backend/cuda/slicing.cpp
+++ b/mlx/backend/cuda/slicing.cpp
@@ -37,7 +37,11 @@ void concatenate_gpu(
     size_t data_offset = strides[axis] * sizes[i];
     out_slice.copy_shared_buffer(
         out, strides, flags, out_slice.size(), data_offset);
-    copy_gpu_inplace(inputs[i], out_slice, CopyType::GeneralGeneral, s);
+    auto ctype = CopyType::GeneralGeneral;
+    if (axis == 0 && inputs[i].flags().row_contiguous) {
+      ctype = CopyType::Vector;
+    }
+    copy_gpu_inplace(inputs[i], out_slice, ctype, s);
   }
 }
 


### PR DESCRIPTION
Tiny improvement for concatenating along axis 0 in contiguous case. This could be useful in `fsdp` / `average_gradients` (we concatenate weights and launch reduction on concatenation).

| Shape | n | Old time (ms) | Old GB/s | New time (ms) | New GB/s |
|---|---:|---:|---:|---:|---:|
| `[65536]` | 2 | 0.0578 | 9.07 | 0.0518 | 10.13 |
| `[65536]` | 16 | 0.1598 | 26.24 | 0.1264 | 33.20 |
| `[1048576]` | 16 | 0.1894 | 354.41 | 0.1540 | 435.91 |
| `[1024,1024]` | 4 | 0.0834 | 201.11 | 0.0671 | 250.03 |
| `[4096,4096]` | 4 | 0.1954 | 1373.50 | 0.1789 | 1500.79 |
| `[8192,8192]` | 10 | 1.0496 | 2557.58 | 1.0154 | 2643.70 |