### PR TITLE
fix: avoid NaN gradients for masked sqrt at zero

### DIFF
--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -5374,14 +5374,13 @@ std::vector<array> Sqrt::vjp(
   assert(cotangents.size() == 1);
   auto dtype = primals[0].dtype();
   if (recip_) {
-    auto scaled_cotan =
-        multiply(array(-0.5, dtype), cotangents[0], stream());
+    auto scaled_cotan = multiply(array(-0.5, dtype), cotangents[0], stream());
     auto mask =
         not_equal(cotangents[0], array(0, cotangents[0].dtype()), stream());
     auto output = where(mask, outputs[0], array(1, dtype), stream());
     auto input = where(mask, primals[0], array(1, dtype), stream());
-    auto out = divide(
-        multiply(scaled_cotan, output, stream()), input, stream());
+    auto out =
+        divide(multiply(scaled_cotan, output, stream()), input, stream());
     return {out};
   } else {
     auto scaled_cotan = multiply(array(0.5, dtype), cotangents[0], stream());

--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -5374,16 +5374,21 @@ std::vector<array> Sqrt::vjp(
   assert(cotangents.size() == 1);
   auto dtype = primals[0].dtype();
   if (recip_) {
-    auto one_over_x_root_x = divide(outputs[0], primals[0], stream());
-    return {multiply(
-        multiply(array(-0.5, dtype), cotangents[0], stream()),
-        one_over_x_root_x,
-        stream())};
+    auto scaled_cotan =
+        multiply(array(-0.5, dtype), cotangents[0], stream());
+    auto mask =
+        not_equal(cotangents[0], array(0, cotangents[0].dtype()), stream());
+    auto output = where(mask, outputs[0], array(1, dtype), stream());
+    auto input = where(mask, primals[0], array(1, dtype), stream());
+    auto out = divide(
+        multiply(scaled_cotan, output, stream()), input, stream());
+    return {out};
   } else {
-    return {divide(
-        multiply(array(0.5, dtype), cotangents[0], stream()),
-        outputs[0],
-        stream())};
+    auto scaled_cotan = multiply(array(0.5, dtype), cotangents[0], stream());
+    auto mask =
+        not_equal(cotangents[0], array(0, cotangents[0].dtype()), stream());
+    auto output = where(mask, outputs[0], array(1, dtype), stream());
+    return {divide(scaled_cotan, output, stream())};
   }
 }
 

--- a/python/tests/test_autograd.py
+++ b/python/tests/test_autograd.py
@@ -121,6 +121,26 @@ class TestAutograd(mlx_tests.MLXTestCase):
         with self.assertRaises(ValueError):
             mx.grad(fun)(mx.ones((2, 2)))
 
+    def test_masked_sqrt_grad_is_finite(self):
+        xy = mx.array([[0.0, 0.0], [3.0, 4.0]], dtype=mx.float32)
+        expected = mx.array([[0.0, 0.0], [0.6, 0.8]], dtype=mx.float32)
+
+        def maximum_radius(xy):
+            x, y = xy[..., 0], xy[..., 1]
+            rho = mx.sqrt(x * x + y * y)
+            return mx.maximum(rho, mx.array(1e-10, dtype=rho.dtype)).sum()
+
+        def where_radius(xy):
+            x, y = xy[..., 0], xy[..., 1]
+            rho = mx.sqrt(x * x + y * y)
+            safe_rho = mx.where(rho > 1e-10, rho, mx.array(1e-10, dtype=rho.dtype))
+            return safe_rho.sum()
+
+        for fn in [maximum_radius, where_radius]:
+            grad = mx.grad(fn)(xy)
+            self.assertTrue(mx.all(mx.isfinite(grad)).item())
+            self.assertTrue(mx.allclose(grad, expected))
+
     def test_grad_trees(self):
         fun = lambda x, y: x * y
         value, dfdx = mx.value_and_grad(fun, (0, 1))(mx.array(0.5), mx.array(2.0))


### PR DESCRIPTION
Fixes #3668

## Proposed changes

Fixes NaN gradients when `sqrt` receives a zero cotangent at singular inputs.

For expressions like:

```python
rho = mx.sqrt(x * x + y * y)
rho_safe = mx.maximum(rho, 1e-10)
```

the forward value is finite at `x = y = 0`, but the VJP previously evaluated the inactive `sqrt(0)` path as `0 / 0`, producing NaN gradients.

This updates `Sqrt::vjp` to substitute a safe denominator when the incoming cotangent is zero, so masked-out paths contribute zero instead of NaN. The change is local to `Sqrt::vjp` and preserves the singular gradient when the cotangent is nonzero.

## Tests

- `DEVICE=cpu python -m pytest -q python/tests/test_autograd.py::TestAutograd::test_masked_sqrt_grad_is_finite`
- `DEVICE=gpu python -m pytest -q python/tests/test_autograd.py::TestAutograd::test_masked_sqrt_grad_is_finite`
- `python -m pytest -q python/tests/test_autograd.py python/tests/test_ops.py::TestOps::test_where python/tests/test_ops.py::TestOps::test_maximum python/tests/test_ops.py::TestOps::test_minimum`


## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
