### PR TITLE
Fix wrong type parameter passed to gemm_splitk_nax

### DIFF
--- a/mlx/backend/metal/jit_kernels.cpp
+++ b/mlx/backend/metal/jit_kernels.cpp
@@ -1047,7 +1047,7 @@ MTL::ComputePipelineState* get_steel_gemm_splitk_nax_kernel(
     const std::string& kernel_name,
     const std::string& hash_name,
     const metal::MTLFCList& func_consts,
-    const array& out,
+    const array& in,
     bool transpose_a,
     bool transpose_b,
     int bm,
@@ -1063,7 +1063,7 @@ MTL::ComputePipelineState* get_steel_gemm_splitk_nax_kernel(
                   << get_template_definition(
                          lib_name,
                          "gemm_splitk_nax",
-                         get_type_string(out.dtype()),
+                         get_type_string(in.dtype()),
                          bm,
                          bn,
                          bk,

--- a/mlx/backend/metal/kernels.h
+++ b/mlx/backend/metal/kernels.h
@@ -328,7 +328,7 @@ MTL::ComputePipelineState* get_steel_gemm_splitk_nax_kernel(
     const std::string& kernel_name,
     const std::string& hash_name,
     const metal::MTLFCList& func_consts,
-    const array& out,
+    const array& in,
     bool transpose_a,
     bool transpose_b,
     int bm,

--- a/mlx/backend/metal/matmul.cpp
+++ b/mlx/backend/metal/matmul.cpp
@@ -737,7 +737,7 @@ void steel_gemm_splitk_axpby_nax(
       /* const std::string& kernel_name = */ base_name,
       /* const std::string& hash_name = */ hash_name,
       /* const metal::MTLFCList& func_consts = */ func_consts,
-      /* const array& out = */ C_split,
+      /* const array& in = */ a,
       /* bool transpose_a = */ transpose_a,
       /* bool transpose_b = */ transpose_b,
       /* int bm = */ bm,


### PR DESCRIPTION
The first parameter is the type of inputs not the output, closes https://github.com/ml-explore/mlx/issues/3797.