### PR TITLE
Add from_dlpack to the array API namespace

### DIFF
--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -1796,6 +1796,20 @@ void init_ops(nb::module_& m) {
             ValueError: If ``copy`` is ``False``.
       )pbdoc");
   m.def(
+      "from_dlpack",
+      [](const nb::object& x) { return create_array(x, std::nullopt); },
+      nb::arg(),
+      nb::sig("def from_dlpack(x: object) -> array"),
+      R"pbdoc(
+        Construct an array from an object that implements the DLPack protocol.
+
+        Args:
+            x (object): An object that implements the ``__dlpack__`` protocol.
+
+        Returns:
+            array: An MLX array constructed from the input.
+      )pbdoc");
+  m.def(
       "zeros_like",
       &mx::zeros_like,
       nb::arg(),

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -2173,6 +2173,17 @@ class TestArray(mlx_tests.MLXTestCase):
         arr_pass = xp.asarray(existing)
         self.assertEqual(arr_pass.tolist(), [4, 5, 6])
 
+    def test_array_namespace_from_dlpack(self):
+        xp = mx.array(1.0).__array_namespace__()
+        self.assertTrue(hasattr(xp, "from_dlpack"))
+
+        x_np = np.array([1, 2, 3], dtype=np.int32)
+        x = xp.from_dlpack(x_np)
+        self.assertTrue(isinstance(x, mx.array))
+        self.assertEqual(x.dtype, mx.int32)
+        self.assertEqual(x.tolist(), [1, 2, 3])
+        self.assertTrue(np.array_equal(np.from_dlpack(x), x_np))
+
     def test_asarray_copy(self):
         existing = mx.array([1, 2, 3])
 


### PR DESCRIPTION
Fixes part of #3484.

Adds `from_dlpack` to the MLX array API namespace (`mlx.core`), so `x.__array_namespace__().from_dlpack(...)` is available, consistent with the [Python array API standard](https://data-apis.org/array-api/latest/). It reuses the existing `create_array` DLPack / ndarray import path that `mx.array` and `asarray` already use, plus a focused test (`test_array_namespace_from_dlpack`).

Note: `asarray(..., copy=...)` (the other item in #3484) already landed in #3510, so no change was needed there.