### PR TITLE
fix grid for large uncontiguous input

### DIFF
--- a/mlx/backend/cuda/binary/binary.cuh
+++ b/mlx/backend/cuda/binary/binary.cuh
@@ -135,7 +135,9 @@ __global__ void binary_g_nd(
   auto block = cg::this_thread_block();
   auto grid = cg::this_grid();
   IdxT index_rest =
-      grid.block_index().y * block.dim_threads().y + block.thread_index().y;
+      (grid.block_index().z * grid.dim_blocks().y + grid.block_index().y) *
+          block.dim_threads().y +
+      block.thread_index().y;
   if (index_rest >= size_rest) {
     return;
   }
@@ -173,7 +175,9 @@ __global__ void binary_g(
   auto block = cg::this_thread_block();
   auto grid = cg::this_grid();
   IdxT index_rest =
-      grid.block_index().y * block.dim_threads().y + block.thread_index().y;
+      (grid.block_index().z * grid.dim_blocks().y + grid.block_index().y) *
+          block.dim_threads().y +
+      block.thread_index().y;
   if (index_rest >= size_rest) {
     return;
   }
@@ -286,7 +290,12 @@ void binary_op_gpu_inplace(
                 dim0 = (dim0 + work_per_thread - 1) / work_per_thread;
                 auto block_dims = get_block_dims(dim0, rest, 1);
                 uint32_t num_blocks_x = cuda::ceil_div(dim0, block_dims.x);
-                uint32_t num_blocks_y = cuda::ceil_div(rest, block_dims.y);
+                uint32_t num_blocks_y_raw = static_cast<uint32_t>(
+                    cuda::ceil_div(rest, size_t{block_dims.y}));
+                uint32_t num_blocks_z =
+                    cuda::ceil_div(num_blocks_y_raw, kMaxGridDim);
+                uint32_t num_blocks_y =
+                    cuda::ceil_div(num_blocks_y_raw, num_blocks_z);
                 if (ndim <= 3) {
                   dispatch_1_2_3(ndim, [&](auto dims_constant) {
                     auto kernel = cu::binary_g_nd<
@@ -307,7 +316,7 @@ void binary_op_gpu_inplace(
                     }
                     encoder.add_kernel_node(
                         kernel,
-                        {num_blocks_x, num_blocks_y},
+                        {num_blocks_x, num_blocks_y, num_blocks_z},
                         block_dims,
                         gpu_ptr<InType>(a),
                         gpu_ptr<InType>(b),
@@ -324,7 +333,7 @@ void binary_op_gpu_inplace(
                   }
                   encoder.add_kernel_node(
                       kernel,
-                      {num_blocks_x, num_blocks_y},
+                      {num_blocks_x, num_blocks_y, num_blocks_z},
                       block_dims,
                       gpu_ptr<InType>(a),
                       gpu_ptr<InType>(b),

--- a/mlx/backend/cuda/binary/binary.cuh
+++ b/mlx/backend/cuda/binary/binary.cuh
@@ -287,15 +287,8 @@ void binary_op_gpu_inplace(
                 if (dim0 >= 4) {
                   work_per_thread = 4;
                 }
-                dim0 = (dim0 + work_per_thread - 1) / work_per_thread;
-                auto block_dims = get_block_dims(dim0, rest, 1);
-                uint32_t num_blocks_x = cuda::ceil_div(dim0, block_dims.x);
-                uint32_t num_blocks_y_raw = static_cast<uint32_t>(
-                    cuda::ceil_div(rest, size_t{block_dims.y}));
-                uint32_t num_blocks_z =
-                    cuda::ceil_div(num_blocks_y_raw, kMaxGridDim);
-                uint32_t num_blocks_y =
-                    cuda::ceil_div(num_blocks_y_raw, num_blocks_z);
+                auto [grid_dims, block_dims] =
+                    get_launch_args_general(dim0, rest, work_per_thread);
                 if (ndim <= 3) {
                   dispatch_1_2_3(ndim, [&](auto dims_constant) {
                     auto kernel = cu::binary_g_nd<
@@ -316,7 +309,7 @@ void binary_op_gpu_inplace(
                     }
                     encoder.add_kernel_node(
                         kernel,
-                        {num_blocks_x, num_blocks_y, num_blocks_z},
+                        grid_dims,
                         block_dims,
                         gpu_ptr<InType>(a),
                         gpu_ptr<InType>(b),
@@ -333,7 +326,7 @@ void binary_op_gpu_inplace(
                   }
                   encoder.add_kernel_node(
                       kernel,
-                      {num_blocks_x, num_blocks_y, num_blocks_z},
+                      grid_dims,
                       block_dims,
                       gpu_ptr<InType>(a),
                       gpu_ptr<InType>(b),

--- a/mlx/backend/cuda/binary_two.cu
+++ b/mlx/backend/cuda/binary_two.cu
@@ -291,15 +291,8 @@ void binary_two_op_gpu_inplace(
                 if (dim0 >= 4) {
                   work_per_thread = 4;
                 }
-                dim0 = (dim0 + work_per_thread - 1) / work_per_thread;
-                auto block_dims = get_block_dims(dim0, rest, 1);
-                uint32_t num_blocks_x = cuda::ceil_div(dim0, block_dims.x);
-                uint32_t num_blocks_y_raw = static_cast<uint32_t>(
-                    cuda::ceil_div(rest, size_t{block_dims.y}));
-                uint32_t num_blocks_z =
-                    cuda::ceil_div(num_blocks_y_raw, kMaxGridDim);
-                uint32_t num_blocks_y =
-                    cuda::ceil_div(num_blocks_y_raw, num_blocks_z);
+                auto [grid_dims, block_dims] =
+                    get_launch_args_general(dim0, rest, work_per_thread);
 
                 if (ndim <= 3) {
                   dispatch_1_2_3(ndim, [&](auto dims_constant) {
@@ -321,7 +314,7 @@ void binary_two_op_gpu_inplace(
                     }
                     encoder.add_kernel_node(
                         kernel,
-                        {num_blocks_x, num_blocks_y, num_blocks_z},
+                        grid_dims,
                         block_dims,
                         gpu_ptr<InType>(a),
                         gpu_ptr<InType>(b),
@@ -339,7 +332,7 @@ void binary_two_op_gpu_inplace(
                   }
                   encoder.add_kernel_node(
                       kernel,
-                      {num_blocks_x, num_blocks_y, num_blocks_z},
+                      grid_dims,
                       block_dims,
                       gpu_ptr<InType>(a),
                       gpu_ptr<InType>(b),

--- a/mlx/backend/cuda/binary_two.cu
+++ b/mlx/backend/cuda/binary_two.cu
@@ -146,7 +146,9 @@ __global__ void binary_two_g_nd(
   auto block = cg::this_thread_block();
   auto grid = cg::this_grid();
   IdxT index_rest =
-      grid.block_index().y * block.dim_threads().y + block.thread_index().y;
+      (grid.block_index().z * grid.dim_blocks().y + grid.block_index().y) *
+          block.dim_threads().y +
+      block.thread_index().y;
   if (index_rest >= size_rest) {
     return;
   }
@@ -189,7 +191,9 @@ __global__ void binary_two_g(
   auto block = cg::this_thread_block();
   auto grid = cg::this_grid();
   IdxT index_rest =
-      grid.block_index().y * block.dim_threads().y + block.thread_index().y;
+      (grid.block_index().z * grid.dim_blocks().y + grid.block_index().y) *
+          block.dim_threads().y +
+      block.thread_index().y;
   if (index_rest >= size_rest) {
     return;
   }
@@ -290,7 +294,12 @@ void binary_two_op_gpu_inplace(
                 dim0 = (dim0 + work_per_thread - 1) / work_per_thread;
                 auto block_dims = get_block_dims(dim0, rest, 1);
                 uint32_t num_blocks_x = cuda::ceil_div(dim0, block_dims.x);
-                uint32_t num_blocks_y = cuda::ceil_div(rest, block_dims.y);
+                uint32_t num_blocks_y_raw = static_cast<uint32_t>(
+                    cuda::ceil_div(rest, size_t{block_dims.y}));
+                uint32_t num_blocks_z =
+                    cuda::ceil_div(num_blocks_y_raw, kMaxGridDim);
+                uint32_t num_blocks_y =
+                    cuda::ceil_div(num_blocks_y_raw, num_blocks_z);
 
                 if (ndim <= 3) {
                   dispatch_1_2_3(ndim, [&](auto dims_constant) {
@@ -312,7 +321,7 @@ void binary_two_op_gpu_inplace(
                     }
                     encoder.add_kernel_node(
                         kernel,
-                        {num_blocks_x, num_blocks_y},
+                        {num_blocks_x, num_blocks_y, num_blocks_z},
                         block_dims,
                         gpu_ptr<InType>(a),
                         gpu_ptr<InType>(b),
@@ -330,7 +339,7 @@ void binary_two_op_gpu_inplace(
                   }
                   encoder.add_kernel_node(
                       kernel,
-                      {num_blocks_x, num_blocks_y},
+                      {num_blocks_x, num_blocks_y, num_blocks_z},
                       block_dims,
                       gpu_ptr<InType>(a),
                       gpu_ptr<InType>(b),

--- a/mlx/backend/cuda/copy/copy_general.cu
+++ b/mlx/backend/cuda/copy/copy_general.cu
@@ -21,7 +21,9 @@ __global__ void copy_gg_nd(
   auto block = cg::this_thread_block();
   auto grid = cg::this_grid();
   IdxT index_rest =
-      grid.block_index().y * block.dim_threads().y + block.thread_index().y;
+      (grid.block_index().z * grid.dim_blocks().y + grid.block_index().y) *
+          block.dim_threads().y +
+      block.thread_index().y;
   if (index_rest >= size_rest) {
     return;
   }
@@ -59,7 +61,9 @@ __global__ void copy_gg(
   auto block = cg::this_thread_block();
   auto grid = cg::this_grid();
   IdxT index_rest =
-      grid.block_index().y * block.dim_threads().y + block.thread_index().y;
+      (grid.block_index().z * grid.dim_blocks().y + grid.block_index().y) *
+          block.dim_threads().y +
+      block.thread_index().y;
   if (index_rest >= size_rest) {
     return;
   }
@@ -123,7 +127,12 @@ void copy_general(
             dim0 = (dim0 + work_per_thread - 1) / work_per_thread;
             auto block_dims = get_block_dims(dim0, rest, 1);
             uint32_t num_blocks_x = cuda::ceil_div(dim0, block_dims.x);
-            uint32_t num_blocks_y = cuda::ceil_div(rest, block_dims.y);
+            uint32_t num_blocks_y_raw = static_cast<uint32_t>(
+                cuda::ceil_div(rest, size_t{block_dims.y}));
+            uint32_t num_blocks_z =
+                cuda::ceil_div(num_blocks_y_raw, kMaxGridDim);
+            uint32_t num_blocks_y =
+                cuda::ceil_div(num_blocks_y_raw, num_blocks_z);
 
             if (ndim <= 3) {
               dispatch_1_2_3(ndim, [&](auto ndim_constant) {
@@ -135,7 +144,7 @@ void copy_general(
                 }
                 encoder.add_kernel_node(
                     kernel,
-                    {num_blocks_x, num_blocks_y},
+                    {num_blocks_x, num_blocks_y, num_blocks_z},
                     block_dims,
                     in_ptr,
                     out_ptr,
@@ -151,7 +160,7 @@ void copy_general(
               }
               encoder.add_kernel_node(
                   kernel,
-                  {num_blocks_x, num_blocks_y},
+                  {num_blocks_x, num_blocks_y, num_blocks_z},
                   block_dims,
                   in_ptr,
                   out_ptr,

--- a/mlx/backend/cuda/copy/copy_general.cu
+++ b/mlx/backend/cuda/copy/copy_general.cu
@@ -124,15 +124,8 @@ void copy_general(
               work_per_thread = 4;
             }
 
-            dim0 = (dim0 + work_per_thread - 1) / work_per_thread;
-            auto block_dims = get_block_dims(dim0, rest, 1);
-            uint32_t num_blocks_x = cuda::ceil_div(dim0, block_dims.x);
-            uint32_t num_blocks_y_raw = static_cast<uint32_t>(
-                cuda::ceil_div(rest, size_t{block_dims.y}));
-            uint32_t num_blocks_z =
-                cuda::ceil_div(num_blocks_y_raw, kMaxGridDim);
-            uint32_t num_blocks_y =
-                cuda::ceil_div(num_blocks_y_raw, num_blocks_z);
+            auto [grid_dims, block_dims] =
+                get_launch_args_general(dim0, rest, work_per_thread);
 
             if (ndim <= 3) {
               dispatch_1_2_3(ndim, [&](auto ndim_constant) {
@@ -144,7 +137,7 @@ void copy_general(
                 }
                 encoder.add_kernel_node(
                     kernel,
-                    {num_blocks_x, num_blocks_y, num_blocks_z},
+                    grid_dims,
                     block_dims,
                     in_ptr,
                     out_ptr,
@@ -160,7 +153,7 @@ void copy_general(
               }
               encoder.add_kernel_node(
                   kernel,
-                  {num_blocks_x, num_blocks_y, num_blocks_z},
+                  grid_dims,
                   block_dims,
                   in_ptr,
                   out_ptr,

--- a/mlx/backend/cuda/copy/copy_general_input.cu
+++ b/mlx/backend/cuda/copy/copy_general_input.cu
@@ -178,15 +178,8 @@ void copy_general_input(
             } else if (dim0 < 4) {
               work_per_thread = 1;
             }
-            dim0 = (dim0 + work_per_thread - 1) / work_per_thread;
-            auto block_dims = get_block_dims(dim0, rest, 1);
-            uint32_t num_blocks_x = cuda::ceil_div(dim0, block_dims.x);
-            uint32_t num_blocks_y_raw = static_cast<uint32_t>(
-                cuda::ceil_div(rest, size_t{block_dims.y}));
-            uint32_t num_blocks_z =
-                cuda::ceil_div(num_blocks_y_raw, kMaxGridDim);
-            uint32_t num_blocks_y =
-                cuda::ceil_div(num_blocks_y_raw, num_blocks_z);
+            auto [grid_dims, block_dims] =
+                get_launch_args_general(dim0, rest, work_per_thread);
 
             if (ndim <= 3) {
               dispatch_1_2_3(ndim, [&](auto dims_constant) {
@@ -201,7 +194,7 @@ void copy_general_input(
                 }
                 encoder.add_kernel_node(
                     kernel,
-                    {num_blocks_x, num_blocks_y, num_blocks_z},
+                    grid_dims,
                     block_dims,
                     in_ptr,
                     out_ptr,
@@ -218,7 +211,7 @@ void copy_general_input(
               }
               encoder.add_kernel_node(
                   kernel,
-                  {num_blocks_x, num_blocks_y, num_blocks_z},
+                  grid_dims,
                   block_dims,
                   in_ptr,
                   out_ptr,

--- a/mlx/backend/cuda/copy/copy_general_input.cu
+++ b/mlx/backend/cuda/copy/copy_general_input.cu
@@ -21,7 +21,9 @@ __global__ void copy_g_nd(
   auto block = cg::this_thread_block();
   auto grid = cg::this_grid();
   IdxT index_rest =
-      grid.block_index().y * block.dim_threads().y + block.thread_index().y;
+      (grid.block_index().z * grid.dim_blocks().y + grid.block_index().y) *
+          block.dim_threads().y +
+      block.thread_index().y;
   if (index_rest >= size_rest) {
     return;
   }
@@ -53,7 +55,9 @@ __global__ void copy_g(
   auto block = cg::this_thread_block();
   auto grid = cg::this_grid();
   IdxT index_rest =
-      grid.block_index().y * block.dim_threads().y + block.thread_index().y;
+      (grid.block_index().z * grid.dim_blocks().y + grid.block_index().y) *
+          block.dim_threads().y +
+      block.thread_index().y;
   if (index_rest >= size_rest) {
     return;
   }
@@ -177,7 +181,12 @@ void copy_general_input(
             dim0 = (dim0 + work_per_thread - 1) / work_per_thread;
             auto block_dims = get_block_dims(dim0, rest, 1);
             uint32_t num_blocks_x = cuda::ceil_div(dim0, block_dims.x);
-            uint32_t num_blocks_y = cuda::ceil_div(rest, block_dims.y);
+            uint32_t num_blocks_y_raw = static_cast<uint32_t>(
+                cuda::ceil_div(rest, size_t{block_dims.y}));
+            uint32_t num_blocks_z =
+                cuda::ceil_div(num_blocks_y_raw, kMaxGridDim);
+            uint32_t num_blocks_y =
+                cuda::ceil_div(num_blocks_y_raw, num_blocks_z);
 
             if (ndim <= 3) {
               dispatch_1_2_3(ndim, [&](auto dims_constant) {
@@ -192,7 +201,7 @@ void copy_general_input(
                 }
                 encoder.add_kernel_node(
                     kernel,
-                    {num_blocks_x, num_blocks_y},
+                    {num_blocks_x, num_blocks_y, num_blocks_z},
                     block_dims,
                     in_ptr,
                     out_ptr,
@@ -209,7 +218,7 @@ void copy_general_input(
               }
               encoder.add_kernel_node(
                   kernel,
-                  {num_blocks_x, num_blocks_y},
+                  {num_blocks_x, num_blocks_y, num_blocks_z},
                   block_dims,
                   in_ptr,
                   out_ptr,

--- a/mlx/backend/cuda/kernel_utils.cu
+++ b/mlx/backend/cuda/kernel_utils.cu
@@ -55,9 +55,7 @@ get_launch_args_general(int dim0, size_t rest, int work_per_thread /* = 1 */) {
   dim0 = (dim0 + work_per_thread - 1) / work_per_thread;
   dim3 block_dims = get_block_dims(dim0, rest, 1);
   uint32_t num_blocks_x = cuda::ceil_div(dim0, block_dims.x);
-  uint32_t num_blocks_y =
-      static_cast<uint32_t>(cuda::ceil_div(rest, size_t{block_dims.y}));
-
+  uint32_t num_blocks_y = cuda::ceil_div(rest, block_dims.y);
   uint32_t num_blocks_z = cuda::ceil_div(num_blocks_y, max_grid_yz_dim);
   num_blocks_y = cuda::ceil_div(num_blocks_y, num_blocks_z);
   return {dim3(num_blocks_x, num_blocks_y, num_blocks_z), block_dims};

--- a/mlx/backend/cuda/kernel_utils.cu
+++ b/mlx/backend/cuda/kernel_utils.cu
@@ -49,4 +49,18 @@ std::tuple<dim3, uint32_t> get_launch_args(
   return std::make_tuple(num_blocks, block_dim);
 }
 
+std::pair<dim3, dim3>
+get_launch_args_general(int dim0, size_t rest, int work_per_thread /* = 1 */) {
+  constexpr uint32_t max_grid_yz_dim = 65535;
+  dim0 = (dim0 + work_per_thread - 1) / work_per_thread;
+  dim3 block_dims = get_block_dims(dim0, rest, 1);
+  uint32_t num_blocks_x = cuda::ceil_div(dim0, block_dims.x);
+  uint32_t num_blocks_y =
+      static_cast<uint32_t>(cuda::ceil_div(rest, size_t{block_dims.y}));
+
+  uint32_t num_blocks_z = cuda::ceil_div(num_blocks_y, max_grid_yz_dim);
+  num_blocks_y = cuda::ceil_div(num_blocks_y, num_blocks_z);
+  return {dim3(num_blocks_x, num_blocks_y, num_blocks_z), block_dims};
+}
+
 } // namespace mlx::core

--- a/mlx/backend/cuda/kernel_utils.cuh
+++ b/mlx/backend/cuda/kernel_utils.cuh
@@ -20,8 +20,6 @@
 
 namespace mlx::core {
 
-static constexpr uint32_t kMaxGridDim = 65535;
-
 template <typename F>
 void dispatch_1_2_3(int n, F&& f) {
   switch (n) {
@@ -147,5 +145,14 @@ inline std::tuple<dim3, uint32_t> get_launch_args(
       work_per_thread,
       max_block_dim);
 }
+
+// Get the grid and block dims for a "general" (non-contiguous) kernel. These
+// kernels map the last dimension to the x grid dimension and the product of the
+// remaining dimensions (|rest|) to the y dimension, with each x thread handling
+// |work_per_thread| elements. Because a single grid dimension can not exceed
+// the hardware limit, the y extent is spread across the y and z grid
+// dimensions.
+std::pair<dim3, dim3>
+get_launch_args_general(int dim0, size_t rest, int work_per_thread = 1);
 
 } // namespace mlx::core

--- a/mlx/backend/cuda/kernel_utils.cuh
+++ b/mlx/backend/cuda/kernel_utils.cuh
@@ -20,6 +20,8 @@
 
 namespace mlx::core {
 
+static constexpr uint32_t kMaxGridDim = 65535;
+
 template <typename F>
 void dispatch_1_2_3(int n, F&& f) {
   switch (n) {

--- a/mlx/backend/cuda/kernel_utils.cuh
+++ b/mlx/backend/cuda/kernel_utils.cuh
@@ -146,12 +146,6 @@ inline std::tuple<dim3, uint32_t> get_launch_args(
       max_block_dim);
 }
 
-// Get the grid and block dims for a "general" (non-contiguous) kernel. These
-// kernels map the last dimension to the x grid dimension and the product of the
-// remaining dimensions (|rest|) to the y dimension, with each x thread handling
-// |work_per_thread| elements. Because a single grid dimension can not exceed
-// the hardware limit, the y extent is spread across the y and z grid
-// dimensions.
 std::pair<dim3, dim3>
 get_launch_args_general(int dim0, size_t rest, int work_per_thread = 1);
 

--- a/mlx/backend/cuda/ternary.cu
+++ b/mlx/backend/cuda/ternary.cu
@@ -53,7 +53,9 @@ __global__ void ternary_g_nd(
   auto block = cg::this_thread_block();
   auto grid = cg::this_grid();
   IdxT index_rest =
-      grid.block_index().y * block.dim_threads().y + block.thread_index().y;
+      (grid.block_index().z * grid.dim_blocks().y + grid.block_index().y) *
+          block.dim_threads().y +
+      block.thread_index().y;
   if (index_rest >= size_rest) {
     return;
   }
@@ -195,7 +197,12 @@ void ternary_op_gpu_inplace(
             dim0 = (dim0 + work_per_thread - 1) / work_per_thread;
             auto block_dims = get_block_dims(dim0, rest, 1);
             uint32_t num_blocks_x = cuda::ceil_div(dim0, block_dims.x);
-            uint32_t num_blocks_y = cuda::ceil_div(rest, block_dims.y);
+            uint32_t num_blocks_y_raw = static_cast<uint32_t>(
+                cuda::ceil_div(rest, size_t{block_dims.y}));
+            uint32_t num_blocks_z =
+                cuda::ceil_div(num_blocks_y_raw, kMaxGridDim);
+            uint32_t num_blocks_y =
+                cuda::ceil_div(num_blocks_y_raw, num_blocks_z);
 
             if (ndim <= 3) {
               dispatch_1_2_3(ndim, [&](auto dims_constant) {
@@ -207,7 +214,7 @@ void ternary_op_gpu_inplace(
                 }
                 encoder.add_kernel_node(
                     kernel,
-                    {num_blocks_x, num_blocks_y},
+                    {num_blocks_x, num_blocks_y, num_blocks_z},
                     block_dims,
                     gpu_ptr<bool>(a),
                     gpu_ptr<DType>(b),
@@ -226,7 +233,7 @@ void ternary_op_gpu_inplace(
               }
               encoder.add_kernel_node(
                   kernel,
-                  {num_blocks_x, num_blocks_y},
+                  {num_blocks_x, num_blocks_y, num_blocks_z},
                   block_dims,
                   gpu_ptr<bool>(a),
                   gpu_ptr<DType>(b),

--- a/mlx/backend/cuda/ternary.cu
+++ b/mlx/backend/cuda/ternary.cu
@@ -194,15 +194,8 @@ void ternary_op_gpu_inplace(
             if (dim0 >= 4) {
               work_per_thread = 4;
             }
-            dim0 = (dim0 + work_per_thread - 1) / work_per_thread;
-            auto block_dims = get_block_dims(dim0, rest, 1);
-            uint32_t num_blocks_x = cuda::ceil_div(dim0, block_dims.x);
-            uint32_t num_blocks_y_raw = static_cast<uint32_t>(
-                cuda::ceil_div(rest, size_t{block_dims.y}));
-            uint32_t num_blocks_z =
-                cuda::ceil_div(num_blocks_y_raw, kMaxGridDim);
-            uint32_t num_blocks_y =
-                cuda::ceil_div(num_blocks_y_raw, num_blocks_z);
+            auto [grid_dims, block_dims] =
+                get_launch_args_general(dim0, rest, work_per_thread);
 
             if (ndim <= 3) {
               dispatch_1_2_3(ndim, [&](auto dims_constant) {
@@ -214,7 +207,7 @@ void ternary_op_gpu_inplace(
                 }
                 encoder.add_kernel_node(
                     kernel,
-                    {num_blocks_x, num_blocks_y, num_blocks_z},
+                    grid_dims,
                     block_dims,
                     gpu_ptr<bool>(a),
                     gpu_ptr<DType>(b),
@@ -233,7 +226,7 @@ void ternary_op_gpu_inplace(
               }
               encoder.add_kernel_node(
                   kernel,
-                  {num_blocks_x, num_blocks_y, num_blocks_z},
+                  grid_dims,
                   block_dims,
                   gpu_ptr<bool>(a),
                   gpu_ptr<DType>(b),

--- a/mlx/backend/cuda/unary/unary.cuh
+++ b/mlx/backend/cuda/unary/unary.cuh
@@ -174,18 +174,11 @@ void unary_op_gpu_inplace(
               kernel = cu::unary_g<Op, InType, OutType, IdxT, 4>;
               work_per_thread = 4;
             }
-            dim0 = (dim0 + work_per_thread - 1) / work_per_thread;
-            auto block_dims = get_block_dims(dim0, rest, 1);
-            uint32_t num_blocks_x = cuda::ceil_div(dim0, block_dims.x);
-            uint32_t num_blocks_y_raw = static_cast<uint32_t>(
-                cuda::ceil_div(rest, size_t{block_dims.y}));
-            uint32_t num_blocks_z =
-                cuda::ceil_div(num_blocks_y_raw, kMaxGridDim);
-            uint32_t num_blocks_y =
-                cuda::ceil_div(num_blocks_y_raw, num_blocks_z);
+            auto [grid_dims, block_dims] =
+                get_launch_args_general(dim0, rest, work_per_thread);
             encoder.add_kernel_node(
                 kernel,
-                {num_blocks_x, num_blocks_y, num_blocks_z},
+                grid_dims,
                 block_dims,
                 gpu_ptr<InType>(in),
                 gpu_ptr<OutType>(out),

--- a/mlx/backend/cuda/unary/unary.cuh
+++ b/mlx/backend/cuda/unary/unary.cuh
@@ -48,7 +48,9 @@ __global__ void unary_g(
   auto block = cg::this_thread_block();
   auto grid = cg::this_grid();
   IdxT index_rest =
-      grid.block_index().y * block.dim_threads().y + block.thread_index().y;
+      (grid.block_index().z * grid.dim_blocks().y + grid.block_index().y) *
+          block.dim_threads().y +
+      block.thread_index().y;
   if (index_rest >= size_rest) {
     return;
   }
@@ -175,10 +177,15 @@ void unary_op_gpu_inplace(
             dim0 = (dim0 + work_per_thread - 1) / work_per_thread;
             auto block_dims = get_block_dims(dim0, rest, 1);
             uint32_t num_blocks_x = cuda::ceil_div(dim0, block_dims.x);
-            uint32_t num_blocks_y = cuda::ceil_div(rest, block_dims.y);
+            uint32_t num_blocks_y_raw = static_cast<uint32_t>(
+                cuda::ceil_div(rest, size_t{block_dims.y}));
+            uint32_t num_blocks_z =
+                cuda::ceil_div(num_blocks_y_raw, kMaxGridDim);
+            uint32_t num_blocks_y =
+                cuda::ceil_div(num_blocks_y_raw, num_blocks_z);
             encoder.add_kernel_node(
                 kernel,
-                {num_blocks_x, num_blocks_y},
+                {num_blocks_x, num_blocks_y, num_blocks_z},
                 block_dims,
                 gpu_ptr<InType>(in),
                 gpu_ptr<OutType>(out),

--- a/python/tests/test_fast.py
+++ b/python/tests/test_fast.py
@@ -1,6 +1,7 @@
 # Copyright © 2023-2024 Apple Inc.
 
 import math
+import os
 import unittest
 
 import mlx.core as mx
@@ -169,15 +170,18 @@ class TestFast(mlx_tests.MLXTestCase):
                 x, dims, traditional=traditional, base=base, scale=scale, offset=offset
             )
 
-        # Test large transposed input
-        shape = [32, 8192, 32, 128]
-        _, _, base, scale, offset, traditional = defaults
-        x = mx.random.normal(shape=shape).astype(mx.float32)
+    @unittest.skipIf("CI" in os.environ, "Allocates too much memory for CI")
+    def test_rope_large_input(self):
+        dims, seq_len, batch_size, n_heads = 32, 8192, 8, 32
+        base, scale, offset, traditional = 10000.0, 1.0, 0, False
+        x = mx.random.normal(shape=[batch_size, seq_len, n_heads, dims]).astype(
+            mx.float32
+        )
         x = x.swapaxes(1, 2)
         rx_fast = mx.fast.rope(
-            x, shape[3], traditional=traditional, base=base, scale=scale, offset=offset
+            x, dims, traditional=traditional, base=base, scale=scale, offset=offset
         )
-        ref = rope_orig(x, shape[3], traditional, base, scale, offset)
+        ref = rope_orig(x, dims, traditional, base, scale, offset)
         self.assertLess(mx.abs(ref - rx_fast).max(), 5e-3)
 
     def test_rope_dims_validation(self):

--- a/python/tests/test_fast.py
+++ b/python/tests/test_fast.py
@@ -169,6 +169,17 @@ class TestFast(mlx_tests.MLXTestCase):
                 x, dims, traditional=traditional, base=base, scale=scale, offset=offset
             )
 
+        # Test large transposed input
+        shape = [32, 8192, 32, 128]
+        _, _, base, scale, offset, traditional = defaults
+        x = mx.random.normal(shape=shape).astype(mx.float32)
+        x = x.swapaxes(1, 2)
+        rx_fast = mx.fast.rope(
+            x, shape[3], traditional=traditional, base=base, scale=scale, offset=offset
+        )
+        ref = rope_orig(x, shape[3], traditional, base, scale, offset)
+        self.assertLess(mx.abs(ref - rx_fast).max(), 5e-3)
+
     def test_rope_dims_validation(self):
         T = 4
         feature_dim = 64


### PR DESCRIPTION
CUDA kernels for non-contiguous tensor operations used a 2D launch grid where y covered all rest dimensions. CUDA limits gridDim.y <= 65,535. This results in errors for large noncontiguous arrays for binary, copy and some unary ops. 
For example, for a tensor of shape (16, 8192, 32, 128) -- queries of batch size 16 for qwen 4B: 

```python
import mlx.core as mx

shape = (32, 8192, 32, 128)  
x = mx.random.normal(shape=shape)
y = mx.random.normal(shape=shape)

x = x.transpose(0, 2, 1, 3) 
y = y.transpose(0, 2, 1, 3)

z = x + y
mx.eval(z)
```

-> `RuntimeError: cudaGraphAddKernelNode(&node, graph_, NULL, 0, &params) failed: invalid argument`. Same will be for `mx.exp(x)` and https://github.com/ml-explore/mlx/issues/3659. 

I split the overflow to `gridDim.z`.
