### PR TITLE
Fix zero VJPs for scatter indices

### DIFF
--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -4482,8 +4482,7 @@ std::vector<array> Scatter::vjp(
         }
       }
     } else {
-      throw std::invalid_argument(
-          "[scatter] Cannot calculate VJP with respect to indices.");
+      vjps.push_back(zeros_like(primals[num], stream()));
     }
   }
   return vjps;
@@ -4594,8 +4593,7 @@ std::vector<array> ScatterAxis::vjp(
     } else if (num == 2) {
       vjps.push_back(take_along_axis(cotangents[0], indices, axis_, stream()));
     } else {
-      throw std::invalid_argument(
-          "[scatter_axis] Cannot calculate VJP with respect to indices.");
+      vjps.push_back(zeros_like(primals[num], stream()));
     }
   }
   return vjps;
@@ -6009,8 +6007,7 @@ std::vector<array> GatherMM::vjp(
           -2,
           stream()));
     } else {
-      throw std::invalid_argument(
-          "[GatherMM] Cannot calculate VJP with respect to indices.");
+      vjps.push_back(zeros_like(primals[arg], stream()));
     }
   }
   return vjps;

--- a/python/tests/test_autograd.py
+++ b/python/tests/test_autograd.py
@@ -444,6 +444,25 @@ class TestAutograd(mlx_tests.MLXTestCase):
         self.assertTrue(mx.array_equal(dfdx, mx.array([1.0, 1.0])))
         self.assertEqual(dfdx.dtype, mx.float32)
 
+    def test_scatter_index_vjp_is_zero(self):
+        def scatter_fun(w):
+            idx = mx.argsort(w)[:2]
+            out = mx.zeros((4,))
+            out[idx] = w[:2]
+            return out.sum()
+
+        grad = mx.grad(scatter_fun)(mx.array([4.0, 3.0, 2.0, 1.0]))
+        self.assertTrue(mx.array_equal(grad, mx.array([1.0, 1.0, 0.0, 0.0])))
+
+        def scatter_axis_fun(w):
+            idx = mx.argsort(w, axis=1)[:, :1]
+            updates = w.sum(axis=1, keepdims=True)
+            out = mx.put_along_axis(mx.zeros((3, 3)), idx, updates, axis=1)
+            return out.sum()
+
+        grad = mx.grad(scatter_axis_fun)(mx.ones((3, 3)))
+        self.assertTrue(mx.array_equal(grad, mx.ones((3, 3))))
+
     def test_scatter_add_vjp(self):
         def fun(src, updates):
             x = src.at[mx.array([1, 3])].add(updates)

--- a/python/tests/test_blas.py
+++ b/python/tests/test_blas.py
@@ -1239,6 +1239,17 @@ class TestBlas(mlx_tests.MLXTestCase):
             self.assertEqual(r.shape, t.shape)
             self.assertTrue(mx.allclose(r, t, atol=1e-4).item())
 
+    def test_gather_matmul_index_vjp_is_zero(self):
+        a = mx.ones((4, 1, 2, 2))
+        b = mx.ones((4, 1, 2, 2))
+
+        def fun(w):
+            indices = mx.reshape(mx.argsort(w)[:2], (1, 2))
+            return mx.gather_mm(a, b, indices, indices).sum()
+
+        grad = mx.grad(fun)(mx.array([3.0, 1.0, 2.0, 0.0]))
+        self.assertTrue(mx.array_equal(grad, mx.zeros((4,))))
+
     def test_gather_mm_sorted(self):
         def gather_mm_ref(a, b, rhs):
             b = b[rhs]


### PR DESCRIPTION
Fixes #3787.

Summary:
- Return zero VJPs for non-differentiable index arguments in Scatter, ScatterAxis, and GatherMM instead of throwing.
- Add regression coverage for computed indices flowing through argsort into scatter, put_along_axis, and gather_mm.

Validation:
- git diff --check
- python -m py_compile python/tests/test_autograd.py python/tests/test_blas.py

I also tried `python setup.py build_ext --inplace` locally, but this machine is missing the Metal toolchain:

`cannot execute tool 'metal' due to missing Metal Toolchain; use: xcodebuild -downloadComponent MetalToolchain`

So I could not run the new MLX runtime tests locally in this environment.
