### PR TITLE
fix: Quote hostname in mlx.launch ssh commands

### DIFF
--- a/python/mlx/_distributed_utils/launch.py
+++ b/python/mlx/_distributed_utils/launch.py
@@ -49,7 +49,7 @@ class RemoteProcess(CommandProcess):
         is_local = host == "127.0.0.1"
         cmd = RemoteProcess.make_launch_script(rank, cwd, files, env, command, is_local)
         if not is_local:
-            cmd = f"ssh -tt -o LogLevel=QUIET {host} {shlex.quote(cmd)}"
+            cmd = f"ssh -tt -o LogLevel=QUIET {shlex.quote(host)} {shlex.quote(cmd)}"
 
         self._host = host
         self._pidfile = None
@@ -91,7 +91,7 @@ class RemoteProcess(CommandProcess):
         # Kill the remote program if possible
         cmd = RemoteProcess.make_kill_script(self._pidfile)
         if not self._is_local:
-            cmd = f"ssh {self._host} {shlex.quote(cmd)}"
+            cmd = f"ssh {shlex.quote(self._host)} {shlex.quote(cmd)}"
         c = run(
             cmd,
             check=True,


### PR DESCRIPTION
## Proposed changes

- Quote the hostname when constructing `ssh` shell commands in `mlx.launch`.
- Applies the quoting to the launch command and the remote termination command.
- Fixes #3776.

Tests: not added; this is a minimal shell-quoting fix.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)