### PR TITLE
Make step activation inclusive at the threshold

### DIFF
--- a/python/mlx/nn/layers/activations.py
+++ b/python/mlx/nn/layers/activations.py
@@ -237,7 +237,7 @@ def step(x: mx.array, threshold: float = 0.0):
         threshold: The value to threshold at.
     """
 
-    return mx.where(x > threshold, 1, 0)
+    return mx.where(x >= threshold, 1, 0)
 
 
 @partial(mx.compile, shapeless=True)

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -972,6 +972,18 @@ class TestLayers(mlx_tests.MLXTestCase):
         self.assertEqual(y.shape, (3,))
         self.assertEqual(y.dtype, mx.float32)
 
+    def test_step(self):
+        x = mx.array([-1.0, 0.0, 1.0])
+
+        # Default threshold of 0: the boundary value is included
+        y = nn.step(x)
+        self.assertTrue(mx.array_equal(y, mx.array([0, 1, 1])))
+        self.assertEqual(y.shape, (3,))
+
+        # A custom threshold is also inclusive
+        y = nn.Step(threshold=1.0)(x)
+        self.assertTrue(mx.array_equal(y, mx.array([0, 0, 1])))
+
     def test_leaky_relu(self):
         x = mx.array([1.0, -1.0, 0.0])
         y = nn.leaky_relu(x)


### PR DESCRIPTION
The `step` activation documents its boundary as inclusive:

```
step(x) = 0  if x < threshold
          1  if x >= threshold
```

Both `nn.step` and the `nn.Step` module render this `x >= threshold` form. The implementation, however, used a strict comparison:

```python
return mx.where(x > threshold, 1, 0)
```

so an input exactly equal to the threshold returned `0` instead of `1`. With the default `threshold=0` this means `step(0.0)` evaluates to `0`, which contradicts the documented behavior.

Switched to `x >= threshold` so the value at the boundary is included, matching the docstring. Added a `test_step` case covering the boundary for both the functional and module forms.