### PR TITLE
Fix JACCL error handling for missing RDMA devices

### DIFF
--- a/mlx/distributed/jaccl/lib/jaccl/mesh.cpp
+++ b/mlx/distributed/jaccl/lib/jaccl/mesh.cpp
@@ -81,6 +81,25 @@ void MeshGroup::initialize() {
 }
 
 void MeshGroup::allocate_buffers() {
+  if (connections_.size() != static_cast<size_t>(size_)) {
+    std::ostringstream msg;
+    msg << "[jaccl] Expected " << size_ << " mesh connections but found "
+        << connections_.size() << ".";
+    throw std::runtime_error(msg.str());
+  }
+  for (int peer = 0; peer < size_; peer++) {
+    if (peer == rank_) {
+      continue;
+    }
+    if (connections_[peer].protection_domain == nullptr) {
+      std::ostringstream msg;
+      msg << "[jaccl] Missing RDMA protection domain for mesh peer " << peer
+          << ". Check that ibv_devices lists rdma_* devices and that "
+          << "JACCL_IBV_DEVICES/MLX_IBV_DEVICES names available RDMA devices.";
+      throw std::runtime_error(msg.str());
+    }
+  }
+
   // Deregister any buffers and free the memory
   buffers_.clear();
   ring_send_buffers_.clear();

--- a/mlx/distributed/jaccl/lib/jaccl/rdma.cpp
+++ b/mlx/distributed/jaccl/lib/jaccl/rdma.cpp
@@ -4,6 +4,8 @@
 #include <unistd.h>
 #include <iostream>
 #include <sstream>
+#include <stdexcept>
+#include <string>
 
 #include "jaccl/rdma.h"
 
@@ -90,6 +92,13 @@ SharedBuffer::~SharedBuffer() {
 }
 
 void SharedBuffer::register_to_protection_domain(ibv_pd* protection_domain) {
+  if (protection_domain == nullptr) {
+    throw std::runtime_error(
+        "[jaccl] Cannot register an RDMA memory region without a protection "
+        "domain. Check that ibv_devices lists rdma_* devices and that "
+        "JACCL_IBV_DEVICES/MLX_IBV_DEVICES names an available RDMA device.");
+  }
+
   auto [it, inserted] = memory_regions_.insert({protection_domain, nullptr});
   if (!inserted) {
     throw std::runtime_error(
@@ -139,6 +148,13 @@ Connection::~Connection() {
 }
 
 void Connection::allocate_protection_domain() {
+  if (ctx == nullptr) {
+    throw std::runtime_error(
+        "[jaccl] Cannot allocate an RDMA protection domain without a device "
+        "context. Check that ibv_devices lists rdma_* devices and that "
+        "JACCL_IBV_DEVICES/MLX_IBV_DEVICES names an available RDMA device.");
+  }
+
   protection_domain = ibv().alloc_pd(ctx);
   if (protection_domain == nullptr) {
     throw std::runtime_error("[jaccl] Couldn't allocate protection domain");
@@ -265,9 +281,54 @@ void Connection::queue_pair_rts() {
 
 std::vector<Connection> create_connections(
     const std::vector<std::string>& device_names) {
+  if (!ibv().is_available()) {
+    throw std::runtime_error(
+        "[jaccl] JACCL RDMA support is unavailable because librdma.dylib "
+        "could not be loaded. Check Thunderbolt RDMA support and that "
+        "ibv_devices can list RDMA devices.");
+  }
+
+  struct DeviceListGuard {
+    ibv_device** devices;
+
+    ~DeviceListGuard() {
+      if (devices != nullptr) {
+        ibv().free_device_list(devices);
+      }
+    }
+  };
+
   std::vector<Connection> connections;
+  connections.reserve(device_names.size());
+
   int num_devices = 0;
   ibv_device** devices = ibv().get_device_list(&num_devices);
+  DeviceListGuard device_list_guard{devices};
+
+  auto available_devices = [&]() {
+    std::ostringstream msg;
+    if (devices == nullptr || num_devices <= 0) {
+      msg << "No RDMA devices were found. JACCL requires ibv_devices to "
+          << "list rdma_* devices.";
+      return msg.str();
+    }
+
+    msg << "Available RDMA devices:";
+    bool found_device = false;
+    for (int i = 0; devices != nullptr && i < num_devices; i++) {
+      const char* device_name = ibv().get_device_name(devices[i]);
+      if (device_name == nullptr) {
+        continue;
+      }
+      msg << (found_device ? "," : "") << " " << device_name;
+      found_device = true;
+    }
+    if (!found_device) {
+      msg << " none.";
+    }
+    return msg.str();
+  };
+
   for (auto& name : device_names) {
     // Empty so add a nullptr context
     if (name.empty()) {
@@ -276,8 +337,11 @@ std::vector<Connection> create_connections(
     }
 
     // Search for the name and try to open the device
-    for (int i = 0; i < num_devices; i++) {
-      if (name == ibv().get_device_name(devices[i])) {
+    bool found = false;
+    for (int i = 0; devices != nullptr && i < num_devices; i++) {
+      const char* device_name = ibv().get_device_name(devices[i]);
+      if (device_name != nullptr && name == device_name) {
+        found = true;
         auto ctx = ibv().open_device(devices[i]);
         if (ctx == nullptr) {
           std::ostringstream msg;
@@ -288,8 +352,15 @@ std::vector<Connection> create_connections(
         break;
       }
     }
+    if (!found) {
+      std::ostringstream msg;
+      msg << "[jaccl] Requested RDMA device '" << name << "' was not found. "
+          << available_devices()
+          << " Check JACCL_IBV_DEVICES/MLX_IBV_DEVICES or run ibv_devices to "
+          << "see the RDMA devices available to JACCL.";
+      throw std::runtime_error(msg.str());
+    }
   }
-  ibv().free_device_list(devices);
 
   return connections;
 }

--- a/mlx/distributed/jaccl/lib/jaccl/ring.cpp
+++ b/mlx/distributed/jaccl/lib/jaccl/ring.cpp
@@ -89,6 +89,33 @@ void RingGroup::initialize() {
 }
 
 void RingGroup::allocate_buffers() {
+  if (left_.size() != static_cast<size_t>(n_conns_) ||
+      right_.size() != static_cast<size_t>(n_conns_)) {
+    std::ostringstream msg;
+    msg << "[jaccl] Expected " << n_conns_
+        << " ring connections in each direction but found " << left_.size()
+        << " left and " << right_.size() << " right.";
+    throw std::runtime_error(msg.str());
+  }
+  for (int wire = 0; wire < n_conns_; wire++) {
+    if (left_[wire].protection_domain == nullptr) {
+      std::ostringstream msg;
+      msg << "[jaccl] Missing RDMA protection domain for left ring "
+          << "connection " << wire
+          << ". Check that ibv_devices lists rdma_* devices and that "
+          << "JACCL_IBV_DEVICES/MLX_IBV_DEVICES names available RDMA devices.";
+      throw std::runtime_error(msg.str());
+    }
+    if (right_[wire].protection_domain == nullptr) {
+      std::ostringstream msg;
+      msg << "[jaccl] Missing RDMA protection domain for right ring "
+          << "connection " << wire
+          << ". Check that ibv_devices lists rdma_* devices and that "
+          << "JACCL_IBV_DEVICES/MLX_IBV_DEVICES names available RDMA devices.";
+      throw std::runtime_error(msg.str());
+    }
+  }
+
   // Deregister any buffers and free the memory
   send_buffers_.clear();
   recv_buffers_.clear();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,10 @@ target_sources(
           ${METAL_TEST_SOURCES})
 
 target_link_libraries(tests PRIVATE mlx doctest)
+if(TARGET jaccl)
+  target_sources(tests PRIVATE jaccl_tests.cpp)
+  target_link_libraries(tests PRIVATE jaccl)
+endif()
 target_compile_options(tests PRIVATE ${SANITIZER_COMPILE_FLAGS})
 target_link_options(tests PRIVATE ${SANITIZER_LINK_FLAGS})
 

--- a/tests/jaccl_tests.cpp
+++ b/tests/jaccl_tests.cpp
@@ -1,0 +1,21 @@
+// Copyright © 2026 Apple Inc.
+
+#include "doctest/doctest.h"
+
+#include <stdexcept>
+#include <string>
+
+#include "jaccl/rdma.h"
+
+TEST_CASE("test JACCL shared buffer rejects null protection domain") {
+  jaccl::SharedBuffer buffer(64);
+
+  try {
+    buffer.register_to_protection_domain(nullptr);
+    FAIL("Expected null protection domain registration to throw");
+  } catch (const std::runtime_error& e) {
+    std::string message(e.what());
+    CHECK(message.find("protection domain") != std::string::npos);
+    CHECK(message.find("ibv_devices") != std::string::npos);
+  }
+}


### PR DESCRIPTION
## Summary

This PR improves JACCL error handling when requested RDMA devices are missing or unavailable.

Instead of allowing initialization to continue far enough that memory registration can be attempted with a null or invalid protection domain, JACCL now fails earlier with clearer runtime errors.

Partially addresses #3777 by fixing the crash/error-handling path.

## Context

Issue #3777 appears to involve two separate concerns:

1. `mlx.distributed_config` reports RDMA as unavailable because `ibv_devices` does not enumerate any `rdma_*` devices.
2. JACCL can later crash during initialization instead of reporting the missing RDMA device/protection domain cleanly.

This PR focuses on the second part.

If the OS/hardware does not expose RDMA verbs devices, JACCL cannot initialize successfully. This PR does not change RDMA enablement behavior, macOS setup requirements, Thunderbolt hardware support detection, or entitlement behavior.

## Root Cause

When a requested RDMA device was missing or unavailable, JACCL could continue into later initialization with missing/null RDMA state. In particular, a null or invalid protection domain could reach memory registration and crash inside `ibv_reg_mr` instead of producing an actionable JACCL error.

## Fix

* Fail fast when a requested non-empty RDMA device name is not found.
* Preserve empty-device placeholders for intentional self entries.
* Add clearer diagnostics for missing RDMA devices, including available-device context where possible.
* Guard null protection domains before memory registration.
* Add defensive checks before mesh/ring buffer registration uses peer protection domains.
* Add a conditional doctest for null protection-domain registration when the `jaccl` target is available.

## Testing

* Ran `pre-commit run --all-files`.
* Ran `git diff --check`.
* Ran `cmake -S . -B build`.
* Ran `cmake --build build -j`.
* Ran `ctest --test-dir build --output-on-failure` — 261/261 tests passed.

Note: the JACCL-specific doctest is gated on the `jaccl` CMake target. In my local environment, CMake configured MLX with the `no_jaccl` path because the installed macOS SDK does not provide the required JACCL/RDMA headers, so full JACCL/RDMA initialization was not exercised locally.
