### PR TITLE
Update nanobind to 2.13.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,7 +377,7 @@ if(MLX_BUILD_PYTHON_BINDINGS)
   FetchContent_Declare(
     nanobind
     GIT_REPOSITORY https://github.com/wjakob/nanobind.git
-    GIT_TAG v2.12.0
+    GIT_TAG v2.13.0
     GIT_SHALLOW TRUE
     EXCLUDE_FROM_ALL)
   FetchContent_MakeAvailable(nanobind)

--- a/examples/extensions/pyproject.toml
+++ b/examples/extensions/pyproject.toml
@@ -3,6 +3,6 @@ requires = [
   "setuptools>=42",
   "cmake>=3.25",
   "mlx>=0.18.0",
-  "nanobind==2.12.0",
+  "nanobind==2.13.0",
 ]
 build-backend = "setuptools.build_meta"

--- a/examples/extensions/requirements.txt
+++ b/examples/extensions/requirements.txt
@@ -1,4 +1,4 @@
 setuptools>=42
 cmake>=3.25
 mlx>=0.31.2
-nanobind==2.12.0
+nanobind==2.13.0

--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -261,7 +261,8 @@ void init_array(nb::module_& m) {
       "ArrayAt",
       R"pbdoc(
       A helper object to apply updates at specific indices.
-      )pbdoc")
+      )pbdoc",
+      nb::pooled(/* capacity = */ 128))
       .def("__getitem__", &ArrayAt::set_indices, "indices"_a.none())
       .def("add", &ArrayAt::add, "value"_a)
       .def("subtract", &ArrayAt::subtract, "value"_a)
@@ -299,7 +300,8 @@ void init_array(nb::module_& m) {
       "array",
       R"pbdoc(An N-dimensional array object.)pbdoc",
       nb::type_slots(array_slots),
-      nb::is_weak_referenceable())
+      nb::is_weak_referenceable(),
+      nb::pooled(/* capacity = */ 128))
       .def(
           "__init__",
           [](mx::array* aptr, nb::object v, std::optional<mx::Dtype> t) {

--- a/python/src/mlx_func.cpp
+++ b/python/src/mlx_func.cpp
@@ -2,6 +2,8 @@
 
 #include "python/src/mlx_func.h"
 
+#include <structmember.h>
+
 // A garbage collected function which wraps nb::cpp_function
 // See https://github.com/wjakob/nanobind/discussions/919
 

--- a/python/src/small_vector.h
+++ b/python/src/small_vector.h
@@ -15,8 +15,8 @@ NAMESPACE_BEGIN(NB_NAMESPACE)
 NAMESPACE_BEGIN(detail)
 
 template <typename Type, size_t Size, typename Alloc>
-struct type_caster<mlx::core::SmallVector<Type, Size, Alloc>> {
-  using List = mlx::core::SmallVector<Type, Size, Alloc>;
+struct type_caster<::mlx::core::SmallVector<Type, Size, Alloc>> {
+  using List = ::mlx::core::SmallVector<Type, Size, Alloc>;
   using Caster = make_caster<Type>;
 
   // For narrow integer element types we fetch each element through a wider


### PR DESCRIPTION
## Proposed changes

Update nanobind to 2.13.0 and align the example extension dependency pins.

This also enables `nb::pooled()` for the short-lived `array` and `ArrayAt` wrappers, following the upstream nanobind change in wjakob/nanobind#1382. That PR made `nb::pooled()` available for GC-tracked types such as classes using `nb::is_weak_referenceable()` and specifically suggested this optimization for MLX symbolic tracing. A small local wrapper creation benchmark showed `ArrayAt` creation improving from about 35 ns to 29 ns.

Two small compatibility fixes are included:

- Qualify `::mlx::core::SmallVector` inside the nanobind namespace now that nanobind defines `nb::mlx`.
- Include `<structmember.h>` directly for `PyMemberDef`, `T_PYSSIZET`, and `READONLY`.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
