### PR TITLE
Fix fp quantized matvec for output dim < 8

### DIFF
--- a/mlx/backend/metal/kernels/fp_quantized.h
+++ b/mlx/backend/metal/kernels/fp_quantized.h
@@ -440,7 +440,7 @@ METAL_FUNC void fp_qmv_impl(
         auto wl = (const device uint8_t*)(ws + row * in_vec_size_w);
         const device auto* sl = scales + row * in_vec_size_g;
 
-        uint8_t s = sl[0];
+        U s = dequantize_scale<U, group_size>(sl[0]);
         result[row] += qdot<U, values_per_thread, bits>(wl, x_thread, s);
       }
 

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -435,7 +435,7 @@ class TestQuantized(mlx_tests.MLXTestCase):
         key = mx.random.key(0)
         k1, k2 = mx.random.split(key)
         tests = product(
-            [256, 512, 67],  # M
+            [256, 512, 67, 5, 7],  # M -- 5, 7 exercise out_vec_size < 8 (#3762)
             [64, 256],  # N
             [0, 1, 3, 8],  # B
         )


### PR DESCRIPTION
### Summary

`fp_qmv_impl` (the Metal `quantized_matmul` matvec path, `M == 1`) has an
`out_vec_size < 8` branch that is taken when the weight matrix has fewer than
one full output tile. Its full-block loop read the fp8 group scale as a raw
byte and passed it straight to `qdot`:

```cpp
uint8_t s = sl[0];                       // raw 0-255 byte
result[row] += qdot<U, values_per_thread, bits>(wl, x_thread, s);
```

Every sibling site decodes the scale first -- including the remainder loop of
this same branch (and the other loops in `fp_qmv_impl`):

```cpp
U s = dequantize_scale<U, group_size>(sl[0]);
```

`qdot` multiplies by `s` directly, so the undecoded byte corrupts the result
for any fp quantization mode (mxfp4 / mxfp8 / nvfp4) whose output dimension is
`< 8`. Affine quantization uses different kernels and is unaffected.

Fixes #3762.

### Repro (M3 Max, Metal)

`x @ dequantize(w).T` vs `quantized_matmul`, mxfp4, `group_size=32`, `K=512`:

| output dim | before | after |
| ---: | --- | --- |
| 5 | rel_err 2.18e+02 | rel_err 3.01e-08 |
| 7 | rel_err 1.83e+02 | rel_err 1.45e-07 |
| 8 | rel_err 2.03e-07 | rel_err 2.03e-07 |
| 12 | rel_err 7.83e-08 | rel_err 7.83e-08 |
| 16 | rel_err 6.74e-08 | rel_err 6.74e-08 |

Affine control is ~1e-7 throughout, unchanged.

### Testing

- Extended `test_fp_qmv` with output dims `M = 5, 7`, which exercise the
  previously-untested `out_vec_size < 8` path.
- `python -m pytest python/tests/test_quantized.py`: 32 passed, 2896 subtests.
