### PR TITLE
Fix BatchNorm docstring to cover 4D input and test the NHWC path

### DIFF
--- a/python/mlx/nn/layers/normalization.py
+++ b/python/mlx/nn/layers/normalization.py
@@ -256,7 +256,7 @@ class GroupNorm(Module):
 
 
 class BatchNorm(Module):
-    r"""Applies Batch Normalization over a 2D or 3D input.
+    r"""Applies Batch Normalization over a 2D, 3D or 4D input.
 
     Computes
 

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -770,6 +770,16 @@ class TestLayers(mlx_tests.MLXTestCase):
         self.assertIn("weight", bn_trainable)
         self.assertIn("bias", bn_trainable)
 
+        # test with 4D input (NHWC)
+        mx.random.seed(42)
+        x = mx.random.normal((2, 3, 3, 6), dtype=mx.float32)
+        bn = nn.BatchNorm(num_features=6, affine=True)
+        y = bn(x)
+        self.assertTrue(x.shape == y.shape)
+        # batch norm over an NHWC input normalizes each channel across N, H, W
+        self.assertTrue(mx.allclose(y.mean(axis=(0, 1, 2)), mx.zeros((6,)), atol=1e-5))
+        self.assertTrue(mx.allclose(y.var(axis=(0, 1, 2)), mx.ones((6,)), atol=1e-2))
+
     def test_batch_norm_stats(self):
         batch_size = 2
         num_features = 4


### PR DESCRIPTION
## Summary

`nn.BatchNorm`'s docstring summary says it applies over a "2D or 3D input", but the layer also supports **4D NHWC** tensors:

- `BatchNorm.__call__` guards `x.ndim < 2 or x.ndim > 4` and its own error message says `"Expected input tensor to have 2, 3 or 4 dimensions"`.
- The docstring **body** already documents the 4D case: *"For four-dimensional arrays, the shape is `NHWC`..."*.

So the summary line contradicts both the code and the rest of its own docstring. This corrects the summary to "2D, 3D or 4D input".

## Test

`test_batch_norm` previously covered only 2D and 3D inputs (plus a 5D `ValueError` check); the 4D NHWC path was never exercised. Added a 4D case asserting the output is normalized per channel across N, H and W (per-channel mean ≈ 0, var ≈ 1).

No behavior change — documentation + test coverage only.