### PR TITLE
fix(metal): end encoding before addCompletedHandler for macOS 26 compatibility

### DIFF
--- a/mlx/backend/metal/eval.cpp
+++ b/mlx/backend/metal/eval.cpp
@@ -63,6 +63,7 @@ void eval(array& arr) {
       scheduler::notify_task_completion(s);
     });
   } else {
+    encoder.end_encoding();
     command_buffer->addCompletedHandler(
         [buffers = std::move(buffers)](MTL::CommandBuffer* cbuf) {});
   }

--- a/mlx/backend/metal/fence.cpp
+++ b/mlx/backend/metal/fence.cpp
@@ -78,6 +78,7 @@ void Fence::wait(Stream stream, const array& x) {
   compute_encoder.set_bytes(f.count, 1);
   compute_encoder.dispatch_threads(kernel_dims, kernel_dims);
 
+  compute_encoder.end_encoding();
   compute_encoder.get_command_buffer()->addCompletedHandler(
       [fence_ = fence_](MTL::CommandBuffer* cbuf) {});
 }
@@ -129,6 +130,7 @@ void Fence::update(Stream stream, const array& x, bool cross_device) {
   compute_encoder.set_bytes(f.count, 1);
   compute_encoder.dispatch_threads(kernel_dims, kernel_dims);
 
+  compute_encoder.end_encoding();
   compute_encoder.get_command_buffer()->addCompletedHandler(
       [fence_ = fence_](MTL::CommandBuffer* cbuf) {});
 }

--- a/python/tests/test_eval.py
+++ b/python/tests/test_eval.py
@@ -195,6 +195,76 @@ class TestEval(mlx_tests.MLXTestCase):
         mx.eval(z)
         mx.set_memory_limit(old_limit)
 
+    @unittest.skipIf(not mx.is_available(mx.gpu), "GPU is not available")
+    def test_eval_small_gpu_ops_else_branch(self):
+        """
+        Exercise the eval.cpp else-branch where addCompletedHandler is
+        called without a prior commit (needs_commit() == false).
+
+        Small scalar GPU operations keep the command buffer under the commit
+        threshold, repeatedly hitting the async-completion path. On affected
+        macOS versions this path aborts before the fix because the completion
+        handler is added while a compute encoder is still active.
+        """
+        for _ in range(200):
+            x = mx.array([1.0])
+            y = mx.array([2.0])
+            z = x + y
+            mx.eval(z)
+        self.assertEqual(z.item(), 3.0)
+
+        # Also test with multiple small operations chained
+        for _ in range(200):
+            x = mx.array(1.0)
+            x = x + 1.0
+            x = x * 2.0
+            x = mx.abs(x)
+            mx.eval(x)
+        self.assertEqual(x.item(), 4.0)
+
+    @unittest.skipIf(not mx.is_available(mx.gpu), "GPU is not available")
+    def test_fence_paths_via_multistream_eval(self):
+        """
+        Exercise internal fence wait/update code paths via multi-stream GPU
+        operations. Multi-stream evaluation triggers fence-based stream
+        synchronization, hitting the addCompletedHandler calls in
+        Fence::wait and Fence::update. On affected macOS versions these paths
+        abort before the fix because the completion handler is added while a
+        compute encoder is still active.
+        """
+        s1 = mx.default_stream(mx.gpu)
+        s2 = mx.new_stream(mx.gpu)
+
+        # Interleave operations on two streams to force fence
+        # synchronization between them
+        x = mx.array(1.0)
+        for _ in range(100):
+            x = mx.abs(x, stream=s1)
+            x = mx.abs(x, stream=s2)
+        mx.eval(x)
+        self.assertEqual(x.item(), 1.0)
+
+        # Reverse stream interleaving
+        x = mx.array(2.0)
+        for _ in range(100):
+            x = mx.multiply(x, mx.array(1.0), stream=s2)
+            x = mx.add(x, mx.array(0.0), stream=s1)
+        mx.eval(x)
+        self.assertEqual(x.item(), 2.0)
+
+        # Many streams with overlapping work
+        x = mx.ones((100, 100))
+        s3 = mx.new_stream(mx.gpu)
+        for _ in range(50):
+            x = mx.abs(x, stream=s1)
+            x = mx.abs(x, stream=s2)
+            x = mx.abs(x, stream=s3)
+        mx.eval(x)
+        self.assertTrue(mx.allclose(x, mx.ones((100, 100))))
+
+        # Clean up extra streams
+        del s1, s2, s3
+
 
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner()

--- a/tests/metal_completed_handler_repro.mm
+++ b/tests/metal_completed_handler_repro.mm
@@ -1,0 +1,90 @@
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
+
+// Standalone repro for the Metal framework assertion fixed by this change.
+//
+// Compile:
+//   clang++ -fobjc-arc -framework Foundation -framework Metal \
+//     tests/metal_completed_handler_repro.mm \
+//     -o /tmp/metal_completed_handler_repro
+//
+// Run:
+//   /tmp/metal_completed_handler_repro
+//   /tmp/metal_completed_handler_repro fixed
+//
+// On affected macOS versions, the first command aborts when addCompletedHandler
+// is called while the compute encoder is still active. The second command ends
+// encoding first and exits successfully.
+
+int main(int argc, const char** argv) {
+  @autoreleasepool {
+    BOOL end_before_handler = argc > 1 && strcmp(argv[1], "fixed") == 0;
+
+    id<MTLDevice> device = MTLCreateSystemDefaultDevice();
+    if (device == nil) {
+      fprintf(stderr, "No Metal device available\n");
+      return 2;
+    }
+
+    id<MTLCommandQueue> queue = [device newCommandQueue];
+    id<MTLCommandBuffer> command_buffer = [queue commandBuffer];
+    id<MTLComputeCommandEncoder> encoder =
+        [command_buffer computeCommandEncoder];
+
+    NSString* source =
+        @"#include <metal_stdlib>\n"
+         "using namespace metal;\n"
+         "kernel void add_one(device float* values [[buffer(0)]],"
+         " uint id [[thread_position_in_grid]]) {\n"
+         "  values[id] += 1.0f;\n"
+         "}\n";
+    NSError* error = nil;
+    id<MTLLibrary> library = [device newLibraryWithSource:source
+                                                  options:nil
+                                                    error:&error];
+    if (library == nil) {
+      fprintf(stderr, "%s\n", error.localizedDescription.UTF8String);
+      return 3;
+    }
+
+    id<MTLFunction> function = [library newFunctionWithName:@"add_one"];
+    id<MTLComputePipelineState> pipeline =
+        [device newComputePipelineStateWithFunction:function error:&error];
+    if (pipeline == nil) {
+      fprintf(stderr, "%s\n", error.localizedDescription.UTF8String);
+      return 4;
+    }
+
+    float value = 1.0f;
+    id<MTLBuffer> buffer =
+        [device newBufferWithBytes:&value
+                            length:sizeof(value)
+                           options:MTLResourceStorageModeShared];
+    [encoder setComputePipelineState:pipeline];
+    [encoder setBuffer:buffer offset:0 atIndex:0];
+    [encoder dispatchThreads:MTLSizeMake(1, 1, 1)
+        threadsPerThreadgroup:MTLSizeMake(1, 1, 1)];
+
+    if (end_before_handler) {
+      [encoder endEncoding];
+    }
+
+    [command_buffer addCompletedHandler:^(id<MTLCommandBuffer> buffer) {
+      (void)buffer;
+    }];
+
+    if (!end_before_handler) {
+      [encoder endEncoding];
+    }
+
+    [command_buffer commit];
+    [command_buffer waitUntilCompleted];
+
+    if (*static_cast<float*>(buffer.contents) != 2.0f) {
+      fprintf(stderr, "Unexpected result\n");
+      return 5;
+    }
+  }
+
+  return 0;
+}


### PR DESCRIPTION
## Proposed changes

On macOS 26.4.1, calling `-[MTLCommandBuffer addCompletedHandler:]` while a
`MTLComputeCommandEncoder` is still active on the same buffer triggers
`MTLReportFailure` → `abort()`. Apple's Metal framework now asserts that
completion handlers must not be added while an encoder is active.

This affects two code paths:

1. **eval.cpp else branch**: `addCompletedHandler` called without first ending
   the encoder (the if branch already called `end_encoding` correctly).

2. **fence.cpp fast paths** (`Fence::wait`, `Fence::update`): `addCompletedHandler`
   called after dispatching fence kernels without ending the encoder first.

### Fix

Adds `end_encoding()` calls before `addCompletedHandler` in all three locations.

### Testing

This is an OS-specific Metal framework assertion added in macOS 26.4.1. A C++
unit test cannot detect this regression on older OS versions. The existing
test suite passes on macOS 26.4.1 with this fix; the crash is reliably
reproducible under model inference (eval/fence code paths are hit on
every MLX operation) and is eliminated by these changes.

Two new GPU tests have been added to `test_eval.py` that exercise the
affected code paths:
- `test_eval_small_gpu_ops_else_branch`: small GPU operations that keep the
  command buffer under the commit threshold, hitting the eval else-branch
- `test_fence_paths_via_multistream_eval`: multi-stream GPU operations that
  trigger internal fence synchronization

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)