### PR TITLE
Metal batched Cholesky

### DIFF
--- a/mlx/backend/cpu/cholesky.cpp
+++ b/mlx/backend/cpu/cholesky.cpp
@@ -33,7 +33,7 @@ void cholesky_impl(const array& a, array& factor, bool upper, Stream stream) {
                     N = a.shape(-1),
                     size = a.size()]() mutable {
     char uplo = (upper) ? 'L' : 'U';
-    size_t num_matrices = size / (N * N);
+    size_t num_matrices = (N > 0) ? size / (size_t(N) * N) : 0;
     for (int i = 0; i < num_matrices; i++) {
       // Compute Cholesky factorization.
       int info;

--- a/mlx/backend/cuda/primitives.cpp
+++ b/mlx/backend/cuda/primitives.cpp
@@ -29,6 +29,10 @@ NO_GPU_MULTI(QRF)
 NO_GPU_MULTI(SVD)
 NO_GPU(Inverse)
 NO_GPU(Cholesky)
+
+bool Cholesky::use_fallback(Dtype, int, size_t, Stream) {
+  return true;
+}
 NO_GPU_MULTI(Eig)
 NO_GPU_MULTI(Eigh)
 

--- a/mlx/backend/metal/CMakeLists.txt
+++ b/mlx/backend/metal/CMakeLists.txt
@@ -44,6 +44,7 @@ if(MLX_METAL_JIT)
   make_jit_source(binary_two)
   make_jit_source(fft kernels/fft/radix.h kernels/fft/readwrite.h)
   make_jit_source(logsumexp)
+  make_jit_source(cholesky)
   make_jit_source(ternary)
   make_jit_source(softmax)
   make_jit_source(scan)
@@ -106,6 +107,7 @@ target_sources(
   mlx
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/allocator.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/binary.cpp
+          ${CMAKE_CURRENT_SOURCE_DIR}/cholesky.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/device_info.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/compiled.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/conv.cpp

--- a/mlx/backend/metal/cholesky.cpp
+++ b/mlx/backend/metal/cholesky.cpp
@@ -1,0 +1,190 @@
+// Copyright © 2025 Apple Inc.
+
+#include <algorithm>
+#include <cassert>
+
+#include "mlx/backend/gpu/copy.h"
+#include "mlx/backend/metal/device.h"
+#include "mlx/backend/metal/kernels.h"
+#include "mlx/backend/metal/utils.h"
+#include "mlx/primitives.h"
+
+namespace mlx::core {
+
+bool Cholesky::use_fallback(Dtype dtype, int n, size_t num_matrices, Stream s) {
+  if (s.device == Device::cpu || dtype != float32) {
+    return true;
+  }
+  // Minimum batch size at which the Metal kernels beat the CPU, measured on
+  // an M3 Pro at both ends of each size range. Below the threshold, and for
+  // sizes where the GPU was not measured to win, the CPU implementation is
+  // used.
+  size_t min_batch;
+  if (n <= 12) {
+    return true;
+  } else if (n <= 31) {
+    min_batch = 1000;
+  } else if (n <= 64) {
+    min_batch = 500;
+  } else if (n <= 128) {
+    min_batch = 250;
+  } else if (n <= 192) {
+    min_batch = 128;
+  } else if (n <= 256) {
+    min_batch = 100;
+  } else if (n <= 512) {
+    min_batch = 80;
+  } else if (n <= 1024) {
+    min_batch = 48;
+  } else if (n <= 2048) {
+    min_batch = 16;
+  } else {
+    return true;
+  }
+  return num_matrices < min_batch;
+}
+
+void Cholesky::eval_gpu(const std::vector<array>& inputs, array& out) {
+  assert(inputs.size() == 1);
+
+  if (inputs[0].dtype() != float32) {
+    throw std::runtime_error(
+        "[Cholesky::eval_gpu] Metal Cholesky only supports float32. "
+        "Use stream=Device::cpu for other types.");
+  }
+
+  auto& s = stream();
+  auto& d = metal::device(s.device);
+  auto& compute_encoder = metal::get_command_encoder(s);
+
+  // The factorization runs in place, so copy the input into the output.
+  const array& in = inputs[0];
+  copy_gpu(
+      in,
+      out,
+      in.flags().row_contiguous ? CopyType::Vector : CopyType::General,
+      s);
+
+  int N = out.shape(-1);
+  size_t num_matrices = (N == 0) ? 0 : out.size() / (size_t(N) * N);
+  if (num_matrices == 0 || N == 0) {
+    return;
+  }
+
+  int upper = upper_ ? 1 : 0;
+  size_t tg_bytes = size_t(N) * N * sizeof(float);
+  size_t max_tg_mem = d.mtl_device()->maxThreadgroupMemoryLength();
+  constexpr int kSimdSize = 32;
+
+  if (N > 128) {
+    // Batched blocked right-looking factorization (see kernels/cholesky.h):
+    // per 32-column panel, one batched panel dispatch (POTF2 + TRSM) and one
+    // batched simdgroup-matrix SYRK dispatch over the trailing lower-triangle
+    // tiles, separated by buffer barriers, then one fixup pass to zero the
+    // strict upper triangle (or transpose in place when upper). Separate
+    // grids keep the SYRK at high occupancy across the whole batch.
+    constexpr int NB = 32;
+    std::string tname = type_to_name(out);
+    auto panel_kernel = get_cholesky_kernel(d, "cholesky_panel_" + tname, out);
+    auto syrk32_kernel =
+        get_cholesky_kernel(d, "cholesky_syrk32_" + tname, out);
+    auto syrk64_kernel =
+        get_cholesky_kernel(d, "cholesky_syrk64_" + tname, out);
+    auto fixup_kernel = get_cholesky_kernel(d, "cholesky_fixup_" + tname, out);
+    size_t panel_tg = std::min<size_t>(
+        256, panel_kernel->maxTotalThreadsPerThreadgroup() / 32 * 32);
+
+    auto dispatch_panel = [&](int p) {
+      compute_encoder.set_compute_pipeline_state(panel_kernel);
+      compute_encoder.set_output_array(out, 0);
+      compute_encoder.set_bytes(N, 1);
+      compute_encoder.set_bytes(p, 2);
+      compute_encoder.dispatch_threadgroups(
+          MTL::Size(num_matrices, 1, 1), MTL::Size(panel_tg, 1, 1));
+      compute_encoder.barrier();
+    };
+    auto dispatch_syrk =
+        [&](MTL::ComputePipelineState* kernel, int p, int kd, bool col0) {
+          int ht = N - p - kd;
+          if (ht <= 0) {
+            return;
+          }
+          int nt = (ht + NB - 1) / NB;
+          int num_tiles = col0 ? nt : nt * (nt + 1) / 2;
+          int c0 = col0 ? 1 : 0;
+          compute_encoder.set_compute_pipeline_state(kernel);
+          compute_encoder.set_output_array(out, 0);
+          compute_encoder.set_bytes(N, 1);
+          compute_encoder.set_bytes(p, 2);
+          compute_encoder.set_bytes(c0, 3);
+          compute_encoder.dispatch_threadgroups(
+              MTL::Size(num_tiles, num_matrices, 1), MTL::Size(128, 1, 1));
+          compute_encoder.barrier();
+        };
+
+    // Panels are processed in pairs: prime the second panel's block-column
+    // with a rank-32 update, factor it, then apply a single rank-64 update
+    // to the rest of the trailing matrix. The panels stay 32 columns wide
+    // while the trailing read-modify-write traffic halves.
+    int p = 0;
+    while (p < N) {
+      dispatch_panel(p);
+      if (N - p > NB) {
+        dispatch_syrk(syrk32_kernel, p, NB, true);
+        dispatch_panel(p + NB);
+        dispatch_syrk(syrk64_kernel, p, 2 * NB, false);
+        p += 2 * NB;
+      } else {
+        p += NB;
+      }
+    }
+    compute_encoder.set_compute_pipeline_state(fixup_kernel);
+    compute_encoder.set_output_array(out, 0);
+    compute_encoder.set_bytes(N, 1);
+    compute_encoder.set_bytes(upper, 2);
+    compute_encoder.dispatch_threads(
+        MTL::Size(N, num_matrices, 1), MTL::Size(std::min(N, 256), 1, 1));
+    return;
+  }
+
+  // N <= 32: one matrix per simdgroup, no barriers. Up to 64 the whole matrix
+  // is staged in threadgroup memory. Otherwise (up to 128) factor directly in
+  // device memory, one matrix per threadgroup.
+  std::string kname;
+  if (N <= kSimdSize) {
+    kname = "cholesky_simd_";
+  } else if (N <= 2 * kSimdSize && tg_bytes <= max_tg_mem) {
+    kname = "cholesky_shared_";
+  } else {
+    kname = "cholesky_device_";
+  }
+  kname += type_to_name(out);
+  auto kernel = get_cholesky_kernel(d, kname, out);
+  size_t max_threads = kernel->maxTotalThreadsPerThreadgroup();
+
+  compute_encoder.set_compute_pipeline_state(kernel);
+  compute_encoder.set_output_array(out, 0);
+  compute_encoder.set_bytes(N, 1);
+  compute_encoder.set_bytes(upper, 2);
+
+  if (N <= kSimdSize) {
+    int simds_per_tg = 4;
+    int nmat = static_cast<int>(num_matrices);
+    compute_encoder.set_bytes(nmat, 3);
+    size_t num_blocks =
+        (num_matrices + simds_per_tg - 1) / size_t(simds_per_tg);
+    MTL::Size grid_dims = MTL::Size(num_blocks, 1, 1);
+    MTL::Size group_dims = MTL::Size(size_t(simds_per_tg) * kSimdSize, 1, 1);
+    compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+  } else {
+    if (tg_bytes <= max_tg_mem) {
+      compute_encoder.set_threadgroup_memory_length(tg_bytes, 0);
+    }
+    size_t tgsize = std::min<size_t>(N, max_threads);
+    MTL::Size grid_dims = MTL::Size(tgsize * num_matrices, 1, 1);
+    MTL::Size group_dims = MTL::Size(tgsize, 1, 1);
+    compute_encoder.dispatch_threads(grid_dims, group_dims);
+  }
+}
+
+} // namespace mlx::core

--- a/mlx/backend/metal/jit/includes.h
+++ b/mlx/backend/metal/jit/includes.h
@@ -23,6 +23,7 @@ const char* gather_axis();
 const char* gather_front();
 const char* hadamard();
 const char* logsumexp();
+const char* cholesky();
 const char* quantized_utils();
 const char* quantized();
 const char* fp_quantized();

--- a/mlx/backend/metal/jit_kernels.cpp
+++ b/mlx/backend/metal/jit_kernels.cpp
@@ -326,6 +326,38 @@ MTL::ComputePipelineState* get_logsumexp_kernel(
   return d.get_kernel(kernel_name, lib);
 }
 
+MTL::ComputePipelineState* get_cholesky_kernel(
+    metal::Device& d,
+    const std::string& kernel_name,
+    const array& out) {
+  // kernel_name is "cholesky_{shared,device}_{type}", e.g.
+  // "cholesky_shared_float32". Build both variants into one library per type.
+  std::string tname = kernel_name.substr(kernel_name.rfind('_') + 1);
+  std::string lib_name = "cholesky_" + tname;
+  auto lib = d.get_library(lib_name, [&] {
+    auto t_str = get_type_string(out.dtype());
+    std::string kernel_source;
+    kernel_source = metal::utils();
+    kernel_source += metal::cholesky();
+    kernel_source += get_template_definition(
+        "cholesky_simd_" + tname, "cholesky_simd", t_str);
+    kernel_source += get_template_definition(
+        "cholesky_shared_" + tname, "cholesky_shared", t_str);
+    kernel_source += get_template_definition(
+        "cholesky_panel_" + tname, "cholesky_panel", t_str);
+    kernel_source += get_template_definition(
+        "cholesky_syrk32_" + tname, "cholesky_syrk", t_str, 32);
+    kernel_source += get_template_definition(
+        "cholesky_syrk64_" + tname, "cholesky_syrk", t_str, 64);
+    kernel_source += get_template_definition(
+        "cholesky_fixup_" + tname, "cholesky_fixup", t_str);
+    kernel_source += get_template_definition(
+        "cholesky_device_" + tname, "cholesky_device", t_str);
+    return kernel_source;
+  });
+  return d.get_kernel(kernel_name, lib);
+}
+
 MTL::ComputePipelineState* get_scan_kernel(
     metal::Device& d,
     const std::string& kernel_name,

--- a/mlx/backend/metal/kernels.h
+++ b/mlx/backend/metal/kernels.h
@@ -64,6 +64,11 @@ MTL::ComputePipelineState* get_logsumexp_kernel(
     const std::string& kernel_name,
     const array& out);
 
+MTL::ComputePipelineState* get_cholesky_kernel(
+    metal::Device& d,
+    const std::string& kernel_name,
+    const array& out);
+
 MTL::ComputePipelineState* get_scan_kernel(
     metal::Device& d,
     const std::string& kernel_name,

--- a/mlx/backend/metal/kernels/CMakeLists.txt
+++ b/mlx/backend/metal/kernels/CMakeLists.txt
@@ -47,6 +47,7 @@ function(build_kernel KERNEL)
 endfunction(build_kernel)
 
 build_kernel(arg_reduce)
+build_kernel(cholesky cholesky.h)
 build_kernel(conv steel/conv/params.h)
 build_kernel(layer_norm)
 build_kernel(random)

--- a/mlx/backend/metal/kernels/cholesky.h
+++ b/mlx/backend/metal/kernels/cholesky.h
@@ -1,0 +1,584 @@
+// Copyright © 2025 Apple Inc.
+
+#include <metal_simdgroup>
+#include <metal_simdgroup_matrix>
+
+// Batched Cholesky factorization.
+//
+// The factorization runs in place in `out`. Three paths by matrix size:
+//  - N <= 32 (cholesky_simd): one matrix per simdgroup. Lane i keeps row i in
+//    registers and lanes communicate with simd_shuffle, so there are no
+//    threadgroup barriers at all; several matrices run per threadgroup.
+//  - N <= 90 (cholesky_shared): one matrix per threadgroup, staged in
+//    threadgroup memory.
+//  - larger (cholesky_device): one matrix per threadgroup, factored directly
+//    in device memory.
+
+// Right-looking, register-resident factorization for N <= 32. Lane i owns row
+// i of the (symmetric) input. After step j every lane i holds the final
+// L[i][j] in r[j] (i >= j). The trailing update at step j broadcasts column j
+// one element at a time with simd_shuffle; simdgroup lockstep replaces
+// barriers.
+template <typename T>
+[[kernel]] void cholesky_simd(
+    device T* out [[buffer(0)]],
+    const constant int& N [[buffer(1)]],
+    const constant int& upper [[buffer(2)]],
+    const constant int& num_matrices [[buffer(3)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simds_per_tg [[simdgroups_per_threadgroup]]) {
+  int mat = int(tg_id) * int(simds_per_tg) + int(simd_group_id);
+  if (mat >= num_matrices) {
+    return;
+  }
+  device T* A = out + size_t(mat) * N * N;
+  int lane = int(simd_lane_id);
+
+  // Row `lane` of the matrix (rows equal columns for the symmetric input).
+  // For N = 32 each row is exactly one cache line.
+  T r[32] = {T(0)};
+  if (lane < N) {
+    for (int k = 0; k < N; ++k) {
+      r[k] = A[lane * N + k];
+    }
+  }
+
+  for (int j = 0; j < N; ++j) {
+    // r[j] on lane j is the fully updated diagonal element.
+    T piv = metal::sqrt(simd_shuffle(r[j], ushort(j)));
+    if (lane == j) {
+      r[j] = piv;
+    } else if (lane > j) {
+      r[j] /= piv; // L[lane][j]
+    }
+    // Trailing update: M[i][k] -= L[i][j] * L[k][j] for j < k <= i.
+    for (int k = j + 1; k < N; ++k) {
+      T lkj = simd_shuffle(r[j], ushort(k));
+      if (lane >= k) {
+        r[k] -= r[j] * lkj;
+      }
+    }
+  }
+
+  if (lane < N) {
+    if (upper == 0) {
+      // Row `lane` of L, upper triangle zeroed.
+      for (int k = 0; k < N; ++k) {
+        A[lane * N + k] = (k <= lane) ? r[k] : T(0);
+      }
+    } else {
+      // R = Lᵀ: lane writes column `lane` (coalesced), lower triangle zeroed.
+      for (int k = 0; k < N; ++k) {
+        A[k * N + lane] = (k <= lane) ? r[k] : T(0);
+      }
+    }
+  }
+}
+
+// In-place factorization bodies. Both produce L (A = L Lᵀ) when !upper or R
+// (A = Rᵀ R) when upper, thread `lid` owns the strided rows/cols
+// {lid, lid+tgsize, ...} (any threadgroup size <= N is correct), and only the
+// relevant triangle + diagonal are written; the caller zeroes the opposite
+// strict triangle.
+//
+// cholesky_core_rl (right-looking) keeps the trailing matrix updated so the
+// pivot is a single sqrt; best when M is in threadgroup memory.
+// cholesky_core_ll (left-looking) touches only one column/row per step and
+// so much less memory; best when M is in device memory.
+template <typename T, typename PtrT>
+inline void cholesky_core_rl(PtrT M, int N, bool upper, uint lid, uint tgsize) {
+  if (!upper) {
+    // Column sweep: scale column j, then each thread applies the rank-1
+    // update to the columns j+1..i of its rows.
+    for (int j = 0; j < N; ++j) {
+      if (lid == uint(j % int(tgsize))) {
+        M[j * N + j] = metal::sqrt(M[j * N + j]);
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup | mem_flags::mem_device);
+      T piv = M[j * N + j];
+      for (int i = int(lid); i < N; i += int(tgsize)) {
+        if (i > j) {
+          M[i * N + j] /= piv;
+        }
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup | mem_flags::mem_device);
+      for (int i = int(lid); i < N; i += int(tgsize)) {
+        if (i > j) {
+          T lij = M[i * N + j];
+          for (int k = j + 1; k <= i; ++k) {
+            M[i * N + k] -= lij * M[k * N + j];
+          }
+        }
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup | mem_flags::mem_device);
+    }
+  } else {
+    // Row sweep producing the upper factor directly (no transpose): scale row
+    // i, then each thread updates rows k > i of the upper triangle it owns.
+    for (int i = 0; i < N; ++i) {
+      if (lid == uint(i % int(tgsize))) {
+        M[i * N + i] = metal::sqrt(M[i * N + i]);
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup | mem_flags::mem_device);
+      T piv = M[i * N + i];
+      for (int j = int(lid); j < N; j += int(tgsize)) {
+        if (j > i) {
+          M[i * N + j] /= piv;
+        }
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup | mem_flags::mem_device);
+      for (int k = int(lid); k < N; k += int(tgsize)) {
+        if (k > i) {
+          T rik = M[i * N + k];
+          for (int j = k; j < N; ++j) {
+            M[k * N + j] -= rik * M[i * N + j];
+          }
+        }
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup | mem_flags::mem_device);
+    }
+  }
+}
+
+template <typename T, typename PtrT>
+inline void cholesky_core_ll(PtrT M, int N, bool upper, uint lid, uint tgsize) {
+  if (!upper) {
+    // Column sweep. Thread owning row j computes the pivot; all threads
+    // owning rows i>j fill column j below the diagonal.
+    for (int j = 0; j < N; ++j) {
+      threadgroup_barrier(mem_flags::mem_threadgroup | mem_flags::mem_device);
+      if (lid == uint(j % int(tgsize))) {
+        T s = M[j * N + j];
+        for (int k = 0; k < j; ++k) {
+          T v = M[j * N + k];
+          s -= v * v;
+        }
+        M[j * N + j] = metal::sqrt(s);
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup | mem_flags::mem_device);
+      T piv = M[j * N + j];
+      for (int i = int(lid); i < N; i += int(tgsize)) {
+        if (i > j) {
+          T s = M[i * N + j];
+          for (int k = 0; k < j; ++k) {
+            s -= M[i * N + k] * M[j * N + k];
+          }
+          M[i * N + j] = s / piv;
+        }
+      }
+    }
+  } else {
+    // Row sweep producing the upper factor directly (no transpose).
+    for (int i = 0; i < N; ++i) {
+      threadgroup_barrier(mem_flags::mem_threadgroup | mem_flags::mem_device);
+      if (lid == uint(i % int(tgsize))) {
+        T s = M[i * N + i];
+        for (int k = 0; k < i; ++k) {
+          T v = M[k * N + i];
+          s -= v * v;
+        }
+        M[i * N + i] = metal::sqrt(s);
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup | mem_flags::mem_device);
+      T piv = M[i * N + i];
+      for (int j = int(lid); j < N; j += int(tgsize)) {
+        if (j > i) {
+          T s = M[i * N + j];
+          for (int k = 0; k < i; ++k) {
+            s -= M[k * N + i] * M[k * N + j];
+          }
+          M[i * N + j] = s / piv;
+        }
+      }
+    }
+  }
+}
+
+// Mid-size matrices: one per threadgroup, staged in threadgroup memory.
+template <typename T>
+[[kernel]] void cholesky_shared(
+    device T* out [[buffer(0)]],
+    const constant int& N [[buffer(1)]],
+    const constant int& upper [[buffer(2)]],
+    threadgroup T* As [[threadgroup(0)]],
+    uint gid [[threadgroup_position_in_grid]],
+    uint lid [[thread_position_in_threadgroup]],
+    uint tgsize [[threads_per_threadgroup]]) {
+  device T* A = out + size_t(gid) * N * N;
+  int nn = N * N;
+  for (int idx = int(lid); idx < nn; idx += int(tgsize)) {
+    As[idx] = A[idx];
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  cholesky_core_rl<T>(As, N, upper != 0, lid, tgsize);
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (int idx = int(lid); idx < nn; idx += int(tgsize)) {
+    int r = idx / N;
+    int c = idx % N;
+    T val;
+    if (upper == 0) {
+      val = (c <= r) ? As[idx] : T(0);
+    } else {
+      val = (r <= c) ? As[idx] : T(0);
+    }
+    A[idx] = val;
+  }
+}
+
+// Large matrices (N > 128): blocked right-looking factorization following the
+// batched-MAGMA design (Dong, Haidar, Tomov & Dongarra, "A Fast Batched
+// Cholesky Factorization on a GPU"): the host loops over panels of NB = 32
+// columns and encodes one batched *panel* dispatch and one batched *SYRK*
+// dispatch per step, with a buffer barrier in between. Separate grids keep
+// the trailing update, where nearly all the FLOPs are, at high occupancy
+// across the whole batch instead of serializing behind the panel inside a
+// single threadgroup. The
+// working state is always the lower triangle; an epilogue pass zeroes the
+// strict upper triangle, or transposes in place for upper = true.
+
+// Panel step at column p: factor the 32x32 diagonal block (POTF2, simdgroup 0
+// with the same register/shuffle method as cholesky_simd), invert it (TRTRI,
+// one column per lane), and apply the TRSM to the panel rows below as a GEMM
+// against the inverted block on the simdgroup-matrix units (the MAGMA batched
+// approach). Each simdgroup owns whole 16-row slices (it reads and writes
+// only its own rows, so the in-place update needs no synchronization) and a
+// sub-16-row tail falls back to one scalar forward-substitution per
+// thread. One threadgroup per matrix.
+template <typename T>
+[[kernel]] void cholesky_panel(
+    device T* out [[buffer(0)]],
+    const constant int& N [[buffer(1)]],
+    const constant int& p [[buffer(2)]],
+    uint gid [[threadgroup_position_in_grid]],
+    uint lid [[thread_position_in_threadgroup]],
+    uint tgsize [[threads_per_threadgroup]],
+    uint sgid [[simdgroup_index_in_threadgroup]],
+    uint slane [[thread_index_in_simdgroup]],
+    uint n_sgs [[simdgroups_per_threadgroup]]) {
+  constexpr int NB = 32;
+  threadgroup T Ldiag[NB * NB];
+  threadgroup T Linv[NB * NB];
+
+  device T* A = out + size_t(gid) * N * N;
+  int W = metal::min(NB, N - p);
+
+  // Stage the lower part of the diagonal block.
+  for (int idx = int(lid); idx < W * W; idx += int(tgsize)) {
+    int r = idx / W;
+    int c = idx % W;
+    Ldiag[r * NB + c] = (c <= r) ? A[size_t(p + r) * N + (p + c)] : T(0);
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // POTF2 on simdgroup 0.
+  if (sgid == 0) {
+    int lane = int(slane);
+    T r[NB] = {T(0)};
+    if (lane < W) {
+      for (int k = 0; k <= lane; ++k) {
+        r[k] = Ldiag[lane * NB + k];
+      }
+    }
+    for (int j = 0; j < W; ++j) {
+      T piv = metal::sqrt(simd_shuffle(r[j], ushort(j)));
+      if (lane == j) {
+        r[j] = piv;
+      } else if (lane > j) {
+        r[j] /= piv;
+      }
+      for (int k = j + 1; k < W; ++k) {
+        T lkj = simd_shuffle(r[j], ushort(k));
+        if (lane >= k) {
+          r[k] -= r[j] * lkj;
+        }
+      }
+    }
+    if (lane < W) {
+      for (int k = 0; k <= lane; ++k) {
+        Ldiag[lane * NB + k] = r[k];
+      }
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // Write the factored diagonal block back.
+  for (int idx = int(lid); idx < W * W; idx += int(tgsize)) {
+    int r = idx / W;
+    int c = idx % W;
+    if (c <= r) {
+      A[size_t(p + r) * N + (p + c)] = Ldiag[r * NB + c];
+    }
+  }
+
+  // Rows below the block exist only when the panel has full width (a narrow
+  // last panel reaches N).
+  if (W < NB) {
+    return;
+  }
+
+  // TRTRI: invert the diagonal block, one column per lane of simdgroup 0
+  // (forward substitution of L x = e_j; the column is zero above j).
+  if (sgid == 0) {
+    int j = int(slane);
+    T x[NB] = {T(0)};
+    MLX_MTL_PRAGMA_UNROLL
+    for (int i = 0; i < NB; ++i) {
+      T s = (i == j) ? T(1) : T(0);
+      MLX_MTL_PRAGMA_UNROLL
+      for (int k = 0; k < i; ++k) {
+        s -= Ldiag[i * NB + k] * x[k];
+      }
+      x[i] = (i >= j) ? s / Ldiag[i * NB + i] : T(0);
+    }
+    for (int i = 0; i < NB; ++i) {
+      Linv[i * NB + j] = x[i];
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // TRSM as a GEMM: X_new = X * Linv^T. Each simdgroup takes 16-row slices
+  // (2x4 arrangement of 8x8 fragments), reading X from device and writing the
+  // result back in place.
+  int first = p + NB;
+  int tail = first + ((N - first) / 16) * 16;
+  for (int r0 = first + int(sgid) * 16; r0 + 16 <= N; r0 += int(n_sgs) * 16) {
+    metal::simdgroup_matrix<T, 8, 8> acc[2][4];
+    MLX_MTL_PRAGMA_UNROLL
+    for (int ra = 0; ra < 2; ++ra) {
+      MLX_MTL_PRAGMA_UNROLL
+      for (int c = 0; c < 4; ++c) {
+        acc[ra][c] = metal::simdgroup_matrix<T, 8, 8>(T(0));
+      }
+    }
+    MLX_MTL_PRAGMA_UNROLL
+    for (int kb = 0; kb < NB; kb += 8) {
+      metal::simdgroup_matrix<T, 8, 8> a[2];
+      MLX_MTL_PRAGMA_UNROLL
+      for (int ra = 0; ra < 2; ++ra) {
+        simdgroup_load(a[ra], A + size_t(r0 + ra * 8) * N + (p + kb), ulong(N));
+      }
+      MLX_MTL_PRAGMA_UNROLL
+      for (int c = 0; c < 4; ++c) {
+        metal::simdgroup_matrix<T, 8, 8> b;
+        simdgroup_load(
+            b, Linv + c * 8 * NB + kb, ulong(NB), ulong2(0, 0), true);
+        MLX_MTL_PRAGMA_UNROLL
+        for (int ra = 0; ra < 2; ++ra) {
+          simdgroup_multiply_accumulate(acc[ra][c], a[ra], b, acc[ra][c]);
+        }
+      }
+    }
+    MLX_MTL_PRAGMA_UNROLL
+    for (int ra = 0; ra < 2; ++ra) {
+      MLX_MTL_PRAGMA_UNROLL
+      for (int c = 0; c < 4; ++c) {
+        simdgroup_store(
+            acc[ra][c], A + size_t(r0 + ra * 8) * N + (p + c * 8), ulong(N));
+      }
+    }
+  }
+
+  // Scalar forward substitution for the sub-16-row tail.
+  for (int r = tail + int(lid); r < N; r += int(tgsize)) {
+    T x[NB];
+    MLX_MTL_PRAGMA_UNROLL
+    for (int j = 0; j < NB; ++j) {
+      x[j] = A[size_t(r) * N + (p + j)];
+    }
+    MLX_MTL_PRAGMA_UNROLL
+    for (int j = 0; j < NB; ++j) {
+      T s = x[j];
+      MLX_MTL_PRAGMA_UNROLL
+      for (int k = 0; k < j; ++k) {
+        s -= x[k] * Ldiag[j * NB + k];
+      }
+      x[j] = s / Ldiag[j * NB + j];
+    }
+    MLX_MTL_PRAGMA_UNROLL
+    for (int j = 0; j < NB; ++j) {
+      A[size_t(r) * N + (p + j)] = x[j];
+    }
+  }
+}
+
+// Trailing (SYRK) update: C -= L21 * L21^T over the 32x32 lower-triangle
+// tiles of the trailing matrix, using the KD panel columns p..p+KD-1 (the
+// trailing matrix starts at p+KD). Grid is (lower tiles) x (batch); each
+// threadgroup of 4 simdgroups computes one tile as a 2x2 arrangement of 16x16
+// simdgroup-matrix products. Boundary tiles (crossing N) take a scalar path.
+// With col0 != 0 only the first tile column is updated (tg_pos.x is the tile
+// row): that primes the next 32-column panel so that a following KD = 64
+// update can process the rest of the trailing with half the C traffic; the
+// panels stay 32 wide while the read-modify-write of C halves.
+template <typename T, int KD>
+[[kernel]] void cholesky_syrk(
+    device T* out [[buffer(0)]],
+    const constant int& N [[buffer(1)]],
+    const constant int& p [[buffer(2)]],
+    const constant int& col0 [[buffer(3)]],
+    uint2 tg_pos [[threadgroup_position_in_grid]],
+    uint2 lid2 [[thread_position_in_threadgroup]],
+    uint2 tgsize2 [[threads_per_threadgroup]],
+    uint sgid [[simdgroup_index_in_threadgroup]]) {
+  constexpr int NB = 32;
+  threadgroup T As[NB * KD];
+  threadgroup T Bs[NB * KD];
+
+  uint lid = lid2.x;
+  uint tgsize = tgsize2.x;
+  device T* A = out + size_t(tg_pos.y) * N * N;
+  int q = p + KD;
+  int Ht = N - q;
+
+  // Lower-triangle tile (ti >= tj) from the linear index.
+  int t = int(tg_pos.x);
+  int ti;
+  int tj;
+  if (col0 != 0) {
+    ti = t;
+    tj = 0;
+  } else {
+    ti = int((metal::sqrt(8.0f * float(t) + 1.0f) - 1.0f) * 0.5f);
+    while (ti * (ti + 1) / 2 > t) {
+      --ti;
+    }
+    while ((ti + 1) * (ti + 2) / 2 <= t) {
+      ++ti;
+    }
+    tj = t - ti * (ti + 1) / 2;
+  }
+
+  // Stage the two panel blocks this tile needs (rows q + ti*32 / q + tj*32 of
+  // panel columns p..p+KD-1), zero-padded past N.
+  for (int idx = int(lid); idx < NB * KD; idx += int(tgsize)) {
+    int r = idx / KD;
+    int c = idx % KD;
+    int ra = q + ti * NB + r;
+    int rb = q + tj * NB + r;
+    As[idx] = (ra < N) ? A[size_t(ra) * N + (p + c)] : T(0);
+    Bs[idx] = (rb < N) ? A[size_t(rb) * N + (p + c)] : T(0);
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  if ((ti + 1) * NB <= Ht) {
+    // Full tile: 4 simdgroups, each a 16x16 block of the 32x32 tile.
+    int sr = int(sgid) / 2;
+    int sc = int(sgid) % 2;
+    metal::simdgroup_matrix<T, 8, 8> acc[2][2];
+    MLX_MTL_PRAGMA_UNROLL
+    for (int fr = 0; fr < 2; ++fr) {
+      MLX_MTL_PRAGMA_UNROLL
+      for (int fc = 0; fc < 2; ++fc) {
+        acc[fr][fc] = metal::simdgroup_matrix<T, 8, 8>(T(0));
+      }
+    }
+    MLX_MTL_PRAGMA_UNROLL
+    for (int kb = 0; kb < KD; kb += 8) {
+      metal::simdgroup_matrix<T, 8, 8> a[2];
+      metal::simdgroup_matrix<T, 8, 8> b[2];
+      MLX_MTL_PRAGMA_UNROLL
+      for (int f = 0; f < 2; ++f) {
+        simdgroup_load(a[f], As + (sr * 16 + f * 8) * KD + kb, ulong(KD));
+        simdgroup_load(
+            b[f],
+            Bs + (sc * 16 + f * 8) * KD + kb,
+            ulong(KD),
+            ulong2(0, 0),
+            true);
+      }
+      MLX_MTL_PRAGMA_UNROLL
+      for (int fr = 0; fr < 2; ++fr) {
+        MLX_MTL_PRAGMA_UNROLL
+        for (int fc = 0; fc < 2; ++fc) {
+          simdgroup_multiply_accumulate(acc[fr][fc], a[fr], b[fc], acc[fr][fc]);
+        }
+      }
+    }
+    device T* C =
+        A + size_t(q + ti * NB + sr * 16) * N + (q + tj * NB + sc * 16);
+    MLX_MTL_PRAGMA_UNROLL
+    for (int fr = 0; fr < 2; ++fr) {
+      MLX_MTL_PRAGMA_UNROLL
+      for (int fc = 0; fc < 2; ++fc) {
+        device T* Cf = C + size_t(fr) * 8 * N + fc * 8;
+        metal::simdgroup_matrix<T, 8, 8> c;
+        simdgroup_load(c, Cf, ulong(N));
+        c.thread_elements()[0] -= acc[fr][fc].thread_elements()[0];
+        c.thread_elements()[1] -= acc[fr][fc].thread_elements()[1];
+        simdgroup_store(c, Cf, ulong(N));
+      }
+    }
+  } else {
+    // Boundary tile: scalar with bounds checks.
+    for (int e = int(lid); e < NB * NB; e += int(tgsize)) {
+      int er = e / NB;
+      int ec = e % NB;
+      if (ti * NB + er < Ht && tj * NB + ec < Ht) {
+        T s = T(0);
+        for (int k = 0; k < KD; ++k) {
+          s += As[er * KD + k] * Bs[ec * KD + k];
+        }
+        A[size_t(q + ti * NB + er) * N + (q + tj * NB + ec)] -= s;
+      }
+    }
+  }
+}
+
+// Epilogue: the factor lives in the lower triangle. Zero the strict upper
+// triangle, or for upper = true move it in place (R = L^T) and zero the
+// strict lower. One thread per (matrix, row): each thread streams contiguous
+// elements of its own row, and for upper only ever writes the strict upper
+// triangle while reading its own lower row, so threads never collide.
+template <typename T>
+[[kernel]] void cholesky_fixup(
+    device T* out [[buffer(0)]],
+    const constant int& N [[buffer(1)]],
+    const constant int& upper [[buffer(2)]],
+    uint2 pos [[thread_position_in_grid]]) {
+  int r = int(pos.x);
+  device T* A = out + size_t(pos.y) * N * N;
+  if (upper == 0) {
+    for (int c = r + 1; c < N; ++c) {
+      A[size_t(r) * N + c] = T(0);
+    }
+  } else {
+    for (int c = 0; c < r; ++c) {
+      A[size_t(c) * N + r] = A[size_t(r) * N + c];
+      A[size_t(r) * N + c] = T(0);
+    }
+  }
+}
+
+// Larger matrices: one per threadgroup, factored directly in device memory.
+template <typename T>
+[[kernel]] void cholesky_device(
+    device T* out [[buffer(0)]],
+    const constant int& N [[buffer(1)]],
+    const constant int& upper [[buffer(2)]],
+    uint gid [[threadgroup_position_in_grid]],
+    uint lid [[thread_position_in_threadgroup]],
+    uint tgsize [[threads_per_threadgroup]]) {
+  device T* A = out + size_t(gid) * N * N;
+
+  cholesky_core_ll<T>(A, N, upper != 0, lid, tgsize);
+  threadgroup_barrier(mem_flags::mem_threadgroup | mem_flags::mem_device);
+
+  int nn = N * N;
+  for (int idx = int(lid); idx < nn; idx += int(tgsize)) {
+    int r = idx / N;
+    int c = idx % N;
+    if (upper == 0) {
+      if (c > r) {
+        A[idx] = T(0);
+      }
+    } else {
+      if (c < r) {
+        A[idx] = T(0);
+      }
+    }
+  }
+}

--- a/mlx/backend/metal/kernels/cholesky.metal
+++ b/mlx/backend/metal/kernels/cholesky.metal
@@ -1,0 +1,23 @@
+// Copyright © 2025 Apple Inc.
+
+#include <metal_common>
+#include <metal_math>
+#include <metal_simdgroup>
+#include <metal_simdgroup_matrix>
+
+using namespace metal;
+
+// clang-format off
+#include "mlx/backend/metal/kernels/utils.h"
+#include "mlx/backend/metal/kernels/cholesky.h"
+
+#define instantiate_cholesky(name, itype)                                      \
+  instantiate_kernel("cholesky_simd_" #name, cholesky_simd, itype)             \
+  instantiate_kernel("cholesky_shared_" #name, cholesky_shared, itype)         \
+  instantiate_kernel("cholesky_panel_" #name, cholesky_panel, itype)           \
+  instantiate_kernel("cholesky_syrk32_" #name, cholesky_syrk, itype, 32)       \
+  instantiate_kernel("cholesky_syrk64_" #name, cholesky_syrk, itype, 64)       \
+  instantiate_kernel("cholesky_fixup_" #name, cholesky_fixup, itype)           \
+  instantiate_kernel("cholesky_device_" #name, cholesky_device, itype)
+
+instantiate_cholesky(float32, float) // clang-format on

--- a/mlx/backend/metal/nojit_kernels.cpp
+++ b/mlx/backend/metal/nojit_kernels.cpp
@@ -79,6 +79,13 @@ MTL::ComputePipelineState* get_logsumexp_kernel(
   return d.get_kernel(kernel_name);
 }
 
+MTL::ComputePipelineState* get_cholesky_kernel(
+    metal::Device& d,
+    const std::string& kernel_name,
+    const array&) {
+  return d.get_kernel(kernel_name);
+}
+
 MTL::ComputePipelineState* get_scan_kernel(
     metal::Device& d,
     const std::string& kernel_name,

--- a/mlx/backend/metal/primitives.cpp
+++ b/mlx/backend/metal/primitives.cpp
@@ -216,11 +216,6 @@ void Inverse::eval_gpu(const std::vector<array>& inputs, array& output) {
   throw std::runtime_error("[Inverse::eval_gpu] Metal inversion NYI.");
 }
 
-void Cholesky::eval_gpu(const std::vector<array>& inputs, array& out) {
-  throw std::runtime_error(
-      "[Cholesky::eval_gpu] Metal Cholesky decomposition NYI.");
-}
-
 void Eig::eval_gpu(
     const std::vector<array>& inputs,
     std::vector<array>& outputs) {

--- a/mlx/backend/no_gpu/primitives.cpp
+++ b/mlx/backend/no_gpu/primitives.cpp
@@ -156,6 +156,10 @@ NO_GPU(Transpose)
 NO_GPU(Unflatten)
 NO_GPU(Inverse)
 NO_GPU(Cholesky)
+
+bool Cholesky::use_fallback(Dtype, int, size_t, Stream) {
+  return true;
+}
 NO_GPU_MULTI(Eigh)
 NO_GPU_MULTI(Eig)
 NO_GPU(View)

--- a/mlx/linalg.cpp
+++ b/mlx/linalg.cpp
@@ -335,7 +335,6 @@ array cholesky(
     const array& a,
     bool upper /* = false */,
     StreamOrDevice s /* = {} */) {
-  check_cpu_stream(s, "[linalg::cholesky]");
   check_float(a.dtype(), "[linalg::cholesky]");
   if (a.ndim() < 2) {
     std::ostringstream msg;
@@ -350,11 +349,19 @@ array cholesky(
         "[linalg::cholesky] Cholesky decomposition is only defined for square "
         "matrices.");
   }
+
+  // Batches of float32 matrices go to the GPU when that is faster than the
+  // CPU; every other shape uses the CPU implementation.
+  auto stream = to_stream(s);
+  if (stream.device == Device::gpu) {
+    int n = a.shape(-1);
+    size_t num_matrices = (n > 0) ? a.size() / (size_t(n) * n) : 0;
+    if (Cholesky::use_fallback(a.dtype(), n, num_matrices, stream)) {
+      stream = default_stream(Device::cpu);
+    }
+  }
   return array(
-      a.shape(),
-      a.dtype(),
-      std::make_shared<Cholesky>(to_stream(s), upper),
-      {a});
+      a.shape(), a.dtype(), std::make_shared<Cholesky>(stream, upper), {a});
 }
 
 array pinv(const array& a, StreamOrDevice s /* = {} */) {

--- a/mlx/primitives.h
+++ b/mlx/primitives.h
@@ -2474,6 +2474,10 @@ class Cholesky : public UnaryPrimitive {
   explicit Cholesky(Stream stream, bool upper)
       : UnaryPrimitive(stream), upper_(upper) {}
 
+  // Whether to run this shape on the CPU (the GPU kernels only beat the CPU
+  // for sufficiently large batches).
+  static bool use_fallback(Dtype dtype, int n, size_t num_matrices, Stream s);
+
   void eval_cpu(const std::vector<array>& inputs, array& out) override;
   void eval_gpu(const std::vector<array>& inputs, array& out) override;
   auto state() const {

--- a/python/tests/test_linalg.py
+++ b/python/tests/test_linalg.py
@@ -276,6 +276,51 @@ class TestLinalg(mlx_tests.MLXTestCase):
         for M, L in zip(AB, Ls):
             self.assertTrue(mx.allclose(L @ L.T, M, rtol=1e-5, atol=1e-7))
 
+    def test_cholesky_gpu(self):
+        if not mx.is_available(mx.gpu):
+            return
+        mx.random.seed(7)
+
+        # Batches above the dispatch threshold run on the GPU; each shape
+        # exercises one of the Metal kernel paths.
+        for batch, n in [
+            (1200, 16),
+            (600, 32),
+            (600, 48),
+            (300, 96),
+            (150, 160),
+            (120, 256),
+        ]:
+            X = mx.random.normal((batch, n, n))
+            A = X @ X.swapaxes(-1, -2) + n * mx.eye(n)
+            for upper in (False, True):
+                L = mx.linalg.cholesky(A, upper=upper, stream=mx.gpu)
+                rec = L.swapaxes(-1, -2) @ L if upper else L @ L.swapaxes(-1, -2)
+                self.assertTrue(mx.allclose(rec, A, rtol=1e-4, atol=1e-4))
+                # The other triangle is exactly zero
+                if upper:
+                    self.assertTrue(mx.all(L == mx.triu(L)))
+                else:
+                    self.assertTrue(mx.all(L == mx.tril(L)))
+
+        # Shapes below the threshold and non-float32 inputs transparently use
+        # the CPU implementation on a GPU stream.
+        X = mx.random.normal((2, 8, 8))
+        A = X @ X.swapaxes(-1, -2) + 8 * mx.eye(8)
+        L = mx.linalg.cholesky(A, stream=mx.gpu)
+        self.assertTrue(mx.allclose(L @ L.swapaxes(-1, -2), A, rtol=1e-5, atol=1e-6))
+        Ad = A.astype(mx.float64, stream=mx.cpu)
+        Ld = mx.linalg.cholesky(Ad, stream=mx.gpu)
+        rec = mx.matmul(Ld, mx.swapaxes(Ld, -1, -2, stream=mx.cpu), stream=mx.cpu)
+        self.assertTrue(mx.allclose(rec, Ad, rtol=1e-8, atol=1e-8, stream=mx.cpu))
+
+        # Zero-size inputs
+        for shape in [(0, 4, 4), (3, 0, 0)]:
+            for stream in (mx.cpu, mx.gpu):
+                L = mx.linalg.cholesky(mx.zeros(shape), stream=stream)
+                mx.eval(L)
+                self.assertEqual(L.shape, shape)
+
     def test_pseudo_inverse(self):
         A = mx.array([[1, 2, 3], [6, -5, 4], [-9, 8, 7]], dtype=mx.float32)
         A_plus = mx.linalg.pinv(A, stream=mx.cpu)


### PR DESCRIPTION
Draft to check scope before polishing: is the shape-based dispatch in `linalg::cholesky` (GPU for batches where it measurably wins, CPU for everything else) the right mechanism, or would you prefer the GPU kernels behind an explicit opt-in, or as part of a broader linalg-on-GPU plan? The same structure extends to LU next. Happy to adjust.

Adds a Metal implementation of `Cholesky::eval_gpu` for batched float32 inputs, following the batched-MAGMA design (Dong, Haidar, Tomov & Dongarra): one matrix per simdgroup in registers for n <= 32, one matrix per threadgroup in threadgroup memory up to n = 64, one per threadgroup in device memory up to n = 128, and a blocked right-looking factorization above that, where the host encodes one batched panel dispatch (POTF2 + TRTRI + TRSM as a simdgroup-matrix GEMM) and one batched SYRK dispatch over 32x32 lower-triangle tiles per 32-column panel. Panels are processed in pairs so the big trailing update runs at rank 64, halving the read-modify-write traffic on the trailing matrix.

The GPU only wins for large enough batches, so `linalg::cholesky` consults `Cholesky::use_fallback` (same pattern as `ScaledDotProductAttention`) at graph construction and keeps every other shape on the CPU implementation. Nothing gets slower: single or small-batch factorizations run exactly the CPU path they run today. This also means `cholesky` now works for any shape and dtype on a GPU stream instead of raising. Minimum batch for GPU dispatch, measured on an M3 Pro at both ends of each size range: 1000 for n in [13, 31], 500 for n <= 64, 250 for n <= 128, 128 for n <= 192, 100 for n <= 256, 80 for n <= 512, 48 for n <= 1024, 16 for n <= 2048, and always CPU for n <= 12 or n > 2048.

Motivated by #1216, which stalled because a single-matrix GPU Cholesky loses to the CPU. Batching is where the GPU win is, and the fallback keeps the default path from regressing anywhere.

Also fixes a division by zero in the CPU implementation for inputs with n = 0 (`cholesky(zeros((3, 0, 0)))` previously aborted the process).

### Benchmarks

M3 Pro, macOS 26.5, float32, best of 30 (ms). CPU is the existing LAPACK/Accelerate path.

| batch | n | CPU | GPU | speedup |
|---:|---:|---:|---:|---:|
| 1000 | 16 | 0.66 | 0.26 | 2.6x |
| 1000 | 32 | 1.62 | 0.68 | 2.4x |
| 500 | 65 | 2.39 | 1.12 | 2.1x |
| 1000 | 90 | 6.78 | 3.37 | 2.0x |
| 1000 | 128 | 9.69 | 7.06 | 1.4x |
| 1000 | 160 | 17.02 | 9.14 | 1.9x |
| 1000 | 192 | 20.67 | 12.59 | 1.6x |
| 1000 | 256 | 33.87 | 21.96 | 1.5x |
| 500 | 384 | 37.73 | 27.63 | 1.4x |
| 256 | 512 | 35.63 | 28.21 | 1.3x |
| 48 | 1024 | 43.47 | 28.19 | 1.5x |
| 16 | 2048 | 76.54 | 61.35 | 1.2x |
| 100 | 32 | 0.18 | -> CPU | unchanged |
| 1 | 1024 | 0.90 | -> CPU | unchanged |
| 1 | 5000 | 73.2 | -> CPU | unchanged |

Every GPU-dispatched shape measures >= 1.1x at the dispatch thresholds, checked at both ends of each size range; shapes just below a threshold run the CPU path unchanged.

### Testing

Verified against the CPU implementation over n = 1..3000 and batch = 1..1000 (kernel-path boundaries, sizes that are not multiples of 8/32/64, narrow last panels, nested batch dims, upper and lower): worst relative reconstruction error ~2e-7, opposite triangle exactly zero. float64 and small batches fall back to the CPU and match it bitwise; float16/bfloat16 raise as before; zero-size inputs work on both streams. For non positive-definite inputs (documented as undefined behaviour) the GPU produces NaNs where the CPU returns a partial factorization. `test_cholesky_gpu` covers each kernel path, the CPU fallbacks, and zero-size inputs. Both the default and `MLX_METAL_JIT=ON` builds pass.
