### PR TITLE
Document default value of dilation in conv layer docstrings

### DIFF
--- a/python/mlx/nn/layers/convolution.py
+++ b/python/mlx/nn/layers/convolution.py
@@ -25,6 +25,7 @@ class Conv1d(Module):
         padding (int, optional): How many positions to 0-pad the input with.
             Default: ``0``.
         dilation (int, optional): The dilation of the convolution.
+            Default: ``1``.
         groups (int, optional): The number of groups for the convolution.
             Default: ``1``.
         bias (bool, optional): If ``True`` add a learnable bias to the output.
@@ -101,6 +102,7 @@ class Conv2d(Module):
         padding (int or tuple, optional): How many positions to 0-pad
             the input with. Default: ``0``.
         dilation (int or tuple, optional): The dilation of the convolution.
+            Default: ``1``.
         groups (int, optional): The number of groups for the convolution.
             Default: ``1``.
         bias (bool, optional): If ``True`` add a learnable bias to the
@@ -182,6 +184,7 @@ class Conv3d(Module):
         padding (int or tuple, optional): How many positions to 0-pad
             the input with. Default: ``0``.
         dilation (int or tuple, optional): The dilation of the convolution.
+            Default: ``1``.
         bias (bool, optional): If ``True`` add a learnable bias to the
             output. Default: ``True``
     """

--- a/python/mlx/nn/layers/convolution_transpose.py
+++ b/python/mlx/nn/layers/convolution_transpose.py
@@ -25,6 +25,7 @@ class ConvTranspose1d(Module):
         padding (int, optional): How many positions to 0-pad the input with.
             Default: ``0``.
         dilation (int, optional): The dilation of the convolution.
+            Default: ``1``.
         output_padding(int, optional): Additional size added to one side of the
             output shape. Default: ``0``.
         bias (bool, optional): If ``True`` add a learnable bias to the output.
@@ -100,6 +101,7 @@ class ConvTranspose2d(Module):
         padding (int or tuple, optional): How many positions to 0-pad
             the input with. Default: ``0``.
         dilation (int or tuple, optional): The dilation of the convolution.
+            Default: ``1``.
         output_padding(int or tuple, optional): Additional size added to one
             side of the output shape. Default: ``0``.
         bias (bool, optional): If ``True`` add a learnable bias to the
@@ -180,6 +182,7 @@ class ConvTranspose3d(Module):
         padding (int or tuple, optional): How many positions to 0-pad
             the input with. Default: ``0``.
         dilation (int or tuple, optional): The dilation of the convolution.
+            Default: ``1``.
         output_padding(int or tuple, optional): Additional size added to one
             side of the output shape. Default: ``0``.
         bias (bool, optional): If ``True`` add a learnable bias to the


### PR DESCRIPTION
The `dilation` parameter defaults to `1` in every `Conv` and `ConvTranspose` layer, but its docstring was the only optional parameter whose default was not documented. `stride`, `padding`, `output_padding` and `groups` all state their defaults, so a reader of the docs could not tell that `dilation` defaults to `1`.

This adds `Default: ``1``.` to the `dilation` entry in `Conv1d`, `Conv2d`, `Conv3d`, `ConvTranspose1d`, `ConvTranspose2d` and `ConvTranspose3d`, matching the sibling parameters.

Docs-only change; `black` clean.