### PR TITLE
Fix CUDA grid launch for large uncontiguous tensors

### DIFF
--- a/mlx/backend/cuda/binary/binary.cuh
+++ b/mlx/backend/cuda/binary/binary.cuh
@@ -135,7 +135,9 @@ __global__ void binary_g_nd(
   auto block = cg::this_thread_block();
   auto grid = cg::this_grid();
   IdxT index_rest =
-      grid.block_index().y * block.dim_threads().y + block.thread_index().y;
+      (grid.block_index().z * grid.dim_blocks().y + grid.block_index().y) *
+          block.dim_threads().y +
+      block.thread_index().y;
   if (index_rest >= size_rest) {
     return;
   }
@@ -173,7 +175,9 @@ __global__ void binary_g(
   auto block = cg::this_thread_block();
   auto grid = cg::this_grid();
   IdxT index_rest =
-      grid.block_index().y * block.dim_threads().y + block.thread_index().y;
+      (grid.block_index().z * grid.dim_blocks().y + grid.block_index().y) *
+          block.dim_threads().y +
+      block.thread_index().y;
   if (index_rest >= size_rest) {
     return;
   }
@@ -286,7 +290,8 @@ void binary_op_gpu_inplace(
                 dim0 = (dim0 + work_per_thread - 1) / work_per_thread;
                 auto block_dims = get_block_dims(dim0, rest, 1);
                 uint32_t num_blocks_x = cuda::ceil_div(dim0, block_dims.x);
-                uint32_t num_blocks_y = cuda::ceil_div(rest, block_dims.y);
+                auto grid_dims = get_2d_grid_dims_split_y(
+                    num_blocks_x, rest, block_dims.y);
                 if (ndim <= 3) {
                   dispatch_1_2_3(ndim, [&](auto dims_constant) {
                     auto kernel = cu::binary_g_nd<
@@ -307,7 +312,7 @@ void binary_op_gpu_inplace(
                     }
                     encoder.add_kernel_node(
                         kernel,
-                        {num_blocks_x, num_blocks_y},
+                        grid_dims,
                         block_dims,
                         gpu_ptr<InType>(a),
                         gpu_ptr<InType>(b),
@@ -324,7 +329,7 @@ void binary_op_gpu_inplace(
                   }
                   encoder.add_kernel_node(
                       kernel,
-                      {num_blocks_x, num_blocks_y},
+                      grid_dims,
                       block_dims,
                       gpu_ptr<InType>(a),
                       gpu_ptr<InType>(b),

--- a/mlx/backend/cuda/binary_two.cu
+++ b/mlx/backend/cuda/binary_two.cu
@@ -146,7 +146,9 @@ __global__ void binary_two_g_nd(
   auto block = cg::this_thread_block();
   auto grid = cg::this_grid();
   IdxT index_rest =
-      grid.block_index().y * block.dim_threads().y + block.thread_index().y;
+      (grid.block_index().z * grid.dim_blocks().y + grid.block_index().y) *
+          block.dim_threads().y +
+      block.thread_index().y;
   if (index_rest >= size_rest) {
     return;
   }
@@ -189,7 +191,9 @@ __global__ void binary_two_g(
   auto block = cg::this_thread_block();
   auto grid = cg::this_grid();
   IdxT index_rest =
-      grid.block_index().y * block.dim_threads().y + block.thread_index().y;
+      (grid.block_index().z * grid.dim_blocks().y + grid.block_index().y) *
+          block.dim_threads().y +
+      block.thread_index().y;
   if (index_rest >= size_rest) {
     return;
   }
@@ -290,7 +294,8 @@ void binary_two_op_gpu_inplace(
                 dim0 = (dim0 + work_per_thread - 1) / work_per_thread;
                 auto block_dims = get_block_dims(dim0, rest, 1);
                 uint32_t num_blocks_x = cuda::ceil_div(dim0, block_dims.x);
-                uint32_t num_blocks_y = cuda::ceil_div(rest, block_dims.y);
+                auto grid_dims = get_2d_grid_dims_split_y(
+                    num_blocks_x, rest, block_dims.y);
 
                 if (ndim <= 3) {
                   dispatch_1_2_3(ndim, [&](auto dims_constant) {
@@ -312,7 +317,7 @@ void binary_two_op_gpu_inplace(
                     }
                     encoder.add_kernel_node(
                         kernel,
-                        {num_blocks_x, num_blocks_y},
+                        grid_dims,
                         block_dims,
                         gpu_ptr<InType>(a),
                         gpu_ptr<InType>(b),
@@ -330,7 +335,7 @@ void binary_two_op_gpu_inplace(
                   }
                   encoder.add_kernel_node(
                       kernel,
-                      {num_blocks_x, num_blocks_y},
+                      grid_dims,
                       block_dims,
                       gpu_ptr<InType>(a),
                       gpu_ptr<InType>(b),

--- a/mlx/backend/cuda/copy/copy_general.cu
+++ b/mlx/backend/cuda/copy/copy_general.cu
@@ -21,7 +21,9 @@ __global__ void copy_gg_nd(
   auto block = cg::this_thread_block();
   auto grid = cg::this_grid();
   IdxT index_rest =
-      grid.block_index().y * block.dim_threads().y + block.thread_index().y;
+      (grid.block_index().z * grid.dim_blocks().y + grid.block_index().y) *
+          block.dim_threads().y +
+      block.thread_index().y;
   if (index_rest >= size_rest) {
     return;
   }
@@ -59,7 +61,9 @@ __global__ void copy_gg(
   auto block = cg::this_thread_block();
   auto grid = cg::this_grid();
   IdxT index_rest =
-      grid.block_index().y * block.dim_threads().y + block.thread_index().y;
+      (grid.block_index().z * grid.dim_blocks().y + grid.block_index().y) *
+          block.dim_threads().y +
+      block.thread_index().y;
   if (index_rest >= size_rest) {
     return;
   }
@@ -123,7 +127,8 @@ void copy_general(
             dim0 = (dim0 + work_per_thread - 1) / work_per_thread;
             auto block_dims = get_block_dims(dim0, rest, 1);
             uint32_t num_blocks_x = cuda::ceil_div(dim0, block_dims.x);
-            uint32_t num_blocks_y = cuda::ceil_div(rest, block_dims.y);
+            auto grid_dims = get_2d_grid_dims_split_y(
+                    num_blocks_x, rest, block_dims.y);
 
             if (ndim <= 3) {
               dispatch_1_2_3(ndim, [&](auto ndim_constant) {
@@ -135,7 +140,7 @@ void copy_general(
                 }
                 encoder.add_kernel_node(
                     kernel,
-                    {num_blocks_x, num_blocks_y},
+                    grid_dims,
                     block_dims,
                     in_ptr,
                     out_ptr,
@@ -151,7 +156,7 @@ void copy_general(
               }
               encoder.add_kernel_node(
                   kernel,
-                  {num_blocks_x, num_blocks_y},
+                  grid_dims,
                   block_dims,
                   in_ptr,
                   out_ptr,

--- a/mlx/backend/cuda/copy/copy_general_input.cu
+++ b/mlx/backend/cuda/copy/copy_general_input.cu
@@ -21,7 +21,9 @@ __global__ void copy_g_nd(
   auto block = cg::this_thread_block();
   auto grid = cg::this_grid();
   IdxT index_rest =
-      grid.block_index().y * block.dim_threads().y + block.thread_index().y;
+      (grid.block_index().z * grid.dim_blocks().y + grid.block_index().y) *
+          block.dim_threads().y +
+      block.thread_index().y;
   if (index_rest >= size_rest) {
     return;
   }
@@ -53,7 +55,9 @@ __global__ void copy_g(
   auto block = cg::this_thread_block();
   auto grid = cg::this_grid();
   IdxT index_rest =
-      grid.block_index().y * block.dim_threads().y + block.thread_index().y;
+      (grid.block_index().z * grid.dim_blocks().y + grid.block_index().y) *
+          block.dim_threads().y +
+      block.thread_index().y;
   if (index_rest >= size_rest) {
     return;
   }
@@ -177,7 +181,8 @@ void copy_general_input(
             dim0 = (dim0 + work_per_thread - 1) / work_per_thread;
             auto block_dims = get_block_dims(dim0, rest, 1);
             uint32_t num_blocks_x = cuda::ceil_div(dim0, block_dims.x);
-            uint32_t num_blocks_y = cuda::ceil_div(rest, block_dims.y);
+            auto grid_dims = get_2d_grid_dims_split_y(
+                    num_blocks_x, rest, block_dims.y);
 
             if (ndim <= 3) {
               dispatch_1_2_3(ndim, [&](auto dims_constant) {
@@ -192,7 +197,7 @@ void copy_general_input(
                 }
                 encoder.add_kernel_node(
                     kernel,
-                    {num_blocks_x, num_blocks_y},
+                    grid_dims,
                     block_dims,
                     in_ptr,
                     out_ptr,
@@ -209,7 +214,7 @@ void copy_general_input(
               }
               encoder.add_kernel_node(
                   kernel,
-                  {num_blocks_x, num_blocks_y},
+                  grid_dims,
                   block_dims,
                   in_ptr,
                   out_ptr,

--- a/mlx/backend/cuda/kernel_utils.cuh
+++ b/mlx/backend/cuda/kernel_utils.cuh
@@ -20,6 +20,19 @@
 
 namespace mlx::core {
 
+static constexpr uint32_t kMaxGridDim = 65535;
+
+inline dim3 get_2d_grid_dims_split_y(
+    uint32_t blocks_x,
+    size_t rest,
+    uint32_t block_y) {
+  uint32_t blocks_y_raw =
+      static_cast<uint32_t>(cuda::ceil_div(rest, size_t{block_y}));
+  uint32_t blocks_z = cuda::ceil_div(blocks_y_raw, kMaxGridDim);
+  uint32_t blocks_y = cuda::ceil_div(blocks_y_raw, blocks_z);
+  return {blocks_x, blocks_y, blocks_z};
+}
+
 template <typename F>
 void dispatch_1_2_3(int n, F&& f) {
   switch (n) {

--- a/mlx/backend/cuda/ternary.cu
+++ b/mlx/backend/cuda/ternary.cu
@@ -53,7 +53,9 @@ __global__ void ternary_g_nd(
   auto block = cg::this_thread_block();
   auto grid = cg::this_grid();
   IdxT index_rest =
-      grid.block_index().y * block.dim_threads().y + block.thread_index().y;
+      (grid.block_index().z * grid.dim_blocks().y + grid.block_index().y) *
+          block.dim_threads().y +
+      block.thread_index().y;
   if (index_rest >= size_rest) {
     return;
   }
@@ -195,7 +197,8 @@ void ternary_op_gpu_inplace(
             dim0 = (dim0 + work_per_thread - 1) / work_per_thread;
             auto block_dims = get_block_dims(dim0, rest, 1);
             uint32_t num_blocks_x = cuda::ceil_div(dim0, block_dims.x);
-            uint32_t num_blocks_y = cuda::ceil_div(rest, block_dims.y);
+            auto grid_dims = get_2d_grid_dims_split_y(
+                    num_blocks_x, rest, block_dims.y);
 
             if (ndim <= 3) {
               dispatch_1_2_3(ndim, [&](auto dims_constant) {
@@ -207,7 +210,7 @@ void ternary_op_gpu_inplace(
                 }
                 encoder.add_kernel_node(
                     kernel,
-                    {num_blocks_x, num_blocks_y},
+                    grid_dims,
                     block_dims,
                     gpu_ptr<bool>(a),
                     gpu_ptr<DType>(b),
@@ -226,7 +229,7 @@ void ternary_op_gpu_inplace(
               }
               encoder.add_kernel_node(
                   kernel,
-                  {num_blocks_x, num_blocks_y},
+                  grid_dims,
                   block_dims,
                   gpu_ptr<bool>(a),
                   gpu_ptr<DType>(b),

--- a/mlx/backend/cuda/unary/unary.cuh
+++ b/mlx/backend/cuda/unary/unary.cuh
@@ -48,7 +48,9 @@ __global__ void unary_g(
   auto block = cg::this_thread_block();
   auto grid = cg::this_grid();
   IdxT index_rest =
-      grid.block_index().y * block.dim_threads().y + block.thread_index().y;
+      (grid.block_index().z * grid.dim_blocks().y + grid.block_index().y) *
+          block.dim_threads().y +
+      block.thread_index().y;
   if (index_rest >= size_rest) {
     return;
   }
@@ -175,10 +177,11 @@ void unary_op_gpu_inplace(
             dim0 = (dim0 + work_per_thread - 1) / work_per_thread;
             auto block_dims = get_block_dims(dim0, rest, 1);
             uint32_t num_blocks_x = cuda::ceil_div(dim0, block_dims.x);
-            uint32_t num_blocks_y = cuda::ceil_div(rest, block_dims.y);
+            auto grid_dims = get_2d_grid_dims_split_y(
+                    num_blocks_x, rest, block_dims.y);
             encoder.add_kernel_node(
                 kernel,
-                {num_blocks_x, num_blocks_y},
+                grid_dims,
                 block_dims,
                 gpu_ptr<InType>(in),
                 gpu_ptr<OutType>(out),

--- a/python/tests/test_fast.py
+++ b/python/tests/test_fast.py
@@ -204,6 +204,15 @@ class TestFast(mlx_tests.MLXTestCase):
             x, dims=feature_dim, traditional=False, base=10000.0, scale=1.0, offset=0
         )
 
+    @unittest.skipIf(not mx.cuda.is_available(), "requires CUDA")
+    def test_rope_large_uncontiguous_cuda_grid(self):
+        dims = 128
+        x = mx.zeros((9, 8192, 32, dims), dtype=mx.float16).swapaxes(1, 2)
+        y = mx.fast.rope(x, dims, traditional=False, base=10000.0, scale=1.0, offset=0)
+
+        self.assertEqual(y.shape, x.shape)
+        self.assertEqual(mx.max(mx.abs(y)).item(), 0)
+
     def test_rope_with_freqs(self):
         mx.random.seed(0)
 


### PR DESCRIPTION
## Summary

- split oversized CUDA grid-y launches across grid-z for general unary, binary, ternary, and copy kernels
- centralize the split calculation in `get_2d_grid_dims_split_y`
- add a CUDA-only ROPE regression for a large non-contiguous tensor shape that exercises the split-grid path without allocating a separate random/reference tensor

## Guardrail notes

This is a CUDA/Linux-scoped correctness fix, not an Apple Metal validation task. I kept it separate from Metal work and from PR #3674.

The regression is CUDA-only and uses a zero `float16` input to keep memory bounded while still requiring the launch geometry that previously exceeded the CUDA grid-y limit.

## Tests

```bash
/Users/chris.s/.pyenv/versions/3.11.7/bin/python -m black --check python/tests/test_fast.py
# 1 file would be left unchanged

git diff --check
# passed

/Users/chris.s/.pyenv/versions/3.11.7/bin/python -m pytest python/tests/test_fast.py -q
# 17 passed, 7 skipped in 0.43s
```

Note: the new regression is skipped in this local environment because CUDA is unavailable. It is intended to run in the upstream CUDA CI lanes.
