### PR TITLE
Add parallel dispatch helper for CPU encoder

### DIFF
--- a/mlx/backend/cpu/encoder.cpp
+++ b/mlx/backend/cpu/encoder.cpp
@@ -3,6 +3,7 @@
 #include "mlx/backend/cpu/encoder.h"
 
 #include <fmt/format.h>
+#include <thread>
 
 namespace mlx::core::cpu {
 
@@ -29,6 +30,20 @@ std::unordered_map<int, CommandEncoder>& get_command_encoders() {
 std::unordered_map<int, CommandEncoder>& get_global_command_encoders() {
   static std::unordered_map<int, CommandEncoder> encoders;
   return encoders;
+}
+
+size_t thread_pool_size() {
+  static size_t size = [] {
+    auto n = std::thread::hardware_concurrency();
+    return n == 0 ? 4 : n;
+  }();
+  return size;
+}
+
+ThreadPool& thread_pool() {
+  // Leak - see Scheduler singleton comment in scheduler.cpp.
+  static ThreadPool* pool = new ThreadPool{thread_pool_size()};
+  return *pool;
 }
 
 } // namespace mlx::core::cpu

--- a/mlx/backend/cpu/encoder.h
+++ b/mlx/backend/cpu/encoder.h
@@ -6,11 +6,15 @@
 
 #include "mlx/array.h"
 #include "mlx/scheduler.h"
+#include "mlx/threadpool.h"
 
 namespace mlx::core::cpu {
 
 // Number of dispatches per scheduler task
 constexpr int DISPATCHES_PER_TASK = 10;
+
+MLX_API ThreadPool& thread_pool();
+MLX_API size_t thread_pool_size();
 
 struct MLX_API CommandEncoder {
   CommandEncoder(Stream stream) : stream_(stream) {}
@@ -54,6 +58,50 @@ struct MLX_API CommandEncoder {
     } else {
       scheduler::enqueue(stream_, std::move(task));
     }
+  }
+
+  template <class F>
+  void dispatch_parallel(size_t n, F&& f, size_t grain_size = 32768) {
+    dispatch([n, grain_size, f = std::forward<F>(f)]() mutable {
+      if (n == 0) {
+        return;
+      }
+
+      if (grain_size == 0) {
+        grain_size = 1;
+      }
+
+      auto num_threads = thread_pool_size();
+
+      if (n <= grain_size || num_threads <= 1) {
+        f(0, n);
+        return;
+      }
+
+      // grain_size is minimum amount of range work to assign to a thread-pool
+      // task. Small ranges run on stream worker to avoid overhead.
+      size_t num_tasks = std::min(num_threads, n / grain_size);
+
+      if (num_tasks <= 1) {
+        f(0, n);
+        return;
+      }
+
+      size_t chunk_size = n / num_tasks + (n % num_tasks != 0);
+
+      std::vector<std::future<void>> futures;
+      futures.reserve(num_tasks);
+
+      for (size_t start = 0; start < n; start += chunk_size) {
+        size_t end = std::min(start + chunk_size, n);
+        futures.emplace_back(
+            thread_pool().enqueue([start, end, &f]() { f(start, end); }));
+      }
+
+      for (auto& future : futures) {
+        future.get();
+      }
+    });
   }
 
  private:

--- a/tests/scheduler_tests.cpp
+++ b/tests/scheduler_tests.cpp
@@ -2,6 +2,7 @@
 
 #include "doctest/doctest.h"
 
+#include "mlx/backend/cpu/encoder.h"
 #include "mlx/mlx.h"
 #include "mlx/scheduler.h"
 
@@ -248,4 +249,33 @@ TEST_CASE("test scheduler races") {
     y = exp(y);
   }
   eval(a, y);
+}
+
+TEST_CASE("test cpu dispatch parallel") {
+  auto s = default_stream(Device::cpu);
+  auto& encoder = cpu::get_command_encoder(s);
+
+  std::vector<int> out(1024, 0);
+  std::atomic<int> chunks{0};
+
+  encoder.dispatch_parallel(
+      out.size(),
+      [&](size_t start, size_t end) {
+        chunks++;
+        for (size_t i = start; i < end; ++i) {
+          out[i] = static_cast<int>(i);
+        }
+      },
+      64);
+
+  synchronize(s);
+
+  for (size_t i = 0; i < out.size(); ++i) {
+    CHECK_EQ(out[i], static_cast<int>(i));
+  }
+  auto expected_chunks =
+      std::min(cpu::thread_pool_size(), out.size() / size_t{64});
+  expected_chunks = std::max<size_t>(expected_chunks, 1);
+
+  CHECK_EQ(chunks.load(), expected_chunks);
 }


### PR DESCRIPTION
## Proposed changes

- Adds a `CommandEncoder::dispatch_parallel` helper for CPU backend work. 
The helper schedules one ordered stream task, splits a `[0, n)` range into 
chunks, runs those chunks on a shared CPU thread pool, and waits for the 
futures before the stream task completes.

- This gives custom CPU primitive authors a built-in way to parallelize large 
kernel loops without managing their own thread pool.

- Fixes #2185 

Tests: added `TEST_CASE("test cpu dispatch parallel")` in `tests/scheduler_tests.cpp`

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
