### PR TITLE
Fix HardShrink to accept its documented lambd argument

### DIFF
--- a/python/mlx/nn/layers/activations.py
+++ b/python/mlx/nn/layers/activations.py
@@ -642,7 +642,6 @@ class HardTanh(Module):
     """
 
 
-@_make_activation_module(hard_shrink)
 class HardShrink(Module):
     r"""Applies the HardShrink function.
 
@@ -651,6 +650,13 @@ class HardShrink(Module):
     Args:
         lambd: the :math:`\lambda` value for Hardshrink. Default: ``0.5``
     """
+
+    def __init__(self, lambd=0.5):
+        super().__init__()
+        self.lambd = lambd
+
+    def __call__(self, x):
+        return hard_shrink(x, self.lambd)
 
 
 @_make_activation_module(softmin)

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -1185,6 +1185,18 @@ class TestLayers(mlx_tests.MLXTestCase):
         self.assertEqual(y.shape, (5,))
         self.assertEqual(y.dtype, mx.float32)
 
+        y = nn.HardShrink()(x)
+        expected_y = mx.array([1.0, 0.0, 0.0, 0.0, -1.5])
+        self.assertTrue(mx.array_equal(y, expected_y))
+        self.assertEqual(y.shape, (5,))
+        self.assertEqual(y.dtype, mx.float32)
+
+        y = nn.HardShrink(lambd=0.1)(x)
+        expected_y = mx.array([1.0, -0.5, 0.0, 0.5, -1.5])
+        self.assertTrue(mx.array_equal(y, expected_y))
+        self.assertEqual(y.shape, (5,))
+        self.assertEqual(y.dtype, mx.float32)
+
     def test_rope(self):
         for kwargs in [{}, {"traditional": False}, {"base": 10000}, {"scale": 0.25}]:
             rope = nn.RoPE(4, **kwargs)


### PR DESCRIPTION
### What

`nn.HardShrink` documents a configurable `lambd` argument (`Default: 0.5`), but the class cannot actually be constructed with one:

```python
nn.HardShrink(lambd=0.3)
# TypeError: Module.__init__() got an unexpected keyword argument 'lambd'
nn.HardShrink(0.3)
# TypeError: ... takes 1 positional argument but 2 were given
```

The class is built with `@_make_activation_module(hard_shrink)`, which sets `__call__` to always apply the default `lambd` and leaves the class with no `__init__` (it inherits `Module.__init__(self)`). So the documented parameter is silently unusable.

### Fix

Replace the decorator with an explicit `__init__`/`__call__` that stores and forwards `lambd`, mirroring the sibling `Softshrink` layer (which already does this and is tested). Every other parameterized activation (`Softshrink`, `ELU`, `CELU`, `LeakyReLU`, `PReLU`, `Step`) follows this same pattern; `HardShrink` was the lone one mistakenly decorated.

### Tests

Extended `test_hard_shrink` to exercise the class path (`nn.HardShrink()` and `nn.HardShrink(lambd=0.1)`), which was previously untested — only the functional `nn.hard_shrink` was covered, which is why the missing parameter went unnoticed.
