### PR TITLE
Fix repeat zero axis shape

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -1306,7 +1306,9 @@ array repeat(const array& arr, int repeats, int axis, StreamOrDevice s) {
   }
 
   if (repeats == 0) {
-    return array({}, arr.dtype());
+    auto shape = arr.shape();
+    shape[axis] = 0;
+    return array(std::initializer_list<int>{}, shape, arr.dtype());
   }
 
   if (repeats == 1) {

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -2551,6 +2551,9 @@ class TestOps(mlx_tests.MLXTestCase):
         data = mx.array([[[13, 3], [16, 6]], [[14, 4], [15, 5]], [[11, 1], [12, 2]]])
         # Test repeat 0 times
         self.assertCmpNumpy([data, 0], mx.repeat, np.repeat)
+        # Test repeat 0 times along an axis preserves the unrepeated dimensions
+        self.assertCmpNumpy([data, 0], mx.repeat, np.repeat, axis=0)
+        self.assertCmpNumpy([data, 0], mx.repeat, np.repeat, axis=1)
         # Test repeat along axis 0
         self.assertCmpNumpy([data, 2], mx.repeat, np.repeat, axis=0)
         # Test repeat along axis 1

--- a/tests/ops_tests.cpp
+++ b/tests/ops_tests.cpp
@@ -3258,8 +3258,12 @@ TEST_CASE("test repeat") {
 
   // 0 repeats
   auto repeat_4 = repeat(data_3, 0, 0);
-  auto expected_4 = array({});
-  CHECK(array_equal(repeat_2, expected_2).item<bool>());
+  auto expected_4 = array(std::initializer_list<int>{}, {0, 3});
+  CHECK(array_equal(repeat_4, expected_4).item<bool>());
+
+  repeat_4 = repeat(data_3, 0, 1);
+  expected_4 = array(std::initializer_list<int>{}, {3, 0});
+  CHECK(array_equal(repeat_4, expected_4).item<bool>());
 
   // negative repeats
   CHECK_THROWS_AS(repeat(data_3, -3, 0), std::invalid_argument);


### PR DESCRIPTION
## Summary
- preserve the unrepeated dimensions for `mx.repeat(..., repeats=0, axis=...)`
- match NumPy shape semantics for explicit-axis zero repeats
- fix the C++ repeat test so it checks the zero-repeat result instead of an earlier nonzero case

## Evidence
Before the change, a direct probe showed:

```text
axis=0: MLX shape (0,), NumPy shape (0, 3)
axis=1: MLX shape (0,), NumPy shape (2, 0)
axis=-1: MLX shape (0,), NumPy shape (2, 0)
```

After the change:

```text
axis=0: MLX shape (0, 3), NumPy shape (0, 3)
axis=1: MLX shape (2, 0), NumPy shape (2, 0)
axis=-1: MLX shape (2, 0), NumPy shape (2, 0)
flat repeat remains (0,)
```

## Tests
```bash
CMAKE_ARGS="-DMLX_BUILD_METAL=OFF" CMAKE_BUILD_PARALLEL_LEVEL=4 \
  /Users/chris.s/.pyenv/versions/3.11.7/bin/python -m pip install -e .

/Users/chris.s/.pyenv/versions/3.11.7/bin/python -m pytest python/tests/test_ops.py::TestOps::test_repeat -q
# 1 passed in 0.18s

/Users/chris.s/.pyenv/versions/3.11.7/bin/python -m pytest python/tests/test_ops.py -q
# 139 passed in 1.91s

cmake -S . -B build-repeat-zero -DMLX_BUILD_METAL=OFF -DMLX_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release
cmake --build build-repeat-zero --target tests -j4
./build-repeat-zero/tests/tests --test-case="test repeat"
# test cases: 1 | 1 passed | 0 failed | 239 skipped
# assertions: 8 | 8 passed | 0 failed

/Users/chris.s/.pyenv/versions/3.11.7/bin/python -m black --check python/tests/test_ops.py
git diff --check
```