### PR TITLE
Fix kl_div_loss docstring formula and two doc nits

### DIFF
--- a/python/mlx/nn/layers/dropout.py
+++ b/python/mlx/nn/layers/dropout.py
@@ -40,7 +40,7 @@ class Dropout2d(Module):
 
     Randomly zero out entire channels independently with probability :math:`p`.
     This layer expects the channels to be last, i.e. the input shape should be
-    ``NWHC`` or ``WHC`` where:``N`` is the batch dimension,``H`` is the input
+    ``NHWC`` or ``HWC`` where:``N`` is the batch dimension,``H`` is the input
     image height,``W`` is the input image width, and``C`` is the number of
     input channels
 

--- a/python/mlx/nn/losses.py
+++ b/python/mlx/nn/losses.py
@@ -321,7 +321,7 @@ def kl_div_loss(
 
     .. code-block:: python
 
-        mx.exp(targets) * (targets - inputs).sum(axis)
+        (mx.exp(targets) * (targets - inputs)).sum(axis)
 
     Args:
         inputs (array): Log probabilities for the predicted distribution.

--- a/python/mlx/optimizers/optimizers.py
+++ b/python/mlx/optimizers/optimizers.py
@@ -39,7 +39,7 @@ class Optimizer:
         :meth:`Optimizer.update`.
 
         Args:
-            model (dict): A Python tree of parameters.
+            parameters (dict): A Python tree of parameters.
 
         Example:
             >>> optimizer = optim.SGD(learning_rate=1e-1, momentum=0.9)

--- a/python/tests/test_losses.py
+++ b/python/tests/test_losses.py
@@ -350,6 +350,12 @@ class TestLosses(mlx_tests.MLXTestCase):
         expected_none = mx.array([0.0, 0.831777])
         self.assertTrue(mx.allclose(losses_none, expected_none))
 
+        # The documented formula must match the implementation: the sum reduces
+        # the elementwise product over `axis`, so the multiply has to be inside
+        # the sum (parenthesization matters).
+        documented = (mx.exp(q_logits) * (q_logits - p_logits)).sum(axis=-1)
+        self.assertTrue(mx.allclose(losses_none, documented))
+
         # Test with reduction 'mean'
         losses_mean = nn.losses.kl_div_loss(p_logits, q_logits, reduction="mean")
         expected_mean = mx.mean(expected_none)


### PR DESCRIPTION
### Summary

Three documentation fixes in the pure-Python layer, one of which corrects a formula a user would copy and get wrong results from.

**`kl_div_loss` documented formula (main fix).** The `reduction == 'none'` snippet reads `mx.exp(targets) * (targets - inputs).sum(axis)`. In Python `.sum(axis)` binds tighter than `*`, so that expression reduces the difference first and then broadcast-multiplies by `exp(targets)` — a different value *and* shape than the implementation, which sums the elementwise product over `axis`:

```python
loss = mx.sum(mx.exp(targets) * (targets - inputs), axis)
```

Corrected the snippet to `(mx.exp(targets) * (targets - inputs)).sum(axis)`. Verified against the existing `test_kl_div_loss` values: the code returns `[0.0, 0.831777]` (shape `[2]`), the old snippet returns shape `[2, 2]`, the parenthesized snippet matches the code. Added an assertion pinning the documented formula to the implementation.

**`Dropout2d` channel-order acronym.** Docstring said `NWHC`/`WHC`; MLX is channels-last, so it should be `NHWC`/`HWC` (`Dropout3d` already documents `NDHWC`). No behavior change — the layer masks whole channels.

**`Optimizer.init` argument name.** Docstring listed the argument as `model`; the parameter is `parameters`.

### Testing

`python -m unittest test_losses.TestLosses.test_kl_div_loss` passes; `black` clean. (No local Metal build — relying on CI for the full suite.)
