### PR TITLE
Add Array API namespace from_dlpack

### DIFF
--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -1796,6 +1796,29 @@ void init_ops(nb::module_& m) {
             ValueError: If ``copy`` is ``False``.
       )pbdoc");
   m.def(
+      "from_dlpack",
+      [](const nb::object& a) {
+        if (!nb::hasattr(a, "__dlpack__")) {
+          throw std::invalid_argument(
+              "[from_dlpack] input must support __dlpack__.");
+        }
+        return create_array(a, std::nullopt);
+      },
+      nb::arg(),
+      nb::sig("def from_dlpack(a: object, /) -> array"),
+      R"pbdoc(
+        Construct an array from an object supporting the DLPack protocol.
+
+        Args:
+            a: Input object supporting ``__dlpack__``.
+
+        Returns:
+            array: An array converted from the input.
+
+        Raises:
+            ValueError: If the input does not support ``__dlpack__``.
+      )pbdoc");
+  m.def(
       "zeros_like",
       &mx::zeros_like,
       nb::arg(),

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -2173,6 +2173,23 @@ class TestArray(mlx_tests.MLXTestCase):
         arr_pass = xp.asarray(existing)
         self.assertEqual(arr_pass.tolist(), [4, 5, 6])
 
+        arr_copy = xp.asarray(existing, copy=True)
+        self.assertEqual(arr_copy.tolist(), [4, 5, 6])
+
+    def test_array_namespace_from_dlpack(self):
+        xp = mx.array(1.0).__array_namespace__()
+        self.assertTrue(hasattr(xp, "from_dlpack"))
+
+        src = np.array([[1, 2], [3, 4]], dtype=np.int32)
+        arr = xp.from_dlpack(src)
+        self.assertEqual(arr.tolist(), [[1, 2], [3, 4]])
+        self.assertEqual(arr.dtype, mx.int32)
+
+        src = mx.array([1.0, 2.0])
+        arr = xp.from_dlpack(src)
+        self.assertEqual(arr.tolist(), [1.0, 2.0])
+        self.assertEqual(arr.dtype, mx.float32)
+
     def test_asarray_copy(self):
         existing = mx.array([1, 2, 3])
 


### PR DESCRIPTION
## Summary
- Add `mlx.core.from_dlpack`, making it available through `array.__array_namespace__()`
- Add Array API namespace tests for `from_dlpack`
- Cover `xp.asarray(..., copy=True)` through the namespace

Fixes #3484

## Testing
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer CMAKE_BUILD_PARALLEL_LEVEL=8 python -m pip install -e .`
- `python -m black --check python/tests/test_array.py`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer python -X faulthandler -m unittest test_array.TestArray.test_array_namespace test_array.TestArray.test_array_namespace_asarray test_array.TestArray.test_array_namespace_from_dlpack test_array.TestArray.test_asarray_copy test_array.TestArray.test_dlpack`
- `git diff --check`