### PR TITLE
Fixes an axis mismatch bug in matrix norm for case -1 and 1 

### DIFF
--- a/mlx/linalg.cpp
+++ b/mlx/linalg.cpp
@@ -84,43 +84,33 @@ inline array matrix_norm(
     bool keepdims,
     StreamOrDevice s) {
   auto dtype = at_least_float(a.dtype());
-  auto row_axis = axis[0];
-  auto col_axis = axis[1];
+  int row_axis = (axis[0] < 0) ? axis[0] + a.ndim() : axis[0];
+  int col_axis = (axis[1] < 0) ? axis[1] + a.ndim() : axis[1];
   if (ord == -1.0) {
-    row_axis = (axis[0] < 0) ? axis[0] + a.ndim() : axis[0];
-    col_axis = (axis[1] < 0) ? axis[1] + a.ndim() : axis[1];
     col_axis -= (!keepdims && col_axis > row_axis && col_axis > 0);
     return astype(
         min(sum(abs(a, s), row_axis, keepdims, s), col_axis, keepdims, s),
         dtype,
         s);
   } else if (ord == 1.0) {
-    row_axis = (axis[0] < 0) ? axis[0] + a.ndim() : axis[0];
-    col_axis = (axis[1] < 0) ? axis[1] + a.ndim() : axis[1];
     col_axis -= (!keepdims && col_axis > row_axis && col_axis > 0);
     return astype(
         max(sum(abs(a, s), row_axis, keepdims, s), col_axis, keepdims, s),
         dtype,
         s);
   } else if (ord == std::numeric_limits<double>::infinity()) {
-    row_axis = (axis[0] < 0) ? axis[0] + a.ndim() : axis[0];
-    col_axis = (axis[1] < 0) ? axis[1] + a.ndim() : axis[1];
     row_axis -= (!keepdims && row_axis > col_axis && row_axis > 0);
     return astype(
         max(sum(abs(a, s), col_axis, keepdims, s), row_axis, keepdims, s),
         dtype,
         s);
   } else if (ord == -std::numeric_limits<double>::infinity()) {
-    row_axis = (axis[0] < 0) ? axis[0] + a.ndim() : axis[0];
-    col_axis = (axis[1] < 0) ? axis[1] + a.ndim() : axis[1];
     row_axis -= (!keepdims && row_axis > col_axis && row_axis > 0);
     return astype(
         min(sum(abs(a, s), col_axis, keepdims, s), row_axis, keepdims, s),
         dtype,
         s);
   } else if (ord == 2.0 || ord == -2.0) {
-    row_axis = (axis[0] < 0) ? axis[0] + a.ndim() : axis[0];
-    col_axis = (axis[1] < 0) ? axis[1] + a.ndim() : axis[1];
     auto a_matrix = (row_axis > col_axis)
         ? moveaxis(moveaxis(a, row_axis, -1, s), col_axis, -1, s)
         : moveaxis(moveaxis(a, col_axis, -1, s), row_axis, -2, s);

--- a/mlx/linalg.cpp
+++ b/mlx/linalg.cpp
@@ -87,12 +87,16 @@ inline array matrix_norm(
   auto row_axis = axis[0];
   auto col_axis = axis[1];
   if (ord == -1.0) {
+    row_axis = (axis[0] < 0) ? axis[0] + a.ndim() : axis[0];
+    col_axis = (axis[1] < 0) ? axis[1] + a.ndim() : axis[1];
     col_axis -= (!keepdims && col_axis > row_axis && col_axis > 0);
     return astype(
         min(sum(abs(a, s), row_axis, keepdims, s), col_axis, keepdims, s),
         dtype,
         s);
   } else if (ord == 1.0) {
+    row_axis = (axis[0] < 0) ? axis[0] + a.ndim() : axis[0];
+    col_axis = (axis[1] < 0) ? axis[1] + a.ndim() : axis[1];
     col_axis -= (!keepdims && col_axis > row_axis && col_axis > 0);
     return astype(
         max(sum(abs(a, s), row_axis, keepdims, s), col_axis, keepdims, s),

--- a/python/tests/test_linalg.py
+++ b/python/tests/test_linalg.py
@@ -65,7 +65,7 @@ class TestLinalg(mlx_tests.MLXTestCase):
                 with self.subTest(shape=shape, keepdims=keepdims):
                     self.assertTrue(np.allclose(out_np, out_mx, atol=1e-5, rtol=1e-6))
 
-        # tests for negative indexing: -1/1inf/-inf/
+        # tests for negative indexing: -1/1/inf/-inf/
         norms = [-1, 1, -float("inf"), float("inf")]
         for shape in [(3, 3), (2, 3, 3), (2, 3, 3, 3)]:
             x_mx = mx.arange(1, math.prod(shape) + 1, dtype=mx.float32).reshape(shape)

--- a/python/tests/test_linalg.py
+++ b/python/tests/test_linalg.py
@@ -65,8 +65,8 @@ class TestLinalg(mlx_tests.MLXTestCase):
                 with self.subTest(shape=shape, keepdims=keepdims):
                     self.assertTrue(np.allclose(out_np, out_mx, atol=1e-5, rtol=1e-6))
 
-        # neg/pos inf norm test
-        norms = [-float("inf"), float("inf")]
+        # tests for negative indexing: -1/1inf/-inf/
+        norms = [-1, 1, -float("inf"), float("inf")]
         for shape in [(3, 3), (2, 3, 3), (2, 3, 3, 3)]:
             x_mx = mx.arange(1, math.prod(shape) + 1, dtype=mx.float32).reshape(shape)
             x_np = np.arange(1, math.prod(shape) + 1, dtype=np.float32).reshape(shape)
@@ -76,7 +76,7 @@ class TestLinalg(mlx_tests.MLXTestCase):
                 for axes in neg_axes:
                     out_np = np.linalg.norm(
                         x_np,
-                        ord=np.inf if ord == float("inf") else -np.inf,
+                        ord=ord,
                         axis=tuple(axes),
                     )
                     out_mx = mx.linalg.norm(x_mx, ord=ord, axis=axes)

--- a/tests/linalg_tests.cpp
+++ b/tests/linalg_tests.cpp
@@ -189,6 +189,13 @@ TEST_CASE("[mlx.core.linalg.norm] double ord") {
           Device::cpu)
           .item<float>(),
       doctest::Approx(3.0));
+  CHECK_EQ(
+      norm(x, -1, std::vector<int>{-1, -2}, false, Device::cpu).item<float>(),
+      doctest::Approx(3.0));
+  CHECK_EQ(
+      norm(x, 1, std::vector<int>{-1, -2}, false, Device::cpu).item<float>(),
+      doctest::Approx(21.0));
+
   x = reshape(arange(18, float32), {2, 3, 3});
   CHECK_THROWS(norm(x, 2.0, std::vector{0, 1, 2}));
   CHECK(allclose(
@@ -281,6 +288,14 @@ TEST_CASE("[mlx.core.linalg.norm] double ord") {
                 std::vector<int>{-2, -1},
                 false,
                 Device::cpu),
+            array({3.0, 30.0}))
+            .item<bool>());
+  CHECK(allclose(
+            norm(x, 1, std::vector<int>{-1, -2}, false, Device::cpu),
+            array({21.0, 48.0}))
+            .item<bool>());
+  CHECK(allclose(
+            norm(x, 1, std::vector<int>{-1, -2}, false, Device::cpu),
             array({3.0, 30.0}))
             .item<bool>());
 }

--- a/tests/linalg_tests.cpp
+++ b/tests/linalg_tests.cpp
@@ -295,7 +295,7 @@ TEST_CASE("[mlx.core.linalg.norm] double ord") {
             array({21.0, 48.0}))
             .item<bool>());
   CHECK(allclose(
-            norm(x, 1, std::vector<int>{-1, -2}, false, Device::cpu),
+            norm(x, -1, std::vector<int>{-1, -2}, false, Device::cpu),
             array({3.0, 30.0}))
             .item<bool>());
 }


### PR DESCRIPTION
## Proposed changes

The following PR aims to fix a  matrix norm calculation bug caused by similar reason #3756 for when we are consider the $\pm1$ norm. Since the matrix norm is calculated as a series of reduction. When `keepdims` is false and negatives axes are passed in, the method fails to adjust the `col_axis` accordingly to account for the loss in dimension. This results in either an index out of bound error or the wrong index being reduced along. The following PR normalizes the axes accordingly to account for this reduction. 
### Reproduction 
To reproduce the bug 
```Python
import mlx.core as mx
import numpy as np
import mlx.core.linalg as la

a_mx = mx.arange(9).reshape(3,3)
a_np = np.arange(9).reshape(3,3)
print(np.linalg.norm(a_np, ord = -1, axis = (-1, -2))) #5.0
print(la.norm(a_mx, ord = -1, axis = [-1, -2])) # throws exception

a_mx = mx.arange(18).reshape(2,3,3)
a_np = np.arange(18).reshape(2,3,3)
print(np.linalg.norm(a_np, ord = -1, axis = (-1, -2))) # [21., 48.]
print(la.norm(a_mx, ord = -1, axis = [-1, -2])) # array([3, 12, 21], dtype=float32)
```
## Testing 
- Existing tests were ran
- Existing test suite for negative axis reduction was extended to account for $\pm 1$ norm to account for all possible negative axes combination for `(3, 3), (2, 3, 3), (2, 3, 3, 3)` matrices 
## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
