### PR TITLE
Add isdtype, result_type, and can_cast

### DIFF
--- a/docs/src/python/ops.rst
+++ b/docs/src/python/ops.rst
@@ -42,6 +42,7 @@ Operations
    broadcast_arrays
    broadcast_shapes
    broadcast_to
+   can_cast
    ceil
    clip
    concat
@@ -94,6 +95,7 @@ Operations
    identity
    imag
    inner
+   isdtype
    isfinite
    isclose
    isinf
@@ -148,6 +150,7 @@ Operations
    remainder
    repeat
    reshape
+   result_type
    right_shift
    roll
    round

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -5039,6 +5039,133 @@ void init_ops(nb::module_& m) {
           False
       )pbdoc");
   m.def(
+      "result_type",
+      [](const nb::args& arrays_and_dtypes) {
+        auto to_dtype = [](const nb::handle& v) -> mx::Dtype {
+          if (nb::isinstance<mx::array>(v)) {
+            return nb::cast<mx::array>(v).dtype();
+          } else if (nb::isinstance<mx::Dtype>(v)) {
+            return nb::cast<mx::Dtype>(v);
+          } else {
+            throw std::invalid_argument(
+                "[result_type] Inputs must be arrays or dtypes.");
+          }
+        };
+        if (arrays_and_dtypes.size() == 0) {
+          throw std::invalid_argument(
+              "[result_type] At least one array or dtype is required.");
+        }
+        mx::Dtype t = to_dtype(arrays_and_dtypes[0]);
+        for (size_t i = 1; i < arrays_and_dtypes.size(); ++i) {
+          t = mx::promote_types(t, to_dtype(arrays_and_dtypes[i]));
+        }
+        return t;
+      },
+      nb::sig(
+          "def result_type(*arrays_and_dtypes: Union[array, Dtype]) -> Dtype"),
+      R"pbdoc(
+        The type that results from applying type promotion to the inputs.
+
+        Args:
+            *arrays_and_dtypes (array or Dtype): A variable number of arrays
+              or dtypes.
+
+        Returns:
+            Dtype: The result type.
+      )pbdoc");
+  m.def(
+      "can_cast",
+      [](const nb::object& from_, const mx::Dtype& to) {
+        mx::Dtype from_dtype = mx::bool_;
+        if (nb::isinstance<mx::array>(from_)) {
+          from_dtype = nb::cast<mx::array>(from_).dtype();
+        } else if (nb::isinstance<mx::Dtype>(from_)) {
+          from_dtype = nb::cast<mx::Dtype>(from_);
+        } else {
+          throw std::invalid_argument(
+              "[can_cast] `from_` must be an array or a dtype.");
+        }
+        return mx::promote_types(from_dtype, to) == to;
+      },
+      "from_"_a,
+      "to"_a,
+      nb::sig("def can_cast(from_: Union[array, Dtype], to: Dtype) -> bool"),
+      R"pbdoc(
+        Determine if one data type can be cast to another according to type
+        promotion rules.
+
+        ``from_`` can be cast to ``to`` if promoting the two together gives
+        back ``to``.
+
+        Args:
+            from_ (array or Dtype): The source array or dtype.
+            to (Dtype): The destination dtype.
+
+        Returns:
+            bool: Whether the cast can be performed.
+      )pbdoc");
+  m.def(
+      "isdtype",
+      [](const mx::Dtype& dtype, const nb::object& kind) {
+        auto check_one = [&dtype](const nb::handle& k) -> bool {
+          if (nb::isinstance<mx::Dtype>(k)) {
+            return dtype == nb::cast<mx::Dtype>(k);
+          } else if (nb::isinstance<nb::str>(k)) {
+            auto s = nb::cast<std::string>(k);
+            if (s == "bool") {
+              return dtype == mx::bool_;
+            } else if (s == "signed integer") {
+              return mx::issubdtype(dtype, mx::signedinteger);
+            } else if (s == "unsigned integer") {
+              return mx::issubdtype(dtype, mx::unsignedinteger);
+            } else if (s == "integral") {
+              return mx::issubdtype(dtype, mx::integer);
+            } else if (s == "real floating") {
+              return mx::issubdtype(dtype, mx::floating);
+            } else if (s == "complex floating") {
+              return mx::issubdtype(dtype, mx::complexfloating);
+            } else if (s == "numeric") {
+              return mx::issubdtype(dtype, mx::number);
+            } else {
+              std::ostringstream msg;
+              msg << "[isdtype] Unknown data type kind: '" << s << "'.";
+              throw std::invalid_argument(msg.str());
+            }
+          } else {
+            throw std::invalid_argument(
+                "[isdtype] `kind` must be a dtype, a string, or a tuple of "
+                "dtypes and strings.");
+          }
+        };
+        if (nb::isinstance<nb::tuple>(kind)) {
+          for (auto k : nb::cast<nb::tuple>(kind)) {
+            if (check_one(k)) {
+              return true;
+            }
+          }
+          return false;
+        }
+        return check_one(kind);
+      },
+      "dtype"_a,
+      "kind"_a,
+      nb::sig(
+          "def isdtype(dtype: Dtype, kind: Union[Dtype, str, tuple[Union[Dtype, str], ...]]) -> bool"),
+      R"pbdoc(
+        Test whether a dtype belongs to one or more data type kinds.
+
+        Args:
+            dtype (Dtype): The dtype to test.
+            kind (Dtype, str, or tuple): A dtype, a kind string, or a tuple
+              of dtypes and kind strings. Supported kind strings are
+              ``"bool"``, ``"signed integer"``, ``"unsigned integer"``,
+              ``"integral"``, ``"real floating"``, ``"complex floating"``,
+              and ``"numeric"``.
+
+        Returns:
+            bool: ``True`` if ``dtype`` matches any of the given kinds.
+      )pbdoc");
+  m.def(
       "bitwise_and",
       [](const ScalarOrArray& a_,
          const ScalarOrArray& b_,

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -125,6 +125,55 @@ class TestDtypes(mlx_tests.MLXTestCase):
         self.assertEqual(mx.iinfo(mx.uint32).max, np.iinfo(np.uint32).max)
         self.assertEqual(mx.iinfo(mx.int8).dtype, mx.int8)
 
+    def test_result_type(self):
+        self.assertEqual(mx.result_type(mx.int8, mx.int16), mx.int16)
+        self.assertEqual(mx.result_type(mx.float32, mx.float64), mx.float64)
+        # Accepts arrays as well as dtypes, and more than two inputs.
+        self.assertEqual(
+            mx.result_type(mx.array([1], dtype=mx.int8), mx.int16, mx.int32),
+            mx.int32,
+        )
+        self.assertEqual(
+            mx.result_type(mx.array(1.0), mx.array(1, dtype=mx.int32)),
+            mx.float32,
+        )
+        with self.assertRaises(ValueError):
+            mx.result_type()
+
+    def test_can_cast(self):
+        self.assertTrue(mx.can_cast(mx.int8, mx.int16))
+        self.assertFalse(mx.can_cast(mx.int16, mx.int8))
+        self.assertTrue(mx.can_cast(mx.float32, mx.float64))
+        self.assertFalse(mx.can_cast(mx.float64, mx.float32))
+        self.assertTrue(mx.can_cast(mx.uint8, mx.int16))
+        self.assertFalse(mx.can_cast(mx.uint16, mx.int16))
+        # Accepts an array for the source.
+        self.assertTrue(mx.can_cast(mx.array([1, 2, 3], dtype=mx.int8), mx.int32))
+
+    def test_isdtype(self):
+        self.assertTrue(mx.isdtype(mx.int32, mx.int32))
+        self.assertFalse(mx.isdtype(mx.int32, mx.int16))
+        self.assertTrue(mx.isdtype(mx.int32, "signed integer"))
+        self.assertTrue(mx.isdtype(mx.uint8, "unsigned integer"))
+        self.assertFalse(mx.isdtype(mx.uint8, "signed integer"))
+        self.assertTrue(mx.isdtype(mx.int16, "integral"))
+        self.assertTrue(mx.isdtype(mx.float32, "real floating"))
+        self.assertTrue(mx.isdtype(mx.complex64, "complex floating"))
+        self.assertTrue(mx.isdtype(mx.bool_, "bool"))
+        self.assertFalse(mx.isdtype(mx.bool_, "numeric"))
+        self.assertTrue(mx.isdtype(mx.float32, "numeric"))
+        # Tuple of kinds (any match).
+        self.assertTrue(mx.isdtype(mx.float32, ("integral", "real floating")))
+        self.assertTrue(mx.isdtype(mx.int8, (mx.int8, mx.int16)))
+        self.assertFalse(mx.isdtype(mx.int32, ("bool", "real floating")))
+        with self.assertRaises(ValueError):
+            mx.isdtype(mx.int32, "not a kind")
+
+        # Reachable through the array API namespace.
+        xp = mx.array(1.0).__array_namespace__()
+        for name in ("result_type", "can_cast", "isdtype"):
+            self.assertTrue(hasattr(xp, name), msg=name)
+
 
 class TestEquality(mlx_tests.MLXTestCase):
     def test_array_eq_array(self):


### PR DESCRIPTION
## Proposed changes

Adds the array API [data-type functions](https://data-apis.org/array-api/latest/API_specification/data_type_functions.html) to `mlx.core`:

- **`result_type(*arrays_and_dtypes)`** — the dtype that results from applying type promotion to the inputs. Folds the existing `promote_types` over each input's dtype; accepts arrays and/or dtypes and any number of them.
- **`can_cast(from_, to)`** — `True` when `promote_types(from_, to) == to`. Accepts an array or a dtype for `from_`.
- **`isdtype(dtype, kind)`** — tests a dtype against a dtype, a kind string (`"bool"`, `"signed integer"`, `"unsigned integer"`, `"integral"`, `"real floating"`, `"complex floating"`, `"numeric"`), or a tuple of those, built on the existing `issubdtype` categories.

These build entirely on existing primitives (`promote_types`, `issubdtype`, the dtype categories), so there are no core changes. Added to the ops docs and tested in `TestDtypes`. Part of #3484.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] `clang-format` and `black` (the formatters configured in `.pre-commit-config.yaml`) report no changes on the modified files
- [x] Added tests (`test_array.TestDtypes::test_result_type`, `test_can_cast`, `test_isdtype`)
- [x] Built from source and ran the tests locally: `test_array.TestDtypes` passes (7/7)