### PR TITLE
Fix use-after-free: buffer-cache trim can free a buffer used by an in-flight command buffer

### DIFF
--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -276,7 +276,18 @@ CommandEncoder::CommandEncoder(
     queue_->addResidencySet(residency_set.mtl_residency_set());
   }
   debug_set_stream_queue_label(queue_.get(), index);
-  buffer_ = NS::RetainPtr(queue_->commandBufferWithUnretainedReferences());
+  // Use retained references so Metal keeps every referenced MTLBuffer alive
+  // until the command buffer completes. With unretained references the
+  // allocator's buffer cache can deallocate a buffer that an in-flight command
+  // buffer still references: when malloc() finds the cache over its limit it
+  // calls buffer_cache_.release_cached_buffers(), whose callback runs
+  // buf->release() on a cached buffer whose command buffer has not yet
+  // completed. With ResourceHazardTrackingModeUntracked buffers that frees the
+  // underlying allocation out from under the GPU, which fails completion with
+  // kIOGPUCommandBufferCallbackErrorInvalidResource. Retained references let
+  // Metal hold the buffer until the command buffer finishes, so release() from
+  // the cache trim only drops MLX's own ref.
+  buffer_ = NS::RetainPtr(queue_->commandBuffer());
 }
 
 CommandEncoder::~CommandEncoder() {
@@ -510,7 +521,10 @@ void CommandEncoder::commit(std::function<void()> completion) {
         }
       });
   buffer_->commit();
-  buffer_ = NS::RetainPtr(queue_->commandBufferWithUnretainedReferences());
+  // Retained references (see CommandEncoder ctor): keep referenced buffers
+  // alive until the command buffer completes so the allocator's cache trim
+  // cannot free a buffer still in use by the GPU.
+  buffer_ = NS::RetainPtr(queue_->commandBuffer());
   buffer_ops_ = 0;
   buffer_sizes_ = 0;
 }


### PR DESCRIPTION
Resolves #3689

## Summary

Command buffers are created with `commandBufferWithUnretainedReferences()`, so Metal does not keep referenced `MTLBuffer`s alive — MLX owns their lifetime. Under memory pressure the allocator's buffer-cache trim can free a buffer that an in-flight command buffer still references, causing a GPU-side use-after-free.

## Root cause

1. `MetalAllocator::free()` recycles a buffer into the reuse cache as soon as its refcount hits 0 — even if a command buffer that uses it is still in flight (e.g. after `async_eval`).
2. When `MetalAllocator::malloc()` finds the cache over `max_pool_size_` (or under memory pressure past `gc_limit_`), it calls `buffer_cache_.release_cached_buffers(...)`, whose free callback runs the real `buf->release()` (and `residency_set_.erase(buf)`).
3. Buffers use `MTL::ResourceHazardTrackingModeUntracked`, and command buffers are unretained, so nothing keeps the `MTLBuffer` alive. Releasing it deallocates the allocation out from under the GPU.
4. The in-flight command buffer then fails completion with `kIOGPUCommandBufferCallbackErrorInvalidResource`, surfacing as a `SIGABRT` on `com.Metal.CompletionQueueDispatch` via `mlx::core::gpu::check_error`.

## Reproduction

Reproduces reliably on a 27B vision model behind a tiered prefix cache that restores KV state and re-runs prefill — steady allocation + cache churn while prior command buffers are still in flight. It is timing-sensitive: running under a debugger or with a much larger cache limit hides it (the larger limit just suppresses the trim), which is the signature of this race.

## Fix

Use retained references at both command-buffer creation sites in `CommandEncoder` (`commandBuffer()` instead of `commandBufferWithUnretainedReferences()`), so Metal holds referenced buffers until the command buffer completes. The cache trim's `release()` then only drops MLX's own reference; Metal keeps the allocation alive until the GPU is done with it.

This trades a small amount of per-command-buffer retain/release overhead for correctness under memory pressure. If a lower-overhead approach is preferred, an alternative would be to defer releasing cached buffers that are still referenced by in-flight command buffers — happy to rework along those lines.

## Testing

With this change, the previously-crashing workload runs to completion (and warm prefix-cache restores remain *faster* than cold runs, confirming the fix is correctness, not a slowdown that masks the race).