### PR TITLE
Fix Bilinear weight shape in docstring

### DIFF
--- a/python/mlx/nn/layers/linear.py
+++ b/python/mlx/nn/layers/linear.py
@@ -118,7 +118,7 @@ class Bilinear(Module):
         y_i = x_1^\top W_i x_2 + b_i
 
     where:
-    :math:`W` has shape ``[output_dims, input1_dims, input2_dims]``, :math:`b` has shape ``[output_dims ]``,
+    :math:`W` has shape ``[output_dims, input2_dims, input1_dims]``, :math:`b` has shape ``[output_dims ]``,
     and :math:`i` indexes the output dimension.
 
     The values are initialized from the uniform distribution :math:`\mathcal{U}(-{k}, {k})`,

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -370,6 +370,9 @@ class TestLayers(mlx_tests.MLXTestCase):
         inputs1 = mx.zeros((10, 2))
         inputs2 = mx.zeros((10, 4))
         layer = nn.Bilinear(input1_dims=2, input2_dims=4, output_dims=6)
+        # Weight is stored as [output_dims, input2_dims, input1_dims]; pin it so
+        # the documented shape stays in sync with the implementation.
+        self.assertEqual(layer.weight.shape, (6, 4, 2))
         outputs = layer(inputs1, inputs2)
         self.assertEqual(outputs.shape, (10, 6))
 


### PR DESCRIPTION
### Summary

`nn.Bilinear` stores its weight as `[output_dims, input2_dims, input1_dims]` — both `__call__` and `extra_repr` unpack it as `out, in2, in1 = self.weight.shape`, and the forward computes `W[o, in2, in1]`. The docstring, however, documented `[output_dims, input1_dims, input2_dims]`, swapping the two input dimensions.

This corrects the docstring to the actual stored order and pins the weight shape in `test_bilinear` so the documented order stays in sync with the implementation.

Behavior is unchanged (docs + test only).

### Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective (pins the weight shape)
- [x] I have run `pre-commit`/`black` on my changes
