### PR TITLE
Fix Conv3d docstring argument order (padding before dilation)

### DIFF
--- a/python/mlx/nn/layers/convolution.py
+++ b/python/mlx/nn/layers/convolution.py
@@ -179,9 +179,9 @@ class Conv3d(Module):
         kernel_size (int or tuple): The size of the convolution filters.
         stride (int or tuple, optional): The size of the stride when
             applying the filter. Default: ``1``.
-        dilation (int or tuple, optional): The dilation of the convolution.
         padding (int or tuple, optional): How many positions to 0-pad
             the input with. Default: ``0``.
+        dilation (int or tuple, optional): The dilation of the convolution.
         bias (bool, optional): If ``True`` add a learnable bias to the
             output. Default: ``True``
     """


### PR DESCRIPTION
The `Conv3d` docstring lists the constructor arguments as `stride`, `dilation`, `padding`, but the actual signature order is `stride`, `padding`, `dilation` — matching `Conv1d` and `Conv2d`.

A caller who follows the docstring order with positional arguments (e.g. `nn.Conv3d(3, 16, 3, 1, 2)` intending `dilation=2`) would instead set `padding=2`. `Conv3d` was the lone outlier here; `Conv1d` and `Conv2d` both document `stride -> padding -> dilation`.

Reorders the `Conv3d` docstring so `padding` precedes `dilation`, matching the signature and the sibling conv layers. Documentation-only, no behavior change.