### PR TITLE
Fix update_modules crash on over-length module lists

### DIFF
--- a/python/mlx/nn/layers/base.py
+++ b/python/mlx/nn/layers/base.py
@@ -634,6 +634,13 @@ def _update_modules(dst, modules, strict):
                 raise ValueError(f'Module does not have sub-module named "{k}".')
     elif isinstance(modules, list):
         for i in range(len(modules)):
+            if i >= len(dst):
+                if strict:
+                    raise ValueError(
+                        f"List index {i} is out of bounds for "
+                        f"destination of length {len(dst)}."
+                    )
+                continue
             current_value = dst[i]
             new_value = modules[i]
             if Module.is_module(current_value) and Module.is_module(new_value):

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -330,6 +330,19 @@ class TestBase(mlx_tests.MLXTestCase):
         m = MyModel()
         m.update_modules(m.leaf_modules())
 
+        # A list with more entries than the destination is rejected when strict
+        m = nn.Sequential(nn.Linear(3, 3), nn.Linear(3, 3))
+        with self.assertRaises(ValueError):
+            m.update_modules({"layers": [{}, {}, nn.Linear(3, 4)]})
+
+        # ...and the extra entries are skipped (not a crash) when strict=False
+        m = nn.Sequential(nn.Linear(3, 3), nn.Linear(3, 3))
+        m.update_modules(
+            {"layers": [{}, nn.Linear(3, 4), nn.Linear(5, 5)]}, strict=False
+        )
+        self.assertEqual(len(m.layers), 2)
+        self.assertEqual(m.layers[1].weight.shape, (4, 3))
+
     def test_parameter_deletion(self):
         m = nn.Linear(32, 32)
         del m.weight


### PR DESCRIPTION
Calling `Module.update_modules` with a list longer than the destination raises a raw `IndexError`, even with `strict=False` where only the provided locations should be updated.

`_update_modules` indexes `dst[i]` for every entry of the update list without a bounds check:

```python
elif isinstance(modules, list):
    for i in range(len(modules)):
        current_value = dst[i]   # IndexError when len(modules) > len(dst)
```

`Module.update` already handles this exact case for parameters -- it skips out-of-range indices when `strict=False` and raises a descriptive `ValueError` when `strict=True`. This mirrors that guard in `_update_modules` so `update_modules` is consistent with `update`.

```python
m = nn.Sequential(nn.Linear(3, 3), nn.Linear(3, 3))
m.update_modules({"layers": [{}, nn.Linear(3, 4), nn.Linear(5, 5)]}, strict=False)
# before: IndexError: list index out of range
# after:  updates layers[1], skips the extra entry
```

Added regression coverage to `test_update_modules`: an over-length list raises `ValueError` under the default `strict=True`, and skips the extra entries under `strict=False`.