### PR TITLE
Document row-wise sparsity in nn.init.sparse

### DIFF
--- a/python/mlx/nn/init.py
+++ b/python/mlx/nn/init.py
@@ -358,9 +358,15 @@ def sparse(
 ) -> Callable[[mx.array], mx.array]:
     r"""An initializer that returns a sparse matrix.
 
+    Sparsity is applied along each row: every row has the same fraction of its
+    entries set to zero. With a weight matrix applied as ``x @ w.T``, this
+    limits each output feature to at most a ``1 - sparsity`` fraction of the
+    input features, following the sparse initialization of Martens, J. (2010),
+    "Deep learning via Hessian-free optimization".
+
     Args:
-        sparsity (float): The fraction of elements in each column to be set to
-        zero.
+        sparsity (float): The fraction of elements in each row to be set to
+          zero.
         mean (float, optional): Mean of the normal distribution. Default:
           ``0.0``.
         std (float, optional): Standard deviation of the normal distribution.
@@ -376,8 +382,8 @@ def sparse(
 
         >>> init_fn = nn.init.sparse(sparsity=0.5)
         >>> init_fn(mx.zeros((2, 2)))
-        array([[-1.91187, -0.117483],
-       [0, 0]], dtype=float32)
+        array([[-1.91187, 0],
+       [0, -0.117483]], dtype=float32)
     """
 
     def initializer(a: mx.array) -> mx.array:
@@ -385,16 +391,16 @@ def sparse(
             raise ValueError("Only tensors with 2 dimensions are supported")
 
         rows, cols = a.shape
-        num_zeros = int(math.ceil(sparsity * rows))
+        num_zeros = int(math.ceil(sparsity * cols))
 
-        # Zero out `num_zeros` random entries in each column, matching the
-        # documented "fraction of elements in each column" contract. Sorting a
-        # per-column random key (axis=0) picks the zeroed rows independently for
-        # every column.
-        order = mx.argsort(mx.random.uniform(shape=a.shape), axis=0)
+        # Zero out `num_zeros` random entries in each row, so every row (output
+        # feature) drops the same fraction of its input connections. Sorting a
+        # per-row random key (axis=1) picks the zeroed columns independently for
+        # every row.
+        order = mx.argsort(mx.random.uniform(shape=a.shape), axis=1)
         a = mx.random.normal(shape=a.shape, scale=std, loc=mean, dtype=dtype)
 
-        a[order[:num_zeros, :], mx.arange(cols).reshape(1, cols)] = 0
+        a[mx.arange(rows).reshape(rows, 1), order[:, :num_zeros]] = 0
 
         return a
 

--- a/python/mlx/nn/init.py
+++ b/python/mlx/nn/init.py
@@ -385,12 +385,16 @@ def sparse(
             raise ValueError("Only tensors with 2 dimensions are supported")
 
         rows, cols = a.shape
-        num_zeros = int(math.ceil(sparsity * cols))
+        num_zeros = int(math.ceil(sparsity * rows))
 
-        order = mx.argsort(mx.random.uniform(shape=a.shape), axis=1)
+        # Zero out `num_zeros` random entries in each column, matching the
+        # documented "fraction of elements in each column" contract. Sorting a
+        # per-column random key (axis=0) picks the zeroed rows independently for
+        # every column.
+        order = mx.argsort(mx.random.uniform(shape=a.shape), axis=0)
         a = mx.random.normal(shape=a.shape, scale=std, loc=mean, dtype=dtype)
 
-        a[mx.arange(rows).reshape(rows, 1), order[:, :num_zeros]] = 0
+        a[order[:num_zeros, :], mx.arange(cols).reshape(1, cols)] = 0
 
         return a
 

--- a/python/tests/test_init.py
+++ b/python/tests/test_init.py
@@ -1,4 +1,5 @@
 # Copyright © 2023 Apple Inc.
+import math
 import unittest
 
 import mlx.core as mx
@@ -105,6 +106,20 @@ class TestInit(mlx_tests.MLXTestCase):
                     )
             with self.assertRaises(ValueError):
                 result = initializer(mx.zeros((1,)))
+
+    def test_sparse_zeros_per_column(self):
+        # The documented contract (matching PyTorch's nn.init.sparse_) is that
+        # `sparsity` is the fraction of elements in each *column* set to zero,
+        # i.e. every column must contain exactly ceil(sparsity * rows) zeros
+        # regardless of the matrix shape. A per-row implementation breaks this
+        # for non-square inputs.
+        for sparsity, shape in [(0.5, (10, 4)), (0.3, (10, 5)), (0.5, (2, 2))]:
+            rows, _ = shape
+            expected = int(math.ceil(sparsity * rows))
+            result = init.sparse(sparsity)(mx.zeros(shape))
+            zeros_per_col = mx.sum(result == 0, axis=0)
+            with self.subTest(shape=shape, sparsity=sparsity):
+                self.assertTrue(mx.all(zeros_per_col == expected).item())
 
     def test_orthogonal(self):
         initializer = init.orthogonal(gain=1.0, dtype=mx.float32)

--- a/python/tests/test_init.py
+++ b/python/tests/test_init.py
@@ -107,19 +107,18 @@ class TestInit(mlx_tests.MLXTestCase):
             with self.assertRaises(ValueError):
                 result = initializer(mx.zeros((1,)))
 
-    def test_sparse_zeros_per_column(self):
-        # The documented contract (matching PyTorch's nn.init.sparse_) is that
-        # `sparsity` is the fraction of elements in each *column* set to zero,
-        # i.e. every column must contain exactly ceil(sparsity * rows) zeros
-        # regardless of the matrix shape. A per-row implementation breaks this
-        # for non-square inputs.
-        for sparsity, shape in [(0.5, (10, 4)), (0.3, (10, 5)), (0.5, (2, 2))]:
-            rows, _ = shape
-            expected = int(math.ceil(sparsity * rows))
+    def test_sparse_zeros_per_row(self):
+        # Sparsity is applied along each row: every row drops exactly
+        # ceil(sparsity * cols) of its entries, independent of matrix shape, so
+        # each output feature (a row of `w` used as `x @ w.T`) keeps the same
+        # number of input connections.
+        for sparsity, shape in [(0.5, (4, 10)), (0.3, (5, 10)), (0.5, (2, 2))]:
+            _, cols = shape
+            expected = int(math.ceil(sparsity * cols))
             result = init.sparse(sparsity)(mx.zeros(shape))
-            zeros_per_col = mx.sum(result == 0, axis=0)
+            zeros_per_row = mx.sum(result == 0, axis=1)
             with self.subTest(shape=shape, sparsity=sparsity):
-                self.assertTrue(mx.all(zeros_per_col == expected).item())
+                self.assertTrue(mx.all(zeros_per_row == expected).item())
 
     def test_orthogonal(self):
         initializer = init.orthogonal(gain=1.0, dtype=mx.float32)


### PR DESCRIPTION
nn.init.sparse zeros ceil(sparsity * cols) entries in each row, but the docstring described the fraction "in each column" and its example zeroed a full row of a 2x2 (which row-wise sparsification cannot produce).

Following @angeloskath's note that the row-wise behavior is intentional - with weights applied as x @ w.T it bounds the input features used by each output feature (Martens, 2010) - this keeps the implementation unchanged and fixes the documentation instead:

- Describe sparsity as applied along each row, with the feature-dimension rationale.
- Correct the sparsity argument wording (row, not column).
- Fix the docstring example so each row carries one zero.
- Replace the per-column test with test_sparse_zeros_per_row, pinning the per-row zero count.

No behavior change.