### PR TITLE
Fix int64 type cast error when loading GGUF metadata arrays

### DIFF
--- a/mlx/io/gguf.cpp
+++ b/mlx/io/gguf.cpp
@@ -161,7 +161,7 @@ void set_mx_value_from_gguf(
           value = array(reinterpret_cast<uint64_t*>(data), {size}, uint64);
           break;
         case GGUF_VALUE_TYPE_INT64:
-          value = array(reinterpret_cast<uint64_t*>(data), {size}, int64);
+          value = array(reinterpret_cast<int64_t*>(data), {size}, int64);
           break;
         case GGUF_VALUE_TYPE_FLOAT32:
           value = array(reinterpret_cast<float*>(data), {size}, float32);

--- a/python/tests/test_load.py
+++ b/python/tests/test_load.py
@@ -339,16 +339,6 @@ class TestLoad(mlx_tests.MLXTestCase):
                 metadata = {"meta": arr}
                 mx.save_gguf(save_file_mlx, save_dict, metadata)
 
-        # int64 negative case
-        arr = mx.array([-1], dtype=mx.int64)
-        metadata = {"meta": arr}
-        mx.save_gguf(save_file_mlx, save_dict, metadata)
-        _, meta_load_dict = mx.load(save_file_mlx, return_metadata=True)
-        self.assertEqual(len(meta_load_dict), 1)
-        self.assertTrue("meta" in meta_load_dict)
-        self.assertTrue(mx.array_equal(meta_load_dict["meta"], arr))
-        self.assertEqual(meta_load_dict["meta"].dtype, mx.int64)
-
     @unittest.skipIf(platform.system() == "Windows", "GGUF is disabled on Windows")
     def test_save_and_load_gguf_metadata_mixed(self):
         if not os.path.isdir(self.test_dir):

--- a/python/tests/test_load.py
+++ b/python/tests/test_load.py
@@ -339,6 +339,16 @@ class TestLoad(mlx_tests.MLXTestCase):
                 metadata = {"meta": arr}
                 mx.save_gguf(save_file_mlx, save_dict, metadata)
 
+        # int64 negative case
+        arr = mx.array([-1], dtype=mx.int64)
+        metadata = {"meta": arr}
+        mx.save_gguf(save_file_mlx, save_dict, metadata)
+        _, meta_load_dict = mx.load(save_file_mlx, return_metadata=True)
+        self.assertEqual(len(meta_load_dict), 1)
+        self.assertTrue("meta" in meta_load_dict)
+        self.assertTrue(mx.array_equal(meta_load_dict["meta"], arr))
+        self.assertEqual(meta_load_dict["meta"].dtype, mx.int64)
+
     @unittest.skipIf(platform.system() == "Windows", "GGUF is disabled on Windows")
     def test_save_and_load_gguf_metadata_mixed(self):
         if not os.path.isdir(self.test_dir):

--- a/tests/load_tests.cpp
+++ b/tests/load_tests.cpp
@@ -216,6 +216,17 @@ TEST_CASE("test gguf metadata") {
     CHECK(array_equal(arr, loaded_arr).item<bool>());
   }
 
+  // 1D int64 array with negative values
+  {
+    std::unordered_map<std::string, GGUFMetaData> original_metadata;
+    auto arr = array({static_cast<int64_t>(-1)}, int64);
+    original_metadata.insert({"test_arr", arr});
+    save_gguf(file_path, original_weights, original_metadata);
+    auto [loaded_weights, loaded_metadata] = load_gguf(file_path);
+    CHECK(array_equal(arr, std::get<array>(loaded_metadata.at("test_arr")))
+              .item<bool>());
+  }
+
   // > 1D array throws
   {
     std::unordered_map<std::string, GGUFMetaData> original_metadata;


### PR DESCRIPTION
## Proposed changes
Small nit but basically fixes an incorrect `reinterpret_cast` from `uint64_t*` to `int64_t*` when loading 64-bit integer metadata arrays. Doesn't have impact on actual behavior of the program as `array::init()` copies the data into `int64_t` storage. 
### Testing 
- Ran existing tests
- Added tests for negative metadata for 64-bit integer array cases 
## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
