### PR TITLE
Use large runner for Windows CUDA builds

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -51,6 +51,7 @@ jobs:
     runs-on: |-
       ${{ case(matrix.os == 'Windows',
                case(matrix.arch == 'aarch64', 'windows-11-arm',
+                    startsWith(matrix.toolkit, 'cuda'), 'windows-2022-large',
                     'windows-2022'),
                case(matrix.arch == 'x86_64' && startsWith(matrix.toolkit, 'cuda'), 'gpu-t4-4-core',
                     matrix.arch == 'aarch64', 'ubuntu-22.04-arm',

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       publish:
-        description: 'Publish to PyPi'
+        description: 'Publish to PyPI'
         required: false
         type: boolean
       dev-release:
@@ -111,7 +111,7 @@ jobs:
     runs-on: |-
       ${{ case(matrix.os == 'Windows',
                case(matrix.arch == 'aarch64', 'windows-11-arm',
-                    'windows-2022'),
+                    'windows-2022-large'),
                case(matrix.arch == 'aarch64', 'ubuntu-22-large-arm',
                     'ubuntu-22-large'))
       }}


### PR DESCRIPTION
With the new large runner the cold build time can be reduced from over 1 hour to 40 minutes.