### PR TITLE
Add NF4 quantization mode

### DIFF
--- a/mlx/backend/metal/CMakeLists.txt
+++ b/mlx/backend/metal/CMakeLists.txt
@@ -79,6 +79,7 @@ if(MLX_METAL_JIT)
   make_jit_source(quantized kernels/quantized_utils.h)
   make_jit_source(fp_quantized kernels/quantized_utils.h kernels/fp8.h
                   kernels/fp4.h)
+  make_jit_source(nf4_quantized kernels/quantized_utils.h kernels/nf4.h)
   make_jit_source(gemv_masked)
 
   make_jit_source(steel/attn/kernels/steel_attention)

--- a/mlx/backend/metal/jit/includes.h
+++ b/mlx/backend/metal/jit/includes.h
@@ -26,6 +26,7 @@ const char* logsumexp();
 const char* quantized_utils();
 const char* quantized();
 const char* fp_quantized();
+const char* nf4_quantized();
 const char* ternary();
 const char* scan();
 const char* scatter_axis();

--- a/mlx/backend/metal/jit_kernels.cpp
+++ b/mlx/backend/metal/jit_kernels.cpp
@@ -1,4 +1,6 @@
 // Copyright © 2024 Apple Inc.
+#include <stdexcept>
+
 #include "mlx/backend/common/compiled.h"
 #include "mlx/backend/metal/jit/includes.h"
 #include "mlx/backend/metal/kernels.h"
@@ -882,22 +884,21 @@ MTL::ComputePipelineState* get_gather_qmm_kernel(
     int wm,
     int wn,
     bool transpose) {
+  if (mode == "nf4") {
+    throw std::runtime_error("[gather_qmm] NF4 is not supported.");
+  }
   const auto& lib_name = kernel_name;
   auto lib = d.get_library(lib_name, [&]() {
     std::string kernel_source;
     concatenate(
         kernel_source, metal::utils(), metal::quantized_utils(), metal::gemm());
     bool is_affine = mode == "affine";
-    bool is_nf4 = mode == "nf4";
     concatenate(
         kernel_source,
-        is_affine ? metal::quantized()
-                  : is_nf4 ? metal::nf4_quantized()
-                           : metal::fp_quantized(),
+        is_affine ? metal::quantized() : metal::fp_quantized(),
         get_template_definition(
             lib_name,
-            (is_affine ? "affine" : is_nf4 ? "nf4" : "fp") +
-                std::string("_gather_qmm_rhs"),
+            (is_affine ? "affine" : "fp") + std::string("_gather_qmm_rhs"),
             get_type_string(x.dtype()),
             group_size,
             bits,

--- a/mlx/backend/metal/jit_kernels.cpp
+++ b/mlx/backend/metal/jit_kernels.cpp
@@ -858,7 +858,9 @@ MTL::ComputePipelineState* get_quantized_kernel(
         metal::utils(),
         metal::gemm(),
         metal::quantized_utils(),
-        (mode == "affine") ? metal::quantized() : metal::fp_quantized(),
+        (mode == "affine") ? metal::quantized()
+                          : (mode == "nf4") ? metal::nf4_quantized()
+                                            : metal::fp_quantized(),
         template_def);
     return kernel_source;
   });
@@ -886,12 +888,16 @@ MTL::ComputePipelineState* get_gather_qmm_kernel(
     concatenate(
         kernel_source, metal::utils(), metal::quantized_utils(), metal::gemm());
     bool is_affine = mode == "affine";
+    bool is_nf4 = mode == "nf4";
     concatenate(
         kernel_source,
-        is_affine ? metal::quantized() : metal::fp_quantized(),
+        is_affine ? metal::quantized()
+                  : is_nf4 ? metal::nf4_quantized()
+                           : metal::fp_quantized(),
         get_template_definition(
             lib_name,
-            (is_affine ? "affine" : "fp") + std::string("_gather_qmm_rhs"),
+            (is_affine ? "affine" : is_nf4 ? "nf4" : "fp") +
+                std::string("_gather_qmm_rhs"),
             get_type_string(x.dtype()),
             group_size,
             bits,

--- a/mlx/backend/metal/kernels/CMakeLists.txt
+++ b/mlx/backend/metal/kernels/CMakeLists.txt
@@ -138,6 +138,8 @@ if(NOT MLX_METAL_JIT)
   build_kernel(quantized quantized.h quantized_utils.h ${STEEL_HEADERS})
   build_kernel(fp_quantized fp4.h fp8.h fp_quantized.h quantized_utils.h
                ${STEEL_HEADERS})
+  build_kernel(nf4_quantized nf4.h nf4_quantized.h quantized_utils.h
+               ${STEEL_HEADERS})
   build_kernel(scan scan.h)
   build_kernel(softmax softmax.h)
   build_kernel(logsumexp logsumexp.h)

--- a/mlx/backend/metal/kernels/nf4.h
+++ b/mlx/backend/metal/kernels/nf4.h
@@ -1,0 +1,62 @@
+// Copyright © 2025 Apple Inc.
+// NormalFloat4 (NF4) lookup table quantization
+// Based on QLoRA: https://arxiv.org/abs/2305.14314
+
+#pragma once
+
+// The 16 NF4 quantization levels, derived from the quantiles of N(0,1).
+// Each 4-bit index maps to one of these values. Weights are reconstructed
+// as: weight = nf4_lut[index] * block_absmax
+//
+// The values are asymmetric: 8 negative, 1 zero, 7 positive.
+// They are normalized to [-1, 1] and placed so each bin captures
+// equal probability mass under a standard normal distribution.
+constant constexpr float nf4_lut[16] = {
+    -1.0f,
+    -0.6961928009986877f,
+    -0.5250730514526367f,
+    -0.39491748809814453f,
+    -0.28444138169288635f,
+    -0.18477343022823334f,
+    -0.09105003625154495f,
+    0.0f,
+    0.07958029955625534f,
+    0.16093020141124725f,
+    0.24611230194568634f,
+    0.33791524171829224f,
+    0.44070982933044434f,
+    0.5626170039176941f,
+    0.7229568362236023f,
+    1.0f,
+};
+
+struct nf4_scalar {
+  // Construct from float: find nearest NF4 level
+  nf4_scalar(float x) {
+    // Binary search / linear scan for nearest value
+    float min_dist = metal::abs(x - nf4_lut[0]);
+    bits = 0;
+    for (uint8_t i = 1; i < 16; i++) {
+      float dist = metal::abs(x - nf4_lut[i]);
+      if (dist < min_dist) {
+        min_dist = dist;
+        bits = i;
+      }
+    }
+  }
+
+  // Dequantize: just a table lookup
+  operator float() const {
+    return nf4_lut[bits & 0x0f];
+  }
+
+  operator float16_t() const {
+    return static_cast<float16_t>(nf4_lut[bits & 0x0f]);
+  }
+
+  operator bfloat16_t() const {
+    return static_cast<bfloat16_t>(nf4_lut[bits & 0x0f]);
+  }
+
+  uint8_t bits;
+};

--- a/mlx/backend/metal/kernels/nf4.h
+++ b/mlx/backend/metal/kernels/nf4.h
@@ -29,34 +29,3 @@ constant constexpr float nf4_lut[16] = {
     0.7229568362236023f,
     1.0f,
 };
-
-struct nf4_scalar {
-  // Construct from float: find nearest NF4 level
-  nf4_scalar(float x) {
-    // Binary search / linear scan for nearest value
-    float min_dist = metal::abs(x - nf4_lut[0]);
-    bits = 0;
-    for (uint8_t i = 1; i < 16; i++) {
-      float dist = metal::abs(x - nf4_lut[i]);
-      if (dist < min_dist) {
-        min_dist = dist;
-        bits = i;
-      }
-    }
-  }
-
-  // Dequantize: just a table lookup
-  operator float() const {
-    return nf4_lut[bits & 0x0f];
-  }
-
-  operator float16_t() const {
-    return static_cast<float16_t>(nf4_lut[bits & 0x0f]);
-  }
-
-  operator bfloat16_t() const {
-    return static_cast<bfloat16_t>(nf4_lut[bits & 0x0f]);
-  }
-
-  uint8_t bits;
-};

--- a/mlx/backend/metal/kernels/nf4_quantized.h
+++ b/mlx/backend/metal/kernels/nf4_quantized.h
@@ -927,6 +927,7 @@ METAL_FUNC void nf4_adjust_matrix_offsets(
     const constant int64_t* w_strides,
     const constant int64_t* s_strides,
     uint3 tid [[threadgroup_position_in_grid]]) {
+  constexpr int scale_bytes = 4;
   uint32_t x_idx = tid.z;
   uint32_t w_idx = tid.z;
   if (x_batch_ndims == 1) {
@@ -936,12 +937,12 @@ METAL_FUNC void nf4_adjust_matrix_offsets(
   }
   if (w_batch_ndims == 1) {
     w += w_idx * w_strides[0];
-    scales += w_idx * s_strides[0];
+    scales += w_idx * s_strides[0] * scale_bytes;
   } else {
     ulong2 idx = elem_to_loc_broadcast(
         w_idx, w_shape, w_strides, s_strides, w_batch_ndims);
     w += idx.x;
-    scales += idx.y;
+    scales += idx.y * scale_bytes;
   }
   y += tid.z * output_stride;
 }

--- a/mlx/backend/metal/kernels/nf4_quantized.h
+++ b/mlx/backend/metal/kernels/nf4_quantized.h
@@ -51,11 +51,6 @@ inline U nf4_dequantize_value(uint8_t x) {
   return U(nf4_lut[x & 0x0f]);
 }
 
-// Quantize a normalized [-1,1] value to the nearest NF4 index
-inline uint8_t nf4_quantize_value(float x) {
-  return nf4_scalar(x).bits;
-}
-
 ///////////////////////////////////////////////////////////////////////////////
 // Vector load helpers (same as fp_quantized.h)
 ///////////////////////////////////////////////////////////////////////////////
@@ -1234,50 +1229,8 @@ template <
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-// Quantize / Dequantize standalone kernels
+// Dequantize standalone kernel
 ///////////////////////////////////////////////////////////////////////////////
-
-template <typename T, const int group_size>
-[[kernel]] void nf4_quantize(
-    const device T* w [[buffer(0)]],
-    device uint8_t* out [[buffer(1)]],
-    device float* scales_out [[buffer(2)]],
-    uint2 tidx [[thread_position_in_grid]],
-    uint2 grid_dim [[threads_per_grid]]) {
-  size_t index = tidx.x + grid_dim.x * size_t(tidx.y);
-
-  // Compute absmax within the simdgroup (one group = 64 elements = 2 simdgroups)
-  float w_thread = w[index];
-  float absmax;
-  if constexpr (group_size == 64) {
-    // Two halves of the simdgroup cover 64 elements
-    absmax = simd_max(metal::abs(w_thread));
-    // For group_size=64 with simd_size=32, we need cross-simdgroup reduction
-    // This is handled by the dispatch: one thread per element, groups of 64
-    float absmax_l = simd_max(tidx.x < 32 ? metal::abs(w_thread) : 0.0f);
-    float absmax_r = simd_max(tidx.x >= 32 ? metal::abs(w_thread) : 0.0f);
-    absmax = max(absmax_l, absmax_r);
-  } else {
-    absmax = simd_max(metal::abs(w_thread));
-  }
-
-  size_t gindex = index / group_size;
-  if (index % group_size == 0) {
-    scales_out[gindex] = absmax;
-  }
-
-  // Normalize to [-1, 1] and find nearest NF4 level
-  float normalized = (absmax == 0.0f) ? 0.0f : w_thread / absmax;
-  uint8_t output = nf4_quantize_value(normalized);
-
-  // Pack two 4-bit values per byte
-  uint8_t sval = simd_shuffle_down(output, 1);
-  output |= sval << 4;
-
-  if (index % 2 == 0) {
-    out[index / 2] = output;
-  }
-}
 
 template <typename T, const int group_size>
 [[kernel]] void nf4_dequantize(

--- a/mlx/backend/metal/kernels/nf4_quantized.h
+++ b/mlx/backend/metal/kernels/nf4_quantized.h
@@ -1,0 +1,1303 @@
+// Copyright © 2025 Apple Inc.
+// NF4 (NormalFloat4) quantized matmul kernels for MLX.
+//
+// These kernels mirror the structure of fp_quantized.h but replace the
+// E2M1 float dequantization with an NF4 lookup table, and read scales
+// as float32 (4 bytes per group) instead of FP8 (1 byte per group).
+//
+// NF4 format: 4-bit indices into a 16-element LUT derived from normal
+// distribution quantiles. Scales are float32 absmax per block of 64.
+
+#include <metal_simdgroup>
+#include <metal_stdlib>
+
+#include "mlx/backend/metal/kernels/nf4.h"
+
+constant bool align_M [[function_constant(200)]];
+constant bool align_N [[function_constant(201)]];
+constant bool align_K [[function_constant(202)]];
+
+using namespace metal;
+
+#define MLX_MTL_CONST static constant constexpr const
+
+MLX_MTL_CONST int SIMD_SIZE = 32;
+MLX_MTL_CONST int QUAD_SIZE = 4;
+
+template <int wsize = 8, int bits = 4>
+inline constexpr short nf4_get_pack_factor() {
+  return wsize / bits;
+}
+
+template <int wsize = 8>
+inline constexpr short nf4_get_bytes_per_pack() {
+  return wsize / 8;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// NF4-specific dequantization
+///////////////////////////////////////////////////////////////////////////////
+
+// Read a float32 scale from the uint8_t scale buffer.
+// NF4 stores one float32 absmax per group (4 bytes per group).
+template <typename T, int group_size>
+static inline T nf4_dequantize_scale(const device uint8_t* s) {
+  return T(*reinterpret_cast<const device float*>(s));
+}
+
+// Dequantize a 4-bit NF4 index to float via LUT lookup
+template <typename U = float>
+inline U nf4_dequantize_value(uint8_t x) {
+  return U(nf4_lut[x & 0x0f]);
+}
+
+// Quantize a normalized [-1,1] value to the nearest NF4 index
+inline uint8_t nf4_quantize_value(float x) {
+  return nf4_scalar(x).bits;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Vector load helpers (same as fp_quantized.h)
+///////////////////////////////////////////////////////////////////////////////
+
+template <typename T, typename U, int values_per_thread>
+inline void nf4_load_vector(const device T* x, thread U* x_thread) {
+#pragma unroll
+  for (int i = 0; i < values_per_thread; i++) {
+    x_thread[i] = x[i];
+  }
+}
+
+template <typename T, typename U, int values_per_thread>
+inline void
+nf4_load_vector_safe(const device T* x, thread U* x_thread, int N) {
+  for (int i = 0; i < N; i++) {
+    x_thread[i] = x[i];
+  }
+  for (int i = N; i < values_per_thread; i++) {
+    x_thread[i] = 0;
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// NF4 dot product and outer product primitives
+//
+// Optimization: build a scaled LUT (nf4_lut[i] * absmax_scale) in thread
+// registers, then the inner loop is just a register-local table lookup per
+// nibble — no constant-memory access and no post-multiply needed.
+///////////////////////////////////////////////////////////////////////////////
+
+template <typename U>
+inline void nf4_build_scaled_lut(U scale, thread U* slut) {
+  // 16 entries, pre-multiplied by the block absmax scale.
+  // The compiler should keep these in registers for the inner loop.
+  slut[0]  = U(nf4_lut[0])  * scale;
+  slut[1]  = U(nf4_lut[1])  * scale;
+  slut[2]  = U(nf4_lut[2])  * scale;
+  slut[3]  = U(nf4_lut[3])  * scale;
+  slut[4]  = U(nf4_lut[4])  * scale;
+  slut[5]  = U(nf4_lut[5])  * scale;
+  slut[6]  = U(nf4_lut[6])  * scale;
+  slut[7]  = U(nf4_lut[7])  * scale;
+  slut[8]  = U(nf4_lut[8])  * scale;
+  slut[9]  = U(nf4_lut[9])  * scale;
+  slut[10] = U(nf4_lut[10]) * scale;
+  slut[11] = U(nf4_lut[11]) * scale;
+  slut[12] = U(nf4_lut[12]) * scale;
+  slut[13] = U(nf4_lut[13]) * scale;
+  slut[14] = U(nf4_lut[14]) * scale;
+  slut[15] = U(nf4_lut[15]) * scale;
+}
+
+template <typename U, int values_per_thread>
+inline U nf4_qdot(const device uint8_t* w, const thread U* x_thread, U scale) {
+  // Build scaled LUT once per group
+  thread U slut[16];
+  nf4_build_scaled_lut(scale, slut);
+
+  U accum = 0;
+  // Process 2 elements per byte (lo nibble, hi nibble)
+  for (int i = 0; i < (values_per_thread / 2); i++) {
+    uint8_t byte = w[i];
+    accum += x_thread[2 * i]     * slut[byte & 0x0f] +
+             x_thread[2 * i + 1] * slut[byte >> 4];
+  }
+  return accum;  // no final multiply — already scaled in LUT
+}
+
+template <typename U, int values_per_thread>
+inline U nf4_qdot_safe(
+    const device uint8_t* w,
+    const thread U* x_thread,
+    U scale,
+    int N) {
+  thread U slut[16];
+  nf4_build_scaled_lut(scale, slut);
+
+  U accum = 0;
+  for (int i = 0; i < (N / 2); i++) {
+    uint8_t byte = w[i];
+    accum += x_thread[2 * i]     * slut[byte & 0x0f] +
+             x_thread[2 * i + 1] * slut[byte >> 4];
+  }
+  return accum;
+}
+
+template <typename U, int values_per_thread>
+inline void
+nf4_qouter(const thread uint8_t* w, U x, U scale, thread U* result) {
+  // For outer product, pre-scale x instead of building full LUT
+  thread U slut[16];
+  nf4_build_scaled_lut(scale, slut);
+
+  for (int i = 0; i < (values_per_thread / 2); i++) {
+    result[2 * i]     += x * slut[w[i] & 0x0f];
+    result[2 * i + 1] += x * slut[w[i] >> 4];
+  }
+}
+
+template <typename U>
+inline void nf4_dequantize_elem(uint8_t w, U scale, threadgroup U* w_local) {
+  // Dequantize two 4-bit values from one byte
+  w_local[0] = U(nf4_lut[w & 0x0f]) * scale;
+  w_local[1] = U(nf4_lut[w >> 4]) * scale;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// NF4 Block Loader
+//
+// Same structure as fp_quantized.h QuantizedBlockLoader but reads float32
+// scales. Scale stride = sizeof(float) bytes per group instead of 1.
+///////////////////////////////////////////////////////////////////////////////
+
+template <
+    typename T,
+    short BROWS,
+    short BCOLS,
+    short dst_ld,
+    short reduction_dim,
+    short tgp_size,
+    short group_size>
+struct NF4BlockLoader {
+  MLX_MTL_CONST short pack_factor = nf4_get_pack_factor();
+  MLX_MTL_CONST short bytes_per_pack = nf4_get_bytes_per_pack();
+  MLX_MTL_CONST short BCOLS_PACKED = BCOLS / pack_factor;
+  MLX_MTL_CONST short n_reads =
+      (BCOLS_PACKED * BROWS < tgp_size) ? 1 : (BCOLS_PACKED * BROWS) / tgp_size;
+  MLX_MTL_CONST short group_steps =
+      group_size < BCOLS ? 1 : group_size / BCOLS;
+  MLX_MTL_CONST short scale_step =
+      group_size < BCOLS ? BCOLS / group_size : 1;
+
+  // Scale stride in bytes: float32 = 4 bytes per scale
+  MLX_MTL_CONST short scale_bytes = 4;
+
+  static_assert(
+      (n_reads * pack_factor) <= group_size,
+      "The number of reads per thread must be less than the group size.");
+
+  const int src_ld;
+  const int tile_stride;
+  short group_step_cnt;
+  const int group_stride;
+
+  const short thread_idx;
+  const short bi;
+  const short bj;
+
+  threadgroup T* dst;
+  const device uint8_t* src;
+  const device uint8_t* scales;
+
+  NF4BlockLoader(
+      const device uint8_t* src_,
+      const device uint8_t* scales_,
+      const int src_ld_,
+      threadgroup T* dst_,
+      ushort simd_group_id [[simdgroup_index_in_threadgroup]],
+      ushort simd_lane_id [[thread_index_in_simdgroup]])
+      : src_ld(src_ld_),
+        tile_stride(
+            reduction_dim ? BCOLS_PACKED * bytes_per_pack
+                          : BROWS * src_ld * bytes_per_pack / pack_factor),
+        group_step_cnt(0),
+        group_stride(BROWS * src_ld / group_size),
+        thread_idx(simd_group_id * 32 + simd_lane_id),
+        bi(n_reads * thread_idx / BCOLS_PACKED),
+        bj((n_reads * thread_idx) % BCOLS_PACKED),
+        dst(dst_ + bi * dst_ld + bj * pack_factor),
+        src(src_ + bi * src_ld * bytes_per_pack / pack_factor +
+            bj * bytes_per_pack),
+        scales(
+            scales_ + (bi * src_ld / group_size +
+                        (bj * pack_factor) / group_size) *
+                scale_bytes) {}
+
+  void load_unsafe() const {
+    if (BCOLS_PACKED * BROWS < tgp_size && bi >= BROWS) {
+      return;
+    }
+
+    T scale = nf4_dequantize_scale<T, group_size>(scales);
+    for (int i = 0; i < n_reads; i++) {
+      nf4_dequantize_elem<T>(src[i * bytes_per_pack], scale, dst + i * pack_factor);
+    }
+  }
+
+  void load_safe(short2 src_tile_dim) const {
+    if (BCOLS_PACKED * BROWS < tgp_size && bi >= BROWS) {
+      return;
+    }
+
+    if (reduction_dim == 1 && bi >= src_tile_dim.x) {
+      for (int i = 0; i < n_reads * pack_factor; i++) {
+        dst[i] = T(0);
+      }
+      return;
+    }
+
+    if (reduction_dim == 0 && bi >= src_tile_dim.y) {
+      for (int i = 0; i < n_reads * pack_factor; i++) {
+        dst[i] = T(0);
+      }
+      return;
+    }
+
+    T scale = nf4_dequantize_scale<T, group_size>(scales);
+    for (int i = 0; i < n_reads; i++) {
+      nf4_dequantize_elem<T>(src[i * bytes_per_pack], scale, dst + i * pack_factor);
+    }
+  }
+
+  void next() {
+    src += tile_stride;
+    if (reduction_dim == 1) {
+      if (group_steps > 1) {
+        group_step_cnt++;
+        if (group_step_cnt == group_steps) {
+          group_step_cnt = 0;
+          scales += scale_bytes;
+        }
+      } else {
+        scales += scale_step * scale_bytes;
+      }
+    } else {
+      scales += group_stride * scale_bytes;
+    }
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+// QMV kernels (matrix-vector, used during token generation)
+///////////////////////////////////////////////////////////////////////////////
+
+template <typename T, int group_size, int D>
+METAL_FUNC void nf4_qmv_quad_impl(
+    const device uint32_t* w,
+    const device uint8_t* scales,
+    const device T* x,
+    device T* y,
+    constant int& in_vec_size,
+    const constant int& out_vec_size,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint quad_gid [[quadgroup_index_in_threadgroup]],
+    uint quad_lid [[thread_index_in_quadgroup]]) {
+  constexpr int quads_per_simd = SIMD_SIZE / QUAD_SIZE;
+  constexpr int pack_factor = nf4_get_pack_factor<32, 4>();
+  constexpr int values_per_thread = D / QUAD_SIZE;
+  constexpr int steps_per_thread =
+      values_per_thread < group_size ? 1 : values_per_thread / group_size;
+  constexpr int values_per_step = values_per_thread / steps_per_thread;
+  constexpr int packs_per_thread = values_per_thread / pack_factor;
+  constexpr int packs_per_step = values_per_step / pack_factor;
+  constexpr int results_per_quadgroup = 8;
+
+  // NF4 scale stride: 4 bytes per float32 scale
+  constexpr int scale_bytes = 4;
+
+  typedef float U;
+
+  thread U x_thread[values_per_thread];
+  thread U result[results_per_quadgroup] = {0};
+
+  const int in_vec_size_w = in_vec_size / pack_factor;
+  const int in_vec_size_g = in_vec_size / group_size;
+  const int out_row = tid.y * quads_per_simd * results_per_quadgroup + quad_gid;
+
+  w += out_row * in_vec_size_w + quad_lid * packs_per_thread;
+  scales +=
+      (out_row * in_vec_size_g + (quad_lid * values_per_thread) / group_size) *
+      scale_bytes;
+  x += tid.x * in_vec_size + quad_lid * values_per_thread;
+  y += tid.x * out_vec_size + out_row;
+
+  nf4_load_vector<T, U, values_per_thread>(x, x_thread);
+
+  for (int row = 0; row < results_per_quadgroup; row++) {
+    auto wl = (const device uint8_t*)(w + row * in_vec_size_w * quads_per_simd);
+    const device uint8_t* sl =
+        scales + row * in_vec_size_g * quads_per_simd * scale_bytes;
+#pragma unroll
+    for (int k = 0; k < steps_per_thread; ++k) {
+      U s = nf4_dequantize_scale<U, group_size>(sl);
+      if (row * quads_per_simd + out_row < out_vec_size) {
+        result[row] +=
+            nf4_qdot<U, values_per_step>(wl, x_thread + k * values_per_step, s);
+      }
+      sl += scale_bytes;
+      wl += (sizeof(uint32_t) / sizeof(uint8_t)) * packs_per_step;
+    }
+  }
+
+  for (int row = 0; row < results_per_quadgroup; row++) {
+    result[row] = quad_sum(result[row]);
+    if (quad_lid == 0 && row * quads_per_simd + out_row < out_vec_size) {
+      y[row * quads_per_simd] = static_cast<T>(result[row]);
+    }
+  }
+}
+
+template <typename T, int group_size>
+METAL_FUNC void nf4_qmv_fast_impl(
+    const device uint32_t* w,
+    const device uint8_t* scales,
+    const device T* x,
+    device T* y,
+    const constant int& in_vec_size,
+    const constant int& out_vec_size,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  constexpr int packs_per_thread = 2;
+  constexpr int num_simdgroups = 2;
+  constexpr int results_per_simdgroup = 4;
+  constexpr int pack_factor = nf4_get_pack_factor<32, 4>();
+  constexpr int bytes_per_pack = nf4_get_bytes_per_pack<32>();
+  constexpr int values_per_thread = pack_factor * packs_per_thread;
+  constexpr int block_size = values_per_thread * SIMD_SIZE;
+  constexpr int scale_step_per_thread = group_size / values_per_thread;
+  constexpr int scale_bytes = 4;
+
+  const device uint8_t* ws = (const device uint8_t*)w;
+
+  typedef float U;
+  thread U x_thread[values_per_thread];
+  thread U result[results_per_simdgroup] = {0};
+
+  const int in_vec_size_w = in_vec_size * bytes_per_pack / pack_factor;
+  const int in_vec_size_g = in_vec_size / group_size;
+  const int out_row = tid.y * (num_simdgroups * results_per_simdgroup) +
+      simd_gid * results_per_simdgroup;
+
+  ws += out_row * in_vec_size_w + simd_lid * packs_per_thread * bytes_per_pack;
+  scales +=
+      (out_row * in_vec_size_g + simd_lid / scale_step_per_thread) *
+      scale_bytes;
+  x += tid.x * in_vec_size + simd_lid * values_per_thread;
+  y += tid.x * out_vec_size + out_row;
+
+  for (int k = 0; k < in_vec_size; k += block_size) {
+    nf4_load_vector<T, U, values_per_thread>(x, x_thread);
+
+    for (int row = 0; row < results_per_simdgroup; row++) {
+      auto wl = (const device uint8_t*)(ws + row * in_vec_size_w);
+      const device uint8_t* sl =
+          scales + row * in_vec_size_g * scale_bytes;
+
+      U s = nf4_dequantize_scale<U, group_size>(sl);
+      result[row] += nf4_qdot<U, values_per_thread>(wl, x_thread, s);
+    }
+
+    ws += block_size * bytes_per_pack / pack_factor;
+    scales += (block_size / group_size) * scale_bytes;
+    x += block_size;
+  }
+
+  for (int row = 0; row < results_per_simdgroup; row++) {
+    result[row] = simd_sum(result[row]);
+    if (simd_lid == 0) {
+      y[row] = static_cast<T>(result[row]);
+    }
+  }
+}
+
+template <typename T, int group_size>
+METAL_FUNC void nf4_qmv_impl(
+    const device uint32_t* w,
+    const device uint8_t* scales,
+    const device T* x,
+    device T* y,
+    const constant int& in_vec_size,
+    const constant int& out_vec_size,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  constexpr int num_simdgroups = 2;
+  constexpr int results_per_simdgroup = 4;
+  constexpr int packs_per_thread = 1;
+  constexpr int pack_factor = nf4_get_pack_factor<32, 4>();
+  constexpr int bytes_per_pack = nf4_get_bytes_per_pack<32>();
+  constexpr int values_per_thread = pack_factor * packs_per_thread;
+  constexpr int block_size = values_per_thread * SIMD_SIZE;
+  constexpr int scale_step_per_thread = group_size / values_per_thread;
+  constexpr int scale_bytes = 4;
+
+  const device uint8_t* ws = (const device uint8_t*)w;
+
+  typedef float U;
+  thread U x_thread[values_per_thread];
+  thread U result[results_per_simdgroup] = {0};
+
+  const int in_vec_size_w = in_vec_size * bytes_per_pack / pack_factor;
+  const int in_vec_size_g = in_vec_size / group_size;
+  const int out_row = tid.y * (num_simdgroups * results_per_simdgroup) +
+      simd_gid * results_per_simdgroup;
+  const int used_out_row = min(out_vec_size - results_per_simdgroup, out_row);
+
+  if (out_row >= out_vec_size) {
+    return;
+  }
+
+  if (out_vec_size < (num_simdgroups * results_per_simdgroup)) {
+    ws +=
+        out_row * in_vec_size_w + simd_lid * packs_per_thread * bytes_per_pack;
+    scales +=
+        (out_row * in_vec_size_g + simd_lid / scale_step_per_thread) *
+        scale_bytes;
+    x += tid.x * in_vec_size + simd_lid * values_per_thread;
+    y += tid.x * out_vec_size + out_row;
+
+    int k = 0;
+    for (; k < in_vec_size - block_size; k += block_size) {
+      nf4_load_vector<T, U, values_per_thread>(x, x_thread);
+      for (int row = 0;
+           row < results_per_simdgroup && out_row + row < out_vec_size;
+           row++) {
+        auto wl = (const device uint8_t*)(ws + row * in_vec_size_w);
+        const device uint8_t* sl =
+            scales + row * in_vec_size_g * scale_bytes;
+        U s = nf4_dequantize_scale<U, group_size>(sl);
+        result[row] += nf4_qdot<U, values_per_thread>(wl, x_thread, s);
+      }
+      ws += block_size * bytes_per_pack / pack_factor;
+      scales += (block_size / group_size) * scale_bytes;
+      x += block_size;
+    }
+    const int remaining = clamp(
+        static_cast<int>(in_vec_size - k - simd_lid * values_per_thread),
+        0,
+        values_per_thread);
+    if (remaining > 0) {
+      nf4_load_vector_safe<T, U, values_per_thread>(x, x_thread, remaining);
+      for (int row = 0;
+           row < results_per_simdgroup && out_row + row < out_vec_size;
+           row++) {
+        auto wl = (const device uint8_t*)(ws + row * in_vec_size_w);
+        const device uint8_t* sl =
+            scales + row * in_vec_size_g * scale_bytes;
+        U s = nf4_dequantize_scale<U, group_size>(sl);
+        result[row] += nf4_qdot<U, values_per_thread>(wl, x_thread, s);
+      }
+    }
+    for (int row = 0;
+         row < results_per_simdgroup && out_row + row < out_vec_size;
+         row++) {
+      result[row] = simd_sum(result[row]);
+      if (simd_lid == 0) {
+        y[row] = static_cast<T>(result[row]);
+      }
+    }
+  } else {
+    ws += used_out_row * in_vec_size_w +
+        simd_lid * packs_per_thread * bytes_per_pack;
+    scales +=
+        (used_out_row * in_vec_size_g + simd_lid / scale_step_per_thread) *
+        scale_bytes;
+    x += tid.x * in_vec_size + simd_lid * values_per_thread;
+    y += tid.x * out_vec_size + used_out_row;
+
+    int k = 0;
+    for (; k < in_vec_size - block_size; k += block_size) {
+      nf4_load_vector<T, U, values_per_thread>(x, x_thread);
+      for (int row = 0; row < results_per_simdgroup; row++) {
+        auto wl = (const device uint8_t*)(ws + row * in_vec_size_w);
+        const device uint8_t* sl =
+            scales + row * in_vec_size_g * scale_bytes;
+        U s = nf4_dequantize_scale<U, group_size>(sl);
+        result[row] += nf4_qdot<U, values_per_thread>(wl, x_thread, s);
+      }
+      ws += block_size * bytes_per_pack / pack_factor;
+      scales += (block_size / group_size) * scale_bytes;
+      x += block_size;
+    }
+    const int remaining = clamp(
+        static_cast<int>(in_vec_size - k - simd_lid * values_per_thread),
+        0,
+        values_per_thread);
+    if (remaining > 0) {
+      nf4_load_vector_safe<T, U, values_per_thread>(x, x_thread, remaining);
+      for (int row = 0; row < results_per_simdgroup; row++) {
+        auto wl = (const device uint8_t*)(ws + row * in_vec_size_w);
+        const device uint8_t* sl =
+            scales + row * in_vec_size_g * scale_bytes;
+        U s = nf4_dequantize_scale<U, group_size>(sl);
+        result[row] +=
+            nf4_qdot_safe<U, values_per_thread>(wl, x_thread, s, remaining);
+      }
+    }
+    for (int row = 0; row < results_per_simdgroup; row++) {
+      result[row] = simd_sum(result[row]);
+      if (simd_lid == 0) {
+        y[row] = static_cast<T>(result[row]);
+      }
+    }
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// QVM kernel (vector-matrix)
+///////////////////////////////////////////////////////////////////////////////
+
+template <typename T, const int group_size>
+METAL_FUNC void nf4_qvm_impl(
+    const device uint32_t* w,
+    const device uint8_t* scales,
+    const device T* x,
+    device T* y,
+    const int in_vec_size,
+    const int out_vec_size,
+    const int in_vec_stride,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  constexpr int num_simdgroups = 2;
+  constexpr int pack_factor = nf4_get_pack_factor<32, 4>();
+  constexpr int bytes_per_pack = nf4_get_bytes_per_pack();
+  constexpr int tn = group_size / pack_factor;
+  constexpr int block_size = SIMD_SIZE;
+  constexpr int scale_bytes = 4;
+
+  using W_T = uint32_t;
+  const device W_T* ws = (const device W_T*)w;
+
+  typedef float U;
+  typedef struct {
+    W_T wi[tn * bytes_per_pack];
+  } vec_w;
+
+  thread vec_w w_local;
+  thread U result[tn * pack_factor] = {0};
+  thread U scale = 0;
+  thread U x_local = 0;
+
+  const int out_vec_size_w = out_vec_size * bytes_per_pack / pack_factor;
+  const int out_vec_size_g = out_vec_size / group_size;
+  int out_col = pack_factor * tn * (tid.y * num_simdgroups + simd_gid);
+  ws += out_col * bytes_per_pack / pack_factor + simd_lid * out_vec_size_w;
+  scales +=
+      (out_col / group_size + simd_lid * out_vec_size_g) * scale_bytes;
+  x += tid.x * in_vec_stride + simd_lid;
+  y += tid.x * out_vec_size + out_col;
+
+  if (out_col >= out_vec_size) {
+    return;
+  }
+
+  int remaining = in_vec_size % block_size;
+  if (remaining == 0) {
+    for (int i = 0; i < in_vec_size; i += block_size) {
+      x_local = *x;
+      scale = nf4_dequantize_scale<U, group_size>(scales);
+      w_local = *((device vec_w*)ws);
+      nf4_qouter<U, tn * pack_factor>(
+          (thread uint8_t*)&w_local, x_local, scale, result);
+      x += block_size;
+      scales += block_size * out_vec_size_g * scale_bytes;
+      ws += block_size * out_vec_size_w;
+    }
+  } else {
+    for (int i = block_size; i < in_vec_size; i += block_size) {
+      x_local = *x;
+      scale = nf4_dequantize_scale<U, group_size>(scales);
+      w_local = *((device vec_w*)ws);
+      nf4_qouter<U, tn * pack_factor>(
+          (thread uint8_t*)&w_local, x_local, scale, result);
+      x += block_size;
+      scales += block_size * out_vec_size_g * scale_bytes;
+      ws += block_size * out_vec_size_w;
+    }
+    if (static_cast<int>(simd_lid) < remaining) {
+      x_local = *x;
+      scale = nf4_dequantize_scale<U, group_size>(scales);
+      w_local = *((device vec_w*)ws);
+    } else {
+      x_local = 0;
+      scale = 0;
+    }
+    nf4_qouter<U, tn * pack_factor>(
+        (thread uint8_t*)&w_local, x_local, scale, result);
+  }
+
+#pragma clang loop unroll(full)
+  for (int k = 0; k < tn * pack_factor; k++) {
+    result[k] = simd_sum(result[k]);
+  }
+
+  if (simd_lid == 0) {
+#pragma clang loop unroll(full)
+    for (int k = 0; k < tn * pack_factor; k++) {
+      y[k] = static_cast<T>(result[k]);
+    }
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// QMM kernel (matrix-matrix, transposed weights)
+///////////////////////////////////////////////////////////////////////////////
+
+template <
+    typename T,
+    const int group_size,
+    const bool aligned_N,
+    const int BM = 32,
+    const int BK = 32,
+    const int BN = 32>
+METAL_FUNC void nf4_qmm_t_impl(
+    const device uint32_t* w,
+    const device uint8_t* scales,
+    const device T* x,
+    device T* y,
+    threadgroup T* Xs,
+    threadgroup T* Ws,
+    const constant int& K,
+    const constant int& N,
+    const constant int& M,
+    const constant int& K_eff,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint lid [[thread_index_in_threadgroup]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  static_assert(BK >= SIMD_SIZE, "BK should be larger than SIMD_SIZE");
+  static_assert(BK % SIMD_SIZE == 0, "BK should be divisible by SIMD_SIZE");
+
+  (void)lid;
+
+  constexpr int WM = 2;
+  constexpr int WN = 2;
+  constexpr int pack_factor = nf4_get_pack_factor<8, 4>();
+  constexpr int bytes_per_pack = nf4_get_bytes_per_pack();
+  constexpr int scale_bytes = 4;
+
+  constexpr int BK_padded = (BK + 16 / sizeof(T));
+
+  using mma_t = mlx::steel::
+      BlockMMA<T, T, BM, BN, BK, WM, WN, false, true, BK_padded, BK_padded>;
+  using loader_x_t =
+      mlx::steel::BlockLoader<T, BM, BK, BK_padded, 1, WM * WN * SIMD_SIZE>;
+  using loader_w_t = NF4BlockLoader<
+      T,
+      BN,
+      BK,
+      BK_padded,
+      1,
+      WM * WN * SIMD_SIZE,
+      group_size>;
+
+  const int K_w = K * bytes_per_pack / pack_factor;
+  const int K_g = K / group_size;
+  const int y_row = tid.y * BM;
+  const int y_col = tid.x * BN;
+
+  auto wl = (const device uint8_t*)w;
+
+  x += y_row * static_cast<int64_t>(K);
+  wl += y_col * K_w;
+  scales += y_col * K_g * scale_bytes;
+  y += y_row * static_cast<int64_t>(N) + y_col;
+
+  const short num_els = min(BM, M - y_row);
+  const short num_outs = min(BN, N - y_col);
+  loader_x_t loader_x(x, K, Xs, simd_gid, simd_lid);
+  loader_w_t loader_w(wl, scales, K, Ws, simd_gid, simd_lid);
+  mma_t mma_op(simd_gid, simd_lid);
+
+  if (num_els < BM) {
+    if (!aligned_N && num_outs < BN) {
+      for (int k = 0; k < K_eff; k += BK) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_safe(short2(BK, num_els));
+        loader_w.load_safe(short2(BK, num_outs));
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(Xs, Ws);
+        loader_x.next();
+        loader_w.next();
+      }
+    } else {
+      for (int k = 0; k < K_eff; k += BK) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_safe(short2(BK, num_els));
+        loader_w.load_unsafe();
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(Xs, Ws);
+        loader_x.next();
+        loader_w.next();
+      }
+    }
+  } else {
+    if (!aligned_N && num_outs < BN) {
+      for (int k = 0; k < K_eff; k += BK) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_unsafe();
+        loader_w.load_safe(short2(BK, num_outs));
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(Xs, Ws);
+        loader_x.next();
+        loader_w.next();
+      }
+    } else {
+      for (int k = 0; k < K_eff; k += BK) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_unsafe();
+        loader_w.load_unsafe();
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(Xs, Ws);
+        loader_x.next();
+        loader_w.next();
+      }
+    }
+  }
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  if (num_els < BM || num_outs < BN) {
+    mma_op.store_result_safe(y, N, short2(num_outs, num_els));
+  } else {
+    mma_op.store_result(y, N);
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// QMM kernel (matrix-matrix, non-transposed weights)
+///////////////////////////////////////////////////////////////////////////////
+
+template <
+    typename T,
+    const int group_size,
+    const int BM = 32,
+    const int BK = 32,
+    const int BN = 32>
+METAL_FUNC void nf4_qmm_n_impl(
+    const device uint32_t* w,
+    const device uint8_t* scales,
+    const device T* x,
+    device T* y,
+    threadgroup T* Xs,
+    threadgroup T* Ws,
+    const constant int& K,
+    const constant int& N,
+    const constant int& M,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint lid [[thread_index_in_threadgroup]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  static_assert(BK >= SIMD_SIZE, "BK should be larger than SIMD_SIZE");
+  static_assert(BK % SIMD_SIZE == 0, "BK should be divisible by SIMD_SIZE");
+
+  (void)lid;
+
+  constexpr int WM = 2;
+  constexpr int WN = 2;
+  constexpr int pack_factor = nf4_get_pack_factor<8, 4>();
+  constexpr int bytes_per_pack = nf4_get_bytes_per_pack();
+  constexpr int scale_bytes = 4;
+
+  constexpr int BK_padded = (BK + 16 / sizeof(T));
+  constexpr int BN_padded = (BN + 16 / sizeof(T));
+
+  using mma_t = mlx::steel::
+      BlockMMA<T, T, BM, BN, BK, WM, WN, false, false, BK_padded, BN_padded>;
+  using loader_x_t = mlx::steel::
+      BlockLoader<T, BM, BK, BK_padded, 1, WM * WN * SIMD_SIZE, 1, 4>;
+  using loader_w_t = NF4BlockLoader<
+      T,
+      BK,
+      BN,
+      BN_padded,
+      0,
+      WM * WN * SIMD_SIZE,
+      group_size>;
+
+  auto wl = (const device uint8_t*)w;
+
+  const int y_row = tid.y * BM;
+  const int y_col = tid.x * BN;
+  x += y_row * static_cast<int64_t>(K);
+  wl += y_col * bytes_per_pack / pack_factor;
+  scales += (y_col / group_size) * scale_bytes;
+  y += y_row * static_cast<int64_t>(N) + y_col;
+
+  const short num_els = min(BM, M - y_row);
+  loader_x_t loader_x(x, K, Xs, simd_gid, simd_lid);
+  loader_w_t loader_w(wl, scales, N, Ws, simd_gid, simd_lid);
+  mma_t mma_op(simd_gid, simd_lid);
+
+  if (num_els < BM) {
+    if ((K % BK) != 0) {
+      const int k_blocks = K / BK;
+      for (int k = 0; k < k_blocks; k++) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_safe(short2(BK, num_els));
+        loader_w.load_unsafe();
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(Xs, Ws);
+        loader_x.next();
+        loader_w.next();
+      }
+      const short num_k = K - k_blocks * BK;
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      loader_x.load_safe(short2(num_k, num_els));
+      loader_w.load_safe(short2(BN, num_k));
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      mma_op.mma(Xs, Ws);
+    } else {
+      for (int k = 0; k < K; k += BK) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_safe(short2(BK, num_els));
+        loader_w.load_unsafe();
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(Xs, Ws);
+        loader_x.next();
+        loader_w.next();
+      }
+    }
+  } else {
+    if ((K % BK) != 0) {
+      const int k_blocks = K / BK;
+      for (int k = 0; k < k_blocks; k++) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_unsafe();
+        loader_w.load_unsafe();
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(Xs, Ws);
+        loader_x.next();
+        loader_w.next();
+      }
+      const short num_k = K - k_blocks * BK;
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      loader_x.load_safe(short2(num_k, BM));
+      loader_w.load_safe(short2(BN, num_k));
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      mma_op.mma(Xs, Ws);
+    } else {
+      for (int k = 0; k < K; k += BK) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_unsafe();
+        loader_w.load_unsafe();
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(Xs, Ws);
+        loader_x.next();
+        loader_w.next();
+      }
+    }
+  }
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  if (num_els < BM) {
+    mma_op.store_result_safe(y, N, short2(BN, num_els));
+  } else {
+    mma_op.store_result(y, N);
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Batch offset helpers (reuse from fp_quantized.h via shared include)
+///////////////////////////////////////////////////////////////////////////////
+
+template <typename T>
+METAL_FUNC void nf4_adjust_matrix_offsets(
+    const device T*& x,
+    const device uint32_t*& w,
+    const device uint8_t*& scales,
+    device T*& y,
+    int output_stride,
+    const constant int& x_batch_ndims,
+    const constant int* x_shape,
+    const constant int64_t* x_strides,
+    const constant int& w_batch_ndims,
+    const constant int* w_shape,
+    const constant int64_t* w_strides,
+    const constant int64_t* s_strides,
+    uint3 tid [[threadgroup_position_in_grid]]) {
+  uint32_t x_idx = tid.z;
+  uint32_t w_idx = tid.z;
+  if (x_batch_ndims == 1) {
+    x += x_idx * x_strides[0];
+  } else {
+    x += elem_to_loc(x_idx, x_shape, x_strides, x_batch_ndims);
+  }
+  if (w_batch_ndims == 1) {
+    w += w_idx * w_strides[0];
+    scales += w_idx * s_strides[0];
+  } else {
+    ulong2 idx = elem_to_loc_broadcast(
+        w_idx, w_shape, w_strides, s_strides, w_batch_ndims);
+    w += idx.x;
+    scales += idx.y;
+  }
+  y += tid.z * output_stride;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Kernel entry points
+///////////////////////////////////////////////////////////////////////////////
+
+template <typename T, int group_size, int D, bool batched>
+[[kernel]] void nf4_qmv_quad(
+    const device uint32_t* w,
+    const device uint8_t* scales,
+    const device T* x,
+    device T* y,
+    const constant int& in_vec_size,
+    const constant int& out_vec_size,
+    const constant int& x_batch_ndims,
+    const constant int* x_shape,
+    const constant int64_t* x_strides,
+    const constant int& w_batch_ndims,
+    const constant int* w_shape,
+    const constant int64_t* w_strides,
+    const constant int64_t* s_strides,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint quad_gid [[quadgroup_index_in_threadgroup]],
+    uint quad_lid [[thread_index_in_quadgroup]]) {
+  if (batched) {
+    int M = x_shape[x_batch_ndims];
+    nf4_adjust_matrix_offsets(
+        x, w, scales, y, out_vec_size * M,
+        x_batch_ndims, x_shape, x_strides,
+        w_batch_ndims, w_shape, w_strides, s_strides, tid);
+  }
+  nf4_qmv_quad_impl<T, group_size, D>(
+      w, scales, x, y, in_vec_size, out_vec_size, tid, quad_gid, quad_lid);
+}
+
+template <typename T, int group_size, bool batched>
+[[kernel]] void nf4_qmv_fast(
+    const device uint32_t* w,
+    const device uint8_t* scales,
+    const device T* x,
+    device T* y,
+    const constant int& in_vec_size,
+    const constant int& out_vec_size,
+    const constant int& x_batch_ndims,
+    const constant int* x_shape,
+    const constant int64_t* x_strides,
+    const constant int& w_batch_ndims,
+    const constant int* w_shape,
+    const constant int64_t* w_strides,
+    const constant int64_t* s_strides,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  if (batched) {
+    int M = x_shape[x_batch_ndims];
+    nf4_adjust_matrix_offsets(
+        x, w, scales, y, out_vec_size * M,
+        x_batch_ndims, x_shape, x_strides,
+        w_batch_ndims, w_shape, w_strides, s_strides, tid);
+  }
+  nf4_qmv_fast_impl<T, group_size>(
+      w, scales, x, y, in_vec_size, out_vec_size, tid, simd_gid, simd_lid);
+}
+
+template <typename T, const int group_size, bool batched>
+[[kernel]] void nf4_qmv(
+    const device uint32_t* w,
+    const device uint8_t* scales,
+    const device T* x,
+    device T* y,
+    const constant int& in_vec_size,
+    const constant int& out_vec_size,
+    const constant int& x_batch_ndims,
+    const constant int* x_shape,
+    const constant int64_t* x_strides,
+    const constant int& w_batch_ndims,
+    const constant int* w_shape,
+    const constant int64_t* w_strides,
+    const constant int64_t* s_strides,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  if (batched) {
+    int M = x_shape[x_batch_ndims];
+    nf4_adjust_matrix_offsets(
+        x, w, scales, y, out_vec_size * M,
+        x_batch_ndims, x_shape, x_strides,
+        w_batch_ndims, w_shape, w_strides, s_strides, tid);
+  }
+  nf4_qmv_impl<T, group_size>(
+      w, scales, x, y, in_vec_size, out_vec_size, tid, simd_gid, simd_lid);
+}
+
+template <typename T, const int group_size, bool batched>
+[[kernel]] void nf4_qvm(
+    const device uint32_t* w,
+    const device uint8_t* scales,
+    const device T* x,
+    device T* y,
+    const constant int& in_vec_size,
+    const constant int& out_vec_size,
+    const constant int& x_batch_ndims,
+    const constant int* x_shape,
+    const constant int64_t* x_strides,
+    const constant int& w_batch_ndims,
+    const constant int* w_shape,
+    const constant int64_t* w_strides,
+    const constant int64_t* s_strides,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  if (batched) {
+    int M = x_shape[x_batch_ndims];
+    nf4_adjust_matrix_offsets(
+        x, w, scales, y, out_vec_size * M,
+        x_batch_ndims, x_shape, x_strides,
+        w_batch_ndims, w_shape, w_strides, s_strides, tid);
+  }
+  nf4_qvm_impl<T, group_size>(
+      w, scales, x, y, in_vec_size, out_vec_size, in_vec_size,
+      tid, simd_gid, simd_lid);
+}
+
+template <typename T, const int group_size, int split_k = 32>
+[[kernel]] void nf4_qvm_split_k(
+    const device uint32_t* w,
+    const device uint8_t* scales,
+    const device T* x,
+    device T* y,
+    const constant int& in_vec_size,
+    const constant int& out_vec_size,
+    const constant int& x_batch_ndims,
+    const constant int* x_shape,
+    const constant int64_t* x_strides,
+    const constant int& w_batch_ndims,
+    const constant int* w_shape,
+    const constant int64_t* w_strides,
+    const constant int64_t* s_strides,
+    const constant int& final_block_size,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  int M = x_shape[x_batch_ndims];
+  nf4_adjust_matrix_offsets(
+      x, w, scales, y, out_vec_size * M,
+      x_batch_ndims, x_shape, x_strides,
+      w_batch_ndims, w_shape, w_strides, s_strides, tid);
+
+  int in_vec_size_adj =
+      tid.z % split_k == split_k - 1 ? final_block_size : in_vec_size;
+  int in_vec_stride = (split_k - 1) * in_vec_size + final_block_size;
+
+  nf4_qvm_impl<T, group_size>(
+      w, scales, x, y, in_vec_size_adj, out_vec_size, in_vec_stride,
+      tid, simd_gid, simd_lid);
+}
+
+template <
+    typename T,
+    const int group_size,
+    const bool aligned_N,
+    const bool batched,
+    const int BM = 32,
+    const int BK = 32,
+    const int BN = 32>
+[[kernel]] void nf4_qmm_t(
+    const device uint32_t* w,
+    const device uint8_t* scales,
+    const device T* x,
+    device T* y,
+    const constant int& K,
+    const constant int& N,
+    const constant int& M,
+    const constant int& x_batch_ndims,
+    const constant int* x_shape,
+    const constant int64_t* x_strides,
+    const constant int& w_batch_ndims,
+    const constant int* w_shape,
+    const constant int64_t* w_strides,
+    const constant int64_t* s_strides,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint lid [[thread_index_in_threadgroup]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  (void)lid;
+
+  constexpr int BK_padded = (BK + 16 / sizeof(T));
+
+  threadgroup T Xs[BM * BK_padded];
+  threadgroup T Ws[BN * BK_padded];
+
+  if (batched) {
+    nf4_adjust_matrix_offsets(
+        x, w, scales, y, M * N,
+        x_batch_ndims, x_shape, x_strides,
+        w_batch_ndims, w_shape, w_strides, s_strides, tid);
+  }
+  nf4_qmm_t_impl<T, group_size, aligned_N, BM, BK, BN>(
+      w, scales, x, y, Xs, Ws, K, N, M, K, tid, lid, simd_gid, simd_lid);
+}
+
+template <
+    typename T,
+    const int group_size,
+    const bool batched,
+    const int BM = 32,
+    const int BK = 32,
+    const int BN = 32>
+[[kernel]] void nf4_qmm_n(
+    const device uint32_t* w,
+    const device uint8_t* scales,
+    const device T* x,
+    device T* y,
+    const constant int& K,
+    const constant int& N,
+    const constant int& M,
+    const constant int& x_batch_ndims,
+    const constant int* x_shape,
+    const constant int64_t* x_strides,
+    const constant int& w_batch_ndims,
+    const constant int* w_shape,
+    const constant int64_t* w_strides,
+    const constant int64_t* s_strides,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint lid [[thread_index_in_threadgroup]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  (void)lid;
+
+  constexpr int BK_padded = (BK + 16 / sizeof(T));
+  constexpr int BN_padded = (BN + 16 / sizeof(T));
+
+  threadgroup T Xs[BM * BK_padded];
+  threadgroup T Ws[BK * BN_padded];
+
+  if (batched) {
+    nf4_adjust_matrix_offsets(
+        x, w, scales, y, M * N,
+        x_batch_ndims, x_shape, x_strides,
+        w_batch_ndims, w_shape, w_strides, s_strides, tid);
+  }
+  nf4_qmm_n_impl<T, group_size, BM, BK, BN>(
+      w, scales, x, y, Xs, Ws, K, N, M, tid, lid, simd_gid, simd_lid);
+}
+
+template <
+    typename T,
+    const int group_size,
+    const bool aligned_N,
+    const int BM = 32,
+    const int BK = 32,
+    const int BN = 32>
+[[kernel]] void nf4_qmm_t_splitk(
+    const device uint32_t* w [[buffer(0)]],
+    const device uint8_t* scales [[buffer(1)]],
+    const device T* x [[buffer(2)]],
+    device T* y [[buffer(3)]],
+    const constant int& K [[buffer(4)]],
+    const constant int& N [[buffer(5)]],
+    const constant int& M [[buffer(6)]],
+    const constant int& k_partition_size [[buffer(7)]],
+    const constant int& split_k_partition_stride [[buffer(8)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint lid [[thread_index_in_threadgroup]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  (void)lid;
+
+  constexpr int BK_padded = (BK + 16 / sizeof(T));
+  constexpr int pack_factor = nf4_get_pack_factor<8, 4>();
+  constexpr int bytes_per_pack = nf4_get_bytes_per_pack();
+  constexpr int scale_bytes = 4;
+  threadgroup T Xs[BM * BK_padded];
+  threadgroup T Ws[BN * BK_padded];
+  const int k_start = tid.z * k_partition_size;
+  x += k_start;
+
+  auto wl = (const device uint8_t*)w;
+  wl += k_start * bytes_per_pack / pack_factor;
+  scales += (k_start / group_size) * scale_bytes;
+  y += tid.z * static_cast<int64_t>(split_k_partition_stride);
+
+  nf4_qmm_t_impl<T, group_size, aligned_N, BM, BK, BN>(
+      (const device uint32_t*)wl,
+      scales, x, y, Xs, Ws, K, N, M, k_partition_size,
+      tid, lid, simd_gid, simd_lid);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Quantize / Dequantize standalone kernels
+///////////////////////////////////////////////////////////////////////////////
+
+template <typename T, const int group_size>
+[[kernel]] void nf4_quantize(
+    const device T* w [[buffer(0)]],
+    device uint8_t* out [[buffer(1)]],
+    device float* scales_out [[buffer(2)]],
+    uint2 tidx [[thread_position_in_grid]],
+    uint2 grid_dim [[threads_per_grid]]) {
+  size_t index = tidx.x + grid_dim.x * size_t(tidx.y);
+
+  // Compute absmax within the simdgroup (one group = 64 elements = 2 simdgroups)
+  float w_thread = w[index];
+  float absmax;
+  if constexpr (group_size == 64) {
+    // Two halves of the simdgroup cover 64 elements
+    absmax = simd_max(metal::abs(w_thread));
+    // For group_size=64 with simd_size=32, we need cross-simdgroup reduction
+    // This is handled by the dispatch: one thread per element, groups of 64
+    float absmax_l = simd_max(tidx.x < 32 ? metal::abs(w_thread) : 0.0f);
+    float absmax_r = simd_max(tidx.x >= 32 ? metal::abs(w_thread) : 0.0f);
+    absmax = max(absmax_l, absmax_r);
+  } else {
+    absmax = simd_max(metal::abs(w_thread));
+  }
+
+  size_t gindex = index / group_size;
+  if (index % group_size == 0) {
+    scales_out[gindex] = absmax;
+  }
+
+  // Normalize to [-1, 1] and find nearest NF4 level
+  float normalized = (absmax == 0.0f) ? 0.0f : w_thread / absmax;
+  uint8_t output = nf4_quantize_value(normalized);
+
+  // Pack two 4-bit values per byte
+  uint8_t sval = simd_shuffle_down(output, 1);
+  output |= sval << 4;
+
+  if (index % 2 == 0) {
+    out[index / 2] = output;
+  }
+}
+
+template <typename T, const int group_size>
+[[kernel]] void nf4_dequantize(
+    const device uint8_t* w [[buffer(0)]],
+    const device float* scales_in [[buffer(1)]],
+    device T* out [[buffer(3)]],
+    uint2 index [[thread_position_in_grid]],
+    uint2 grid_dim [[threads_per_grid]]) {
+  constexpr int pack_factor = 2; // 4-bit = 2 per byte
+  size_t offset = index.x + grid_dim.x * size_t(index.y);
+  size_t oindex = offset * pack_factor;
+  size_t gindex = oindex / group_size;
+
+  out += oindex;
+
+  float scale = scales_in[gindex];
+
+  uint val = w[offset];
+#pragma clang loop unroll(full)
+  for (int i = 0; i < pack_factor; i++) {
+    uint8_t d = (val >> (4 * i)) & 0x0f;
+    out[i] = static_cast<T>(scale * nf4_dequantize_value<float>(d));
+  }
+}

--- a/mlx/backend/metal/kernels/nf4_quantized.h
+++ b/mlx/backend/metal/kernels/nf4_quantized.h
@@ -6,7 +6,7 @@
 // as float32 (4 bytes per group) instead of FP8 (1 byte per group).
 //
 // NF4 format: 4-bit indices into a 16-element LUT derived from normal
-// distribution quantiles. Scales are float32 absmax per block of 64.
+// distribution quantiles. Scales are float32 absmax per quantization group.
 
 #include <metal_simdgroup>
 #include <metal_stdlib>

--- a/mlx/backend/metal/kernels/nf4_quantized.metal
+++ b/mlx/backend/metal/kernels/nf4_quantized.metal
@@ -87,12 +87,7 @@
   instantiate_nf4_aligned(qmm_t_splitk, type, true, group_size) \
   instantiate_nf4_aligned(qmm_t_splitk, type, false, group_size)
 
-#define instantiate_nf4_quantize_dequantize(type, group_size) \
-  instantiate_kernel( \
-    "nf4_quantize_" #type "_gs_" #group_size "_b_4", \
-    nf4_quantize, \
-    type, \
-    group_size) \
+#define instantiate_nf4_dequantize(type, group_size) \
   instantiate_kernel( \
     "nf4_dequantize_" #type "_gs_" #group_size "_b_4", \
     nf4_dequantize, \
@@ -104,7 +99,7 @@
   instantiate_nf4_all_quad(type, group_size) \
   instantiate_nf4_all_splitk(type, group_size) \
   instantiate_nf4_all_aligned(type, group_size) \
-  instantiate_nf4_quantize_dequantize(type, group_size)
+  instantiate_nf4_dequantize(type, group_size)
 
 // NF4 with group_size=64 (the bitsandbytes default)
 instantiate_nf4_all(float, 64)

--- a/mlx/backend/metal/kernels/nf4_quantized.metal
+++ b/mlx/backend/metal/kernels/nf4_quantized.metal
@@ -1,0 +1,123 @@
+// Copyright © 2025 Apple Inc.
+// NF4 quantized kernel instantiations
+
+// clang-format off
+#include "mlx/backend/metal/kernels/utils.h"
+#include "mlx/backend/metal/kernels/steel/gemm/gemm.h"
+#include "mlx/backend/metal/kernels/quantized_utils.h"
+#include "mlx/backend/metal/kernels/nf4_quantized.h"
+
+// NF4 is always 4-bit with group_size=64.
+// We instantiate for all three compute types.
+
+#define instantiate_nf4(name, type, group_size) \
+  instantiate_kernel( \
+      "nf4_" #name "_" #type "_gs_" #group_size "_b_4", \
+      nf4_ ## name, \
+      type, \
+      group_size)
+
+#define instantiate_nf4_batched(name, type, batched, group_size) \
+  instantiate_kernel( \
+      "nf4_" #name "_" #type "_gs_" #group_size "_b_4_batch_" #batched, \
+      nf4_ ## name, \
+      type, \
+      group_size, \
+      batched)
+
+#define instantiate_nf4_aligned(name, type, aligned, group_size) \
+  instantiate_kernel( \
+      "nf4_" #name "_" #type "_gs_" #group_size "_b_4_alN_" #aligned, \
+      nf4_ ## name, \
+      type, \
+      group_size, \
+      aligned)
+
+#define instantiate_nf4_aligned_batched(name, type, aligned, batched, group_size) \
+  instantiate_kernel( \
+      "nf4_" #name "_" #type "_gs_" #group_size "_b_4_alN_" #aligned "_batch_" #batched, \
+      nf4_ ## name, \
+      type, \
+      group_size, \
+      aligned, \
+      batched)
+
+#define instantiate_nf4_quad(name, type, D, batched, group_size) \
+  instantiate_kernel( \
+      "nf4_" #name "_" #type "_gs_" #group_size "_b_4_d_" #D "_batch_" #batched, \
+      nf4_ ## name, \
+      type, \
+      group_size, \
+      D, \
+      batched)
+
+#define instantiate_nf4_split_k(name, type, split_k, group_size) \
+  instantiate_kernel( \
+      "nf4_" #name "_" #type "_gs_" #group_size "_b_4_spk_" #split_k, \
+      nf4_ ## name, \
+      type, \
+      group_size, \
+      split_k)
+
+#define instantiate_nf4_batched_wrap(name, type, group_size) \
+  instantiate_nf4_batched(name, type, 1, group_size) \
+  instantiate_nf4_batched(name, type, 0, group_size)
+
+#define instantiate_nf4_all_batched(type, group_size) \
+  instantiate_nf4_batched_wrap(qmv_fast, type, group_size) \
+  instantiate_nf4_batched_wrap(qmv, type, group_size) \
+  instantiate_nf4_batched_wrap(qvm, type, group_size) \
+  instantiate_nf4_batched_wrap(qmm_n, type, group_size)
+
+#define instantiate_nf4_all_aligned(type, group_size) \
+  instantiate_nf4_aligned_batched(qmm_t, type, true, 1, group_size) \
+  instantiate_nf4_aligned_batched(qmm_t, type, true, 0, group_size) \
+  instantiate_nf4_aligned_batched(qmm_t, type, false, 1, group_size) \
+  instantiate_nf4_aligned_batched(qmm_t, type, false, 0, group_size)
+
+#define instantiate_nf4_all_quad(type, group_size) \
+  instantiate_nf4_quad(qmv_quad, type, 64, 1, group_size) \
+  instantiate_nf4_quad(qmv_quad, type, 64, 0, group_size) \
+  instantiate_nf4_quad(qmv_quad, type, 128, 1, group_size) \
+  instantiate_nf4_quad(qmv_quad, type, 128, 0, group_size)
+
+#define instantiate_nf4_all_splitk(type, group_size) \
+  instantiate_nf4_split_k(qvm_split_k, type, 8, group_size) \
+  instantiate_nf4_split_k(qvm_split_k, type, 32, group_size) \
+  instantiate_nf4_aligned(qmm_t_splitk, type, true, group_size) \
+  instantiate_nf4_aligned(qmm_t_splitk, type, false, group_size)
+
+#define instantiate_nf4_quantize_dequantize(type, group_size) \
+  instantiate_kernel( \
+    "nf4_quantize_" #type "_gs_" #group_size "_b_4", \
+    nf4_quantize, \
+    type, \
+    group_size) \
+  instantiate_kernel( \
+    "nf4_dequantize_" #type "_gs_" #group_size "_b_4", \
+    nf4_dequantize, \
+    type, \
+    group_size)
+
+#define instantiate_nf4_all(type, group_size) \
+  instantiate_nf4_all_batched(type, group_size) \
+  instantiate_nf4_all_quad(type, group_size) \
+  instantiate_nf4_all_splitk(type, group_size) \
+  instantiate_nf4_all_aligned(type, group_size) \
+  instantiate_nf4_quantize_dequantize(type, group_size)
+
+// NF4 with group_size=64 (the bitsandbytes default)
+instantiate_nf4_all(float, 64)
+instantiate_nf4_all(bfloat16_t, 64)
+instantiate_nf4_all(float16_t, 64)
+
+// Also support group_size=32 for flexibility
+instantiate_nf4_all(float, 32)
+instantiate_nf4_all(bfloat16_t, 32)
+instantiate_nf4_all(float16_t, 32)
+
+// And group_size=128 (ROCm default)
+instantiate_nf4_all(float, 128)
+instantiate_nf4_all(bfloat16_t, 128)
+instantiate_nf4_all(float16_t, 128)
+// clang-format on

--- a/mlx/backend/metal/kernels/nf4_quantized.metal
+++ b/mlx/backend/metal/kernels/nf4_quantized.metal
@@ -7,8 +7,8 @@
 #include "mlx/backend/metal/kernels/quantized_utils.h"
 #include "mlx/backend/metal/kernels/nf4_quantized.h"
 
-// NF4 is always 4-bit with group_size=64.
-// We instantiate for all three compute types.
+// NF4 is always 4-bit. Instantiate the supported group sizes for all three
+// compute types.
 
 #define instantiate_nf4(name, type, group_size) \
   instantiate_kernel( \

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -27,7 +27,15 @@ auto get_quantized_kernel_wrapped(
     int bits,
     Args... args) {
   std::string template_def;
-  std::string fname = ((mode == "affine") ? "affine_" : "fp_") + func;
+  std::string prefix;
+  if (mode == "affine") {
+    prefix = "affine_";
+  } else if (mode == "nf4") {
+    prefix = "nf4_";
+  } else {
+    prefix = "fp_";
+  }
+  std::string fname = prefix + func;
   template_def = get_template_definition(
       name, fname, type, group_size, bits, std::forward<Args>(args)...);
   return get_quantized_kernel(d, name, template_def, mode);
@@ -44,7 +52,15 @@ auto get_qmm_nax_kernel_wrapped(
     int bits,
     Args... args) {
   std::string template_def;
-  std::string fname = ((mode == "affine") ? "affine_" : "fp_") + func;
+  std::string prefix;
+  if (mode == "affine") {
+    prefix = "affine_";
+  } else if (mode == "nf4") {
+    prefix = "nf4_";
+  } else {
+    prefix = "fp_";
+  }
+  std::string fname = prefix + func;
   template_def = get_template_definition(
       name, fname, type, group_size, bits, std::forward<Args>(args)...);
   return get_qmm_nax_kernel(d, name, template_def, mode);
@@ -692,7 +708,8 @@ void qmm(
     metal::Device& d,
     const Stream& s,
     const std::string& mode) {
-  if (metal::is_nax_available() && transpose && (K % 64 == 0) &&
+  if (metal::is_nax_available() && mode != "nf4" && transpose &&
+      (K % 64 == 0) &&
       (env::enable_tf32() || x.dtype() != float32)) {
     return qmm_nax(
         /* const array& x = */ x,
@@ -883,7 +900,8 @@ void gather_qmm(
     metal::Device& d,
     const Stream& s,
     const std::string& mode) {
-  if (metal::is_nax_available() && transpose && (K % 64 == 0) &&
+  if (metal::is_nax_available() && mode != "nf4" && transpose &&
+      (K % 64 == 0) &&
       (env::enable_tf32() || x.dtype() != float32)) {
     return gather_qmm_nax(
         /* const array& x = */ x,
@@ -1228,7 +1246,7 @@ void gather_qmm_rhs(
     metal::Device& d,
     const Stream& s,
     const std::string mode) {
-  if (metal::is_nax_available() && transpose &&
+  if (metal::is_nax_available() && mode != "nf4" && transpose &&
       (env::enable_tf32() || x_.dtype() != float32)) {
     return gather_qmm_rhs_nax(
         /* const array& x_ = */ x_,

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -36,8 +36,13 @@ auto get_quantized_kernel_wrapped(
     prefix = "fp_";
   }
   std::string fname = prefix + func;
-  template_def = get_template_definition(
-      name, fname, type, group_size, bits, std::forward<Args>(args)...);
+  if (mode == "nf4") {
+    template_def = get_template_definition(
+        name, fname, type, group_size, std::forward<Args>(args)...);
+  } else {
+    template_def = get_template_definition(
+        name, fname, type, group_size, bits, std::forward<Args>(args)...);
+  }
   return get_quantized_kernel(d, name, template_def, mode);
 }
 
@@ -61,8 +66,13 @@ auto get_qmm_nax_kernel_wrapped(
     prefix = "fp_";
   }
   std::string fname = prefix + func;
-  template_def = get_template_definition(
-      name, fname, type, group_size, bits, std::forward<Args>(args)...);
+  if (mode == "nf4") {
+    template_def = get_template_definition(
+        name, fname, type, group_size, std::forward<Args>(args)...);
+  } else {
+    template_def = get_template_definition(
+        name, fname, type, group_size, bits, std::forward<Args>(args)...);
+  }
   return get_qmm_nax_kernel(d, name, template_def, mode);
 }
 

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -4439,10 +4439,10 @@ std::pair<Dtype, QuantizationMode> validate_mode_with_type(
       return {dtype, qmode};
     }
   } else if (qmode == QuantizationMode::NF4) {
-    // NF4 uses float32 scales (absmax per block)
-    if (!issubdtype(scales.dtype(), floating)) {
+    // NF4 uses float32 absmax scales.
+    if (scales.dtype() != float32) {
       std::ostringstream msg;
-      msg << "[" << tag << "] NF4 scale type must be floating point but "
+      msg << "[" << tag << "] NF4 scale type must be float32 absmax scales but "
           << "received type " << scales.dtype() << ".";
       throw std::invalid_argument(msg.str());
     }

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -4518,6 +4518,12 @@ array quantized_matmul(
 
   auto [group_size, bits] =
       quantization_params_from_mode(qmode, group_size_, bits_);
+  if (qmode == QuantizationMode::NF4 &&
+      !(to_stream(s).device == Device::gpu && metal::is_available())) {
+    throw std::invalid_argument(
+        "[quantized_matmul] NF4 quantization mode is only supported on the "
+        "Metal backend.");
+  }
   // Check and extract the quantized matrix shape against x
   auto [w_inner_dims, w_outer_dims] = extract_quantized_matmul_dims(
       "quantized_matmul", x, w, scales, biases, transpose, group_size, bits);
@@ -5333,6 +5339,7 @@ array dequantize(
       out = view(reshape(out, {-1, 4}, s), int8, s);
       auto idx_lo = bitwise_and(out, array(0x0F, int8), s);
       auto idx_hi = right_shift(out, array(4, int8), s);
+      idx_hi = bitwise_and(idx_hi, array(0x0F, int8), s);
       auto lo = gather(lut, idx_lo, 0, {1}, s);
       auto hi = gather(lut, idx_hi, 0, {1}, s);
       out = concatenate({lo, hi}, -1, s);

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -4934,6 +4934,30 @@ std::vector<array> fp_quantize(
   return fallback(inputs);
 }
 
+array nf4_lut(Dtype dtype, Stream s) {
+  return astype(
+      array({
+          -1.0f,
+          -0.6961928009986877f,
+          -0.5250730514526367f,
+          -0.39491748809814453f,
+          -0.28444138169288635f,
+          -0.18477343022823334f,
+          -0.09105003625154495f,
+          0.0f,
+          0.07958029955625534f,
+          0.16093020141124725f,
+          0.24611230194568634f,
+          0.33791524171829224f,
+          0.44070982933044434f,
+          0.5626170039176941f,
+          0.7229568362236023f,
+          1.0f,
+      }),
+      dtype,
+      s);
+}
+
 std::vector<array> quantize(
     const array& w,
     std::optional<int> group_size_ /* = std::nullopt */,
@@ -5000,14 +5024,7 @@ std::vector<array> quantize(
       // Normalize to [-1, 1]
       auto z = array(0.0f, scales.dtype());
       auto wn = where(equal(scales, z, s), z, divide(wq, scales, s), s);
-      // NF4 LUT values
-      auto lut = array({
-          -1.0f, -0.6961928f, -0.5250731f, -0.3949175f,
-          -0.2844414f, -0.1847734f, -0.0910500f, 0.0f,
-          0.0795803f, 0.1609302f, 0.2461123f, 0.3379152f,
-          0.4407098f, 0.5626170f, 0.7229568f, 1.0f,
-      });
-      lut = astype(lut, w.dtype(), s);
+      auto lut = nf4_lut(w.dtype(), s);
       // Find nearest LUT value for each normalized weight
       wq = argmin(
           abs(subtract(expand_dims(wn, -1, s), lut, s), s), -1, false, s);
@@ -5312,11 +5329,7 @@ array dequantize(
             const std::vector<array>& inputs) mutable -> std::vector<array> {
       auto out = inputs[0];
       auto scales = inputs[1];
-      auto lut = array(
-          {-1.0f, -0.6961928f, -0.5250731f, -0.3949175f, -0.2844414f,
-           -0.1847734f, -0.0910500f, 0.0f, 0.0795803f, 0.1609302f,
-           0.2461123f, 0.3379152f, 0.4407098f, 0.5626170f, 0.7229568f, 1.0f},
-          out_type);
+      auto lut = nf4_lut(out_type, s);
       out = view(reshape(out, {-1, 4}, s), int8, s);
       auto idx_lo = bitwise_and(out, array(0x0F, int8), s);
       auto idx_hi = right_shift(out, array(4, int8), s);

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -4395,6 +4395,10 @@ std::pair<int, int> quantization_params_from_mode(
       default_group_size = 32;
       default_bits = 8;
       break;
+    case QuantizationMode::NF4:
+      default_group_size = 64;
+      default_bits = 4;
+      break;
   }
   return {
       group_size_.has_value() ? *group_size_ : default_group_size,
@@ -4433,6 +4437,24 @@ std::pair<Dtype, QuantizationMode> validate_mode_with_type(
       return {*out_type, qmode};
     } else {
       return {dtype, qmode};
+    }
+  } else if (qmode == QuantizationMode::NF4) {
+    // NF4 uses float32 scales (absmax per block)
+    if (!issubdtype(scales.dtype(), floating)) {
+      std::ostringstream msg;
+      msg << "[" << tag << "] NF4 scale type must be floating point but "
+          << "received type " << scales.dtype() << ".";
+      throw std::invalid_argument(msg.str());
+    }
+    if (biases) {
+      std::ostringstream msg;
+      msg << "[" << tag << "] Biases must be null for NF4 quantization.";
+      throw std::invalid_argument(msg.str());
+    }
+    if (out_type.has_value()) {
+      return {*out_type, qmode};
+    } else {
+      return {scales.dtype(), qmode};
     }
   } else if (scales.dtype() != uint8) {
     std::ostringstream msg;
@@ -4953,6 +4975,53 @@ std::vector<array> quantize(
   validate_global_scale("quantize", qmode, global_scale);
   if (qmode == QuantizationMode::Affine) {
     return affine_quantize(w, group_size, bits, s);
+  } else if (qmode == QuantizationMode::NF4) {
+    if (group_size != 32 && group_size != 64 && group_size != 128) {
+      std::ostringstream msg;
+      msg << "[quantize] nf4 quantization requires group size 32, 64, or 128 "
+          << "but got " << group_size << ".";
+      throw std::invalid_argument(msg.str());
+    }
+    if (bits != 4) {
+      std::ostringstream msg;
+      msg << "[quantize] nf4 quantization requires bits to be 4 but got "
+          << bits << ".";
+      throw std::invalid_argument(msg.str());
+    }
+    // NF4 quantization: normalize by absmax, map to nearest LUT value
+    // Produces: uint32 packed weights, float32 scales (absmax per group)
+    auto fallback = [group_size, s = to_stream(s)](
+                        const std::vector<array>& inputs) -> std::vector<array> {
+      auto& w = inputs[0];
+      auto new_shape = w.shape();
+      new_shape.back() = -1;
+      auto wq = reshape(w, {-1, group_size}, s);
+      auto scales = max(abs(wq, s), -1, true, s);
+      // Normalize to [-1, 1]
+      auto z = array(0.0f, scales.dtype());
+      auto wn = where(equal(scales, z, s), z, divide(wq, scales, s), s);
+      // NF4 LUT values
+      auto lut = array({
+          -1.0f, -0.6961928f, -0.5250731f, -0.3949175f,
+          -0.2844414f, -0.1847734f, -0.0910500f, 0.0f,
+          0.0795803f, 0.1609302f, 0.2461123f, 0.3379152f,
+          0.4407098f, 0.5626170f, 0.7229568f, 1.0f,
+      });
+      lut = astype(lut, w.dtype(), s);
+      // Find nearest LUT value for each normalized weight
+      wq = argmin(
+          abs(subtract(expand_dims(wn, -1, s), lut, s), s), -1, false, s);
+      // Pack 8 x 4-bit values into uint32
+      auto shifts = power(array(2, uint32), arange(0, 32, 4, uint32, s), s);
+      wq = reshape(wq, {-1, 4, 8}, s);
+      wq = sum(multiply(wq, shifts, s), -1, false, s);
+      wq = reshape(wq, new_shape, s);
+      scales = reshape(squeeze(scales, -1, s), new_shape, s);
+      return {std::move(wq), astype(scales, float32, s)};
+    };
+    // NF4 quantize always uses the graph-based fallback (not a dedicated
+    // GPU kernel) since quantization is a one-time cost.
+    return fallback({w});
   } else {
     return fp_quantize(w, group_size, bits, qmode, global_scale, to_stream(s));
   }
@@ -5223,6 +5292,54 @@ array dequantize(
         affine_dequantize(w, scales, *biases, group_size, bits, s),
         out_type,
         s);
+  } else if (qmode == QuantizationMode::NF4) {
+    if (group_size != 32 && group_size != 64 && group_size != 128) {
+      std::ostringstream msg;
+      msg << "[dequantize] nf4 quantization requires group size 32, 64, or 128 "
+          << "but got " << group_size << ".";
+      throw std::invalid_argument(msg.str());
+    }
+    if (bits != 4) {
+      std::ostringstream msg;
+      msg << "[dequantize] nf4 quantization requires bits to be 4 but got "
+          << bits << ".";
+      throw std::invalid_argument(msg.str());
+    }
+    // NF4 dequantization: LUT lookup * float32 absmax scale
+    int out_size = w.shape(-1) * 32 / bits;
+    auto fallback =
+        [group_size, out_type, s = to_stream(s)](
+            const std::vector<array>& inputs) mutable -> std::vector<array> {
+      auto out = inputs[0];
+      auto scales = inputs[1];
+      auto lut = array(
+          {-1.0f, -0.6961928f, -0.5250731f, -0.3949175f, -0.2844414f,
+           -0.1847734f, -0.0910500f, 0.0f, 0.0795803f, 0.1609302f,
+           0.2461123f, 0.3379152f, 0.4407098f, 0.5626170f, 0.7229568f, 1.0f},
+          out_type);
+      out = view(reshape(out, {-1, 4}, s), int8, s);
+      auto idx_lo = bitwise_and(out, array(0x0F, int8), s);
+      auto idx_hi = right_shift(out, array(4, int8), s);
+      auto lo = gather(lut, idx_lo, 0, {1}, s);
+      auto hi = gather(lut, idx_hi, 0, {1}, s);
+      out = concatenate({lo, hi}, -1, s);
+      out = reshape(out, {-1, group_size}, s);
+      scales = reshape(astype(scales, out_type, s), {-1, 1}, s);
+      auto wshape = inputs[0].shape();
+      wshape.back() = -1;
+      return {reshape(multiply(out, scales, s), wshape, s)};
+    };
+    if (to_stream(s).device == Device::gpu) {
+      auto out_shape = w.shape();
+      out_shape.back() = out_size;
+      return array(
+          std::move(out_shape),
+          out_type,
+          std::make_shared<fast::Quantize>(
+              to_stream(s), fallback, group_size, bits, qmode, true),
+          {w, scales});
+    }
+    return fallback({w, scales})[0];
   } else {
     return fp_dequantize(
         w,
@@ -5290,6 +5407,11 @@ array gather_qmm(
 
   auto [out_type, qmode] =
       validate_mode_with_type("gather_qmm", scales, biases, std::nullopt, mode);
+  if (qmode == QuantizationMode::NF4) {
+    throw std::runtime_error(
+        "[gather_qmm] NF4 quantization mode is not yet supported for "
+        "gather_qmm. Use quantized_matmul instead.");
+  }
   auto [group_size, bits] =
       quantization_params_from_mode(qmode, group_size_, bits_);
   auto [w_inner_dims, w_outer_dims] = extract_quantized_matmul_dims(

--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -3433,8 +3433,10 @@ std::string quantization_mode_to_string(QuantizationMode mode) {
     case QuantizationMode::Mxfp8:
       return "mxfp8";
     case QuantizationMode::Nvfp4:
-    default:
       return "nvfp4";
+    case QuantizationMode::NF4:
+    default:
+      return "nf4";
   }
 }
 
@@ -3449,6 +3451,8 @@ QuantizationMode string_to_quantization_mode(
     return QuantizationMode::Mxfp8;
   } else if (mode == "nvfp4") {
     return QuantizationMode::Nvfp4;
+  } else if (mode == "nf4") {
+    return QuantizationMode::NF4;
   }
   std::string msg;
   if (!tag.empty()) {

--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -3435,9 +3435,9 @@ std::string quantization_mode_to_string(QuantizationMode mode) {
     case QuantizationMode::Nvfp4:
       return "nvfp4";
     case QuantizationMode::NF4:
-    default:
       return "nf4";
   }
+  throw std::runtime_error("Unknown QuantizationMode");
 }
 
 QuantizationMode string_to_quantization_mode(

--- a/mlx/primitives.h
+++ b/mlx/primitives.h
@@ -152,7 +152,7 @@ class MLX_API UnaryPrimitive : public Primitive {
   UnaryPrimitive& operator=(UnaryPrimitive&& other) = delete;
 };
 
-enum class QuantizationMode { Affine, Mxfp4, Mxfp8, Nvfp4 };
+enum class QuantizationMode { Affine, Mxfp4, Mxfp8, Nvfp4, NF4 };
 
 std::string quantization_mode_to_string(QuantizationMode mode);
 QuantizationMode string_to_quantization_mode(

--- a/python/mlx/nn/layers/quantized.py
+++ b/python/mlx/nn/layers/quantized.py
@@ -14,6 +14,7 @@ def _defaults_for_mode(mode, group_size, bits):
         "mxfp4": (32, 4),
         "nvfp4": (16, 4),
         "mxfp8": (32, 8),
+        "nf4": (64, 4),
     }
     default_group_size, default_bits = mode_defaults[mode]
     return group_size or default_group_size, bits or default_bits

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -221,6 +221,18 @@ class TestBase(mlx_tests.MLXTestCase):
         self.assertTrue(isinstance(m.layers[2], nn.QuantizedLinear))
         self.assertTrue(isinstance(m.layers[2].scales, mx.array))
 
+        m = nn.Sequential(nn.Embedding(5, 256), nn.ReLU(), nn.Linear(256, 256))
+        nn.quantize(m, mode="nf4")
+        self.assertTrue(isinstance(m.layers[0], nn.QuantizedEmbedding))
+        self.assertTrue(isinstance(m.layers[1], nn.ReLU))
+        self.assertTrue(isinstance(m.layers[2], nn.QuantizedLinear))
+        self.assertEqual(m.layers[2].group_size, 64)
+        self.assertEqual(m.layers[2].bits, 4)
+        self.assertEqual(m.layers[2].mode, "nf4")
+        self.assertTrue(isinstance(m.layers[2].scales, mx.array))
+        self.assertEqual(m.layers[2].scales.dtype, mx.float32)
+        self.assertNotIn("biases", m.layers[2])
+
         m = nn.Sequential(
             nn.Embedding(5, 256), nn.ReLU(), nn.Linear(256, 256, bias=False)
         )
@@ -248,6 +260,21 @@ class TestBase(mlx_tests.MLXTestCase):
         qlin.unfreeze(keys=["scales"])
         size = tree_reduce(lambda acc, p: acc + p.size, qlin.trainable_parameters(), 0)
         self.assertTrue(size > 0)
+
+    def test_nf4_quantized_linear(self):
+        lin = nn.Linear(64, 16, bias=False)
+        qlin = lin.to_quantized(mode="nf4")
+        self.assertEqual(qlin.group_size, 64)
+        self.assertEqual(qlin.bits, 4)
+        self.assertEqual(qlin.mode, "nf4")
+        self.assertNotIn("biases", qlin)
+
+        x = mx.random.normal(shape=(3, 64)).astype(mx.float32)
+        w_hat = mx.dequantize(qlin.weight, qlin.scales, mode="nf4")
+        y = qlin(x)
+        y_ref = x @ w_hat.T
+        self.assertEqual(y.shape, y_ref.shape)
+        self.assertLess((y - y_ref).abs().max(), 2e-3)
 
     def test_quantized_sharded_linear_construction(self):
         input_dims, output_dims = 1536, 1024

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -276,6 +276,22 @@ class TestBase(mlx_tests.MLXTestCase):
         self.assertEqual(y.shape, y_ref.shape)
         self.assertLess((y - y_ref).abs().max(), 2e-3)
 
+    def test_nf4_quantized_embedding(self):
+        emb = nn.Embedding(16, 64)
+        qemb = emb.to_quantized(mode="nf4")
+        self.assertEqual(qemb.group_size, 64)
+        self.assertEqual(qemb.bits, 4)
+        self.assertEqual(qemb.mode, "nf4")
+        self.assertEqual(qemb.scales.dtype, mx.float32)
+        self.assertNotIn("biases", qemb)
+
+        x = mx.array([0, 2, 7, 15])
+        y = qemb(x)
+        y_ref = mx.dequantize(qemb.weight[x], qemb.scales[x], mode="nf4")
+        self.assertEqual(y.shape, (4, 64))
+        self.assertEqual(y.dtype, mx.float32)
+        self.assertTrue(mx.array_equal(y, y_ref))
+
     def test_quantized_sharded_linear_construction(self):
         input_dims, output_dims = 1536, 1024
         for bits in [2, 3, 4, 5, 6, 8]:

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -204,6 +204,21 @@ class TestQuantized(mlx_tests.MLXTestCase):
         w_hat = mx.dequantize(w_q, scales, mode="nf4")
         self.assertTrue(mx.allclose(w, w_hat, rtol=1e-5, atol=1e-5))
 
+        scale_factors = mx.array([[0.5], [2.0], [0.25], [4.0]])
+        w_scaled = w * scale_factors
+        w_q, scales = mx.quantize(w_scaled, mode="nf4")
+        self.assertTrue(mx.all(scales != 1.0))
+        w_hat = mx.dequantize(w_q, scales, mode="nf4")
+        self.assertTrue(mx.allclose(w_scaled, w_hat, rtol=1e-5, atol=1e-5))
+
+        w_q = mx.array(
+            [[0x76543210, 0xFEDCBA98, 0x76543210, 0xFEDCBA98]], dtype=mx.uint32
+        )
+        scales = mx.ones((1, 1), dtype=mx.float32)
+        expected = mx.concatenate([lut, lut], axis=0).reshape(1, 32)
+        w_hat = mx.dequantize(w_q, scales, group_size=32, mode="nf4", stream=mx.cpu)
+        self.assertTrue(mx.allclose(expected, w_hat, rtol=1e-5, atol=1e-5))
+
         a = mx.zeros((4, 64))
         w_q, scales = mx.quantize(a, mode="nf4")
         w_hat = mx.dequantize(w_q, scales, mode="nf4")
@@ -495,16 +510,21 @@ class TestQuantized(mlx_tests.MLXTestCase):
         k1, k2 = mx.random.split(key)
         tests = product(
             [1, 8],  # M
-            [64, 128],  # N
+            [64, 256],  # N
             [64, 128],  # K
             [True, False],  # transposed
+            [0, 3],  # batch
         )
-        for M, N, K, transposed in tests:
-            with self.subTest(shape=(M, N, K), transposed=transposed):
-                x = (mx.random.normal(shape=(M, K), key=k1) / K**0.5).astype(
+        for M, N, K, transposed, B in tests:
+            with self.subTest(shape=(B, M, N, K), transposed=transposed):
+                x_shape = (M, K) if B == 0 else (B, M, K)
+                x = (mx.random.normal(shape=x_shape, key=k1) / K**0.5).astype(
                     mx.float32
                 )
-                w_shape = (N, K) if transposed else (K, N)
+                if B == 0:
+                    w_shape = (N, K) if transposed else (K, N)
+                else:
+                    w_shape = (B, N, K) if transposed else (B, K, N)
                 w = (mx.random.normal(shape=w_shape, key=k2) / K**0.5).astype(
                     mx.float32
                 )
@@ -513,7 +533,7 @@ class TestQuantized(mlx_tests.MLXTestCase):
                 y_q = mx.quantized_matmul(
                     x, w_q, scales, transpose=transposed, mode="nf4"
                 )
-                y_hat = (x @ w_hat.T) if transposed else (x @ w_hat)
+                y_hat = (x @ mx.swapaxes(w_hat, -1, -2)) if transposed else (x @ w_hat)
                 self.assertEqual(y_q.shape, y_hat.shape)
                 self.assertLess((y_q - y_hat).abs().max(), 2e-3)
 

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -751,6 +751,14 @@ class TestQuantized(mlx_tests.MLXTestCase):
             )
 
         wq, scales = mx.quantize(w, mode="nf4")
+        scales16 = scales.astype(mx.float16)
+        x = mx.random.normal(shape=(1, 256))
+        with self.assertRaises(ValueError):
+            mx.dequantize(wq, scales16, mode="nf4")
+
+        with self.assertRaises(ValueError):
+            mx.quantized_matmul(x, wq, scales16, mode="nf4")
+
         with self.assertRaises(RuntimeError):
             mx.gather_qmm(
                 x,

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -537,6 +537,32 @@ class TestQuantized(mlx_tests.MLXTestCase):
                 self.assertEqual(y_q.shape, y_hat.shape)
                 self.assertLess((y_q - y_hat).abs().max(), 2e-3)
 
+        for group_size, transposed in product([32, 128], [True, False]):
+            with self.subTest(group_size=group_size, transposed=transposed):
+                M, N, K = 5, 128, 128
+                x = (mx.random.normal(shape=(M, K), key=k1) / K**0.5).astype(
+                    mx.float32
+                )
+                w_shape = (N, K) if transposed else (K, N)
+                w = (mx.random.normal(shape=w_shape, key=k2) / K**0.5).astype(
+                    mx.float32
+                )
+                w_q, scales = mx.quantize(w, group_size=group_size, mode="nf4")
+                w_hat = mx.dequantize(
+                    w_q, scales, group_size=group_size, mode="nf4"
+                )
+                y_q = mx.quantized_matmul(
+                    x,
+                    w_q,
+                    scales,
+                    transpose=transposed,
+                    group_size=group_size,
+                    mode="nf4",
+                )
+                y_hat = (x @ mx.swapaxes(w_hat, -1, -2)) if transposed else (x @ w_hat)
+                self.assertEqual(y_q.shape, y_hat.shape)
+                self.assertLess((y_q - y_hat).abs().max(), 2e-3)
+
     def test_qvm(self):
         key = mx.random.key(0)
         k1, k2 = mx.random.split(key)

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -173,6 +173,65 @@ class TestQuantized(mlx_tests.MLXTestCase):
         )
         self.assertTrue(mx.allclose(w, w_hat, rtol=1e-5, atol=1e-5))
 
+    def test_nf4_quantize_dequantize(self):
+        lut = mx.array(
+            [
+                -1.0,
+                -0.6961928,
+                -0.5250731,
+                -0.3949175,
+                -0.2844414,
+                -0.1847734,
+                -0.0910500,
+                0.0,
+                0.0795803,
+                0.1609302,
+                0.2461123,
+                0.3379152,
+                0.4407098,
+                0.5626170,
+                0.7229568,
+                1.0,
+            ]
+        )
+        w = mx.tile(lut, (4, 8)).astype(mx.float32)
+
+        w_q, scales = mx.quantize(w, mode="nf4")
+        self.assertEqual(w_q.shape, (4, 16))
+        self.assertEqual(scales.shape, (4, 2))
+        self.assertEqual(scales.dtype, mx.float32)
+
+        w_hat = mx.dequantize(w_q, scales, mode="nf4")
+        self.assertTrue(mx.allclose(w, w_hat, rtol=1e-5, atol=1e-5))
+
+        a = mx.zeros((4, 64))
+        w_q, scales = mx.quantize(a, mode="nf4")
+        w_hat = mx.dequantize(w_q, scales, mode="nf4")
+        self.assertTrue(mx.all(w_hat == 0))
+
+        for group_size in [32, 64, 128]:
+            with self.subTest(group_size=group_size):
+                w_q, scales = mx.quantize(w, group_size=group_size, mode="nf4")
+                w_hat = mx.dequantize(
+                    w_q, scales, group_size=group_size, mode="nf4"
+                )
+                self.assertTrue(mx.allclose(w, w_hat, rtol=1e-5, atol=1e-5))
+
+        with self.assertRaises(ValueError):
+            mx.quantize(w, bits=3, mode="nf4")
+
+        with self.assertRaises(ValueError):
+            mx.quantize(w, group_size=16, mode="nf4")
+
+        with self.assertRaises(ValueError):
+            mx.dequantize(w_q, scales, bits=3, mode="nf4")
+
+        with self.assertRaises(ValueError):
+            mx.dequantize(w_q, scales.astype(mx.uint8), mode="nf4")
+
+        with self.assertRaises(ValueError):
+            mx.dequantize(w_q, scales, mx.zeros(scales.shape), mode="nf4")
+
     def test_qqmv(self):
         key = mx.random.key(0)
         k1, k2 = mx.random.split(key)
@@ -431,6 +490,33 @@ class TestQuantized(mlx_tests.MLXTestCase):
             self.assertEqual(y_q.shape, y_hat.shape)
             self.assertLess((y_q - y_hat).abs().max(), 1e-3)
 
+    def test_nf4_qmm(self):
+        key = mx.random.key(0)
+        k1, k2 = mx.random.split(key)
+        tests = product(
+            [1, 8],  # M
+            [64, 128],  # N
+            [64, 128],  # K
+            [True, False],  # transposed
+        )
+        for M, N, K, transposed in tests:
+            with self.subTest(shape=(M, N, K), transposed=transposed):
+                x = (mx.random.normal(shape=(M, K), key=k1) / K**0.5).astype(
+                    mx.float32
+                )
+                w_shape = (N, K) if transposed else (K, N)
+                w = (mx.random.normal(shape=w_shape, key=k2) / K**0.5).astype(
+                    mx.float32
+                )
+                w_q, scales = mx.quantize(w, mode="nf4")
+                w_hat = mx.dequantize(w_q, scales, mode="nf4")
+                y_q = mx.quantized_matmul(
+                    x, w_q, scales, transpose=transposed, mode="nf4"
+                )
+                y_hat = (x @ w_hat.T) if transposed else (x @ w_hat)
+                self.assertEqual(y_q.shape, y_hat.shape)
+                self.assertLess((y_q - y_hat).abs().max(), 2e-3)
+
     def test_qvm(self):
         key = mx.random.key(0)
         k1, k2 = mx.random.split(key)
@@ -616,6 +702,16 @@ class TestQuantized(mlx_tests.MLXTestCase):
         with self.assertRaises(ValueError):
             mx.gather_qmm(
                 x, wq, scales, biases, rhs_indices=rhs_indices, bits=4, group_size=32
+            )
+
+        wq, scales = mx.quantize(w, mode="nf4")
+        with self.assertRaises(RuntimeError):
+            mx.gather_qmm(
+                x,
+                wq,
+                scales,
+                rhs_indices=rhs_indices,
+                mode="nf4",
             )
 
     def test_throw(self):

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -219,6 +219,21 @@ class TestQuantized(mlx_tests.MLXTestCase):
         w_hat = mx.dequantize(w_q, scales, group_size=32, mode="nf4", stream=mx.cpu)
         self.assertTrue(mx.allclose(expected, w_hat, rtol=1e-5, atol=1e-5))
 
+        w_q = mx.array(
+            [[0xFEDCBA98, 0x76543210, 0x10325476, 0x98BADCFE]], dtype=mx.uint32
+        )
+        expected = mx.concatenate(
+            [
+                lut[8:],
+                lut[:8],
+                lut[[6, 7, 4, 5, 2, 3, 0, 1]],
+                lut[[14, 15, 12, 13, 10, 11, 8, 9]],
+            ],
+            axis=0,
+        ).reshape(1, 32)
+        w_hat = mx.dequantize(w_q, scales, group_size=32, mode="nf4", stream=mx.cpu)
+        self.assertTrue(mx.allclose(expected, w_hat, rtol=1e-5, atol=1e-5))
+
         a = mx.zeros((4, 64))
         w_q, scales = mx.quantize(a, mode="nf4")
         w_hat = mx.dequantize(w_q, scales, mode="nf4")
@@ -758,6 +773,9 @@ class TestQuantized(mlx_tests.MLXTestCase):
 
         with self.assertRaises(ValueError):
             mx.quantized_matmul(x, wq, scales16, mode="nf4")
+
+        with self.assertRaises(ValueError):
+            mx.quantized_matmul(x, wq, scales, mode="nf4", stream=mx.cpu)
 
         with self.assertRaises(RuntimeError):
             mx.gather_qmm(


### PR DESCRIPTION
### Summary

Adds NormalFloat4 (NF4) as a quantization mode for MLX quantized primitives and
quantized `nn` layers.

This extends the existing quantization surface with:

- `mode="nf4"` parsing and defaults
- NF4 quantize/dequantize support with float32 absmax scales
- Metal NF4 quantized matmul kernels
- `nn.QuantizedLinear(..., mode="nf4")`
- explicit errors for unsupported NF4 routes such as indexed `gather_qmm` and non-Metal NF4 `quantized_matmul`

NF4 uses 4-bit indices into the standard 16-value NormalFloat4 lookup table from QLoRA, with one float32 absmax scale per quantization group. The Metal kernels are separate from the existing FP4/FP8 kernels because NF4 dequantization is lookup-table based and uses float32 absmax scales rather than encoded byte scales.

### Details

The new mode defaults to `bits=4` and `group_size=64`, matching the common NF4
layout. The core NF4 paths also accept group sizes 32 and 128.

`mx.quantize(..., mode="nf4")` uses the graph fallback path and returns packed
`uint32` weights plus float32 scales. `mx.dequantize(..., mode="nf4")` and
`mx.quantized_matmul(..., mode="nf4")` route through the existing quantized
primitive structure, with Metal kernels for the performance-sensitive matmul
path.

The initial implementation does not support indexed NF4 `gather_qmm`; those calls now fail explicitly instead of falling through to missing Metal kernels.

NF4 `quantized_matmul` is currently Metal-only and fails explicitly on non-Metal streams. NF4 `dequantize` remains available through the graph fallback path.

### Tests

```sh
PYTHONPATH=python/tests uv run python -m unittest \
  python.tests.test_quantized \
  python.tests.test_nn.TestBase.test_quantize \
  python.tests.test_nn.TestBase.test_quantize_freeze \
  python.tests.test_nn.TestBase.test_nf4_quantized_linear \
  python.tests.test_nn.TestBase.test_nf4_quantized_embedding -v
```

```text
Ran 35 tests in 0.514s
OK
```

```sh
cmake --build build --target tests test_teardown --parallel 10
./build/tests/tests
./build/tests/test_teardown
```

```text
test cases: 256 | 256 passed | 0 failed | 0 skipped
assertions: 3453 | 3453 passed | 0 failed
test_teardown exited successfully
```
