### PR TITLE
Improve CPU float64 exp SIMD accuracy

### DIFF
--- a/mlx/backend/cpu/simd/math.h
+++ b/mlx/backend/cpu/simd/math.h
@@ -7,6 +7,7 @@
 namespace mlx::core::simd {
 
 constexpr float inf = std::numeric_limits<float>::infinity();
+constexpr double inf_double = std::numeric_limits<double>::infinity();
 
 /**
  * Compute exp(x) in an optimizer friendly way as follows:
@@ -28,6 +29,35 @@ template <typename T, int N>
 Simd<T, N> exp(Simd<T, N> in) {
   if constexpr (is_complex<T>) {
     return Simd<T, 1>{std::exp(in.value)};
+  } else if constexpr (std::is_same_v<T, double>) {
+    auto x_init = in;
+    auto x = x_init * 1.4426950408889634; // multiply with log_2(e)
+    Simd<double, N> ipart, fpart;
+    ipart = floor(x + 0.5);
+    fpart = x - ipart;
+
+    x = 6.77872635482254254e-14;
+    x = fma(x, fpart, 1.36914888539041241e-12);
+    x = fma(x, fpart, 2.56784359934881958e-11);
+    x = fma(x, fpart, 4.44553827187081007e-10);
+    x = fma(x, fpart, 7.05491162080112088e-09);
+    x = fma(x, fpart, 1.01780860092396960e-07);
+    x = fma(x, fpart, 1.32154867901443053e-06);
+    x = fma(x, fpart, 1.52527338040598377e-05);
+    x = fma(x, fpart, 1.54035303933816061e-04);
+    x = fma(x, fpart, 1.33335581464284411e-03);
+    x = fma(x, fpart, 9.61812910762847688e-03);
+    x = fma(x, fpart, 5.55041086648215762e-02);
+    x = fma(x, fpart, 2.40226506959100694e-01);
+    x = fma(x, fpart, 6.93147180559945286e-01);
+    x = fma(x, fpart, 1.00000000000000000e+00);
+
+    Simd<int64_t, N> epart = (Simd<int64_t, N>(ipart) + 1023) << 52;
+
+    auto result = select(isnan(x_init), x_init, (*(Simd<double, N>*)&epart) * x);
+    result = select(x_init > 709.0, Simd<double, N>(inf_double), result);
+    result = select(x_init < -708.0, Simd<double, N>(0), result);
+    return result;
   } else {
     Simd<float, N> x_init = in;
     auto x = x_init * 1.442695f; // multiply with log_2(e)

--- a/tests/ops_tests.cpp
+++ b/tests/ops_tests.cpp
@@ -1521,6 +1521,15 @@ TEST_CASE("test arithmetic unary ops") {
     x = array(2.0);
     CHECK_EQ(exp(x).item<float>(), doctest::Approx(std::exp(2.0f)));
 
+    x = array({0.1, 0.5, 0.9, 1.25}, float64);
+    auto exp_x = exp(x);
+    CHECK_EQ(exp_x.dtype(), float64);
+    for (int i = 0; i < x.size(); ++i) {
+      auto actual = take(exp_x, array(i)).item<double>();
+      auto expected = std::exp(take(x, array(i)).item<double>());
+      CHECK(actual == doctest::Approx(expected).epsilon(1e-12));
+    }
+
     CHECK(array_equal(exp(array({})), array({})).item<bool>());
 
     x = array(neginf);


### PR DESCRIPTION
## Summary

This is narrow partial progress for #3047: it improves CPU `float64` accuracy for `exp` by adding a double-precision SIMD polynomial path in `mlx/backend/cpu/simd/math.h`.

It intentionally does **not** claim to fix the other fp64 unary ops mentioned in #3047 (`sin`, `cos`, `erf`, `erfinv`). I checked the prior closed PR #3058 and kept this patch aligned with the maintainer feedback there: this is not a scalar element-wise `std::exp` fallback.

## Evidence

Pre-change, CPU `float64` `exp([0.1, 0.5, 0.9, 1.25])` showed fp32-scale error from another local checkout at `0.32.0.dev20260621+5abdd04b`:

- max absolute error: `2.783627603974992e-07`

Post-change, after rebuilding the local editable MLX package from this branch:

- `python -m pip install -e . --no-build-isolation` passed
- CPU `float64` exp max absolute error: `4.440892098500626e-16`
- softmax-like fp64 exp-normalization max absolute error: `1.3877787807814457e-17`
- `python -m pytest python/tests/test_double.py -q` passed: `10 passed`
- `python -m pytest python/tests/test_ops.py -q -k 'exp or softmax'` passed: `7 passed, 134 deselected`

I also added a C++ `ops_tests.cpp` regression that checks `float64` `exp` against `std::exp` at `1e-12` tolerance. I could not run the C++ doctest binary locally because the editable build tree did not include the C++ test executable / doctest headers, so this is draft until that is covered by CI or a local C++ test build.

## Notes

- Related issue: #3047
- Prior attempt checked: #3058
- This is a draft until C++ test coverage is confirmed.
