### PR TITLE
Avoid NaNs for zero-cotangent sqrt VJPs

### DIFF
--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -5398,14 +5398,24 @@ std::vector<array> Sqrt::vjp(
   auto dtype = primals[0].dtype();
   if (recip_) {
     auto one_over_x_root_x = divide(outputs[0], primals[0], stream());
-    return {multiply(
+    auto vjp = multiply(
         multiply(array(-0.5, dtype), cotangents[0], stream()),
         one_over_x_root_x,
+        stream());
+    return {where(
+        equal(cotangents[0], array(0, dtype), stream()),
+        zeros_like(cotangents[0], stream()),
+        vjp,
         stream())};
   } else {
-    return {divide(
+    auto vjp = divide(
         multiply(array(0.5, dtype), cotangents[0], stream()),
         outputs[0],
+        stream());
+    return {where(
+        equal(cotangents[0], array(0, dtype), stream()),
+        zeros_like(cotangents[0], stream()),
+        vjp,
         stream())};
   }
 }

--- a/python/tests/test_autograd.py
+++ b/python/tests/test_autograd.py
@@ -166,6 +166,34 @@ class TestAutograd(mlx_tests.MLXTestCase):
         with self.assertRaises(ValueError):
             mx.grad(fun)(mx.ones((2, 2)))
 
+    def test_zero_cotangent_sqrt_vjp_is_finite(self):
+        def fun(xy):
+            x, y = xy[..., 0], xy[..., 1]
+            rho = mx.sqrt(x * x + y * y)
+            return mx.sum(mx.maximum(rho, mx.array(1e-10, dtype=rho.dtype)))
+
+        xy = mx.array(
+            [[0.0, 0.0], [0.5, 0.3], [-0.7, 0.1]],
+            dtype=mx.float32,
+        )
+        grad = mx.grad(fun)(xy)
+
+        self.assertTrue(mx.all(mx.isfinite(grad)).item())
+        self.assertTrue(mx.allclose(grad[0], mx.zeros((2,))).item())
+        self.assertTrue(
+            mx.allclose(
+                grad[1:],
+                mx.array(
+                    [
+                        [0.857493, 0.514496],
+                        [-0.989949, 0.141421],
+                    ],
+                    dtype=mx.float32,
+                ),
+                atol=1e-5,
+            ).item()
+        )
+
     def test_grad_trees(self):
         fun = lambda x, y: x * y
         value, dfdx = mx.value_and_grad(fun, (0, 1))(mx.array(0.5), mx.array(2.0))


### PR DESCRIPTION
## Summary

Fixes #3668 by making `sqrt` / `rsqrt` VJPs return exact zero when the incoming cotangent is exactly zero before applying the singular derivative.

This avoids the `0 * NaN` / `0 * inf` trap in masked paths such as:

```python
rho = mx.sqrt(x * x + y * y)
rho_safe = mx.maximum(rho, mx.array(1e-10, dtype=rho.dtype))
mx.grad(lambda xy: mx.sum(rho_safe))(xy)
```

At the origin, `maximum` correctly masks the `sqrt` branch with a zero cotangent, but `Sqrt::vjp` still divided by `sqrt(0)`. The new guard preserves the zero cotangent and leaves the normal nonzero derivative path unchanged.

## Validation

- Reproduced #3668 on current `main` before the patch: the first gradient row was `[nan, nan]`.
- Rebuilt editable MLX locally on Apple Silicon macOS:
  `/Users/chris.s/conductor/workspaces/mlx-upstream/.venv-pr3720/bin/python -m pip install -e . --no-build-isolation`
- Ran focused regression:
  `PYTHONPATH=python/tests /Users/chris.s/conductor/workspaces/mlx-upstream/.venv-pr3720/bin/python -m unittest python.tests.test_autograd.TestAutograd.test_zero_cotangent_sqrt_vjp_is_finite`
- Ran adjacent autograd suite:
  `PYTHONPATH=python/tests /Users/chris.s/conductor/workspaces/mlx-upstream/.venv-pr3720/bin/python -m unittest python.tests.test_autograd.TestAutograd`
- Ran `git diff --check`.

## Duplicate / Prior Work Check

Searched open and closed issues/PRs for:

- `maximum VJP NaN rho eps`
- `gradient NaN maximum`
- `sqrt maximum grad nan`

No related open, closed, or merged PRs were found.
