### PR TITLE
[CUDA] Disable managed memory on Tegra

### DIFF
--- a/mlx/backend/cuda/allocator.cpp
+++ b/mlx/backend/cuda/allocator.cpp
@@ -33,9 +33,6 @@ bool supports_managed_memory() {
     int device_count = gpu::device_count();
     for (int i = 0; i < device_count; ++i) {
       auto& d = cu::device(i);
-      if (!d.managed_memory()) {
-        return false;
-      }
       // Empirically on Windows (and WSL) if there is no concurrentManagedAccess
       // the managed memory also does not work.
       // The same has been observed on NVIDIA Tegra, typically on Jetson Orin

--- a/mlx/backend/cuda/allocator.cpp
+++ b/mlx/backend/cuda/allocator.cpp
@@ -28,29 +28,6 @@ constexpr int small_block_size = 8;
 // size and small_block_size.
 constexpr int small_pool_size = 4 * page_size;
 
-// Check if running on Windows or Windows Subsystem for Linux
-bool is_windows() {
-#if defined(_WIN32)
-  return true;
-#elif defined(__linux__)
-  // WSL kernels contain "microsoft" or "WSL" in /proc/version
-  static bool is_wsl = []() {
-    std::ifstream version("/proc/version");
-    if (version.is_open()) {
-      std::string line;
-      std::getline(version, line);
-      return line.find("microsoft") != std::string::npos ||
-          line.find("Microsoft") != std::string::npos ||
-          line.find("WSL") != std::string::npos;
-    }
-    return false;
-  }();
-  return is_wsl;
-#else
-  return false;
-#endif
-}
-
 bool supports_managed_memory() {
   static bool managed_memory = []() {
     int device_count = gpu::device_count();
@@ -61,7 +38,15 @@ bool supports_managed_memory() {
       }
       // Empirically on Windows (and WSL) if there is no concurrentManagedAccess
       // the managed memory also does not work.
-      if (is_windows() && !d.concurrent_managed_access()) {
+      // The same has been observed on NVIDIA Tegra, typically on Jetson Orin
+      // Nano boards.
+      // NVIDIA documentation describes Windows, WSL, and Tegra as having a
+      // specific unified memory paradigm called "Limited unified memory
+      // support", which corresponds to concurrentManagedAccess = 0.
+      // See:
+      //   https://docs.nvidia.com/cuda/cuda-programming-guide/02-basics/understanding-memory.html#table-unified-memory-levels
+      //   https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/unified-memory.html#um-legacy-devices
+      if (!d.concurrent_managed_access()) {
         return false;
       }
     }


### PR DESCRIPTION
## Proposed changes

Currently, on Windows and WSL, managed memory support is disabled when concurrentManagedAccess = 0.
This PR wants to disable it on all platforms where concurrentManagedAccess = 0, not just on Windows.
This addresses segmentation fault problems seen on NVIDIA Tegra. See https://github.com/ml-explore/mlx/issues/3645.
In fact, Windows, WSL, and Tegra share the same unified memory paradigm called "Limited unified memory support", which is identified by concurrentManagedAccess = 0.
See
- https://docs.nvidia.com/cuda/cuda-programming-guide/02-basics/understanding-memory.html#table-unified-memory-levels
- https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/unified-memory.html#um-legacy-devices

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
