### PR TITLE
Fix Q4_1 GGUF loading

### DIFF
--- a/mlx/io/gguf_quants.cpp
+++ b/mlx/io/gguf_quants.cpp
@@ -8,10 +8,12 @@
 
 namespace mlx::core {
 
-void unpack_32_4(uint8_t* data, int8_t* dst) {
+// Unpacks a block of 32 4-bit weights. `data` must point at the first
+// quant byte, past the block header.
+void unpack_32_4(const uint8_t* data, int8_t* dst) {
   std::fill_n(dst, 16, 0);
   for (int j = 0; j < 16; ++j) {
-    uint8_t x = (data[j + 2] & 0x0F); // j+2 to skip scale bytes.
+    uint8_t x = (data[j] & 0x0F);
     if (j % 2 != 0) {
       x <<= 4;
     }
@@ -19,7 +21,7 @@ void unpack_32_4(uint8_t* data, int8_t* dst) {
   }
   // Last 16 weights are in the higher bits
   for (int j = 0; j < 16; ++j) {
-    uint8_t x = (data[j + 2] >> 4);
+    uint8_t x = (data[j] >> 4);
     if (j % 2 != 0) {
       x <<= 4;
     }
@@ -42,7 +44,7 @@ void extract_q4_0_data(
   for (int64_t i = 0; i < scales_arr.size(); i++) {
     scales[i] = *((float16_t*)data);
     biases[i] = -8 * scales[i];
-    unpack_32_4(data, weights);
+    unpack_32_4(data + 2, weights); // skip the scale bytes
     weights += 16;
     data += bytes_per_block;
   }
@@ -64,7 +66,7 @@ void extract_q4_1_data(
   for (int64_t i = 0; i < scales_arr.size(); i++) {
     scales[i] = *((float16_t*)data);
     biases[i] = *((float16_t*)(data) + 1);
-    unpack_32_4(data, weights);
+    unpack_32_4(data + 4, weights); // skip the scale and bias bytes
     weights += 16;
     data += bytes_per_block;
   }

--- a/python/tests/test_load.py
+++ b/python/tests/test_load.py
@@ -2,6 +2,7 @@
 
 import os
 import platform
+import struct
 import tempfile
 import unittest
 from pathlib import Path
@@ -163,6 +164,87 @@ class TestLoad(mlx_tests.MLXTestCase):
         load_dict = mx.load(Path(save_file_mlx))
         self.assertTrue("test" in load_dict)
         self.assertTrue(mx.array_equal(load_dict["test"], save_dict["test"]))
+
+    @unittest.skipIf(platform.system() == "Windows", "GGUF is disabled on Windows")
+    def test_load_gguf_quantized(self):
+        # Write a minimal GGUF v3 file with one quantized tensor and check
+        # that the loaded (weight, scales, biases) triplet dequantizes to the
+        # values prescribed by the GGML block formats.
+        rows, cols = 2, 64
+        n_blocks = rows * cols // 32
+        np.random.seed(7)
+
+        def write_gguf(path, ggml_type_id, blocks):
+            with open(path, "wb") as f:
+                f.write(b"GGUF")
+                # version, tensor count, metadata kv count
+                f.write(struct.pack("<IQQ", 3, 1, 0))
+                name = b"tensor.weight"
+                f.write(struct.pack("<Q", len(name)) + name)
+                # dims are stored in GGML order: ne[0] = cols, ne[1] = rows
+                f.write(struct.pack("<IQQIQ", 2, cols, rows, ggml_type_id, 0))
+                f.write(b"\x00" * (-f.tell() % 32))  # default alignment
+                f.write(blocks.tobytes())
+
+        def packed_nibbles(q):
+            # GGML nibble order: byte j = element j | element j + 16 << 4
+            return (q[:, :16] | (q[:, 16:] << 4)).astype(np.uint8)
+
+        d = np.full((n_blocks, 1), 0.5, dtype=np.float16)
+        m = np.full((n_blocks, 1), -1.25, dtype=np.float16)
+        q4 = np.random.randint(0, 16, size=(n_blocks, 32)).astype(np.uint8)
+        q8 = np.random.randint(-128, 128, size=(n_blocks, 32)).astype(np.int8)
+        d32 = d.astype(np.float32)
+        m32 = m.astype(np.float32)
+
+        # (name, ggml type id, bits, block bytes, expected dequantized values)
+        cases = [
+            (
+                "Q4_0",
+                2,
+                4,
+                np.concatenate([d.view(np.uint8), packed_nibbles(q4)], axis=1),
+                d32 * (q4.astype(np.float32) - 8),
+            ),
+            (
+                "Q4_1",
+                3,
+                4,
+                np.concatenate(
+                    [d.view(np.uint8), m.view(np.uint8), packed_nibbles(q4)],
+                    axis=1,
+                ),
+                d32 * q4.astype(np.float32) + m32,
+            ),
+            (
+                "Q8_0",
+                8,
+                8,
+                np.concatenate([d.view(np.uint8), q8.view(np.uint8)], axis=1),
+                d32 * q8.astype(np.float32),
+            ),
+        ]
+        for name, type_id, bits, blocks, expected in cases:
+            with self.subTest(qtype=name):
+                save_file = os.path.join(self.test_dir, f"quant_{name}.gguf")
+                write_gguf(save_file, type_id, blocks)
+                load_dict = mx.load(save_file)
+                self.assertEqual(load_dict["tensor.weight"].dtype, mx.uint32)
+                self.assertEqual(load_dict["tensor.scales"].shape, (rows, cols // 32))
+                self.assertEqual(load_dict["tensor.biases"].shape, (rows, cols // 32))
+                dequantized = mx.dequantize(
+                    load_dict["tensor.weight"],
+                    load_dict["tensor.scales"],
+                    load_dict["tensor.biases"],
+                    group_size=32,
+                    bits=bits,
+                )
+                self.assertTrue(
+                    np.array_equal(
+                        np.array(dequantized, copy=False).astype(np.float32),
+                        expected.reshape(rows, cols),
+                    )
+                )
 
     def test_load_f8_e4m3(self):
         if not os.path.isdir(self.test_dir):


### PR DESCRIPTION
Problem

`mx.load()` on a GGUF file containing **Q4_1** tensors returns silently corrupted weights. Scales and biases load correctly and every shape checks out, so nothing fails loudly — the dequantized values are just wrong.


`unpack_32_4()` in `mlx/io/gguf_quants.cpp` hard-codes a 2-byte block-header skip (`data[j + 2]`, "to skip scale bytes"). That matches Q4_0's 18-byte block (`|f16 d|16B quants|`), but Q4_1 blocks are 20 bytes with a 4-byte header (`|f16 d|f16 m|16B quants|`). `extract_q4_1_data()` passes the block start, so the two bias bytes get decoded as the first four nibbles and the last two quant bytes of every block are dropped.

## Fix

`unpack_32_4()` now takes a pointer to the first quant byte and each caller skips its own header explicitly (`data + 2` for Q4_0, `data + 4` for Q4_1). No behavior change for Q4_0/Q8_0.

## Validation

Against the `gguf` python package's reference `dequantize` (N(0,1) weights, shape `(8, 64)`):

| qtype | max abs err before | after |
|---|---|---|
| Q8_0 | 0.0020 | 0.0020 |
| Q4_0 | 0.0020 | 0.0020 |
| Q4_1 | **5.08** | 0.0020 |


Found while building GGUF support for the vLLM Metal plugin (vllm-project/vllm-metal#415).