### PR TITLE
Add bits and smallest_normal to finfo

### DIFF
--- a/mlx/types/limits.h
+++ b/mlx/types/limits.h
@@ -30,6 +30,9 @@ struct numeric_limits<float16_t> {
   constexpr static float16_t lowest() {
     return bits_to_half(0xFBFF);
   }
+  static constexpr float16_t min() {
+    return bits_to_half(0x0400);
+  }
   static constexpr float16_t max() {
     return bits_to_half(0x7BFF);
   }
@@ -55,6 +58,9 @@ struct numeric_limits<bfloat16_t> {
  public:
   constexpr static bfloat16_t lowest() {
     return bits_to_bfloat(0xFF7F);
+  }
+  static constexpr bfloat16_t min() {
+    return bits_to_bfloat(0x0080);
   }
   static constexpr bfloat16_t max() {
     return bits_to_bfloat(0x7F7F);

--- a/mlx/utils.cpp
+++ b/mlx/utils.cpp
@@ -305,10 +305,17 @@ std::string get_var(const char* name, const char* default_value) {
 } // namespace env
 
 template <typename T>
-void set_finfo_limits(double& min, double& max, double& eps) {
+void set_finfo_limits(
+    int& bits,
+    double& min,
+    double& max,
+    double& eps,
+    double& smallest_normal) {
+  bits = 8 * sizeof(T);
   min = numeric_limits<T>::lowest();
   max = numeric_limits<T>::max();
   eps = numeric_limits<T>::epsilon();
+  smallest_normal = numeric_limits<T>::min();
 }
 
 finfo::finfo(Dtype dtype) : dtype(dtype) {
@@ -318,16 +325,16 @@ finfo::finfo(Dtype dtype) : dtype(dtype) {
     throw std::invalid_argument(msg.str());
   }
   if (dtype == float32) {
-    set_finfo_limits<float>(min, max, eps);
+    set_finfo_limits<float>(bits, min, max, eps, smallest_normal);
   } else if (dtype == float16) {
-    set_finfo_limits<float16_t>(min, max, eps);
+    set_finfo_limits<float16_t>(bits, min, max, eps, smallest_normal);
   } else if (dtype == bfloat16) {
-    set_finfo_limits<bfloat16_t>(min, max, eps);
+    set_finfo_limits<bfloat16_t>(bits, min, max, eps, smallest_normal);
   } else if (dtype == float64) {
-    set_finfo_limits<double>(min, max, eps);
+    set_finfo_limits<double>(bits, min, max, eps, smallest_normal);
   } else if (dtype == complex64) {
     this->dtype = float32;
-    set_finfo_limits<float>(min, max, eps);
+    set_finfo_limits<float>(bits, min, max, eps, smallest_normal);
   }
 }
 

--- a/mlx/utils.h
+++ b/mlx/utils.h
@@ -76,9 +76,11 @@ MLX_API void abort_with_exception(const std::exception& error);
 struct MLX_API finfo {
   explicit finfo(Dtype dtype);
   Dtype dtype;
+  int bits;
   double min;
   double max;
   double eps;
+  double smallest_normal;
 };
 
 /** Holds information about integral types. */

--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -201,6 +201,10 @@ void init_array(nb::module_& m) {
       )pbdoc")
       .def(nb::init<mx::Dtype>())
       .def_ro(
+          "bits",
+          &mx::finfo::bits,
+          R"pbdoc(The number of bits occupied by the type.)pbdoc")
+      .def_ro(
           "min",
           &mx::finfo::min,
           R"pbdoc(The smallest representable number.)pbdoc")
@@ -215,6 +219,10 @@ void init_array(nb::module_& m) {
             The difference between 1.0 and the next smallest
             representable number larger than 1.0.
           )pbdoc")
+      .def_ro(
+          "smallest_normal",
+          &mx::finfo::smallest_normal,
+          R"pbdoc(The smallest positive normal number.)pbdoc")
       .def_ro("dtype", &mx::finfo::dtype, R"pbdoc(The :obj:`Dtype`.)pbdoc")
       .def("__repr__", [](const mx::finfo& f) {
         std::ostringstream os;

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -106,12 +106,32 @@ class TestDtypes(mlx_tests.MLXTestCase):
         self.assertEqual(mx.finfo(mx.float32).min, np.finfo(np.float32).min)
         self.assertEqual(mx.finfo(mx.float32).max, np.finfo(np.float32).max)
         self.assertEqual(mx.finfo(mx.float32).eps, np.finfo(np.float32).eps)
+        self.assertEqual(mx.finfo(mx.float32).bits, np.finfo(np.float32).bits)
+        self.assertEqual(
+            mx.finfo(mx.float32).smallest_normal,
+            float(np.finfo(np.float32).smallest_normal),
+        )
         self.assertEqual(mx.finfo(mx.float32).dtype, mx.float32)
 
         self.assertEqual(mx.finfo(mx.float16).min, np.finfo(np.float16).min)
         self.assertEqual(mx.finfo(mx.float16).max, np.finfo(np.float16).max)
         self.assertEqual(mx.finfo(mx.float16).eps, np.finfo(np.float16).eps)
+        self.assertEqual(mx.finfo(mx.float16).bits, np.finfo(np.float16).bits)
+        self.assertEqual(
+            mx.finfo(mx.float16).smallest_normal,
+            float(np.finfo(np.float16).smallest_normal),
+        )
         self.assertEqual(mx.finfo(mx.float16).dtype, mx.float16)
+
+        # bfloat16 has no numpy equivalent; check against known IEEE values.
+        self.assertEqual(mx.finfo(mx.bfloat16).bits, 16)
+        self.assertAlmostEqual(
+            mx.finfo(mx.bfloat16).smallest_normal, 2.0**-126, places=40
+        )
+
+        # finfo of a complex type reports its real component (array API).
+        self.assertEqual(mx.finfo(mx.complex64).dtype, mx.float32)
+        self.assertEqual(mx.finfo(mx.complex64).bits, 32)
 
     def test_iinfo(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Proposed changes

The array API [`finfo` object](https://data-apis.org/array-api/latest/API_specification/generated/array_api.finfo.html) requires `bits` (number of bits of the type) and `smallest_normal` (smallest positive normal number), in addition to the `min`/`max`/`eps`/`dtype` that `mlx.core.finfo` already exposes. This adds both.

It is also a practical prerequisite for running the conformance suite against MLX: `hypothesis.extra.array_api` reads `finfo(dtype).bits` and `finfo(dtype).smallest_normal` when generating float arrays, and currently raises `AttributeError: 'mlx.core.finfo' object has no attribute 'bits'`, which aborts data generation for every float test.

Changes:
- Add `bits` and `smallest_normal` to `mlx::finfo` (`mlx/utils.h`, `mlx/utils.cpp`) and to the Python binding (`python/src/array.cpp`).
- Add `min()` (smallest positive normal) to the `float16_t` / `bfloat16_t` `numeric_limits` specializations in `mlx/types/limits.h`, which previously defined only `lowest()`/`max()`/`epsilon()`. `float`/`double` already inherit it from `std::numeric_limits`.
- Extend `test_finfo` to cover `bits` and `smallest_normal` (vs NumPy for float32/float16, vs known IEEE values for bfloat16, and the real-component remap for complex64).

Resulting values:

| dtype | bits | smallest_normal |
| --- | --- | --- |
| float32 | 32 | 1.1754943508222875e-38 |
| float16 | 16 | 6.103515625e-05 |
| bfloat16 | 16 | 1.1754943508222875e-38 (2^-126) |
| float64 | 64 | 2.2250738585072014e-308 |
| complex64 | 32 | 1.1754943508222875e-38 (reports the real component) |

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] `clang-format` and `black` (the formatters configured in `.pre-commit-config.yaml`) report no changes on the modified files
- [x] Added tests (`test_finfo`)
- [x] Built from source and ran the tests locally: `test_array.TestDtypes` passes. Verified against `data-apis/array-api-tests` (`ARRAY_API_TESTS_MODULE=mlx.core`) that the previous `finfo` `AttributeError` no longer occurs and real-float elementwise tests (e.g. `test_ceil`, `test_floor`) now run and pass where they previously aborted during data generation