### PR TITLE
Fix shapeless compile eliding reductions over size-1 dimensions

### DIFF
--- a/mlx/backend/cuda/reduce.cu
+++ b/mlx/backend/cuda/reduce.cu
@@ -15,12 +15,20 @@ void Reduce::eval_gpu(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 1);
   array in = inputs[0];
 
-  // Make sure no identity reductions trickle down here.
   assert(!axes_.empty());
-  assert(out.size() != in.size());
 
   auto& s = stream();
   auto& encoder = cu::get_command_encoder(s);
+
+  // When all the reduced axes have size 1 at runtime, which can happen with
+  // shapeless compilation, the reduction is the identity so just cast-copy
+  // the input to the output.
+  if (out.size() == in.size()) {
+    CopyType ctype =
+        in.flags().contiguous ? CopyType::Vector : CopyType::General;
+    copy_gpu(in, out, ctype, s);
+    return;
+  }
 
   if (in.size() == 0) {
     init_reduce(encoder, in, out, reduce_type_);

--- a/mlx/backend/metal/reduce.cpp
+++ b/mlx/backend/metal/reduce.cpp
@@ -952,9 +952,17 @@ void Reduce::eval_gpu(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 1);
   array in = inputs[0];
 
-  // Make sure no identity reductions trickle down here
   assert(!axes_.empty());
-  assert(out.size() != in.size());
+
+  // When all the reduced axes have size 1 at runtime, which can happen with
+  // shapeless compilation, the reduction is the identity so just cast-copy
+  // the input to the output.
+  if (out.size() == in.size()) {
+    CopyType ctype =
+        in.flags().contiguous ? CopyType::Vector : CopyType::General;
+    copy_gpu(in, out, ctype, stream());
+    return;
+  }
 
   // Continue with reduction operation
   // Minimum of 4 bytes since we use size 4 structs for all reduce

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -51,6 +51,12 @@ std::tuple<Shape, std::vector<int>, bool> compute_reduce_shape(
     is_noop &= (out_shape.back() == shape[i]);
   }
   std::vector<int> sorted_axes(axes_set.begin(), axes_set.end());
+  // Dimensions that are size 1 at trace time can be dynamic when compiling
+  // shapeless, so the reduction cannot be elided from the graph. Reductions
+  // over no axes stay no-ops since they are shape independent.
+  if (is_noop && !sorted_axes.empty() && detail::in_dynamic_tracing()) {
+    is_noop = false;
+  }
   return {out_shape, sorted_axes, is_noop};
 }
 

--- a/python/tests/test_compile.py
+++ b/python/tests/test_compile.py
@@ -1110,6 +1110,45 @@ class TestCompile(mlx_tests.MLXTestCase):
         self.assertEqual(out[0].shape, (3, 1, 4, 2))
         self.assertEqual(out[1].shape, (2, 2, 5))
 
+    def test_shapeless_compile_reduce_after_gather(self):
+        # Reductions over dimensions that happen to have size 1 at trace time
+        # used to be elided from the graph, so replays with larger dynamic
+        # shapes returned stale values (issue #3201)
+        buf = mx.array([10.0, 20.0, 30.0, 40.0, 50.0])
+        reductions = [
+            mx.sum,
+            mx.mean,
+            mx.prod,
+            mx.min,
+            mx.max,
+            mx.all,
+            mx.any,
+            mx.argmin,
+            mx.argmax,
+        ]
+        for reduction in reductions:
+
+            def fun(buf, idx):
+                return reduction(mx.take(buf, idx, axis=0))
+
+            # Trace with a size-1 reduction and replay with larger sizes
+            cfun = mx.compile(fun, shapeless=True)
+            for n in [1, 2, 3, 4]:
+                idx = mx.arange(n)
+                self.assertTrue(
+                    mx.array_equal(cfun(buf, idx), fun(buf, idx)),
+                    f"{reduction.__name__} failed for n={n}",
+                )
+
+            # Replay with size 1 so the reduction is an identity at runtime
+            cfun = mx.compile(fun, shapeless=True)
+            for n in [2, 1]:
+                idx = mx.arange(n)
+                self.assertTrue(
+                    mx.array_equal(cfun(buf, idx), fun(buf, idx)),
+                    f"{reduction.__name__} failed for replay with n={n}",
+                )
+
     def test_leaks(self):
         gc.collect()
         if mx.metal.is_available():


### PR DESCRIPTION
## Proposed changes

Fixes #3201.

This picks up where #3202 left off: reductions over dimensions that are size 1
at trace time are elided from the graph, so shapeless replays with larger
dynamic shapes return stale values.

The reason #3202 failed CI was not a numerical regression. Once the reduction
is kept in the graph it can be a runtime identity (`out.size() == in.size()`,
e.g. a replay with size 1), and `Reduce::eval_gpu` rejects that case with
debug-only asserts in both the Metal and CUDA backends — which is why the
CPU-only jobs passed while the macOS and CUDA jobs aborted on the PR's own new
test. This PR replaces those asserts with an explicit identity path that
cast-copies the input to the output (the CPU backend already computes the
identity case correctly).

The frontend change is also restricted to non-empty reduction axes. The
unconditional version in #3202 could create a `Reduce` with no axes (0-dim
input, or an empty axes list for `all`/`any`/`max`), tripping
`assert(!axes_.empty())` in the same functions. No-axis reductions are shape
independent so eliding them stays correct.

The regression test covers all eight reductions plus `mean` on the output of
`mx.take`, in both directions: trace at size 1 and replay larger (the original
bug), and trace at size 2 and replay at size 1 (the runtime-identity path that
broke #3202). Verified against a Debug (assertions enabled) CPU build;
`test_compile`, `test_reduce`, and `test_ops` pass.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

Notes on the pre-commit box: `clang-format` (the three C++ files) and
`black`/`isort --profile=black` (the test file) were run and report clean, but
with `clang-format` v22.1.5 rather than the v21.1.8 the repo pins, and the full
`pre-commit run --all-files` was not run, so I have left that box unchecked for
the maintainer to confirm.

This change was developed with the help of Claude Code.
