### PR TITLE
Add small-batch quantized matvec kernel (qmv_wide)

### DIFF
--- a/mlx/backend/metal/kernels/fp_quantized.h
+++ b/mlx/backend/metal/kernels/fp_quantized.h
@@ -586,20 +586,20 @@ METAL_FUNC void fp_qmv_wide_impl(
       const device uint16_t* wq = (const device uint16_t*)wg;
 #pragma unroll
       for (int i = 0; i < nf4; i++) {
-        w4[i] = s *
-            float4(Dequantize<4>{}(wq[i]),
-                   Dequantize<4>{}(wq[i] >> 4),
-                   Dequantize<4>{}(wq[i] >> 8),
-                   Dequantize<4>{}(wq[i] >> 12));
+        w4[i] = float4(
+            Dequantize<4>{}(wq[i]),
+            Dequantize<4>{}(wq[i] >> 4),
+            Dequantize<4>{}(wq[i] >> 8),
+            Dequantize<4>{}(wq[i] >> 12));
       }
     } else {
 #pragma unroll
       for (int i = 0; i < nf4; i++) {
-        w4[i] = s *
-            float4(Dequantize<8>{}(wg[4 * i]),
-                   Dequantize<8>{}(wg[4 * i + 1]),
-                   Dequantize<8>{}(wg[4 * i + 2]),
-                   Dequantize<8>{}(wg[4 * i + 3]));
+        w4[i] = float4(
+            Dequantize<8>{}(wg[4 * i]),
+            Dequantize<8>{}(wg[4 * i + 1]),
+            Dequantize<8>{}(wg[4 * i + 2]),
+            Dequantize<8>{}(wg[4 * i + 3]));
       }
     }
 
@@ -611,7 +611,7 @@ METAL_FUNC void fp_qmv_wide_impl(
       for (int j = 0; j < nf4; j++) {
         acc += dot(w4[j], float4(xv4[j]));
       }
-      result[v] += acc;
+      result[v] += s * acc;
     }
   }
 

--- a/mlx/backend/metal/kernels/fp_quantized.h
+++ b/mlx/backend/metal/kernels/fp_quantized.h
@@ -525,6 +525,125 @@ METAL_FUNC void fp_qmv_impl(
   }
 }
 
+// Quantized matrix-vector for a small batch of input vectors, the M in
+// [2, vector_limit) band between qmv (M==1) and qmm. Each thread owns one
+// output row that k_lanes lanes reduce over K; the vecs_per_tg vectors are
+// streamed so each weight group is dequantized once and reused across them.
+template <typename T, int group_size, int bits, int vecs_per_tg, int k_lanes>
+METAL_FUNC void fp_qmv_wide_impl(
+    const device uint32_t* w,
+    const device uint8_t* scales,
+    const device T* x,
+    device T* y,
+    const constant int& in_vec_size,
+    const constant int& out_vec_size,
+    const constant int& M,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  constexpr int num_simdgroups = 2;
+  constexpr int results_per_simdgroup = SIMD_SIZE / k_lanes;
+  constexpr int pack_factor = get_pack_factor<32, bits>();
+  constexpr int bytes_per_pack = get_bytes_per_pack<32>();
+  constexpr int nf4 = group_size / 4; // float4 lanes per quant group
+
+  typedef float U;
+
+  const short k_lane =
+      simd_lid % k_lanes; // this lane's slot in the K reduction
+  const short sg_row = simd_lid / k_lanes; // which output row of the simdgroup
+
+  const int out_row = tid.y * (results_per_simdgroup * num_simdgroups) +
+      results_per_simdgroup * simd_gid + sg_row;
+  const int vec0 = tid.x * vecs_per_tg; // first input vector handled here
+
+  const int row = min(out_row, out_vec_size - 1);
+
+  const int in_vec_size_w = in_vec_size * bytes_per_pack / pack_factor;
+  const int in_vec_size_g = in_vec_size / group_size;
+  const device uint8_t* wrow = (const device uint8_t*)w + row * in_vec_size_w;
+  const device uint8_t* srow = scales + row * in_vec_size_g;
+
+  // One device pointer per streamed vector; the clamp keeps an out-of-range
+  // tail slot reading a valid row (it is never written below).
+  const device T* xv[vecs_per_tg];
+  for (int v = 0; v < vecs_per_tg; v++) {
+    xv[v] = x + min(vec0 + v, M - 1) * in_vec_size;
+  }
+
+  U result[vecs_per_tg] = {0};
+
+  // Each lane reduces a strided subset of the row's quant groups: one group is
+  // dequantized to float4 lanes and dot()'d against each streamed vector. One
+  // group per iteration keeps weight-register pressure low for occupancy.
+  for (int g = k_lane; g < in_vec_size_g; g += k_lanes) {
+    const int k0 = g * group_size;
+    U s = dequantize_scale<U, group_size>(srow[g]);
+    const device uint8_t* wg = wrow + k0 * bytes_per_pack / pack_factor;
+
+    float4 w4[nf4];
+    if constexpr (bits == 4) {
+      const device uint16_t* wq = (const device uint16_t*)wg;
+#pragma unroll
+      for (int i = 0; i < nf4; i++) {
+        w4[i] = s *
+            float4(Dequantize<4>{}(wq[i]),
+                   Dequantize<4>{}(wq[i] >> 4),
+                   Dequantize<4>{}(wq[i] >> 8),
+                   Dequantize<4>{}(wq[i] >> 12));
+      }
+    } else {
+#pragma unroll
+      for (int i = 0; i < nf4; i++) {
+        w4[i] = s *
+            float4(Dequantize<8>{}(wg[4 * i]),
+                   Dequantize<8>{}(wg[4 * i + 1]),
+                   Dequantize<8>{}(wg[4 * i + 2]),
+                   Dequantize<8>{}(wg[4 * i + 3]));
+      }
+    }
+
+#pragma unroll
+    for (int v = 0; v < vecs_per_tg; v++) {
+      const device vec<T, 4>* xv4 = (const device vec<T, 4>*)(xv[v] + k0);
+      float acc = 0;
+#pragma unroll
+      for (int j = 0; j < nf4; j++) {
+        acc += dot(w4[j], float4(xv4[j]));
+      }
+      result[v] += acc;
+    }
+  }
+
+  // Reduce each vector's partial over its k_lanes with a shuffle ladder:
+  // simd_sum would mix the results_per_simdgroup rows a simdgroup spans.
+  for (int v = 0; v < vecs_per_tg; v++) {
+    if constexpr (k_lanes >= 32) {
+      result[v] += simd_shuffle_down(result[v], 16);
+    }
+    if constexpr (k_lanes >= 16) {
+      result[v] += simd_shuffle_down(result[v], 8);
+    }
+    if constexpr (k_lanes >= 8) {
+      result[v] += simd_shuffle_down(result[v], 4);
+    }
+    if constexpr (k_lanes >= 4) {
+      result[v] += simd_shuffle_down(result[v], 2);
+    }
+    if constexpr (k_lanes >= 2) {
+      result[v] += simd_shuffle_down(result[v], 1);
+    }
+  }
+
+  if (k_lane == 0 && out_row < out_vec_size) {
+    for (int v = 0; v < vecs_per_tg; v++) {
+      if (vec0 + v < M) {
+        y[(vec0 + v) * out_vec_size + out_row] = static_cast<T>(result[v]);
+      }
+    }
+  }
+}
+
 template <typename T, const int group_size, int bits>
 METAL_FUNC void fp_qvm_impl(
     const device uint32_t* w,
@@ -1085,6 +1204,51 @@ template <typename T, const int group_size, int bits, bool batched>
   }
   fp_qmv_impl<T, group_size, bits>(
       w, scales, x, y, in_vec_size, out_vec_size, tid, simd_gid, simd_lid);
+}
+
+template <
+    typename T,
+    int group_size,
+    int bits,
+    int vecs_per_tg,
+    int k_lanes,
+    bool batched>
+[[kernel]] void fp_qmv_wide(
+    const device uint32_t* w,
+    const device uint8_t* scales,
+    const device T* x,
+    device T* y,
+    const constant int& in_vec_size,
+    const constant int& out_vec_size,
+    const constant int& M,
+    const constant int& x_batch_ndims,
+    const constant int* x_shape,
+    const constant int64_t* x_strides,
+    const constant int& w_batch_ndims,
+    const constant int* w_shape,
+    const constant int64_t* w_strides,
+    const constant int64_t* s_strides,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  if (batched) {
+    adjust_matrix_offsets(
+        x,
+        w,
+        scales,
+        y,
+        out_vec_size * M,
+        x_batch_ndims,
+        x_shape,
+        x_strides,
+        w_batch_ndims,
+        w_shape,
+        w_strides,
+        s_strides,
+        tid);
+  }
+  fp_qmv_wide_impl<T, group_size, bits, vecs_per_tg, k_lanes>(
+      w, scales, x, y, in_vec_size, out_vec_size, M, tid, simd_gid, simd_lid);
 }
 
 template <typename T, const int group_size, int bits, bool batched>

--- a/mlx/backend/metal/kernels/fp_quantized.metal
+++ b/mlx/backend/metal/kernels/fp_quantized.metal
@@ -52,6 +52,17 @@
       D,       \
       batched)
 
+#define instantiate_quantized_wide(mode, name, type, vecs_per_tg, k_lanes, group_size, bits, batched) \
+  instantiate_kernel( \
+      #mode "_" #name "_" #type "_gs_" #group_size "_b_" #bits "_nv_" #vecs_per_tg "_kl_" #k_lanes "_batch_" #batched, \
+      fp_ ## name,    \
+      type,    \
+      group_size,      \
+      bits,       \
+      vecs_per_tg,       \
+      k_lanes,       \
+      batched)
+
 #define instantiate_quantized_split_k(mode, name, type, split_k, group_size, bits) \
   instantiate_kernel( \
       #mode "_" #name "_" #type "_gs_" #group_size "_b_" #bits "_spk_" #split_k, \
@@ -105,6 +116,17 @@
   instantiate_quantized_quad(mode, qmv_quad, type, 128, 1, group_size, bits) \
   instantiate_quantized_quad(mode, qmv_quad, type, 128, 0, group_size, bits)
 
+// vecs_per_tg (input-vector tile) 2..5; the fp path uses k_lanes=16.
+#define instantiate_quantized_wide_wrap(mode, name, type, vecs_per_tg, k_lanes, group_size, bits) \
+  instantiate_quantized_wide(mode, name, type, vecs_per_tg, k_lanes, group_size, bits, 0)         \
+  instantiate_quantized_wide(mode, name, type, vecs_per_tg, k_lanes, group_size, bits, 1)
+
+#define instantiate_quantized_all_wide(type, mode, group_size, bits) \
+  instantiate_quantized_wide_wrap(mode, qmv_wide, type, 2, 16, group_size, bits) \
+  instantiate_quantized_wide_wrap(mode, qmv_wide, type, 3, 16, group_size, bits) \
+  instantiate_quantized_wide_wrap(mode, qmv_wide, type, 4, 16, group_size, bits) \
+  instantiate_quantized_wide_wrap(mode, qmv_wide, type, 5, 16, group_size, bits)
+
 #define instantiate_quantized_all_splitk(type, mode, group_size, bits) \
   instantiate_quantized_split_k(mode, qvm_split_k, type, 8, group_size, bits) \
   instantiate_quantized_split_k(mode, qvm_split_k, type, 32, group_size, bits) \
@@ -139,6 +161,7 @@
   instantiate_quantized_all_batched(type, mode, group_size, bits) \
   instantiate_quantized_all_single(type, mode, group_size, bits)  \
   instantiate_quantized_all_quad(type, mode, group_size, bits)    \
+  instantiate_quantized_all_wide(type, mode, group_size, bits)    \
   instantiate_quantized_all_splitk(type, mode, group_size, bits)  \
   instantiate_quantized_all_aligned(type, mode, group_size, bits) \
   instantiate_quantized_all_rhs(type, mode, group_size, bits)     \

--- a/mlx/backend/metal/kernels/quantized.h
+++ b/mlx/backend/metal/kernels/quantized.h
@@ -480,9 +480,10 @@ qouter(const thread uint8_t* w, U x, U scale, U bias, thread U* result) {
   }
 }
 
-template <typename U, int N, int bits>
-inline void
-dequantize(const device uint8_t* w, U scale, U bias, threadgroup U* w_local) {
+// Decode one quantized block (scale * q + bias) into w_local. W (the output
+// pointer type) serves the threadgroup block loader or a thread-local decode.
+template <typename U, int N, int bits, typename W>
+inline void dequantize(const device uint8_t* w, U scale, U bias, W w_local) {
   static_assert(
       bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
           bits == 8,
@@ -969,6 +970,103 @@ METAL_FUNC void qmv_impl(
       result[row] = simd_sum(result[row]);
       if (simd_lid == 0) {
         y[row] = static_cast<T>(result[row]);
+      }
+    }
+  }
+}
+
+// Affine analog of fp_qmv_wide. Weights carry a scale and bias per group, so
+// each group is decoded in 8-value sub-chunks (scale * q + bias, registers
+// bounded for any group_size) and reused across the vecs_per_tg vectors.
+template <typename T, int group_size, int bits, int vecs_per_tg, int k_lanes>
+METAL_FUNC void qmv_wide_impl(
+    const device uint32_t* w,
+    const device T* scales,
+    const device T* biases,
+    const device T* x,
+    device T* y,
+    const constant int& in_vec_size,
+    const constant int& out_vec_size,
+    const constant int& M,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  constexpr int num_simdgroups = 2;
+  constexpr int results_per_simdgroup = SIMD_SIZE / k_lanes;
+  constexpr int sub = 8; // values per sub-chunk (== bits bytes, byte-aligned)
+
+  typedef float U;
+
+  const short k_lane = simd_lid % k_lanes;
+  const short sg_row = simd_lid / k_lanes;
+
+  const int out_row = tid.y * (results_per_simdgroup * num_simdgroups) +
+      results_per_simdgroup * simd_gid + sg_row;
+  const int vec0 = tid.x * vecs_per_tg;
+
+  const int row = min(out_row, out_vec_size - 1);
+
+  const int in_vec_size_w = in_vec_size * bits / 8; // bytes per weight row
+  const int in_vec_size_g = in_vec_size / group_size;
+  const device uint8_t* wrow = (const device uint8_t*)w + row * in_vec_size_w;
+  const device T* srow = scales + row * in_vec_size_g;
+  const device T* brow = biases + row * in_vec_size_g;
+
+  const device T* xv[vecs_per_tg];
+  for (int v = 0; v < vecs_per_tg; v++) {
+    xv[v] = x + min(vec0 + v, M - 1) * in_vec_size;
+  }
+
+  U result[vecs_per_tg] = {0};
+
+  // Each lane reduces a strided subset of the row's groups: decode the group in
+  // 8-value sub-chunks and reuse each chunk across the streamed vectors.
+  for (int g = k_lane; g < in_vec_size_g; g += k_lanes) {
+    U scale = srow[g];
+    U bias = brow[g];
+#pragma unroll
+    for (int sc = 0; sc < group_size / sub; sc++) {
+      const int k0 = g * group_size + sc * sub;
+      const device uint8_t* wc = wrow + k0 * bits / 8;
+      U w_dq[sub];
+      dequantize<U, sub, bits>(wc, scale, bias, w_dq);
+#pragma unroll
+      for (int v = 0; v < vecs_per_tg; v++) {
+        const device T* xc = xv[v] + k0;
+        U acc = 0;
+#pragma unroll
+        for (int i = 0; i < sub; i++) {
+          acc += static_cast<U>(xc[i]) * w_dq[i];
+        }
+        result[v] += acc;
+      }
+    }
+  }
+
+  // Reduce each vector's partial over its k_lanes with a shuffle ladder:
+  // simd_sum would mix the results_per_simdgroup rows a simdgroup spans.
+  for (int v = 0; v < vecs_per_tg; v++) {
+    if constexpr (k_lanes >= 32) {
+      result[v] += simd_shuffle_down(result[v], 16);
+    }
+    if constexpr (k_lanes >= 16) {
+      result[v] += simd_shuffle_down(result[v], 8);
+    }
+    if constexpr (k_lanes >= 8) {
+      result[v] += simd_shuffle_down(result[v], 4);
+    }
+    if constexpr (k_lanes >= 4) {
+      result[v] += simd_shuffle_down(result[v], 2);
+    }
+    if constexpr (k_lanes >= 2) {
+      result[v] += simd_shuffle_down(result[v], 1);
+    }
+  }
+
+  if (k_lane == 0 && out_row < out_vec_size) {
+    for (int v = 0; v < vecs_per_tg; v++) {
+      if (vec0 + v < M) {
+        y[(vec0 + v) * out_vec_size + out_row] = static_cast<T>(result[v]);
       }
     }
   }
@@ -1592,6 +1690,65 @@ template <typename T, const int group_size, const int bits, bool batched>
       y,
       in_vec_size,
       out_vec_size,
+      tid,
+      simd_gid,
+      simd_lid);
+}
+
+template <
+    typename T,
+    int group_size,
+    int bits,
+    int vecs_per_tg,
+    int k_lanes,
+    bool batched>
+[[kernel]] void affine_qmv_wide(
+    const device uint32_t* w,
+    const device T* scales,
+    const device T* biases,
+    const device T* x,
+    device T* y,
+    const constant int& in_vec_size,
+    const constant int& out_vec_size,
+    const constant int& M,
+    const constant int& x_batch_ndims,
+    const constant int* x_shape,
+    const constant int64_t* x_strides,
+    const constant int& w_batch_ndims,
+    const constant int* w_shape,
+    const constant int64_t* w_strides,
+    const constant int64_t* s_strides,
+    const constant int64_t* b_strides,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  if (batched) {
+    adjust_matrix_offsets<T>(
+        x,
+        w,
+        scales,
+        biases,
+        y,
+        out_vec_size * M,
+        x_batch_ndims,
+        x_shape,
+        x_strides,
+        w_batch_ndims,
+        w_shape,
+        w_strides,
+        s_strides,
+        b_strides,
+        tid);
+  }
+  qmv_wide_impl<T, group_size, bits, vecs_per_tg, k_lanes>(
+      w,
+      scales,
+      biases,
+      x,
+      y,
+      in_vec_size,
+      out_vec_size,
+      M,
       tid,
       simd_gid,
       simd_lid);

--- a/mlx/backend/metal/kernels/quantized.metal
+++ b/mlx/backend/metal/kernels/quantized.metal
@@ -52,6 +52,17 @@
       D,                                                            \
       batched)
 
+#define instantiate_quantized_wide(name, type, group_size, bits, vecs_per_tg, k_lanes, batched)               \
+  instantiate_kernel(                                                                                          \
+      #name "_" #type "_gs_" #group_size "_b_" #bits "_nv_" #vecs_per_tg "_kl_" #k_lanes "_batch_" #batched,   \
+      name,                                                         \
+      type,                                                         \
+      group_size,                                                   \
+      bits,                                                         \
+      vecs_per_tg,                                                  \
+      k_lanes,                                                      \
+      batched)
+
 #define instantiate_quantized_split_k(name, type, group_size, bits, split_k)     \
   instantiate_kernel(                                                            \
       #name "_" #type "_gs_" #group_size "_b_" #bits "_spk_" #split_k, \
@@ -107,6 +118,18 @@
   instantiate_quantized_quad(affine_qmv_quad, type, group_size, bits, 128, 1)  \
   instantiate_quantized_quad(affine_qmv_quad, type, group_size, bits, 128, 0)
 
+// vecs_per_tg (input-vector tile) 2..5; affine uses k_lanes=8 (more rows per
+// simdgroup) where the fp path uses 16.
+#define instantiate_quantized_wide_wrap(name, type, group_size, bits, vecs_per_tg, k_lanes) \
+  instantiate_quantized_wide(name, type, group_size, bits, vecs_per_tg, k_lanes, 0)         \
+  instantiate_quantized_wide(name, type, group_size, bits, vecs_per_tg, k_lanes, 1)
+
+#define instantiate_quantized_all_wide(type, group_size, bits) \
+  instantiate_quantized_wide_wrap(affine_qmv_wide, type, group_size, bits, 2, 8) \
+  instantiate_quantized_wide_wrap(affine_qmv_wide, type, group_size, bits, 3, 8) \
+  instantiate_quantized_wide_wrap(affine_qmv_wide, type, group_size, bits, 4, 8) \
+  instantiate_quantized_wide_wrap(affine_qmv_wide, type, group_size, bits, 5, 8)
+
 #define instantiate_quantized_all_splitk(type, group_size, bits)   \
   instantiate_quantized_split_k(affine_qvm_split_k, type, group_size, bits, 8)   \
   instantiate_quantized_split_k(affine_qvm_split_k, type, group_size, bits, 32)  \
@@ -133,6 +156,7 @@
   instantiate_quantized_all_batched(type, group_size, bits) \
   instantiate_quantized_all_aligned(type, group_size, bits) \
   instantiate_quantized_all_quad(type, group_size, bits)    \
+  instantiate_quantized_all_wide(type, group_size, bits)    \
   instantiate_quantized_all_splitk(type, group_size, bits)  \
   instantiate_quantized_all_splitk_qmm(type, group_size, bits) \
   instantiate_quantized_all_rhs(type, group_size, bits)

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -295,6 +295,96 @@ void qmv(
   compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
 }
 
+// affine qmv_wide only beats qmv on gen-15+; fp benefits on every gen.
+inline bool use_qmv_wide(const std::string& mode, metal::Device& d) {
+  return mode != "affine" || d.get_architecture_gen() >= 15;
+}
+
+// Dispatches qmv_wide (fp modes -> fp_qmv_wide, affine -> affine_qmv_wide):
+// vecs_per_tg input vectors streamed and reused per weight group.
+void qmv_wide(
+    const array& x,
+    const array& w,
+    const array& scales,
+    const std::optional<array>& biases,
+    array& out,
+    int group_size,
+    int bits,
+    int M,
+    int N,
+    int K,
+    metal::Device& d,
+    const Stream& s,
+    const std::string& mode) {
+  // vecs_per_tg is the per-threadgroup input-vector tile. Each tile re-reads
+  // the weights, so use the fewest tiles, then the smallest tile that fills
+  // them.
+  int n_tiles = (M + 4) / 5; // ceil(M / 5); tile size caps at 5
+  int vecs_per_tg = (M + n_tiles - 1) / n_tiles;
+
+  // k_lanes: lanes reducing K per output row (32/k_lanes rows per simdgroup).
+  // The affine subchunk decode has enough ALU per weight load to favor more
+  // rows per simdgroup (kl8); the fp modes' vectorized dot is balanced at 16.
+  int k_lanes = mode == "affine" ? 8 : 16;
+  constexpr int num_simdgroups = 2;
+  int B = out.size() / M / N;
+  bool batched = B > 1;
+  // Output rows per threadgroup: (32 / k_lanes) per simdgroup x num_simdgroups.
+  int rows_per_tg = (32 / k_lanes) * num_simdgroups;
+
+  MTL::Size group_dims(32, num_simdgroups, 1);
+  MTL::Size grid_dims(
+      (M + vecs_per_tg - 1) / vecs_per_tg,
+      (N + rows_per_tg - 1) / rows_per_tg,
+      B);
+
+  std::string kname;
+  kname.reserve(64);
+  std::string type_string = get_type_string(x.dtype());
+  concatenate(
+      kname,
+      mode + "_qmv_wide_",
+      type_string,
+      "_gs_",
+      group_size,
+      "_b_",
+      bits,
+      "_nv_",
+      vecs_per_tg,
+      "_kl_",
+      k_lanes,
+      batched ? "_batch_1" : "_batch_0");
+  auto kernel = get_quantized_kernel_wrapped(
+      d,
+      kname,
+      "qmv_wide",
+      mode,
+      type_string,
+      group_size,
+      bits,
+      vecs_per_tg,
+      k_lanes,
+      batched);
+
+  auto& compute_encoder = metal::get_command_encoder(s);
+  compute_encoder.set_compute_pipeline_state(kernel);
+
+  int c = 0;
+  compute_encoder.set_input_array(w, c++);
+  compute_encoder.set_input_array(scales, c++);
+  if (biases) {
+    compute_encoder.set_input_array(*biases, c++);
+  }
+  compute_encoder.set_input_array(x, c++);
+  compute_encoder.set_output_array(out, c++);
+  compute_encoder.set_bytes(K, c++);
+  compute_encoder.set_bytes(N, c++);
+  compute_encoder.set_bytes(M, c++);
+  add_strides_and_shapes(compute_encoder, !batched, x, w, scales, biases, c);
+
+  compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+}
+
 void qvm_split_k(
     const array& x,
     const array& w,
@@ -1381,6 +1471,13 @@ void dispatch_qmv(
   // It is a qmv with a small inner dimension so route to qmv_quad kernel
   if ((K == 128 || K == 64) && is_power_of_2(bits)) {
     qmv_quad(x, w, scales, biases, out, group_size, bits, M, N, K, d, s, mode);
+    return;
+  }
+
+  // Small batch so route to qmv_wide, which reuses each weight group across the
+  // M vectors.
+  if (M >= 2 && use_qmv_wide(mode, d)) {
+    qmv_wide(x, w, scales, biases, out, group_size, bits, M, N, K, d, s, mode);
     return;
   }
   qmv(x, w, scales, biases, out, group_size, bits, M, N, K, d, s, mode);

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -482,6 +482,83 @@ class TestQuantized(mlx_tests.MLXTestCase):
             self.assertEqual(y_q.shape, y_hat.shape)
             self.assertLess((y_q - y_hat).abs().max(), 1e-3)
 
+    def test_qmv_wide(self):
+        # M in [2, vector_limit) routes to qmv_wide -- except K in {64, 128}
+        # with power-of-2 bits, which stays on qmv_quad. Check both paths
+        # against a dequantize-then-matmul reference, with ragged M (token
+        # tail) and ragged N (output-tile remainder). B > 1 stacks a distinct
+        # weight matrix per slab and exercises the batched variant.
+        key = mx.random.key(0)
+        k1, k2 = mx.random.split(key)
+        # M <= 9 < vector_limit for these shapes (K, N <= 2048), so all stay on
+        # the mat-vec path; 7 and 9 also exercise the token-tail guard.
+        Ms = [2, 3, 4, 5, 6, 7, 9]
+        Ns = [256, 67]  # 67 is a non-multiple of the 4-row output tile
+        Bs = [1, 3]
+
+        # Affine: every bit-width and group size.
+        for group_size, bits, K in product(
+            [32, 64, 128], [2, 3, 4, 5, 6, 8], [128, 512]
+        ):
+            for M, N, B in product(Ms, Ns, Bs):
+                with self.subTest(M=M, N=N, K=K, B=B, group_size=group_size, bits=bits):
+                    x_shape = (M, K) if B == 1 else (B, M, K)
+                    w_shape = (N, K) if B == 1 else (B, N, K)
+                    x = mx.random.normal(shape=x_shape, key=k1)
+                    w = mx.random.normal(shape=w_shape, key=k2)
+                    w_q, scales, biases = mx.quantize(w, group_size, bits)
+                    w_hat = mx.dequantize(w_q, scales, biases, group_size, bits)
+                    y_q = mx.quantized_matmul(
+                        x, w_q, scales, biases, True, group_size, bits
+                    )
+                    y_hat = x @ mx.swapaxes(w_hat, -1, -2)
+                    self.assertEqual(y_q.shape, y_hat.shape)
+                    self.assertLess((y_q - y_hat).abs().max(), 1e-3)
+
+        # FP modes (group_size and bits implied by the mode).
+        for mode, K in product(["mxfp4", "nvfp4", "mxfp8"], [128, 512]):
+            for M, N, B in product(Ms, Ns, Bs):
+                with self.subTest(M=M, N=N, K=K, B=B, mode=mode):
+                    x_shape = (M, K) if B == 1 else (B, M, K)
+                    w_shape = (N, K) if B == 1 else (B, N, K)
+                    x = mx.random.normal(shape=x_shape, key=k1)
+                    w = mx.random.normal(shape=w_shape, key=k2)
+                    w_q, scales = mx.quantize(w, mode=mode)
+                    w_hat = mx.dequantize(w_q, scales, mode=mode)
+                    y_q = mx.quantized_matmul(x, w_q, scales, transpose=True, mode=mode)
+                    y_hat = x @ mx.swapaxes(w_hat, -1, -2)
+                    self.assertEqual(y_q.shape, y_hat.shape)
+                    self.assertLess((y_q - y_hat).abs().max(), 1e-3)
+
+        # Tiny shapes (M, K, N): small K and non-multiple output rows.
+        tiny = [(2, 32, 10), (4, 32, 7), (3, 64, 5), (5, 64, 3)]
+        settings = [(4, 32, "affine"), (6, 32, "affine"), (4, 16, "nvfp4")]
+        for M, K, N in tiny:
+            for bits, group_size, mode in settings:
+                with self.subTest(
+                    M=M, K=K, N=N, bits=bits, group_size=group_size, mode=mode
+                ):
+                    x = mx.random.normal(shape=(M, K), key=k1)
+                    w = mx.random.normal(shape=(N, K), key=k2)
+                    w_q, *sb = mx.quantize(
+                        w, group_size=group_size, bits=bits, mode=mode
+                    )
+                    w_hat = mx.dequantize(
+                        w_q, *sb, group_size=group_size, bits=bits, mode=mode
+                    )
+                    y_q = mx.quantized_matmul(
+                        x,
+                        w_q,
+                        *sb,
+                        transpose=True,
+                        group_size=group_size,
+                        bits=bits,
+                        mode=mode,
+                    )
+                    y_hat = x @ mx.swapaxes(w_hat, -1, -2)
+                    self.assertEqual(y_q.shape, y_hat.shape)
+                    self.assertLess((y_q - y_hat).abs().max(), 1e-3)
+
     def test_qvm(self):
         key = mx.random.key(0)
         k1, k2 = mx.random.split(key)


### PR DESCRIPTION
Speculative decoding (e.g. MTP) verifies a small batch of draft tokens at once, M of 2-8. That batch is too large for `qmv`, which re-reads the whole quantized weight per vector, and too small for `qmm`. `qmv_wide` dequantizes each weight group once and reuses it across the tile, so the weight read amortizes over the batch. The approach is adapted from llama.cpp's `kernel_mul_mv_ext`.

`qmv_wide` is selected for M in `[2, vector_limit)` and covers every quantization mode (affine, nvfp4, mxfp4, mxfp8), dtype, and batched weights. The fp modes use it on all GPU generations; affine is gated to gen-15+, where it overtakes `qmv` (the `qmv` entries below are affine on gen-14 staying on the old path).

### Benchmarks

Speedup over the per-vector `qmv` path (GPU kernel time) on the Gemma-4-12B MLP gate/up matmul `[15360x3840]` with bf16 activations, by M and quant mode. The benefit grows with M as the weight read amortizes:

**M=2**

| GPU | int4 | int8 | nvfp4 | mxfp4 | mxfp8 |
|---|---|---|---|---|---|
| M2 Pro | qmv | qmv | 1.3x | 1.3x | 1.3x |
| M3 Ultra | 1.1x | 1.2x | 1.4x | 1.2x | 1.4x |
| M4 Pro | 1.2x | 1.0x | 1.4x | 1.2x | 1.4x |
| M5 Max | 1.3x | 1.2x | 1.6x | 1.4x | 1.3x |

**M=4**

| GPU | int4 | int8 | nvfp4 | mxfp4 | mxfp8 |
|---|---|---|---|---|---|
| M2 Pro | qmv | qmv | 1.7x | 1.4x | 1.7x |
| M3 Ultra | 1.4x | 1.6x | 1.6x | 1.1x | 1.8x |
| M4 Pro | 1.4x | 1.6x | 1.7x | 1.2x | 2.0x |
| M5 Max | 1.6x | 1.7x | 2.0x | 1.3x | 1.6x |

**M=8**

| GPU | int4 | int8 | nvfp4 | mxfp4 | mxfp8 |
|---|---|---|---|---|---|
| M2 Pro | qmv | qmv | 1.7x | 1.4x | 1.7x |
| M3 Ultra | 1.4x | 1.7x | 1.7x | 1.2x | 2.0x |
| M4 Pro | 1.4x | 1.8x | 1.7x | 1.2x | 2.2x |
| M5 Max | 1.6x | 1.8x | 2.0x | 1.3x | 1.8x |