### PR TITLE
Fix logsumexp JVP axis reduction

### DIFF
--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -2949,10 +2949,11 @@ std::vector<array> LogSumExp::jvp(
     const std::vector<int>& argnums) {
   assert(primals.size() == 1);
   assert(tangents.size() == 1);
-  return {multiply(
+  auto weighted_tangent = multiply(
       tangents[0],
       softmax(primals[0], std::vector<int>{-1}, true, stream()),
-      stream())};
+      stream());
+  return {sum(weighted_tangent, -1, true, stream())};
 }
 
 std::vector<Shape> LogSumExp::output_shapes(const std::vector<array>& inputs) {

--- a/python/tests/test_autograd.py
+++ b/python/tests/test_autograd.py
@@ -1032,6 +1032,18 @@ class TestAutograd(mlx_tests.MLXTestCase):
         out, jout = mx.jvp(mx.max, primals=(a,), tangents=(b,))
         self.assertEqual(jout[0].item(), 0)
 
+        a = mx.array([[0.0, 1.0, 2.0], [2.0, 0.0, -1.0]])
+        b = mx.array([[3.0, 5.0, 7.0], [11.0, 13.0, 17.0]])
+        _, jout = mx.jvp(lambda x: mx.logsumexp(x, axis=-1), (a,), (b,))
+        expected = mx.sum(mx.softmax(a, axis=-1) * b, axis=-1)
+        self.assertEqual(jout[0].shape, (2,))
+        self.assertTrue(mx.allclose(jout[0], expected))
+
+        _, jout = mx.jvp(lambda x: mx.logsumexp(x, axis=-1, keepdims=True), (a,), (b,))
+        expected = mx.sum(mx.softmax(a, axis=-1) * b, axis=-1, keepdims=True)
+        self.assertEqual(jout[0].shape, (2, 1))
+        self.assertTrue(mx.allclose(jout[0], expected))
+
     def test_complex_prod_vjp(self):
         def prod(x):
             return x.prod(axis=0)


### PR DESCRIPTION
## Summary
- reduce `LogSumExp::jvp` over the primitive reduction axis so the tangent matches the logsumexp output shape
- add Python regression coverage for `mx.jvp(mx.logsumexp(..., axis=-1))` with and without `keepdims`

Fixes #3707.

## Tests
- `python -m black --check python/tests/test_autograd.py`
- `git diff --check`
- `PYTHONPATH=/private/tmp/mlx-upstream-pr-work/python python -m pytest python/tests/test_autograd.py::TestAutograd::test_reduce_jvp -q` currently exercises the installed pre-fix extension in this checkout and reproduces the old failure (`[squeeze] Cannot squeeze axis 1 with size 3`); the source fix requires rebuilding MLX to exercise the updated C++ primitive.

Note: `clang-format` is not installed in this local environment.