### PR TITLE
Fix infinite norm negative axis mismatch bug for matrices with 2 or more dimensions.

### DIFF
--- a/mlx/linalg.cpp
+++ b/mlx/linalg.cpp
@@ -99,12 +99,16 @@ inline array matrix_norm(
         dtype,
         s);
   } else if (ord == std::numeric_limits<double>::infinity()) {
+    row_axis = (axis[0] < 0) ? axis[0] + a.ndim() : axis[0];
+    col_axis = (axis[1] < 0) ? axis[1] + a.ndim() : axis[1];
     row_axis -= (!keepdims && row_axis > col_axis && row_axis > 0);
     return astype(
         max(sum(abs(a, s), col_axis, keepdims, s), row_axis, keepdims, s),
         dtype,
         s);
   } else if (ord == -std::numeric_limits<double>::infinity()) {
+    row_axis = (axis[0] < 0) ? axis[0] + a.ndim() : axis[0];
+    col_axis = (axis[1] < 0) ? axis[1] + a.ndim() : axis[1];
     row_axis -= (!keepdims && row_axis > col_axis && row_axis > 0);
     return astype(
         min(sum(abs(a, s), col_axis, keepdims, s), row_axis, keepdims, s),

--- a/python/tests/test_linalg.py
+++ b/python/tests/test_linalg.py
@@ -65,6 +65,27 @@ class TestLinalg(mlx_tests.MLXTestCase):
                 with self.subTest(shape=shape, keepdims=keepdims):
                     self.assertTrue(np.allclose(out_np, out_mx, atol=1e-5, rtol=1e-6))
 
+        # neg/pos inf norm test
+        norms = [-float("inf"), float("inf")]
+        for shape in [(3, 3), (2, 3, 3), (2, 3, 3, 3)]:
+            x_mx = mx.arange(1, math.prod(shape) + 1, dtype=mx.float32).reshape(shape)
+            x_np = np.arange(1, math.prod(shape) + 1, dtype=np.float32).reshape(shape)
+            neg_indices = [-i for i in range(1, x_np.ndim + 1)]
+            neg_axes = [list(p) for p in itertools.permutations(neg_indices, 2)]
+            print(neg_axes)
+            for ord in norms:
+                for axes in neg_axes:
+                    out_np = np.linalg.norm(
+                        x_np,
+                        ord=np.inf if ord == float("inf") else -np.inf,
+                        axis=tuple(axes),
+                    )
+                    out_mx = mx.linalg.norm(x_mx, ord=ord, axis=axes)
+                    with self.subTest(ord=ord, axes=axes):
+                        self.assertTrue(
+                            np.allclose(out_np, out_mx, atol=1e-5, rtol=1e-6)
+                        )
+
     def test_complex_norm(self):
         for shape in [(3,), (2, 3), (2, 3, 3)]:
             x_np = np.random.uniform(size=shape).astype(

--- a/python/tests/test_linalg.py
+++ b/python/tests/test_linalg.py
@@ -72,7 +72,6 @@ class TestLinalg(mlx_tests.MLXTestCase):
             x_np = np.arange(1, math.prod(shape) + 1, dtype=np.float32).reshape(shape)
             neg_indices = [-i for i in range(1, x_np.ndim + 1)]
             neg_axes = [list(p) for p in itertools.permutations(neg_indices, 2)]
-            print(neg_axes)
             for ord in norms:
                 for axes in neg_axes:
                     out_np = np.linalg.norm(

--- a/tests/linalg_tests.cpp
+++ b/tests/linalg_tests.cpp
@@ -269,7 +269,7 @@ TEST_CASE("[mlx.core.linalg.norm] double ord") {
             norm(
                 x,
                 std::numeric_limits<double>::infinity(),
-                std::vector<int>{0, 1},
+                std::vector<int>{-2, -1},
                 false,
                 Device::cpu),
             array({21.0, 48.0}))
@@ -278,7 +278,7 @@ TEST_CASE("[mlx.core.linalg.norm] double ord") {
             norm(
                 x,
                 -std::numeric_limits<double>::infinity(),
-                std::vector<int>{0, 1},
+                std::vector<int>{-2, -1},
                 false,
                 Device::cpu),
             array({3.0, 30.0}))

--- a/tests/linalg_tests.cpp
+++ b/tests/linalg_tests.cpp
@@ -3,6 +3,7 @@
 #include "doctest/doctest.h"
 
 #include <cmath>
+#include <limits>
 
 #include "mlx/mlx.h"
 #include "mlx/ops.h"
@@ -170,7 +171,24 @@ TEST_CASE("[mlx.core.linalg.norm] double ord") {
   CHECK_EQ(
       norm(x, 2.0, std::vector<int>{-2, -1}, false, Device::cpu).item<float>(),
       doctest::Approx(14.226707));
-
+  CHECK_EQ(
+      norm(
+          x,
+          std::numeric_limits<double>::infinity(),
+          std::vector<int>{-2, -1},
+          false,
+          Device::cpu)
+          .item<float>(),
+      doctest::Approx(21.0));
+  CHECK_EQ(
+      norm(
+          x,
+          -std::numeric_limits<double>::infinity(),
+          std::vector<int>{-2, -1},
+          false,
+          Device::cpu)
+          .item<float>(),
+      doctest::Approx(3.0));
   x = reshape(arange(18, float32), {2, 3, 3});
   CHECK_THROWS(norm(x, 2.0, std::vector{0, 1, 2}));
   CHECK(allclose(
@@ -246,6 +264,24 @@ TEST_CASE("[mlx.core.linalg.norm] double ord") {
             array({4.979028e-16, 7.009628e-16}),
             /* rtol = */ 1e-5,
             /* atol = */ 1e-6)
+            .item<bool>());
+  CHECK(allclose(
+            norm(
+                x,
+                std::numeric_limits<double>::infinity(),
+                std::vector<int>{0, 1},
+                false,
+                Device::cpu),
+            array({21.0, 48.0}))
+            .item<bool>());
+  CHECK(allclose(
+            norm(
+                x,
+                -std::numeric_limits<double>::infinity(),
+                std::vector<int>{0, 1},
+                false,
+                Device::cpu),
+            array({3.0, 30.0}))
             .item<bool>());
 }
 


### PR DESCRIPTION
## Proposed changes
The following changes aims to fix an axis mismatch bug that occurs when one tries to calculate the $\pm\infty$ norm of some matrix A with 2 or more dimensions by passing in a series of negative axes and when `keepdim` is false.
As an example consider the following snippet of code:
```python
import mlx.core as mx 
from mlx.core import linalg as la 
import numpy as np 
a_np = np.arange(9, dtype =np.float32).reshape((3,3))
a_mx = mx.arange(9, dtype = mx.float32).reshape((3,3)) 
# numpy as reference: 21.0
print(np.linalg.norm(a_np, ord = np.inf , axis  = (-2,-1)))
# raises IndexError: Invalid axis -2 for array with 1 dimensions.
print(la.norm(a_mx, ord = float('inf'), axis  = (-2,-1)))
```
Based on the numpy implementation, one should expect the following to return the float value of 21.0. However, we get an index error and the culprit of this error is how the matrix_norm is calculated when `keepdims` is false and we receive negative index. 
If we take a look at the matrix_norm code. It's clear that the norm method for pos/neg infinite norm is implemented series of chained reductions:
`max(sum(abs(a, s), col_axis, keepdims, s), row_axis, keepdims, s)`
`min(sum(abs(a, s), col_axis, keepdims, s), row_axis, keepdims, s)`
Hence, when we specify that we want to reduce along `(row_axis, col_axis)` and keepdims is false, we need to account for the reduction in dimensions when we call max or min.  Otherwise, we either end up with an index out of bound error or we reduce the wrong axis by one due to an off by one error.

The non-negative cases handle this via:  
`row_axis -= (!keepdims && row_axis > col_axis && row_axis > 0);`
However, this is skipped for negative cases due to the ` row_axis > 0`. To address this issue, this pr converts the respective for  `(row_axis, col_axis)` to the equivalent non-negative values when negative axes values. This ensures proper behavior is achieved.
### Testing 
- Ran existing unit tests for C++ and Python API on M5 Macbook Air 
- Added tests for pos/neg infinite norm for all possible negative indexing axis tuples for shapes `(3, 3), (2, 3, 3), (2, 3, 3, 3)` where outputs were verified against  expected numpy outputs. 
## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
