### PR TITLE
Fix Metal JIT crash for 64-bit ScatterAxis ops (Fixes #3690)

### DIFF
--- a/mlx/backend/metal/indexing.cpp
+++ b/mlx/backend/metal/indexing.cpp
@@ -519,6 +519,12 @@ void GatherAxis::eval_gpu(const std::vector<array>& inputs, array& out) {
 }
 
 void ScatterAxis::eval_gpu(const std::vector<array>& inputs, array& out) {
+  if (size_of(out.dtype()) == 8) {
+    std::ostringstream msg;
+    msg << "[ScatterAxis::eval_gpu] Does not support " << out.dtype();
+    throw std::invalid_argument(msg.str());
+  }
+
   auto& src = inputs[0];
   auto& idx = inputs[1];
   auto& upd = inputs[2];

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -1353,6 +1353,18 @@ class TestOps(mlx_tests.MLXTestCase):
         self.assertEqual(b.size, 0)
         self.assertEqual(b.shape, a.shape)
 
+    def test_put_along_axis_unsupported_type(self):
+        if not mx.metal.is_available():
+            return
+        
+        source = mx.zeros((2, 2))
+        indices = mx.array([[0, 1], [0, 1]])
+        update = mx.array([[1, 2], [3, 4]], dtype=mx.int64)
+        
+        with self.assertRaises(ValueError):
+            out = mx.put_along_axis(source, indices, update, axis=1, stream=mx.gpu)
+            mx.eval(out)
+
     def test_split(self):
         a = mx.array([1, 2, 3])
         splits = mx.split(a, 3)


### PR DESCRIPTION
### Summary
This PR fixes issue #3690, where 64-bit dtypes (`int64`, `uint64`) passed into `put_along_axis` or `scatter_add_axis` would completely bypass validation and violently crash the Metal JIT compiler.

### What changed
* **Added Missing Guard:** Discovered that `ScatterAxis::eval_gpu` was missing the 8-byte dtype guard that was already present in standard `Scatter::eval_gpu`.
* **Safe Error Handling:** If `out.dtype()` is 8 bytes, it now cleanly throws a `std::invalid_argument` error before sending anything to the Metal compiler.
* **Regression Testing:** Added `test_put_along_axis_unsupported_type` in `test_ops.py` to ensure it successfully raises a `ValueError` for `int64` payloads under Metal without crashing the framework.

Let me know if there's anything else you'd like me to tweak..!
