### PR TITLE
Add mx.while_loop (scan like)

### DIFF
--- a/benchmarks/python/while_loop_bench.py
+++ b/benchmarks/python/while_loop_bench.py
@@ -1,0 +1,109 @@
+# Copyright © 2026 Apple Inc.
+"""Benchmark: chunked mx.while_loop vs naive per-iter-sync Python loop.
+
+Reproduces the per-iteration GPU-sync pathology of
+https://github.com/tillahoffmann/jax-mps/issues/83 and shows the chunked
+amortization. Prints results; does NOT assert a speedup.
+"""
+
+import math
+import time
+
+import mlx.core as mx
+
+
+def naive_while(cond, body, init, max_iterations):
+    """Python while loop that syncs every iteration (the pathology)."""
+    carry = init
+    n = 0
+    while bool(mx.all(cond(carry))):
+        carry = body(carry)
+        mx.eval(carry)  # per-iteration host sync
+        n += 1
+        if n >= max_iterations:
+            break
+    return carry
+
+
+def time_it(fn, *args, warmup=2, iters=5, **kwargs):
+    """Return median ms per call (syncs included)."""
+    for _ in range(warmup):
+        mx.eval(fn(*args, **kwargs))
+    times = []
+    for _ in range(iters):
+        t0 = time.perf_counter()
+        mx.eval(fn(*args, **kwargs))
+        t1 = time.perf_counter()
+        times.append((t1 - t0) * 1000)
+    times.sort()
+    return times[len(times) // 2]
+
+
+def main():
+    print(f"MLX version: {mx.__version__}  Metal: {mx.metal.is_available()}")
+
+    def make_cond(n):
+        # Capture n by value (default arg) to avoid late-binding surprises if
+        # n is reassigned later in this function.
+        def cond(c, _n=n):
+            return c < _n
+
+        return cond
+
+    def body(c):
+        return c + 1
+
+    # Warm up compile caches.
+    mx.while_loop(
+        make_cond(1000), body, mx.array(0), max_iterations=2000, chunk_size=64
+    )
+    naive_while(make_cond(100), body, mx.array(0), 100)
+
+    # Naive is O(N) syncs; only measure at N=1000 (the pathology reproducer).
+    print("\n=== Naive (per-iter sync) vs chunked (chunk_size=64), N=1000 ===")
+    N = 1000
+    cond = make_cond(N)
+    init = mx.array(0)
+    t_naive = time_it(naive_while, cond, body, init, N)
+    t_chunk = time_it(
+        lambda init, cap, cs: mx.while_loop(
+            cond, body, init, max_iterations=cap, chunk_size=cs
+        ),
+        init,
+        N * 2,
+        64,
+    )
+    print(
+        f"  N={N}: naive={t_naive:8.1f}ms  chunked={t_chunk:7.1f}ms  "
+        f"speedup={t_naive / t_chunk:5.1f}x  syncs_chunked~={math.ceil(N / 64)}"
+    )
+
+    print("\n=== chunked only at N=10000 (naive too slow to time) ===")
+    N = 10000
+    cond = make_cond(N)
+    init = mx.array(0)
+    t_chunk10 = time_it(
+        lambda init, cap, cs: mx.while_loop(
+            cond, body, init, max_iterations=cap, chunk_size=cs
+        ),
+        init,
+        N * 2,
+        64,
+    )
+    print(f"  N={N} chunked(cs=64): {t_chunk10:7.1f}ms  syncs~={math.ceil(N / 64)}")
+
+    print("\n=== chunk_size sweep at N=10000 (skipping cs<4, too slow) ===")
+    for cs in [4, 8, 16, 32, 64, 128, 256, 512, 1024, 4096]:
+        t = time_it(
+            lambda init, cap, cs: mx.while_loop(
+                cond, body, init, max_iterations=cap, chunk_size=cs
+            ),
+            init,
+            N * 2,
+            cs,
+        )
+        print(f"  chunk_size={cs:4d}: {t:7.1f}ms  syncs~={math.ceil(N / cs)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/mlx/__init__.py
+++ b/python/mlx/__init__.py
@@ -1,0 +1,32 @@
+# Copyright © 2026 Apple Inc.
+"""MLX: A framework for machine learning on Apple silicon.
+
+This module makes ``mlx`` a regular package (previously a namespace
+package) so that pure-Python transforms can be registered onto the
+``mlx.core`` C extension *after* it has been fully initialized.
+
+Registering a pure-Python attribute on ``mlx.core`` from inside the
+C extension's ``NB_MODULE`` (e.g. via ``_reprlib_fix``) is unsafe because
+that hook runs before ``mlx.core`` is in ``sys.modules``, so an
+``import mlx.core`` from there re-enters ``NB_MODULE`` and fatally
+double-registers nanobind enumerations. Importing ``mlx.core`` from here
+instead guarantees the C extension is fully built before we patch it.
+"""
+
+# Import the C extension FIRST so it is fully initialized and in
+# ``sys.modules`` before ``_while_loop`` is imported (``_while_loop`` does
+# ``import mlx.core`` at module top and relies on finding it already loaded).
+# When a user does ``import mlx.core as mx``, Python imports the parent package
+# ``mlx`` (running this file), which loads and fully initializes ``mlx.core``;
+# the subsequent ``import mlx.core`` then finds it already in ``sys.modules``.
+# `isort: off` preserves this required order (isort would otherwise sort
+# ``_while_loop`` ahead of ``core`` alphabetically).
+# isort: off
+from . import core as _core  # noqa: F401  (ensures C extension is loaded)
+from . import _while_loop as _wl  # noqa: F401
+
+# isort: on
+
+_core.while_loop = _wl.while_loop
+
+del _core, _wl

--- a/python/mlx/_stub_patterns.txt
+++ b/python/mlx/_stub_patterns.txt
@@ -16,6 +16,27 @@ mlx.core.__suffix__:
   scalar: TypeAlias = Union[int, float, bool]
   list_or_scalar: TypeAlias = Union[scalar, list["list_or_scalar"]]
   bool_: Dtype = ...
+  def while_loop(
+      cond_fun: Callable[[Any], Union[bool, array]],
+      body_fun: Callable[[Any], Any],
+      init_val: Any,
+      *,
+      max_iterations: Optional[int] = None,
+      chunk_size: int = 16,
+  ) -> Any:
+      """Run a while loop with chunked speculative execution.
+
+      Repeatedly applies ``body_fun`` while ``cond_fun`` is true, amortizing
+      the per-iteration host-GPU sync: a compiled chunk applies up to
+      ``chunk_size`` body iterations lazily (with a running mask so iterations
+      past termination are no-ops) before a *single* host sync.
+
+      Not differentiable and not traceable inside ``mx.grad``/``mx.compile``/
+      ``mx.vmap`` (raises). ``body_fun`` is evaluated eagerly on every
+      speculative iteration (keep it pure and total). All carry leaves must be
+      ``mx.array``.
+      """
+      ...
 
 mlx.core.distributed.__prefix__:
   from mlx.core import array, Dtype, Device, Stream, scalar

--- a/python/mlx/_while_loop.py
+++ b/python/mlx/_while_loop.py
@@ -1,0 +1,411 @@
+# Copyright © 2026 Apple Inc.
+#
+# Pure-Python chunked-speculative ``while_loop`` for :mod:`mlx.core`.
+#
+# This module implements ``mx.while_loop`` without any C++ control-flow
+# primitive. The loop condition is evaluated on the host, but a compiled
+# "chunk" applies up to ``chunk_size`` body iterations lazily (with a running
+# mask so post-termination iterations are no-ops) before a *single* host sync.
+# Host syncs therefore drop from O(N) to O(N/chunk_size), which is the root
+# cause of the per-iteration GPU-sync pathology reported in
+# https://github.com/tillahoffmann/jax-mps/issues/83 .
+#
+# Registration: ``mlx.core.while_loop`` is set by ``mlx/__init__.py`` *after*
+# the C extension is fully loaded (see the comment there for why we cannot
+# register from ``_reprlib_fix``).
+
+from __future__ import annotations
+
+import numbers
+from typing import Any, Callable, Optional, Tuple
+
+import mlx.core as mx
+import numpy as np
+from mlx.utils import tree_flatten, tree_map
+
+__all__ = ["while_loop"]
+
+
+# --- tunables / constants -----------------------------------------------------
+
+_DEFAULT_CHUNK_SIZE = 16
+_MAX_CHUNK_SIZE = 4096  # @mx.compile unrolls the chunk; >4096 can exceed Metal
+# resource limits. Verified safe at 4096 across body depths.
+_HUGE = 2**62  # "unbounded" sentinel for max_iterations=None; fits int64.
+_INT64_MAX = 2**63 - 1
+
+
+# --- helpers ------------------------------------------------------------------
+
+
+def _to_bool_array(x: Any) -> mx.array:
+    """Coerce a cond_fun return value to an ``mx.array``.
+
+    Python/NumPy scalar bools are wrapped as 1-element arrays so that
+    ``mx.all`` reduces them to a 0-d bool (``mx.array(True)`` used directly
+    inside ``@mx.compile`` can trigger a backend dedup bug when returned).
+    """
+    if isinstance(x, mx.array):
+        return x
+    if isinstance(x, (bool, np.bool_)):
+        return mx.array([bool(x)])
+    return mx.array(x)
+
+
+def _cond(carry: Any, cond_fun: Callable[[Any], Any]) -> mx.array:
+    """Evaluate the condition on a carry, reducing to a 0-d bool array."""
+    return mx.all(_to_bool_array(cond_fun(carry)))
+
+
+def _flatten_leaves(tree: Any) -> list:
+    return [v for _, v in tree_flatten(tree)]
+
+
+def _walk(tree: Any):
+    """Return a hashable structural signature capturing container types,
+    dict keys (order-independent), nesting, and per-leaf (shape, dtype).
+
+    Used to validate that ``body_fun`` preserves the carry's structure, shape,
+    and dtype. ``tree_flatten``'s dotted keys collide across different
+    structures (e.g. ``{'a': {'b': x}}`` vs ``{'a.b': x}``), so we walk the tree
+    ourselves.
+    """
+    if isinstance(tree, mx.array):
+        return ("__leaf__", tuple(int(d) for d in tree.shape), str(tree.dtype))
+    if isinstance(tree, dict):
+        # frozenset of (key, child-signature) -> order-independent.
+        items = frozenset((k, _walk(v)) for k, v in tree.items())
+        return ("__dict__", items)
+    if isinstance(tree, (list, tuple)):
+        return (type(tree).__name__, tuple(_walk(v) for v in tree))
+    raise ValueError(
+        f"mx.while_loop: unsupported carry node type {type(tree).__name__!r}; "
+        "carry may only contain mx.array leaves in dict/list/tuple containers."
+    )
+
+
+def _is_tracer(arr: Any) -> bool:
+    """True if ``arr`` is a tracer inside a transform (grad/compile/vmap).
+
+    ``mx.array.is_tracer`` is exposed via a one-line C++ binding in
+    ``python/src/array.cpp`` (``mx::array::is_tracer()`` returns
+    ``is_tracer_flag && in_tracing() || retain_graph()``). Returns False on
+    builds where it is not yet bound (older MLX); in that case the try/except
+    around ``mx.eval`` and the uncompiled-output check still provide best-effort
+    detection.
+    """
+    is_t = getattr(arr, "is_tracer", None)
+    if is_t is None:
+        return False
+    return bool(is_t())
+
+
+# --- pre-flight validation ----------------------------------------------------
+
+
+def _preflight(
+    cond_fun: Callable,
+    body_fun: Callable,
+    init_val: Any,
+    chunk_size: Any,
+    max_iterations: Any,
+) -> Tuple[int, Optional[int]]:
+    """Validate inputs and detect transform context. Raises ValueError /
+    RuntimeError early with clear messages.
+
+    Returns ``(chunk_size_int, max_iterations_int_or_None)``.
+    """
+    # chunk_size
+    if isinstance(chunk_size, bool) or not isinstance(chunk_size, numbers.Integral):
+        raise ValueError(
+            f"mx.while_loop: chunk_size must be an integer, got "
+            f"{type(chunk_size).__name__}"
+        )
+    chunk_size = int(chunk_size)
+    if not (1 <= chunk_size <= _MAX_CHUNK_SIZE):
+        raise ValueError(
+            f"mx.while_loop: chunk_size must be in [1, {_MAX_CHUNK_SIZE}], "
+            f"got {chunk_size}"
+        )
+
+    # max_iterations
+    if max_iterations is not None:
+        if isinstance(max_iterations, bool) or not isinstance(
+            max_iterations, numbers.Integral
+        ):
+            raise ValueError(
+                f"mx.while_loop: max_iterations must be an integer or None, "
+                f"got {type(max_iterations).__name__}"
+            )
+        max_iterations = int(max_iterations)
+        if not (0 <= max_iterations <= _INT64_MAX):
+            raise ValueError(
+                f"mx.while_loop: max_iterations must be in [0, {_INT64_MAX}], "
+                f"got {max_iterations}"
+            )
+
+    # init_val: >=1 leaf, all mx.array
+    init_leaves = _flatten_leaves(init_val)
+    if not init_leaves:
+        raise ValueError(
+            "mx.while_loop: init_val must contain at least one mx.array leaf"
+        )
+    for leaf in init_leaves:
+        if not isinstance(leaf, mx.array):
+            raise ValueError(
+                f"mx.while_loop: all carry leaves must be mx.array, got "
+                f"{type(leaf).__name__}. Wrap Python scalars in mx.array."
+            )
+
+    # Transform guard (layer 1): direct-tracer init (e.g. mx.vmap(while_loop)
+    # or mx.grad with a traced init).
+    if any(_is_tracer(leaf) for leaf in init_leaves):
+        raise RuntimeError(
+            "mx.while_loop is not differentiable and cannot be traced inside "
+            "mx.grad/mx.compile/mx.vmap (init_val contains a tracer)."
+        )
+
+    return chunk_size, max_iterations
+
+
+def _validate_body_structure(init_val: Any, body_out: Any) -> None:
+    """Validate body_fun output: all mx.array leaves, no tracers (closure-over-
+    tracer detection), and matching pytree structure / shapes / dtypes.
+
+    The body-output tracer check is the KEY grad guard: @mx.compile bakes
+    closure-captured tracers as constants (severing the tracer chain), so the
+    compiled chunk output is NOT a tracer even inside mx.grad. But the
+    *uncompiled* body_fun(init_val) output IS a tracer if body_fun closes over a
+    traced parameter. Checking here catches the constant-init + closure-over-
+    tracer grad case that would otherwise silently produce wrong gradients.
+    """
+    body_out_leaves = _flatten_leaves(body_out)
+    for leaf in body_out_leaves:
+        if not isinstance(leaf, mx.array):
+            raise ValueError(
+                f"mx.while_loop: body_fun must return mx.array leaves, got "
+                f"{type(leaf).__name__}"
+            )
+    if any(_is_tracer(leaf) for leaf in body_out_leaves):
+        raise RuntimeError(
+            "mx.while_loop is not differentiable and cannot be traced inside "
+            "mx.grad/mx.compile/mx.vmap (body_fun output is a tracer, likely "
+            "because body_fun closes over a traced array)."
+        )
+
+    init_sig = _walk(init_val)
+    body_sig = _walk(body_out)
+    if init_sig != body_sig:
+        raise ValueError(
+            "mx.while_loop: body_fun must return the same pytree structure, "
+            "shapes, and dtypes as init_val. "
+            f"init signature: {init_sig!r}; body signature: {body_sig!r}."
+        )
+
+
+# --- compiled-chunk builder ---------------------------------------------------
+#
+# A fresh ``@mx.compile``d chunk is built for each ``while_loop`` call (NOT
+# cached across calls). This is *required for correctness*: ``@mx.compile``
+# bakes closure-captured Python values (e.g. a threshold closed over by
+# ``cond_fun``) as constants at trace time. A cross-call cache keyed only by
+# function identity would reuse a stale chunk when the user mutates a closed-
+# over variable, causing the in-chunk condition (baked, old) to disagree with
+# the driver's ``cond_final`` (current), which can hang the loop. Building per
+# call is safe; ``mx.compile``'s own cache still amortizes compilation across
+# the many chunks *within* a single call (same function object).
+
+
+def _build_chunk(cond_fun: Callable, body_fun: Callable, chunk_size: int):
+    """Return a fresh ``@mx.compile``d chunk for this call's cond/body/chunk."""
+
+    @mx.compile
+    def _chunk(carry, remaining):
+        for _ in range(chunk_size):
+            c = _cond(carry, cond_fun)
+            do = c & (remaining > 0)
+            new = body_fun(carry)
+            carry = tree_map(lambda n, o: mx.where(do, n, o), new, carry)
+            remaining = mx.where(do, remaining - 1, remaining)
+        return carry, remaining
+
+    return _chunk
+
+
+# --- public API ---------------------------------------------------------------
+
+
+def while_loop(
+    cond_fun: Callable[[Any], Any],
+    body_fun: Callable[[Any], Any],
+    init_val: Any,
+    *,
+    max_iterations: Optional[int] = None,
+    chunk_size: int = _DEFAULT_CHUNK_SIZE,
+) -> Any:
+    """Run a while loop with chunked speculative execution.
+
+    Repeatedly applies ``body_fun`` while ``cond_fun`` is true, with the
+    semantics::
+
+        carry = init_val
+        while bool(mx.all(cond_fun(carry))):
+            carry = body_fun(carry)
+        return carry
+
+    Unlike a naive Python loop, this function amortizes the per-iteration
+    host-GPU synchronization: a compiled "chunk" applies up to ``chunk_size``
+    body iterations lazily (with a running mask so iterations past termination
+    are no-ops) before a *single* host sync to read the condition. Syncs
+    therefore drop from O(N) to O(N / chunk_size), addressing the
+    per-iteration GPU-sync pathology of while loops on accelerators.
+
+    Args:
+        cond_fun (Callable): Takes the carry pytree and returns a boolean
+            :class:`array` (or a value coercible to one; reduced to a scalar
+            with :func:`mx.all`).
+        body_fun (Callable): Takes the carry pytree and returns a new carry
+            with the **same** pytree structure, per-leaf shape, and per-leaf
+            dtype.
+        init_val (Any): The initial carry pytree. **Every leaf must be an
+            :class:`mx.array`.**
+        max_iterations (int, optional): Hard cap on the number of body
+            applications. If the loop has not terminated (``cond_fun`` still
+            true) when the cap is reached, ``RuntimeError`` is raised. ``None``
+            (default) means unbounded; a non-terminating loop will hang.
+        chunk_size (int): Number of speculative body applications per compiled
+            chunk (default ``16``). Larger values reduce sync count but
+            increase per-chunk memory (O(chunk_size * carry_size) intermediate
+            buffers) and one-time compile cost. Must be in ``[1, 4096]``.
+
+    Returns:
+        Any: The first carry for which ``bool(mx.all(cond_fun(carry)))`` is
+        ``False``.
+
+    Raises:
+        RuntimeError: if called inside :func:`mx.grad`, :func:`mx.compile`, or
+            :func:`mx.vmap` (``while_loop`` is not differentiable and cannot be
+            traced because it requires a host sync); or if ``max_iterations``
+            is exceeded without termination.
+        ValueError: on invalid arguments or a body that changes the carry's
+            structure / shape / dtype.
+
+    .. warning::
+
+        **Not differentiable.** ``mx.while_loop`` cannot be used inside
+        ``mx.grad`` (gradients are undefined for a data-dependent trip count).
+        It will raise rather than silently produce wrong gradients.
+
+    .. warning::
+
+        **Not traceable into ``mx.compile``.** Because the driver must read
+        the condition on the host, ``while_loop`` cannot be compiled into an
+        outer fused graph. Calling it inside ``@mx.compile`` raises.
+
+    .. warning::
+
+        **``body_fun`` is evaluated eagerly and speculatively.** ``mx.where``
+        computes both branches, so ``body_fun(carry)`` runs ``chunk_size`` times
+        during the first chunk's compilation trace (subsequent chunks reuse the
+        cached graph and do not re-evaluate body), plus once during structure
+        validation. Keep ``body_fun`` **pure and total**: no side effects; must
+        not error on a "stopped" carry; NaN produced on an *active* carry will
+        contaminate the result (NaN on a *stopped* carry is masked away). Use
+        ``mx.where`` inside ``body_fun`` to guard risky operations.
+
+    .. warning::
+
+        **``body_fun``/``cond_fun`` must not mutate closure-captured Python
+        state that the other reads.** The compiled chunk bakes closure-captured
+        Python values (e.g. a threshold closed over by ``cond_fun``) as
+        constants at trace time. If ``body_fun`` mutates such a value mid-loop,
+        the in-chunk condition (baked, stale) will disagree with the driver's
+        re-evaluated condition, which can hang the loop. Note that
+        ``max_iterations`` will **not** bound such a hang: ``remaining`` only
+        decrements on masked-active iterations, so a stalled chunk never
+        reaches the cap. Pass all loop-dependent values through the carry, not
+        through closure mutation.
+
+    .. note::
+
+        **Threading:** MLX streams are thread-local. Worker threads using
+        ``while_loop`` must call ``mx.set_default_device(mx.default_device())``
+        before doing so (a general MLX requirement, not specific to
+        ``while_loop``).
+    """
+    chunk_size, max_iterations = _preflight(
+        cond_fun, body_fun, init_val, chunk_size, max_iterations
+    )
+
+    # Check cond(init) BEFORE calling body_fun, so that a loop whose condition
+    # is false at entry is a true zero-iteration no-op (body never called --
+    # matching JAX semantics). This requires one host sync; it is safe because
+    # _is_tracer(cond_init) below catches closure-over-tracer (grad) before the
+    # sync (a tracer sync would corrupt the grad trace).
+    cond_init = _cond(init_val, cond_fun)  # mx.all-reduced to a 0-d bool
+    if _is_tracer(cond_init):
+        raise RuntimeError(
+            "mx.while_loop is not differentiable and cannot be traced inside "
+            "mx.grad/mx.compile/mx.vmap (cond_fun output is a tracer, likely "
+            "because cond_fun closes over a traced array)."
+        )
+    mx.eval(cond_init)
+    if not bool(cond_init):
+        return init_val  # cond false at init -> zero-iteration no-op
+    if max_iterations == 0:
+        # cond is true at init but budget is already zero -> must raise, no
+        # need to validate body or build a chunk.
+        raise RuntimeError("mx.while_loop: max_iterations exceeded without termination")
+
+    # cond(init) is true -> validate body structure / closure-tracer, then run.
+    _validate_body_structure(init_val, body_fun(init_val))
+
+    _chunk = _build_chunk(cond_fun, body_fun, chunk_size)
+
+    carry = init_val
+    remaining = mx.array(
+        _HUGE if max_iterations is None else max_iterations, dtype=mx.int64
+    )
+
+    while True:
+        try:
+            carry, remaining = _chunk(carry, remaining)
+        except (ValueError, RuntimeError) as e:
+            msg = str(e)
+            if "function transformations" in msg or "Not allowed inside" in msg:
+                raise RuntimeError(
+                    "mx.while_loop: cond_fun/body_fun must not call mx.eval or "
+                    "read array values internally (the body runs inside "
+                    "@mx.compile). Use mx.where to guard risky operations."
+                ) from e
+            raise
+        # cond_final is computed OUTSIDE @mx.compile so that (a) returning it
+        # does not trigger the backend dedup bug for constant conds, and
+        # (b) it remains a tracer-detectable value for the host-sync guard.
+        cond_final = _cond(carry, cond_fun)
+
+        # Transform guard (layer 2, defense-in-depth): catches any tracer that
+        # survived the chunk (e.g. direct-tracer carry that wasn't masked).
+        if _is_tracer(cond_final):
+            raise RuntimeError(
+                "mx.while_loop is not differentiable and cannot be traced "
+                "inside mx.grad/mx.compile/mx.vmap."
+            )
+
+        try:
+            mx.eval(cond_final, remaining)  # ONE host sync per chunk
+        except (ValueError, RuntimeError) as e:
+            msg = str(e)
+            if "function transformations" in msg or "Not allowed inside" in msg:
+                raise RuntimeError(
+                    "mx.while_loop cannot be used inside mx.compile/mx.vmap "
+                    "(it requires a host sync to read the condition)."
+                ) from e
+            raise
+
+        if not bool(cond_final):
+            return carry
+        if int(remaining) <= 0:
+            raise RuntimeError(
+                "mx.while_loop: max_iterations exceeded without termination"
+            )

--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -801,6 +801,11 @@ void init_array(nb::module_& m) {
       .def("__neg__", [](const mx::array& a) { return -a; })
       .def("__bool__", [](mx::array& a) { return nb::bool_(to_scalar(a)); })
       .def(
+          "is_tracer",
+          &mx::array::is_tracer,
+          "True if this array is a tracer being traced inside a function "
+          "transformation such as grad, compile, or vmap.")
+      .def(
           "__repr__",
           [](mx::array& a) {
             nb::gil_scoped_release nogil;

--- a/python/tests/test_while_loop.py
+++ b/python/tests/test_while_loop.py
@@ -1,0 +1,743 @@
+# Copyright © 2026 Apple Inc.
+"""Tests for the pure-Python chunked ``mx.while_loop``."""
+
+import math
+import os
+import threading
+import unittest
+
+import mlx.core as mx
+import mlx_tests
+import numpy as np
+from mlx._while_loop import _DEFAULT_CHUNK_SIZE, _MAX_CHUNK_SIZE, _to_bool_array
+
+
+def _reference_loop(cond_fun, body_fun, init_val, max_iterations=None):
+    """Ground-truth Python while loop mirroring while_loop semantics, including
+    cond coercion (Python/numpy bools are wrapped like _to_bool_array)."""
+    carry = init_val
+    n = 0
+    while bool(mx.all(_to_bool_array(cond_fun(carry)))):
+        if max_iterations is not None and n >= max_iterations:
+            raise RuntimeError("max_iterations exceeded")
+        carry = body_fun(carry)
+        n += 1
+    return carry
+
+
+class TestWhileLoop(mlx_tests.MLXTestCase):
+    def setUp(self):
+        super().setUp()
+        mx.clear_cache()
+        mx.reset_peak_memory()
+
+    def tearDown(self):
+        super().tearDown()
+
+    # ---- T1-T4: correctness vs reference (scalar + pytree) ----
+
+    def test_counter_scalar(self):
+        for chunk_size in [1, 2, 8, 64]:
+            with self.subTest(chunk_size=chunk_size):
+                cond = lambda c: c < 100
+                body = lambda c: c + 1
+                out = mx.while_loop(cond, body, mx.array(0), chunk_size=chunk_size)
+                ref = _reference_loop(cond, body, mx.array(0))
+                self.assertEqualArray(out, ref)
+
+    def test_factorial_tuple_carry(self):
+        for chunk_size in [1, 4, 16]:
+            with self.subTest(chunk_size=chunk_size):
+                cond = lambda c: c[1] < 6
+                body = lambda c: (c[0] * (c[1] + 1), c[1] + 1)
+                init = (mx.array(1), mx.array(0))
+                out = mx.while_loop(cond, body, init, chunk_size=chunk_size)
+                ref = _reference_loop(cond, body, init)
+                self.assertEqualArray(out[0], ref[0])
+                self.assertEqualArray(out[1], ref[1])
+
+    def test_sum_until_list_carry(self):
+        cond = lambda c: c[0] < 50
+        body = lambda c: [c[0] + c[1], c[1] - 1]
+        init = [mx.array(0), mx.array(10)]
+        out = mx.while_loop(cond, body, init, chunk_size=8)
+        ref = _reference_loop(cond, body, init)
+        self.assertEqualArray(out[0], ref[0])
+
+    def test_geometric_dict_carry(self):
+        for chunk_size in [1, 4, 16, 64]:
+            with self.subTest(chunk_size=chunk_size):
+                cond = lambda c: c["i"] < 10
+                body = lambda c: {"i": c["i"] + 1, "v": c["v"] * 2}
+                init = {"i": mx.array(0), "v": mx.array(1.0)}
+                out = mx.while_loop(cond, body, init, chunk_size=chunk_size)
+                ref = _reference_loop(cond, body, init)
+                self.assertEqualArray(out["v"], ref["v"])
+
+    # ---- T5: cond false at init ----
+
+    def test_cond_false_at_init(self):
+        cond = lambda c: mx.array(False)
+        body = lambda c: c + 1
+        init = mx.array(42)
+        out = mx.while_loop(cond, body, init, chunk_size=8)
+        self.assertEqualArray(out, init)  # unchanged
+
+    def test_body_not_called_when_cond_false_at_init(self):
+        # JAX semantics: body is never called when cond is false at entry.
+        calls = [0]
+
+        def body(c):
+            calls[0] += 1
+            return c + 1
+
+        out = mx.while_loop(
+            lambda c: mx.array(False),
+            body,
+            mx.array(0),
+            chunk_size=8,
+            max_iterations=20,
+        )
+        self.assertEqual(int(out.item()), 0)
+        self.assertEqual(calls[0], 0)  # body NOT called (zero-iteration no-op)
+
+    def test_vectorized_carry(self):
+        # Multi-element carry leaf with element-wise cond (reduced by mx.all).
+        init = mx.array([0, 0, 0])
+        cond = (
+            lambda c: c < 5
+        )  # element-wise; mx.all reduces -> all lanes advance together
+        body = lambda c: c + 1
+        for chunk_size in [1, 2, 4, 8]:
+            with self.subTest(chunk_size=chunk_size):
+                out = mx.while_loop(
+                    cond, body, init, max_iterations=20, chunk_size=chunk_size
+                )
+                ref = _reference_loop(cond, body, init)
+                self.assertEqualArray(out, ref)
+
+    def test_nested_pytree_carry(self):
+        # Nested dict/list/tuple carry exercises _walk recursion.
+        init = {"outer": {"a": mx.array(0)}, "list": [mx.array(1.0), (mx.array(2),)]}
+        cond = lambda c: c["outer"]["a"] < 5
+        body = lambda c: {
+            "outer": {"a": c["outer"]["a"] + 1},
+            "list": [c["list"][0] * 2, (c["list"][1][0] + 1,)],
+        }
+        for chunk_size in [1, 4, 16]:
+            with self.subTest(chunk_size=chunk_size):
+                out = mx.while_loop(
+                    cond, body, init, max_iterations=20, chunk_size=chunk_size
+                )
+                ref = _reference_loop(cond, body, init)
+                self.assertEqualArray(out["outer"]["a"], ref["outer"]["a"])
+                self.assertEqualArray(out["list"][0], ref["list"][0])
+
+    # ---- T6: max_iterations cap ----
+
+    def test_cap_raises_when_cond_always_true(self):
+        for chunk_size in [1, 2, 5, 10]:
+            with self.subTest(chunk_size=chunk_size):
+                with self.assertRaisesRegex(RuntimeError, "max_iterations"):
+                    mx.while_loop(
+                        lambda c: mx.array(True),
+                        lambda c: c + 1,
+                        mx.array(0),
+                        max_iterations=10,
+                        chunk_size=chunk_size,
+                    )
+
+    def test_trip_equals_max_no_raise(self):
+        # trip-count == max_iterations (multiple of chunk_size) -> RETURNS, not raise
+        for chunk_size, n in [(1, 10), (2, 10), (5, 10), (10, 10), (8, 16)]:
+            with self.subTest(chunk_size=chunk_size, n=n):
+                out = mx.while_loop(
+                    lambda c: c < n,
+                    lambda c: c + 1,
+                    mx.array(0),
+                    max_iterations=n,
+                    chunk_size=chunk_size,
+                )
+                self.assertEqual(int(out.item()), n)
+
+    # ---- T7: NaN safety ----
+
+    def test_nan_safety(self):
+        # Stopped-lane NaN is masked away by the loop-level where.
+        with self.subTest("stopped_lane_nan_masked"):
+
+            def cond(c):
+                return c < 3
+
+            def body(c):
+                # Active lane gets +1; stopped lane "would" get NaN but is masked.
+                return mx.where(c < 3, c + 1.0, mx.array(float("nan")))
+
+            out = mx.while_loop(
+                cond, body, mx.array(0.0), max_iterations=10, chunk_size=4
+            )
+            self.assertFalse(math.isnan(out.item()))
+            self.assertEqual(out.item(), 3.0)
+
+        # Active-lane NaN DOES contaminate (documented limitation).
+        with self.subTest("active_lane_nan_contaminates"):
+
+            def cond2(c):
+                return c < 5
+
+            def body2(c):
+                # Produces NaN on active lane (c == 3 -> sqrt(3-3)=0 ok; but force NaN)
+                return mx.where(c == 3, mx.array(float("nan")), c + 1.0)
+
+            out = mx.while_loop(
+                cond2, body2, mx.array(0.0), max_iterations=20, chunk_size=4
+            )
+            self.assertTrue(math.isnan(out.item()))
+
+    # ---- T8: perf (sync count, not wall-time ratio) ----
+
+    @unittest.skipIf(
+        os.getenv("MLX_SKIP_PERF_TESTS") or not mx.metal.is_available(),
+        "perf test skipped on CPU or when MLX_SKIP_PERF_TESTS set",
+    )
+    def test_sync_count_amortized(self):
+        # The driver does exactly one mx.eval per chunk. Monkeypatch mx.eval to
+        # count. bool()/item() do NOT call mx.eval (they use to_scalar on
+        # already-evaluated arrays), so this counts driver syncs.
+        N, chunk_size = 200, 16
+        orig_eval = mx.eval
+        count = [0]
+
+        def counting_eval(*args):
+            count[0] += 1
+            return orig_eval(*args)
+
+        mx.eval = counting_eval
+        try:
+            out = mx.while_loop(
+                lambda c: c < N,
+                lambda c: c + 1,
+                mx.array(0),
+                max_iterations=N * 2,
+                chunk_size=chunk_size,
+            )
+            mx.eval(out)
+        finally:
+            mx.eval = orig_eval
+        # +1 for the final explicit mx.eval(out); +1 slack for the initial
+        # cond(init) check. Asserts the amortization O(N/chunk_size), not a
+        # wall-time ratio. Assumes bool()/item() don't call mx.eval (true on
+        # this build; see impl driver).
+        self.assertLessEqual(count[0], math.ceil(N / chunk_size) + 2)
+
+    # ---- T9: chunk_size=1 ----
+
+    def test_chunk_size_1(self):
+        out = mx.while_loop(lambda c: c < 7, lambda c: c + 1, mx.array(0), chunk_size=1)
+        self.assertEqual(int(out.item()), 7)
+
+    # ---- T10: idempotency past termination ----
+
+    def test_idempotency_past_termination(self):
+        # Behavior: result is correct (carry where cond is false).
+        out = mx.while_loop(
+            lambda c: c < 3,
+            lambda c: c + 1,
+            mx.array(0),
+            chunk_size=8,
+            max_iterations=20,
+        )
+        self.assertEqual(int(out.item()), 3)
+
+    def test_speculative_body_calls_are_eager(self):
+        # White-box contract: body is evaluated eagerly (chunk_size times during
+        # the first chunk's compile trace + 1 structure-validation call) even
+        # past termination; output is masked by mx.where. Bodies must be pure.
+        calls = [0]
+
+        def body(c):
+            calls[0] += 1
+            return c + 1
+
+        out = mx.while_loop(
+            lambda c: c < 3, body, mx.array(0), chunk_size=8, max_iterations=20
+        )
+        self.assertEqual(int(out.item()), 3)
+        # 1 (validation) + chunk_size (first-chunk trace) calls minimum.
+        self.assertGreaterEqual(calls[0], 8)
+
+    # ---- T11: structure/shape/dtype validation ----
+
+    def test_structure_mismatch_extra_key(self):
+        with self.assertRaisesRegex(ValueError, "structure"):
+            mx.while_loop(
+                lambda c: c["i"] < 3,
+                lambda c: {"i": c["i"] + 1, "extra": mx.array(0)},
+                {"i": mx.array(0)},
+                max_iterations=10,
+            )
+
+    def test_structure_mismatch_missing_key(self):
+        with self.assertRaisesRegex(ValueError, "structure"):
+            mx.while_loop(
+                lambda c: c["i"] < 3,
+                lambda c: {},
+                {"i": mx.array(0)},
+                max_iterations=10,
+            )
+
+    def test_structure_mismatch_shape(self):
+        with self.assertRaisesRegex(ValueError, "structure"):
+            mx.while_loop(
+                lambda c: c[0] < 3,
+                lambda c: [mx.zeros((5,))],  # init is (1,)
+                [mx.array(0)],
+                max_iterations=10,
+            )
+
+    def test_structure_mismatch_dtype(self):
+        with self.assertRaisesRegex(ValueError, "structure"):
+            mx.while_loop(
+                lambda c: c < 3,
+                lambda c: c.astype(mx.float32),  # init int32 -> body float32
+                mx.array(0),
+                max_iterations=10,
+            )
+
+    def test_structure_tuple_vs_list(self):
+        with self.assertRaisesRegex(ValueError, "structure"):
+            mx.while_loop(
+                lambda c: c[0] < 3,
+                lambda c: [c[0] + 1],  # body returns list; init is tuple
+                (mx.array(0),),
+                max_iterations=10,
+            )
+
+    def test_structure_key_order_accepted(self):
+        # Same keys, different insertion order -> accepted (order-independent).
+        init = {"b": mx.array(0), "a": mx.array(0)}
+        body = lambda c: {"a": c["a"] + 1, "b": c["b"] + 1}
+        cond = lambda c: c["a"] < 5
+        out = mx.while_loop(cond, body, init, chunk_size=2, max_iterations=20)
+        self.assertEqual(int(out["a"].item()), 5)
+        self.assertEqual(int(out["b"].item()), 5)
+
+    # ---- T12: not differentiable ----
+
+    @unittest.skipUnless(
+        hasattr(mx.array(0.0), "is_tracer"),
+        "requires array.is_tracer() C++ binding",
+    )
+    def test_not_differentiable_grad_direct(self):
+        def loss(x):
+            return mx.while_loop(
+                lambda c: c < 5,
+                lambda c: c + x,
+                mx.array(0.0),
+                max_iterations=10,
+                chunk_size=4,
+            ).sum()
+
+        with self.assertRaisesRegex(RuntimeError, "not differentiable|tracer"):
+            mx.grad(loss)(mx.array(1.0))
+
+    @unittest.skipUnless(
+        hasattr(mx.array(0.0), "is_tracer"),
+        "requires array.is_tracer() C++ binding",
+    )
+    def test_not_differentiable_grad_closure(self):
+        # The v4 key case: constant init, body closes over the traced param.
+        def loss(w):
+            return mx.while_loop(
+                lambda c: c < 10.0,
+                lambda c: c + w,
+                mx.array(0.0),
+                max_iterations=20,
+                chunk_size=4,
+            ).sum()
+
+        with self.assertRaisesRegex(RuntimeError, "not differentiable|tracer"):
+            mx.grad(loss)(mx.array(1.0))
+
+    @unittest.skipUnless(
+        hasattr(mx.array(0.0), "is_tracer"),
+        "requires array.is_tracer() C++ binding",
+    )
+    def test_not_differentiable_vmap(self):
+        with self.assertRaisesRegex(RuntimeError, "not differentiable|tracer"):
+            mx.vmap(
+                lambda x: mx.while_loop(
+                    lambda c: c < 3,
+                    lambda c: c + 1,
+                    x,
+                    max_iterations=10,
+                    chunk_size=4,
+                )
+            )(mx.array([0, 1, 2]))
+
+    # ---- T13: not compile-traceable ----
+
+    @unittest.skipUnless(
+        hasattr(mx.array(0.0), "is_tracer"),
+        "requires array.is_tracer() C++ binding",
+    )
+    def test_not_compile_traceable(self):
+        with self.assertRaisesRegex(
+            RuntimeError, "not differentiable|tracer|cannot be used"
+        ):
+            mx.compile(
+                lambda x: mx.while_loop(
+                    lambda c: c < 3,
+                    lambda c: c + 1,
+                    x,
+                    max_iterations=10,
+                    chunk_size=4,
+                )
+            )(mx.array(0))
+
+    # ---- T14: multi-output tuple ----
+
+    def test_multi_output_tuple(self):
+        cond = lambda c: c[1] < 5
+        body = lambda c: (c[0] + c[1], c[1] + 1)
+        out = mx.while_loop(cond, body, (mx.array(0), mx.array(0)), chunk_size=4)
+        ref = _reference_loop(cond, body, (mx.array(0), mx.array(0)))
+        self.assertEqualArray(out[0], ref[0])
+        self.assertEqualArray(out[1], ref[1])
+
+    # ---- T15: chunk_size boundaries ----
+
+    def test_chunk_size_1024(self):
+        out = mx.while_loop(
+            lambda c: c < 100, lambda c: c + 1, mx.array(0), chunk_size=1024
+        )
+        self.assertEqual(int(out.item()), 100)
+
+    def test_chunk_size_4096_correctness(self):
+        out = mx.while_loop(
+            lambda c: c < 5000, lambda c: c + 1, mx.array(0), chunk_size=4096
+        )
+        self.assertEqual(int(out.item()), 5000)
+
+    def test_chunk_size_too_large_rejected(self):
+        with self.assertRaisesRegex(ValueError, "chunk_size"):
+            mx.while_loop(
+                lambda c: c < 5,
+                lambda c: c + 1,
+                mx.array(0),
+                chunk_size=_MAX_CHUNK_SIZE + 1,
+            )
+
+    def test_chunk_size_zero_negative_nonint_rejected(self):
+        for bad in [0, -1, 1.5, True, "8"]:
+            with self.subTest(bad=bad):
+                with self.assertRaisesRegex(ValueError, "chunk_size"):
+                    mx.while_loop(
+                        lambda c: c < 5, lambda c: c + 1, mx.array(0), chunk_size=bad
+                    )
+
+    # ---- T16: kw-only ----
+
+    def test_max_iterations_keyword_only(self):
+        with self.assertRaises(TypeError):
+            mx.while_loop(
+                lambda c: c < 5, lambda c: c + 1, mx.array(0), 10
+            )  # positional
+
+    # ---- T17-T19: max_iterations validation ----
+
+    def test_max_iterations_invalid(self):
+        for bad in [True, 1.5, -1, 2**63, "10"]:
+            with self.subTest(bad=bad):
+                with self.assertRaisesRegex(ValueError, "max_iterations"):
+                    mx.while_loop(
+                        lambda c: c < 5,
+                        lambda c: c + 1,
+                        mx.array(0),
+                        max_iterations=bad,
+                    )
+
+    def test_max_iterations_zero(self):
+        # max=0, cond true -> raise; cond false -> return init.
+        with self.assertRaisesRegex(RuntimeError, "max_iterations"):
+            mx.while_loop(
+                lambda c: mx.array(True), lambda c: c + 1, mx.array(0), max_iterations=0
+            )
+        out = mx.while_loop(
+            lambda c: mx.array(False), lambda c: c + 1, mx.array(7), max_iterations=0
+        )
+        self.assertEqual(int(out.item()), 7)
+
+    def test_max_iterations_not_multiple_of_chunk(self):
+        # max=5, chunk=2 -> raise exactly at 5 (cond always true).
+        with self.assertRaisesRegex(RuntimeError, "max_iterations"):
+            mx.while_loop(
+                lambda c: mx.array(True),
+                lambda c: c + 1,
+                mx.array(0),
+                max_iterations=5,
+                chunk_size=2,
+            )
+        # trip=5, max=5, chunk=2 -> return 5.
+        out = mx.while_loop(
+            lambda c: c < 5,
+            lambda c: c + 1,
+            mx.array(0),
+            max_iterations=5,
+            chunk_size=2,
+        )
+        self.assertEqual(int(out.item()), 5)
+
+    def test_max_iterations_none_terminating(self):
+        out = mx.while_loop(
+            lambda c: c < 10,
+            lambda c: c + 1,
+            mx.array(0),
+            max_iterations=None,
+            chunk_size=4,
+        )
+        self.assertEqual(int(out.item()), 10)
+
+    def test_max_iterations_huge(self):
+        out = mx.while_loop(
+            lambda c: c < 5,
+            lambda c: c + 1,
+            mx.array(0),
+            max_iterations=2**62,
+            chunk_size=8,
+        )
+        self.assertEqual(int(out.item()), 5)
+
+    # ---- T21: init_val validation ----
+
+    def test_init_val_no_array(self):
+        with self.assertRaisesRegex(ValueError, "mx.array"):
+            mx.while_loop(lambda c: c < 5, lambda c: c + 1, 0, max_iterations=10)
+
+    def test_init_val_empty(self):
+        for init in [(), {}]:
+            with self.subTest(init=init):
+                with self.assertRaisesRegex(ValueError, "mx.array"):
+                    mx.while_loop(
+                        lambda c: mx.array(False), lambda c: c, init, max_iterations=10
+                    )
+
+    def test_init_val_nonarray_leaf(self):
+        with self.assertRaisesRegex(ValueError, "mx.array"):
+            mx.while_loop(
+                lambda c: c["a"] < 5,
+                lambda c: {"a": c["a"] + 1, "s": "x"},
+                {"a": mx.array(0), "s": "x"},
+                max_iterations=10,
+            )
+
+    def test_body_returns_nonarray_leaf(self):
+        with self.assertRaisesRegex(ValueError, "mx.array"):
+            mx.while_loop(
+                lambda c: c < 5,
+                lambda c: 1,  # Python int
+                mx.array(0),
+                max_iterations=10,
+            )
+
+    # ---- T22: cond coercion ----
+
+    def test_cond_python_bool(self):
+        # cond always True -> cap hit at the while_loop call (raises there).
+        with self.assertRaisesRegex(RuntimeError, "max_iterations"):
+            mx.while_loop(
+                lambda c: True,
+                lambda c: c + 1,
+                mx.array(0),
+                max_iterations=5,
+                chunk_size=2,
+            )
+        # cond False -> returns init unchanged.
+        out = mx.while_loop(
+            lambda c: False,
+            lambda c: c + 1,
+            mx.array(7),
+            max_iterations=5,
+            chunk_size=2,
+        )
+        self.assertEqual(int(out.item()), 7)
+
+    def test_cond_numpy_bool(self):
+        out = mx.while_loop(
+            lambda c: np.bool_(False),
+            lambda c: c + 1,
+            mx.array(7),
+            max_iterations=5,
+            chunk_size=2,
+        )
+        self.assertEqual(int(out.item()), 7)
+
+    def test_cond_multielement_array(self):
+        # cond returns a multi-element array -> mx.all reduces.
+        out = mx.while_loop(
+            lambda c: mx.array([c < 5, c < 100]),  # both must be true
+            lambda c: c + 1,
+            mx.array(0),
+            max_iterations=20,
+            chunk_size=4,
+        )
+        self.assertEqual(int(out.item()), 5)
+
+    # ---- T23: cond oscillating ----
+
+    def test_cond_oscillating_stops_at_first_false(self):
+        # cond flips T->F->T; should stop at first F (carry=2).
+        def cond(c):
+            return c != 2
+
+        out = mx.while_loop(
+            cond, lambda c: c + 1, mx.array(0), max_iterations=20, chunk_size=4
+        )
+        self.assertEqual(int(out.item()), 2)
+
+    # ---- T24: compiled body inside while_loop ----
+
+    def test_compiled_body_inside_while_loop(self):
+        @mx.compile
+        def body(c):
+            return c * 2 + 1
+
+        out = mx.while_loop(
+            lambda c: c < 50, body, mx.array(0), max_iterations=20, chunk_size=4
+        )
+        ref = _reference_loop(lambda c: c < 50, body, mx.array(0))
+        self.assertEqualArray(out, ref)
+
+    # ---- T25: determinism ----
+
+    def test_determinism(self):
+        results = []
+        for _ in range(5):
+            out = mx.while_loop(
+                lambda c: c < 20, lambda c: c + 1, mx.array(0), chunk_size=4
+            )
+            results.append(int(out.item()))
+        self.assertEqual(len(set(results)), 1)
+
+    # ---- T26: random property (linear recurrence) ----
+
+    def test_random_linear_recurrence(self):
+        rng = np.random.default_rng(2024)
+        for _ in range(15):
+            # Positive increment guarantees termination at c == N.
+            step = float(rng.uniform(0.5, 2.0))
+            N = int(rng.integers(10, 100))
+            chunk_size = int(rng.choice([1, 2, 4, 8, 16, 32]))
+            cond = lambda c: c < N
+            body = lambda c: c + step
+            init = mx.array(0.0)
+            out = mx.while_loop(
+                cond, body, init, max_iterations=N * 2, chunk_size=chunk_size
+            )
+            ref = _reference_loop(cond, body, init)
+            self.assertTrue(mx.allclose(out, ref).item())
+
+    # ---- T27: random pytree carry ----
+
+    def test_random_pytree_carry(self):
+        rng = np.random.default_rng(2025)
+        for _ in range(10):
+            chunk_size = int(rng.choice([1, 4, 16]))
+            init = {"a": mx.array(rng.integers(0, 5)), "b": mx.array(rng.uniform(0, 1))}
+            cond = lambda c: c["a"] < 10
+            body = lambda c: {"a": c["a"] + 1, "b": c["b"] * 2}
+            out = mx.while_loop(
+                cond, body, init, max_iterations=50, chunk_size=chunk_size
+            )
+            ref = _reference_loop(cond, body, init)
+            self.assertEqualArray(out["a"], ref["a"])
+            self.assertEqualArray(out["b"], ref["b"])
+
+    # ---- T29: multi-threaded ----
+
+    def test_multi_threaded(self):
+        results = [[] for _ in range(4)]
+
+        def runner(i):
+            mx.set_default_device(mx.default_device())
+            for _ in range(5):
+                out = mx.while_loop(
+                    lambda c: c < 10, lambda c: c + 1, mx.array(0.0), chunk_size=4
+                )
+                results[i].append(out.item())
+
+        threads = [threading.Thread(target=runner, args=(i,)) for i in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        for r in results:
+            self.assertEqual(r, [10.0] * 5)
+
+    # ---- T30: constant cond (the iter2 crash case) ----
+
+    def test_constant_cond_no_crash(self):
+        for cond in [
+            lambda c: mx.array(True),
+            lambda c: True,
+            lambda c: np.bool_(True),
+        ]:
+            with self.subTest(cond=cond):
+                with self.assertRaisesRegex(RuntimeError, "max_iterations"):
+                    mx.while_loop(
+                        cond,
+                        lambda c: c + 1,
+                        mx.array(0),
+                        max_iterations=3,
+                        chunk_size=4,
+                    )
+        for cond in [
+            lambda c: mx.array(False),
+            lambda c: False,
+            lambda c: np.bool_(False),
+        ]:
+            with self.subTest(cond=cond):
+                out = mx.while_loop(
+                    cond, lambda c: c + 1, mx.array(7), max_iterations=10, chunk_size=4
+                )
+                self.assertEqual(int(out.item()), 7)
+
+    # ---- T36: numpy integer args ----
+
+    def test_numpy_integer_args(self):
+        out = mx.while_loop(
+            lambda c: c < 5,
+            lambda c: c + 1,
+            mx.array(0),
+            max_iterations=np.int64(100),
+            chunk_size=np.int64(4),
+        )
+        self.assertEqual(int(out.item()), 5)
+
+    # ---- T33: recursive while_loop in body is NOT supported ----
+
+    def test_recursive_while_loop_raises(self):
+        # A while_loop called inside another while_loop's body receives a
+        # tracer carry (the outer body is @mx.compile'd), so it must raise.
+        # This is a documented limitation: while_loop cannot be nested inside
+        # a compiled body because the inner loop requires a host sync.
+        def body(c):
+            return mx.while_loop(
+                lambda d: d < 2, lambda d: d + 1, c, max_iterations=5, chunk_size=2
+            )
+
+        with self.assertRaises(RuntimeError):
+            mx.while_loop(
+                lambda c: c < 4, body, mx.array(0), max_iterations=20, chunk_size=2
+            )
+
+    # ---- chunk_size default ----
+
+    def test_default_chunk_size(self):
+        self.assertEqual(_DEFAULT_CHUNK_SIZE, 16)
+        out = mx.while_loop(lambda c: c < 20, lambda c: c + 1, mx.array(0))
+        self.assertEqual(int(out.item()), 20)
+
+
+if __name__ == "__main__":
+    mlx_tests.MLXTestRunner()


### PR DESCRIPTION
## Summary

Adds a pure-Python `mx.while_loop` that solves the **per-iteration GPU-sync pathology** of while loops on accelerators. A `@mx.compile`d "chunk" applies up to `chunk_size` body iterations lazily (with a running mask so post-termination iterations are no-ops) before a *single* host sync to read the condition, reducing host GPU syncs from **O(N) to O(N / chunk_size)**.

```python
mx.while_loop(cond_fun, body_fun, init_val, *, max_iterations=None, chunk_size=16) -> Any
# semantics: while bool(mx.all(cond_fun(c))): c = body_fun(c)
```

## Issues solved

- **tillahoffmann/jax-mps#83** — *While loop performance: ~0.7ms per iteration due to per-iteration GPU sync.* While loops (`stablehlo.while` / `lax.fori_loop`) are ~1750x slower than CPU because each iteration syncs to read the condition on the host. This PR provides the "MLX while primitive" (approach #2 in that issue) and the chunked-speculative/batch-eval approaches (#1/#3) at the MLX level, dropping per-iteration syncs to per-chunk syncs.
- **#1441** — *[FEATURE] MLX equivalent for jax.lax.scan and jax.lax.while_loop.* Provides the `while_loop` half of that request as a pure-Python transform (no risky C++ control-flow primitive; the `scan` half remains future work).

## Changes

| File | Change |
|---|---|
| `python/mlx/_while_loop.py` (new) | The implementation: chunked-speculative driver, pre-flight validation (args / pytree structure / shape / dtype / all-`mx.array` leaves), multi-layer transform guard, bounded `chunk_size`, `max_iterations` cap. |
| `python/mlx/__init__.py` (new) | Registers `mx.while_loop` after `mlx.core` is fully initialized. Required: registering from `_reprlib_fix` (runs mid-`NB_MODULE`) fatally re-enters `NB_MODULE`. Uses `# isort: off` to preserve the load order. |
| `python/src/array.cpp` (+5 lines) | One-line binding `mx.array.is_tracer()` → `mx::array::is_tracer()` (`is_tracer_flag && in_tracing() || retain_graph()`). Used for robust transform-context detection. |
| `python/mlx/_stub_patterns.txt` (+21) | Type stub for `while_loop` in the `mlx.core.__suffix__` block (`is_tracer` is auto-generated by stubgen). |
| `python/tests/test_while_loop.py` (new) | 53 tests. |
| `benchmarks/python/while_loop_bench.py` (new) | Naive per-iter-sync vs chunked, + `chunk_size` sweep. |

Only **one 5-line C++ addition** (the `is_tracer` binding); the rest is pure Python.

## Key design points / properties

- **Not differentiable and not traceable** into `mx.grad` / `mx.compile` / `mx.vmap` — raises a clear `RuntimeError` and **never silently produces wrong gradients**. The pre-flight calls `body_fun(init_val)` / `cond_fun(init_val)` *uncompiled* and checks `is_tracer()` on the outputs, which catches the constant-init + closure-over-tracer `grad` case that `@mx.compile` would otherwise mask (the v4 key fix, empirically verified).
- **`cond_final` is computed in the driver, outside `@mx.compile`** — avoids a backend `IndexError` dedup bug for constant conditions and fixes an off-by-one cap bug (trip-count == `max_iterations` returns instead of raising).
- **A fresh `@mx.compile`d chunk is built per call** (no cross-call cache) — `@mx.compile` bakes closure-captured Python values as constants, so a cross-call cache would reuse a stale chunk when a closed-over variable changes (hang). `mx.compile`'s own cache still amortizes compilation across the many chunks within a single call.
- `body_fun` is evaluated eagerly/speculatively (keep it **pure and total**; NaN on an *active* carry contaminates, NaN on a *stopped* carry is masked). All carry leaves must be `mx.array`. `max_iterations` caps the loop (raises if exceeded); `chunk_size` trades syncs vs memory (default 16; 128–256 typically optimal for long loops).
- **Documented limitation:** `body_fun`/`cond_fun` must not mutate closure-captured Python state that the other reads (the chunk bakes closure constants; `max_iterations` will not bound such a hang — pass loop-dependent values through the carry).

## Test cases (53 in `test_while_loop.py`)

- **Correctness vs Python reference** (scalar, tuple, list, dict, nested pytree, vectorized/multi-element carry) across `chunk_size` sweeps; random/property tests (seeded) for a linear recurrence and a random pytree carry.
- **Termination semantics**: cond false at init → returns init with **zero body calls** (matches JAX); trip-count == `max_iterations` returns (no spurious raise); `max_iterations` cap raises exactly when exceeded; `max_iterations=0` semantics; partial chunks (`max` not a multiple of `chunk_size`).
- **NaN safety**: stopped-lane NaN masked (result finite); active-lane NaN contaminates (documented).
- **Validation**: `chunk_size` ∈ [1, 4096] (rejects 0/-1/non-int/bool/>4096; accepts `np.int64`); `max_iterations` ∈ [0, 2^63-1] or `None` (rejects bool/float/negative/overflow); `init_val` ≥1 `mx.array` leaf (rejects empty/`str`/`None`/numpy/Python-scalar leaves); body structure / shape / dtype invariant (tuple-vs-list, extra/missing key, shape change, dtype change → `ValueError`; same-keys-different-order accepted).
- **Not differentiable / not traceable**: `mx.grad` (direct tracer init + closure-over-tracer), `mx.vmap`, `mx.compile`, and recursive `while_loop` in a body all raise `RuntimeError` (skip-guarded on `is_tracer`).
- **Cond coercion**: Python `bool`, `np.bool_`, 0-d / 1-element / multi-element arrays, oscillating `T→F→T` (stops at first false), constant `True`/`False`.
- **Performance (sync-count, not wall-time)**: asserts `mx.eval` count ≤ `ceil(N / chunk_size) + 2`; skipped on CPU / `MLX_SKIP_PERF_TESTS`.
- **Concurrency**: 4 threads × 5 calls (each sets `mx.set_default_device`).
- **Misc**: determinism (5×), `@mx.compile`d body inside `while_loop`, kw-only args, `numpy` integer args, constant-cond-no-crash.

## Benchmark

Naive per-iter-sync Python loop vs chunked `mx.while_loop` (prints; no assertions):
- N=1000: naive ~361 ms vs chunked (cs=64) ~19 ms → **~18× speedup**.
- chunked N=10000 (cs=64): ~168 ms (~157 syncs vs 10000 for naive).
- `chunk_size` sweep shows a U-shape (optimal ~128–256; worsens at 4096 due to compile/memory).

## Tested version / environment

- **MLX 0.32.0.dev** (`0.32.0.dev20260626+0386ad49e`, built from `main` @ `0386ad49e`, 2026-06-26).
- **macOS 26.5.1**, **Apple Silicon (arm64)**, **Metal toolchain 17F109**.
- Conda env `mlx-dev` rebuilt from source (with the one-line `is_tracer` C++ binding).
- **53 `test_while_loop` tests pass**; **125 pass** with `test_compile` + `test_eval` (no regression). The 4 `test_array` torch/dlpack failures are **pre-existing** (unrelated; confirmed on baseline without these changes).

## Notes

- The implementation went through a Construction Beehive workflow: exploration → planning (4-iteration plan-review loop, converged) → implementation → test gate → implementation review (3 cycles, all 4 reviewers converged) → fact-check (12/12 claims verified) → supervisor (CONDITIONAL PASS). See the audit trail for details.
- Non-differentiability and the closure-mutation limitation are inherent to a host-driven, `@mx.compile`-chunked `while_loop` (matching JAX's `lax.while_loop` non-differentiability). A native C++ `while` primitive with on-device condition evaluation (no host sync) is future work for fully traceable loops.
