### PR TITLE
Fix state corruption when a primitive throws during eval

### DIFF
--- a/mlx/transforms.cpp
+++ b/mlx/transforms.cpp
@@ -221,85 +221,113 @@ array eval_impl(std::vector<array> outputs, bool async) {
   }
 
   std::set<Stream> open_streams;
-  while (!tape.empty()) {
-    auto arr = std::move(tape.back());
-    tape.pop_back();
+  try {
+    while (!tape.empty()) {
+      auto arr = std::move(tape.back());
+      tape.pop_back();
 
-    auto stream = arr.primitive().stream();
-    open_streams.insert(stream);
+      auto stream = arr.primitive().stream();
+      open_streams.insert(stream);
 
-    if (async) {
-      // Lookup corresponding event
-      auto e = events.find(stream.index);
-      if (e == events.end()) {
-        e = events.emplace(stream.index, Event{stream}).first;
-      }
-      e->second.set_value(1);
-      arr.attach_event(e->second);
-      for (auto& s : arr.siblings()) {
-        s.attach_event(e->second);
-      }
-    }
-
-    for (auto& in : arr.inputs()) {
-      if (auto it = needs_fence.find(in.id()); it != needs_fence.end()) {
-        // Use fence to wait within a single eval
-        // Get the input array's stream fence and wait on the
-        // output arrays stream
-        fences[it->second.first].wait(stream, in);
-      } else if (in.event().valid()) {
-        if (in.event().is_signaled()) {
-          in.detach_event();
-        } else if (in.event().stream() != stream) {
-          // Use event to wait across async eval
-          in.event().wait(stream);
+      if (async) {
+        // Lookup corresponding event
+        auto e = events.find(stream.index);
+        if (e == events.end()) {
+          e = events.emplace(stream.index, Event{stream}).first;
+        }
+        e->second.set_value(1);
+        arr.attach_event(e->second);
+        for (auto& s : arr.siblings()) {
+          s.attach_event(e->second);
         }
       }
-    }
 
-    if (arr.primitive().device() == Device::gpu) {
-      gpu::eval(arr);
-    } else {
-      cpu::eval(arr);
-    }
-
-    if (scheduler::n_active_tasks() > MAX_ACTIVE_TASKS ||
-        (get_active_memory() > get_memory_limit() &&
-         scheduler::n_active_tasks() > 0)) {
-      // Commit any open streams
-      for (auto& s : open_streams) {
-        if (s.device == Device::gpu) {
-          gpu::finalize(s);
+      for (auto& in : arr.inputs()) {
+        if (auto it = needs_fence.find(in.id()); it != needs_fence.end()) {
+          // Use fence to wait within a single eval
+          // Get the input array's stream fence and wait on the
+          // output arrays stream
+          fences[it->second.first].wait(stream, in);
+        } else if (in.event().valid()) {
+          if (in.event().is_signaled()) {
+            in.detach_event();
+          } else if (in.event().stream() != stream) {
+            // Use event to wait across async eval
+            in.event().wait(stream);
+          }
         }
       }
-      scheduler::wait_for_one();
-      while (get_active_memory() > get_memory_limit() &&
-             scheduler::n_active_tasks() > 0) {
+
+      if (arr.primitive().device() == Device::gpu) {
+        gpu::eval(arr);
+      } else {
+        cpu::eval(arr);
+      }
+
+      if (scheduler::n_active_tasks() > MAX_ACTIVE_TASKS ||
+          (get_active_memory() > get_memory_limit() &&
+           scheduler::n_active_tasks() > 0)) {
+        // Commit any open streams
+        for (auto& s : open_streams) {
+          if (s.device == Device::gpu) {
+            gpu::finalize(s);
+          }
+        }
         scheduler::wait_for_one();
-      }
-    }
-
-    auto maybe_update_fence = [&fences, &needs_fence, stream](const array& a) {
-      if (auto nf = needs_fence.find(a.id()); nf != needs_fence.end()) {
-        auto it = fences.find(stream.index);
-        if (it == fences.end()) {
-          it = fences.emplace(stream.index, Fence{stream}).first;
+        while (get_active_memory() > get_memory_limit() &&
+               scheduler::n_active_tasks() > 0) {
+          scheduler::wait_for_one();
         }
-        it->second.update(stream, a, nf->second.second);
       }
-    };
 
-    arr.set_status(array::Status::evaluated);
-    // TODO Maybe always want the fence coherent kernel in the same cbuf
-    // as the other kernels?
-    maybe_update_fence(arr);
-    for (auto& sib : arr.siblings()) {
-      sib.set_status(array::Status::evaluated);
-      maybe_update_fence(sib);
+      auto maybe_update_fence =
+          [&fences, &needs_fence, stream](const array& a) {
+            if (auto nf = needs_fence.find(a.id()); nf != needs_fence.end()) {
+              auto it = fences.find(stream.index);
+              if (it == fences.end()) {
+                it = fences.emplace(stream.index, Fence{stream}).first;
+              }
+              it->second.update(stream, a, nf->second.second);
+            }
+          };
+
+      arr.set_status(array::Status::evaluated);
+      // TODO Maybe always want the fence coherent kernel in the same cbuf
+      // as the other kernels?
+      maybe_update_fence(arr);
+      for (auto& sib : arr.siblings()) {
+        sib.set_status(array::Status::evaluated);
+        maybe_update_fence(sib);
+      }
+      if (!arr.is_tracer()) {
+        arr.detach();
+      }
     }
-    if (!arr.is_tracer()) {
-      arr.detach();
+  } catch (...) {
+    // A primitive threw from inside its eval (e.g. argument validation in
+    // eval_gpu, or a JIT compile failure). Arrays evaluated earlier in this
+    // tape are already marked evaluated, but their kernels sit in pending
+    // command buffers that only the epilogue below would commit, and events
+    // attached during this eval would never be signaled. Left that way, a
+    // later read of an affected array returns an unwritten buffer or blocks
+    // forever. Signal the events and flush the touched streams, then let the
+    // exception propagate.
+    for (auto& [idx, e] : events) {
+      try {
+        auto es = e.stream();
+        e.signal(es);
+        open_streams.insert(es);
+      } catch (...) {
+      }
     }
+    for (auto& s : open_streams) {
+      try {
+        synchronize(s);
+      } catch (...) {
+        // Preserve the original exception.
+      }
+    }
+    throw;
   }
 
   // Signal the event in its stream

--- a/python/tests/test_eval.py
+++ b/python/tests/test_eval.py
@@ -195,6 +195,38 @@ class TestEval(mlx_tests.MLXTestCase):
         mx.eval(z)
         mx.set_memory_limit(old_limit)
 
+    @unittest.skipIf(not mx.is_available(mx.gpu), "GPU is not available")
+    def test_eval_exception_does_not_corrupt_state(self):
+        # An exception thrown from inside a primitive's eval (here a Metal
+        # compile error raised lazily at eval time) must not corrupt arrays
+        # evaluated earlier in the same batch: they are already marked
+        # evaluated, so their pending command buffers must still be
+        # committed before the exception propagates.
+        a = mx.full((1024,), 3.0)
+        b = a * 2.0  # encoded in the same eval batch as the failing kernel
+
+        kernel = mx.fast.metal_kernel(
+            name="test_eval_exception_bad_kernel",
+            input_names=["inp"],
+            output_names=["out"],
+            source="this is not metal code {",
+        )
+        with self.assertRaises(Exception):
+            (y,) = kernel(
+                inputs=[b],
+                output_shapes=[b.shape],
+                output_dtypes=[b.dtype],
+                grid=(1, 1, 1),
+                threadgroup=(1, 1, 1),
+            )
+            mx.eval(y)
+
+        self.assertTrue(mx.all(b == 6.0).item())
+
+        # Fresh computations after the failure stay correct.
+        x = mx.full((512,), 2.0)
+        self.assertEqual((x + 1.0).sum().item(), 512.0 * 3.0)
+
 
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner()

--- a/python/tests/test_eval.py
+++ b/python/tests/test_eval.py
@@ -195,7 +195,7 @@ class TestEval(mlx_tests.MLXTestCase):
         mx.eval(z)
         mx.set_memory_limit(old_limit)
 
-    @unittest.skipIf(not mx.is_available(mx.gpu), "GPU is not available")
+    @unittest.skipIf(not mx.metal.is_available(), "Metal is not available")
     def test_eval_exception_does_not_corrupt_state(self):
         # An exception thrown from inside a primitive's eval (here a Metal
         # compile error raised lazily at eval time) must not corrupt arrays


### PR DESCRIPTION
## Summary

An exception escaping a primitive's `eval_cpu`/`eval_gpu` unwinds `eval_impl` (`mlx/transforms.cpp`) before its per-stream epilogue runs, leaving the just-touched streams half-finished. The exception reaches the caller, so a `try/except` looks like it handled the error, but two invariants are now broken:

1. **Silent corruption (sync).** Arrays evaluated earlier in the same batch are already marked `Status::evaluated`, but their kernels sit in a command buffer that is never committed. A later read returns unwritten memory (stale buffer-pool bytes).
2. **Deadlock (async).** Events attached during the failed eval are never signaled, so a later read of an affected array blocks forever in `array::wait`.

Neither is a crash. The process keeps running with wrong numbers, or it hangs.

## Who hits it

The trigger is an exception out of `eval_gpu`/`eval_cpu`. Built-in ops validate at graph-construction time, so pure-builtin code rarely reaches this path — which is likely why it hasn't been reported. It bites the extension ecosystem:

- `mx.fast.metal_kernel` whose source fails to JIT-compile (compile happens lazily, at eval).
- Custom C++ primitives that validate or fail inside `eval_gpu`.

I found it while A/B-testing two custom paged-attention kernels: one primitive's argument check threw inside `eval_gpu`, and the *next*, valid primitive's output came back as an unwritten buffer ~50% of runs.

## Fix

Wrap the eval tape loop in a handler that does the minimal version of the normal epilogue, then re-raises:

- **Signal** every event created for this eval, releasing any async waiter. On a GPU stream `signal` *encodes* the signal into the command buffer after the pending kernels — it does not fire early.
- **Synchronize** every touched stream, committing the pending command buffers and draining them (kernels run, *then* the signal fires), so no waiter can observe a half-written array.
- `throw;` re-raises the original exception; both cleanup loops swallow secondary errors so they can't mask it.

Zero cost on the happy path (the `try` only matters when an exception is in flight).

## Test plan

- New regression test: `python/tests/test_eval.py::test_eval_exception_does_not_corrupt_state` (asserts a bystander array reads back correctly after a caught eval exception, and that fresh computation still works). The async/deadlock case is left out of the unit test so a regression can't hang CI; it lives in the standalone repro below.
- `test_eval.py` 14 passed; `test_array.py` / `test_fast.py` / `test_compile.py` 153 passed, 2 skipped.

<details>
<summary><b>Standalone reproduction</b> (RED on an unpatched build, GREEN with this PR — run locally, not added to the tree)</summary>

Save as `repro_eval_exception.py` at the repo root and run with `python repro_eval_exception.py`. Exit 0 = green, 1 = red. It triggers the bug through the public API with a deliberately broken custom kernel; the async case is isolated in a watchdog subprocess so a regression reports `DEADLOCK` instead of hanging.

**Unpatched (base commit):**
```
[ok]     bad kernel raises at eval
[WEDGED] producer array written before read: 1024/1024 elements wrong
[ok]     20 fresh compute rounds exact: 0 wrong
[WEDGED] async path: ... DEADLOCK: child hung >30s
RED: 2 check(s) failed
```

**With this PR:**
```
[ok] bad kernel raises at eval
[ok] producer array written before read: all 6.0
[ok] 20 fresh compute rounds exact: 0 wrong
[ok] async path: no hang, correct read: child exit 0
GREEN: exception contained, no state corruption
```

```python
"""Repro: an exception thrown from inside mx.eval corrupts later evals.

A C++ exception escaping Primitive::eval_gpu (here: a Metal compile error
from mx.fast.metal_kernel, raised lazily at eval time) unwinds eval_impl
before the per-stream epilogue runs. Two observable failures follow:

1. Sync wedge: arrays evaluated earlier in the same batch are already
   marked Status::evaluated, but their kernels sit in a command buffer
   that is never committed. A subsequent read returns whatever bytes the
   buffer pool handed out.
2. Async hang: per-stream events attached during the failed eval are
   never signaled, so a later read of an affected array blocks forever
   in array::wait.

Exit code 0 = green, 1 = red (bug present).
"""

import subprocess
import sys

import mlx.core as mx

BAD_SOURCE = "this is not metal code {"


def make_bad_kernel():
    return mx.fast.metal_kernel(
        name="repro_bad_kernel",
        input_names=["inp"],
        output_names=["out"],
        source=BAD_SOURCE,
    )


def run_bad(kernel, x, async_eval=False):
    """Dispatch the bad kernel on x and eval; return True if it raised."""
    try:
        (y,) = kernel(
            inputs=[x],
            output_shapes=[x.shape],
            output_dtypes=[x.dtype],
            grid=(1, 1, 1),
            threadgroup=(1, 1, 1),
        )
        if async_eval:
            mx.async_eval(y)
        mx.eval(y)
        return False
    except Exception as e:
        print(f"  caught expected exception: {type(e).__name__}", flush=True)
        return True


def child_async_read():
    """Async variant; exits 0 iff the post-failure read is correct."""
    c = mx.full((256,), 5.0)
    d = c * 2.0  # expected: all 10.0, encoded in the same batch as the bad kernel
    if not run_bad(make_bad_kernel(), d, async_eval=True):
        print("  bad kernel did not raise", flush=True)
        sys.exit(2)
    vals = memoryview(d)  # hangs here when events are left unsignaled
    n_bad = sum(1 for v in vals if v != 10.0)
    print(f"  async read: {n_bad}/256 elements wrong", flush=True)
    sys.exit(0 if n_bad == 0 else 3)


if len(sys.argv) > 1 and sys.argv[1] == "--async-child":
    child_async_read()

print(f"mlx {mx.__version__}", flush=True)
failures = []


def check(name, ok, detail=""):
    tag = "ok" if ok else "WEDGED"
    print(f"[{tag}] {name}{': ' + detail if detail else ''}", flush=True)
    if not ok:
        failures.append(name)


# --- 1. sync: exception raised and catchable ------------------------------
a = mx.full((1024,), 3.0)
b = a * 2.0  # lazy producer, encoded in the same eval batch as the bad kernel
check("bad kernel raises at eval", run_bad(make_bad_kernel(), b))

# --- 2. sync: producer from the failed batch reads back correctly ---------
vals = memoryview(b)
n_bad = sum(1 for v in vals if v != 6.0)
check(
    "producer array written before read",
    n_bad == 0,
    f"{n_bad}/1024 elements wrong" if n_bad else "all 6.0",
)

# --- 3. fresh, unrelated computations stay correct -------------------------
wrong = 0
for i in range(20):
    x = mx.full((512,), float(i))
    y1, y2 = (x + 1.0).sum(), (x + 1.0).sum()
    mx.eval(y1, y2)
    if not (y1.item() == y2.item() == 512.0 * (i + 1.0)):
        wrong += 1
check("20 fresh compute rounds exact", wrong == 0, f"{wrong} wrong")

# --- 4. async: no hang, correct read (run in a watchdog subprocess) --------
try:
    proc = subprocess.run(
        [sys.executable, __file__, "--async-child"],
        capture_output=True,
        text=True,
        timeout=30,
    )
    sys.stdout.write(proc.stdout)
    ok = proc.returncode == 0
    detail = f"child exit {proc.returncode}"
except subprocess.TimeoutExpired:
    ok, detail = False, "DEADLOCK: child hung >30s reading after async failure"
check("async path: no hang, correct read", ok, detail)

print(flush=True)
if failures:
    print(f"RED: {len(failures)} check(s) failed: {failures}", flush=True)
    sys.exit(1)
print("GREEN: exception contained, no state corruption", flush=True)
```

</details>

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
