### PR TITLE
Fix gaussian_nll_loss documented default reduction (none -> mean)

### DIFF
--- a/python/mlx/nn/losses.py
+++ b/python/mlx/nn/losses.py
@@ -286,7 +286,7 @@ def gaussian_nll_loss(
         eps (float, optional): Small positive constant for numerical stability.
             Default: ``1e-6``.
         reduction (str, optional): Specifies the reduction to apply to the output:
-          ``'none'`` | ``'mean'`` | ``'sum'``. Default: ``'none'``.
+          ``'none'`` | ``'mean'`` | ``'sum'``. Default: ``'mean'``.
 
     Returns:
         array: The Gaussian NLL loss.

--- a/python/tests/test_losses.py
+++ b/python/tests/test_losses.py
@@ -335,6 +335,12 @@ class TestLosses(mlx_tests.MLXTestCase):
         expected_sum_full = mx.sum(expected_none_full)
         self.assertTrue(mx.allclose(losses_sum_full, expected_sum_full))
 
+        # The default reduction is "mean" (matches the documented default): a
+        # scalar equal to the explicit mean reduction, not the per-element array.
+        losses_default = nn.losses.gaussian_nll_loss(inputs, targets, vars)
+        self.assertEqual(losses_default.ndim, 0)
+        self.assertTrue(mx.allclose(losses_default, expected_mean))
+
     def test_kl_div_loss(self):
         p_logits = mx.log(mx.array([[0.5, 0.5], [0.8, 0.2]]))
         q_logits = mx.log(mx.array([[0.5, 0.5], [0.2, 0.8]]))


### PR DESCRIPTION
`nn.losses.gaussian_nll_loss` defaults to `reduction="mean"` in its signature — consistent with the PyTorch API and the other mean-reducing losses (`l1_loss`, `mse_loss`, `binary_cross_entropy`) — but its docstring stated the default was `'none'`.

Calling it without a reduction returns a scalar (the mean), so the documented `'none'` misled callers expecting a per-element array:

```python
>>> nn.losses.gaussian_nll_loss(inputs, targets, vars).ndim
0  # scalar (mean), not the per-element array the docs implied
```

This corrects the docstring to `'mean'` and adds a regression test pinning the default reduction. No behavior change.