### PR TITLE
Fix ConvTranspose kernel size repr

### DIFF
--- a/python/mlx/nn/layers/convolution_transpose.py
+++ b/python/mlx/nn/layers/convolution_transpose.py
@@ -140,7 +140,7 @@ class ConvTranspose2d(Module):
     def _extra_repr(self):
         return (
             f"{self.weight.shape[-1]}, {self.weight.shape[0]}, "
-            f"kernel_size={self.weight.shape[1:2]}, stride={self.stride}, "
+            f"kernel_size={self.weight.shape[1:3]}, stride={self.stride}, "
             f"padding={self.padding}, dilation={self.dilation}, "
             f"output_padding={self.output_padding}, "
             f"bias={'bias' in self}"
@@ -222,7 +222,7 @@ class ConvTranspose3d(Module):
     def _extra_repr(self):
         return (
             f"{self.weight.shape[-1]}, {self.weight.shape[0]}, "
-            f"kernel_size={self.weight.shape[1:3]}, stride={self.stride}, "
+            f"kernel_size={self.weight.shape[1:4]}, stride={self.stride}, "
             f"padding={self.padding}, dilation={self.dilation}, "
             f"output_padding={self.output_padding}, "
             f"bias={'bias' in self}"

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -888,6 +888,16 @@ class TestLayers(mlx_tests.MLXTestCase):
         y = c(x)
         self.assertEqual(y.shape, (4, 7, 7, 8))
 
+    def test_conv_transpose_extra_repr(self):
+        self.assertIn(
+            "kernel_size=(3, 5)",
+            str(nn.ConvTranspose2d(4, 8, kernel_size=(3, 5))),
+        )
+        self.assertIn(
+            "kernel_size=(2, 3, 4)",
+            str(nn.ConvTranspose3d(4, 8, kernel_size=(2, 3, 4))),
+        )
+
     def test_sequential(self):
         x = mx.ones((10, 2))
         m = nn.Sequential(nn.Linear(2, 10), nn.ReLU(), nn.Linear(10, 1))


### PR DESCRIPTION
## Summary
- include all spatial dimensions in ConvTranspose2d and ConvTranspose3d kernel_size repr
- add a regression test with non-square and non-cubic kernels

## Tests
- python -m unittest test_nn.TestLayers.test_conv1d test_nn.TestLayers.test_conv2d test_nn.TestLayers.test_conv_transpose_extra_repr
- python -m unittest test_nn