### PR TITLE
Add Array API from_dlpack

### DIFF
--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -1796,6 +1796,20 @@ void init_ops(nb::module_& m) {
             ValueError: If ``copy`` is ``False``.
       )pbdoc");
   m.def(
+      "from_dlpack",
+      [](const nb::object& x) { return create_array(x, std::nullopt); },
+      nb::arg(),
+      nb::sig("def from_dlpack(x: DLPackCompatible, /) -> array"),
+      R"pbdoc(
+        Construct an array from an object supporting the DLPack protocol.
+
+        Args:
+            x: Input object supporting ``__dlpack__`` and ``__dlpack_device__``.
+
+        Returns:
+            array: An array constructed from the DLPack-compatible input.
+      )pbdoc");
+  m.def(
       "zeros_like",
       &mx::zeros_like,
       nb::arg(),

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -2242,6 +2242,18 @@ class TestArray(mlx_tests.MLXTestCase):
         arr_pass = xp.asarray(existing)
         self.assertEqual(arr_pass.tolist(), [4, 5, 6])
 
+    def test_array_namespace_from_dlpack(self):
+        xp = mx.array(1.0).__array_namespace__()
+        self.assertTrue(hasattr(xp, "from_dlpack"))
+
+        arr = xp.from_dlpack(mx.array([1, 2, 3]))
+        self.assertEqual(arr.tolist(), [1, 2, 3])
+
+        np_arr = np.array([4, 5, 6], dtype=np.int32)
+        arr_from_np = xp.from_dlpack(np_arr)
+        self.assertEqual(arr_from_np.tolist(), [4, 5, 6])
+        self.assertEqual(arr_from_np.dtype, mx.int32)
+
     def test_asarray_copy(self):
         existing = mx.array([1, 2, 3])
 


### PR DESCRIPTION
## Summary
- add `mlx.core.from_dlpack` so the Array API namespace returned by `__array_namespace__()` exposes `from_dlpack`
- reuse existing MLX array construction for DLPack-compatible inputs
- add namespace tests for MLX and NumPy DLPack-compatible arrays

Closes #3484.

## Tests
- `CMAKE_ARGS="-DMLX_BUILD_METAL=OFF" CMAKE_BUILD_PARALLEL_LEVEL=4 python -m pip install -e .`
- `python -m pytest python/tests/test_array.py -q -k "array_namespace_from_dlpack or array_namespace_asarray or asarray_copy"`
- `python -m black --check python/tests/test_array.py`
- `/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-format --dry-run --Werror python/src/ops.cpp`