### PR TITLE
Bypass the PyTorch index TLS issues

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -20,9 +20,7 @@ runs:
       run: |
         echo "::group::Install Python package"
         # Install cpu-only torch to save space.
-        # Fall back to PyPI if PyTorch index has issues.
-        uv pip install torch --index-url https://download.pytorch.org/whl/cpu \
-          || uv pip install torch
+        uv pip install torch --torch-backend=cpu
         uv pip install --no-build-isolation -e ".[dev]" -v
         echo "::endgroup::"
 

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -19,8 +19,10 @@ runs:
         CMAKE_ARGS: ${{ inputs.cmake-args }}
       run: |
         echo "::group::Install Python package"
-        # Install cpu-only torch to save space
-        uv pip install torch --index-url https://download.pytorch.org/whl/cpu
+        # Install cpu-only torch to save space.
+        # Fall back to PyPI if PyTorch index has issues.
+        uv pip install torch --index-url https://download.pytorch.org/whl/cpu \
+          || uv pip install torch
         uv pip install --no-build-isolation -e ".[dev]" -v
         echo "::endgroup::"
 

--- a/.github/actions/test-wheel/action.yml
+++ b/.github/actions/test-wheel/action.yml
@@ -32,8 +32,7 @@ runs:
       run: |
         echo "::group::Test local packages"
         # Fall back to PyPI if PyTorch index has issues.
-        uv pip install torch --index-url https://download.pytorch.org/whl/cpu \
-          || uv pip install torch
+        uv pip install torch --torch-backend=cpu
         uv pip install numpy
         if ${{ inputs.toolkit == 'cpu' }} ; then
           uv pip install wheelhouse/mlx_cpu*.whl

--- a/.github/actions/test-wheel/action.yml
+++ b/.github/actions/test-wheel/action.yml
@@ -31,7 +31,9 @@ runs:
       shell: bash
       run: |
         echo "::group::Test local packages"
-        uv pip install torch --index-url https://download.pytorch.org/whl/cpu
+        # Fall back to PyPI if PyTorch index has issues.
+        uv pip install torch --index-url https://download.pytorch.org/whl/cpu \
+          || uv pip install torch
         uv pip install numpy
         if ${{ inputs.toolkit == 'cpu' }} ; then
           uv pip install wheelhouse/mlx_cpu*.whl


### PR DESCRIPTION
Fallback to PyPI to bypass the TLS issues.
