### PR TITLE
Batch short CUDA row reductions

### DIFF
--- a/mlx/backend/cuda/reduce/row_reduce.cu
+++ b/mlx/backend/cuda/reduce/row_reduce.cu
@@ -96,8 +96,9 @@ row_reduce_simple(const T* in, U* out, size_t n_rows, int size) {
     accs[i] = init;
   }
 
+  const size_t max_start_row = n_rows > M ? n_rows - M : 0;
   const size_t start_row =
-      min(n_rows - M, static_cast<size_t>(grid.block_rank() * M));
+      min(max_start_row, static_cast<size_t>(grid.block_rank() * M));
   const size_t full_blocks = size / (block.size() * N);
   const size_t final_offset = full_blocks * (block.size() * N);
   in += start_row * size + block.thread_rank() * N;

--- a/mlx/backend/cuda/reduce/row_reduce.cu
+++ b/mlx/backend/cuda/reduce/row_reduce.cu
@@ -265,7 +265,10 @@ void row_reduce_simple(
       // blocks, so batch a few rows per block when the tail handling remains
       // simple.
       auto kernel = cu::row_reduce_simple<T, U, OP, N_READS>;
-      if (reductions <= WARP_SIZE && grid.x >= 2048) {
+      if (reductions <= WARP_SIZE / 2 && grid.x >= 4096) {
+        grid.x = (grid.x + 7) / 8;
+        kernel = cu::row_reduce_simple<T, U, OP, N_READS, 8>;
+      } else if (reductions <= WARP_SIZE && grid.x >= 2048) {
         grid.x = (grid.x + 3) / 4;
         kernel = cu::row_reduce_simple<T, U, OP, N_READS, 4>;
       } else if (grid.x >= 1024) {

--- a/mlx/backend/cuda/reduce/row_reduce.cu
+++ b/mlx/backend/cuda/reduce/row_reduce.cu
@@ -261,9 +261,14 @@ void row_reduce_simple(
       int threads = warps * WARP_SIZE;
       dim3 block(threads, 1, 1);
 
-      // Pick the kernel
+      // Pick the kernel. Short row reductions launch many lightly-loaded
+      // blocks, so batch a few rows per block when the tail handling remains
+      // simple.
       auto kernel = cu::row_reduce_simple<T, U, OP, N_READS>;
-      if (grid.x >= 1024) {
+      if (reductions <= WARP_SIZE && grid.x >= 2048) {
+        grid.x = (grid.x + 3) / 4;
+        kernel = cu::row_reduce_simple<T, U, OP, N_READS, 4>;
+      } else if (grid.x >= 1024) {
         grid.x = (grid.x + 1) / 2;
         kernel = cu::row_reduce_simple<T, U, OP, N_READS, 2>;
       }

--- a/tests/gpu_tests.cpp
+++ b/tests/gpu_tests.cpp
@@ -197,6 +197,18 @@ TEST_CASE("test gpu reduce with axes") {
   }
 }
 
+TEST_CASE("test gpu short row reduce batching") {
+  auto x = reshape(arange(0, 4099 * 16, 1, float32), {4099, 16});
+
+  auto sum_gpu = sum(x, -1, false, Device::gpu);
+  auto sum_cpu = sum(x, -1, false, Device::cpu);
+  CHECK(array_equal(sum_gpu, sum_cpu, Device::cpu).item<bool>());
+
+  auto max_gpu = max(x, -1, false, Device::gpu);
+  auto max_cpu = max(x, -1, false, Device::cpu);
+  CHECK(array_equal(max_gpu, max_cpu, Device::cpu).item<bool>());
+}
+
 TEST_CASE("test gpu binary ops") {
   // scalar-scalar
   {


### PR DESCRIPTION
## Summary
- batch short CUDA row reductions over 8 rows per block when the reduced row is very small and there are many output rows
- keep the 4-row and existing 2-row batching paths for larger or smaller cases
- add a CUDA regression test for a ragged 4099-row tail

## Motivation
For reductions like `sum(x, axis=-1)` over many short contiguous rows, the current CUDA row-reduce path launches many lightly loaded blocks. This extends the existing row batching path so very short reductions can process 8 rows/block, while falling back to 4 rows/block, 2 rows/block, or the original 1 row/block path outside that narrow shape class.

## Validation
- `pre-commit run clang-format --files mlx/backend/cuda/reduce/row_reduce.cu tests/gpu_tests.cpp`
- `git diff --check`
- Previous RunPod CUDA A6000 source build and benchmark for the first candidate commit, base `350f2cf84c815eb0b9bb8e1c21a8f8db65d535da` vs candidate `958b21c9fe68aa9035a0315e8c5571f81667cd22`
- Current head `f76dde664a5c8dd2cb31f746e52ff8893a6b7432` extends that candidate with the narrower 8-row fast path; current-head CUDA benchmark is pending upstream CI or a working remote artifact channel

Corrected benchmark for the first candidate forced `mx.eval()` inside each timed iteration:

| shape | base median ms | candidate median ms | speedup |
| --- | ---: | ---: | ---: |
| `(4099, 16)` | 0.021998 | 0.021704 | 1.014x |
| `(8192, 16)` | 0.023657 | 0.022767 | 1.039x |
| `(32768, 16)` | 0.047221 | 0.034732 | 1.360x |
| `(8192, 32)` | 0.028633 | 0.021384 | 1.339x |
| `(4096, 64)` | 0.028207 | 0.020786 | 1.357x |
| `(1024, 4096)` | 0.080877 | 0.080929 | 0.999x |

The long-row case is intentionally neutral because it does not take the new short-row batching path.
