### PR TITLE
Fix binary_cross_entropy docstring argument order (weights before with_logits)

### DIFF
--- a/python/mlx/nn/losses.py
+++ b/python/mlx/nn/losses.py
@@ -136,8 +136,8 @@ def binary_cross_entropy(
         inputs (array): The predicted values. If ``with_logits`` is ``True``, then
             ``inputs`` are unnormalized logits. Otherwise, ``inputs`` are probabilities.
         targets (array): The binary target values in {0, 1}.
-        with_logits (bool, optional): Whether ``inputs`` are logits. Default: ``True``.
         weights (array, optional): Optional weights for each target. Default: ``None``.
+        with_logits (bool, optional): Whether ``inputs`` are logits. Default: ``True``.
         reduction (str, optional): Specifies the reduction to apply to the output:
           ``'none'`` | ``'mean'`` | ``'sum'``. Default: ``'mean'``.
 


### PR DESCRIPTION
The `binary_cross_entropy` Args block documents the parameters as `inputs, targets, with_logits, weights, reduction`, but the actual signature order is `inputs, targets, weights, with_logits, reduction`:

```python
def binary_cross_entropy(
    inputs, targets,
    weights=None,          # 3rd positional
    with_logits=True,      # 4th positional
    reduction="mean",
)
```

A caller following the docstring order positionally, e.g. `binary_cross_entropy(logits, targets, False)` intending `with_logits=False`, instead binds `weights=False`. The `weights is not None` branch then does `weights.shape` on a bool and raises `AttributeError: 'bool' object has no attribute 'shape'`.

```
>>> nn.losses.binary_cross_entropy(mx.array([0.1,0.2]), mx.array([0,1]), False)
AttributeError: 'bool' object has no attribute 'shape'
```

This reorders the two Args entries so `weights` precedes `with_logits`, matching the signature. The sibling `cross_entropy` in the same file already documents `weights` in its correct signature position. Docstring-only change.