### PR TITLE
Fix CPU dynamic slice copy bound for collapsed shapes

### DIFF
--- a/mlx/backend/cpu/copy.cpp
+++ b/mlx/backend/cpu/copy.cpp
@@ -70,7 +70,6 @@ void copy_general_general(
       dynamic_i_offset ? dynamic_i_offset->data<int64_t>() : nullptr;
   auto o_offset_ptr =
       dynamic_o_offset ? dynamic_o_offset->data<int64_t>() : nullptr;
-  auto size = src.size();
   if (data_shape.empty()) {
     auto val = static_cast<DstT>(*src_ptr);
     *dst_ptr = val;
@@ -107,6 +106,8 @@ void copy_general_general(
     dst_ptr += o_offset_ptr[0];
   }
 
+  auto size = std::accumulate(
+      shape.begin(), shape.end(), int64_t{1}, std::multiplies<int64_t>());
   ContiguousIterator in(shape, strides[0], ndim - 3);
   ContiguousIterator out(shape, strides[1], ndim - 3);
   auto stride = std::accumulate(

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -3209,6 +3209,11 @@ class TestOps(mlx_tests.MLXTestCase):
         out = mx.slice(x, mx.array([1, 2, 3]), (0, 1, 2), (3, 2, 1))
         self.assertTrue(mx.array_equal(expected, out))
 
+        x = mx.arange(5 * 6 * 7 * 8).reshape(5, 6, 7, 8)
+        expected = x[1:3, 2:4, 3:5, 4:6]
+        out = mx.slice(x, mx.array([1, 2, 3, 4]), (0, 1, 2, 3), (2, 2, 2, 2))
+        self.assertTrue(mx.array_equal(expected, out))
+
         x = mx.zeros(shape=(4, 4, 4))
         update = mx.random.randint(0, 100, shape=(3, 2, 1))
         out = mx.slice_update(x, update, mx.array([1, 2, 3]), (0, 1, 2))


### PR DESCRIPTION
## Proposed changes

Fixes a CPU copy bug where `copy_general_general` iterated over `src.size()` even when callers provided a smaller `data_shape`.

`DynamicSlice::eval_cpu` passes the output shape into `copy_cpu_inplace`, so CPU dynamic slices with higher-rank collapsed shapes could copy past the destination bounds. In practice this caused crashes and unnecessary extra work. The fix computes the copy size from `data_shape`, matching the requested copy region.

## Reproduce

Before this patch, the CPU path crashes while the GPU path returns the expected slice.

```python
import mlx.core as mx

x = mx.arange(5 * 6 * 7 * 8).reshape(5, 6, 7, 8)
starts = mx.array([1, 2, 3, 4])
axes = (0, 1, 2, 3)
sizes = (2, 2, 2, 2)

with mx.stream(mx.gpu):
    expected = x[1:3, 2:4, 3:5, 4:6]
    gpu_out = mx.slice(x, starts, axes, sizes)
    print("gpu ok:", mx.array_equal(expected, gpu_out).item())

with mx.stream(mx.cpu):
    expected = x[1:3, 2:4, 3:5, 4:6]
    cpu_out = mx.slice(x, starts, axes, sizes)
    print("cpu ok:", mx.array_equal(expected, cpu_out).item())
```

Behavior:
- GPU: prints `gpu ok: True`
- CPU: segfaults on the dynamic slice

## Tests
```bash
python -m pytest python/tests/test_ops.py -k dynamic_slicing -q
DEVICE=cpu ./build/tests/tests --test-case='test dynamic slice'
```

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
