### PR TITLE
Document random.normal reproducibility boundary

### DIFF
--- a/mlx/random.h
+++ b/mlx/random.h
@@ -93,7 +93,12 @@ inline array uniform(
   return uniform(shape, float32, key, s);
 }
 
-/** Generate samples from the standard normal distribution. */
+/** Generate samples from the standard normal distribution.
+ *
+ * Seeded samples are reproducible for a fixed MLX version, backend, and
+ * hardware target, but are not guaranteed to be bit-exact across different
+ * Apple GPU generations.
+ */
 MLX_API array normal(
     const Shape& shape,
     Dtype dtype,

--- a/python/src/random.cpp
+++ b/python/src/random.cpp
@@ -196,6 +196,11 @@ void init_random(nb::module_& parent_module) {
         real numbers and $\text{Re}(x),\text{Im}(x) \sim \mathcal{N}(0,
         \frac{1}{2})$ for complex numbers.
 
+        Seeded samples are reproducible for a fixed MLX version, backend, and
+        hardware target. They are not guaranteed to be bit-exact across
+        different Apple GPU generations because the Metal implementation may
+        use hardware-dependent math paths.
+
         Args:
             shape (list(int), optional): Shape of the output. Default: ``()``.
             dtype (Dtype, optional): Type of the output. Default: ``float32``.


### PR DESCRIPTION
## Summary

- Document that `mx.random.normal` seeded outputs are reproducible for a fixed MLX/backend/hardware target
- Clarify that bit-exact outputs are not guaranteed across Apple GPU generations

## Rationale

Issue #3568 reports cross-generation Apple GPU differences for `mx.random.normal`
while `mx.random.uniform` and key generation remain bit-exact. The issue's
follow-up narrows the likely source to hardware-dependent Metal math in the
normal sampling path. Until MLX exposes a portable deterministic normal path,
the API docs should make the reproducibility boundary explicit.

## Tests

- `git diff --check`
- `python -m py_compile python/mlx/core/random.pyi`
