### PR TITLE
Fix dimension count in orthogonal initializer error message

### DIFF
--- a/python/mlx/nn/init.py
+++ b/python/mlx/nn/init.py
@@ -415,8 +415,8 @@ def orthogonal(
     def initializer(a: mx.array) -> mx.array:
         if a.ndim != 2:
             raise ValueError(
-                f"Orthogonal initialization requires a 2D array but got"
-                " a {a.ndim}D array."
+                "Orthogonal initialization requires a 2D array but got"
+                f" a {a.ndim}D array."
             )
 
         rows, cols = a.shape

--- a/python/tests/test_init.py
+++ b/python/tests/test_init.py
@@ -134,6 +134,11 @@ class TestInit(mlx_tests.MLXTestCase):
             "Orthogonal init failed on a rectangular matrix.",
         )
 
+        # A non-2D input reports its actual number of dimensions
+        with self.assertRaises(ValueError) as cm:
+            initializer(mx.zeros((2, 3, 4), dtype=mx.float32))
+        self.assertIn("3D array", str(cm.exception))
+
 
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner()


### PR DESCRIPTION
The error raised by `nn.init.orthogonal` for a non-2D input never reported the actual number of dimensions. The message was split across two string literals where only the first carried the `f` prefix:

```python
raise ValueError(
    f"Orthogonal initialization requires a 2D array but got"
    " a {a.ndim}D array."
)
```

The `{a.ndim}` lives on the plain (non-f) string, so it was printed verbatim:

```
Orthogonal initialization requires a 2D array but got a {a.ndim}D array.
```

Moving the `f` prefix onto the segment that contains the placeholder fixes the interpolation:

```
Orthogonal initialization requires a 2D array but got a 3D array.
```

Added an assertion to `test_orthogonal` that a 3D input reports `3D array` in the message.