### PR TITLE
Add from_dlpack

### DIFF
--- a/docs/src/python/ops.rst
+++ b/docs/src/python/ops.rst
@@ -83,6 +83,7 @@ Operations
    floor
    floor_divide
    full
+   from_dlpack
    from_fp8
    gather_mm
    gather_qmm

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -1796,6 +1796,49 @@ void init_ops(nb::module_& m) {
             ValueError: If ``copy`` is ``False``.
       )pbdoc");
   m.def(
+      "from_dlpack",
+      [](const nb::object& x,
+         const nb::object& device,
+         std::optional<bool> copy) {
+        if (!device.is_none()) {
+          throw std::invalid_argument(
+              "[from_dlpack] Only the default device is supported, so "
+              "``device`` must be ``None``.");
+        }
+        if (copy.has_value() && !*copy) {
+          throw std::invalid_argument(
+              "[from_dlpack] copy=False is not supported.");
+        }
+        return create_array(x, std::nullopt);
+      },
+      nb::arg(),
+      nb::kw_only(),
+      "device"_a = nb::none(),
+      "copy"_a = nb::none(),
+      nb::sig(
+          "def from_dlpack(x: object, /, *, device: Optional[Device] = None, copy: Optional[bool] = None) -> array"),
+      R"pbdoc(
+        Construct an array from an object that implements the DLPack or
+        Python buffer protocol (for example a NumPy array or a tensor from
+        another array library).
+
+        Args:
+            x (object): An object exposing ``__dlpack__`` (or the buffer
+              protocol / array interface).
+            device (Device, optional): Must be ``None`` (the default). MLX
+              arrays are not pinned to a device, so only the default placement
+              is supported.
+            copy (bool, optional): Must be ``True`` or unspecified. ``False``
+              is not supported, since MLX always copies the incoming buffer
+              and cannot return a non-copying view.
+
+        Returns:
+            array: An MLX array with a copy of the input's data.
+
+        Raises:
+            ValueError: If ``copy`` is ``False`` or ``device`` is not ``None``.
+      )pbdoc");
+  m.def(
       "zeros_like",
       &mx::zeros_like,
       nb::arg(),

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -2045,6 +2045,31 @@ class TestArray(mlx_tests.MLXTestCase):
         y = np.from_dlpack(x)
         self.assertTrue(mx.array_equal(y, x))
 
+    def test_from_dlpack(self):
+        # Import from NumPy (buffer / DLPack protocol).
+        a = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
+        x = mx.from_dlpack(a)
+        self.assertTrue(isinstance(x, mx.array))
+        self.assertEqual(x.dtype, mx.float32)
+        self.assertTrue(mx.array_equal(x, mx.array(a)))
+
+        b = np.arange(6, dtype=np.int32).reshape(2, 3)
+        self.assertTrue(mx.array_equal(mx.from_dlpack(b), mx.array(b)))
+
+        # Round-trip an MLX array through from_dlpack.
+        y = mx.arange(8).reshape(2, 4)
+        self.assertTrue(mx.array_equal(mx.from_dlpack(y), y))
+
+        # Available on the array API namespace.
+        xp = mx.array(1.0).__array_namespace__()
+        self.assertTrue(hasattr(xp, "from_dlpack"))
+
+        # copy=False and a non-default device are not supported.
+        with self.assertRaises(ValueError):
+            mx.from_dlpack(a, copy=False)
+        with self.assertRaises(ValueError):
+            mx.from_dlpack(a, device=mx.gpu)
+
     @unittest.skipUnless(has_torch_mps, "PyTorch MPS is required")
     def test_torch_mps_dlpack_non_cpu_error(self):
         x = torch.arange(12, device="mps", dtype=torch.float32).reshape(3, 4)


### PR DESCRIPTION
## Proposed changes

Adds the array API [`from_dlpack`](https://data-apis.org/array-api/latest/API_specification/generated/array_api.from_dlpack.html) creation function:

```python
from_dlpack(x, /, *, device=None, copy=None) -> array
```

MLX already imports objects that implement the DLPack or Python buffer protocol through `mx.array(...)` (via `create_array` in `python/src/convert.cpp`); this exposes that capability under the array API name. The existing import path always copies the incoming (CPU) buffer, so the option handling mirrors `asarray`:

- `copy=False` raises `ValueError` (MLX cannot return a non-copying view).
- a non-default `device` raises `ValueError` (MLX arrays are not pinned to a device).
- `copy=True` / `None` and `device=None` import normally.

This is the first of the two methods named directly in #3484 (`asarray` / `asarray(copy=)` already landed on `main`).

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] `clang-format` and `black` (the formatters configured in `.pre-commit-config.yaml`) report no changes on the modified files
- [x] Added a test (`test_array.TestArray.test_from_dlpack`)
- [x] Built from source and ran the tests locally: `test_from_dlpack`, the existing `test_dlpack`, and `test_array_namespace` pass. Verified manually that `from_dlpack` imports a NumPy array, round-trips an MLX array, is present on the `__array_namespace__()` object, and raises for `copy=False` / non-default `device`