### PR TITLE
Fix Glorot/He uniform init docstrings to label the uniform bound, not sigma

### DIFF
--- a/python/mlx/nn/init.py
+++ b/python/mlx/nn/init.py
@@ -194,12 +194,13 @@ def glorot_uniform(
 ) -> Callable[[mx.array, float], mx.array]:
     r"""A Glorot uniform initializer.
 
-    This initializer samples from a uniform distribution with a range
-    computed from the number of input (``fan_in``) and output (``fan_out``)
+    This initializer samples from a uniform distribution on the interval
+    :math:`[-\text{limit}, \text{limit}]`, where the bound :math:`\text{limit}`
+    is computed from the number of input (``fan_in``) and output (``fan_out``)
     units according to:
 
     .. math::
-        \sigma = \gamma \sqrt{\frac{6.0}{\text{fan\_in} + \text{fan\_out}}}
+        \text{limit} = \gamma \sqrt{\frac{6.0}{\text{fan\_in} + \text{fan\_out}}}
 
     For more details see the original reference: `Understanding the difficulty
     of training deep feedforward neural networks
@@ -295,13 +296,14 @@ def he_uniform(
 ) -> Callable[[mx.array, Literal["fan_in", "fan_out"], float], mx.array]:
     r"""A He uniform (Kaiming uniform) initializer.
 
-    This initializer samples from a uniform distribution with a range
-    computed from the number of input (``fan_in``) or output (``fan_out``)
+    This initializer samples from a uniform distribution on the interval
+    :math:`[-\text{limit}, \text{limit}]`, where the bound :math:`\text{limit}`
+    is computed from the number of input (``fan_in``) or output (``fan_out``)
     units according to:
 
     .. math::
 
-        \sigma = \gamma \sqrt{\frac{3.0}{\text{fan}}}
+        \text{limit} = \gamma \sqrt{\frac{3.0}{\text{fan}}}
 
     where :math:`\text{fan}` is either the number of input units when the
     ``mode`` is ``"fan_in"`` or output units when the ``mode`` is


### PR DESCRIPTION
## Proposed changes

The `glorot_uniform` and `he_uniform` docstrings in `python/mlx/nn/init.py`
write the sampling bound with the symbol `\sigma`, but both initializers draw
from a symmetric uniform distribution, `uniform(-a, a)`, so the value shown is
the bound `a`, not a standard deviation. `\sigma` conventionally denotes the
standard deviation, and for `uniform(-a, a)` the standard deviation is
`a / sqrt(3)`:

- `glorot_uniform`: bound `a = gain * sqrt(6 / (fan_in + fan_out))`, so the
  actual standard deviation is `gain * sqrt(2 / (fan_in + fan_out))`, which is
  exactly the `\sigma` documented for `glorot_normal`.
- `he_uniform`: bound `a = gain * sqrt(3 / fan)`, so the actual standard
  deviation is `gain / sqrt(fan)`, which is exactly the `\sigma` documented for
  `he_normal`.

So the documented `\sigma` for the uniform initializers is off by a factor of
`sqrt(3)` from the real standard deviation. It is also inconsistent with the
surrounding prose, which already describes the quantity as a "range", and with
the normal initializers in the same file, where `\sigma` correctly denotes the
standard deviation. For comparison, PyTorch's `kaiming_uniform_` docstring
labels the same quantity `bound` and samples `U(-bound, bound)`.

This relabels the quantity as the bound `a` and shows the sampling interval
`[-a, a]`. It is a documentation-only change with no effect on behavior; the
sampled values are unchanged.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes (docstring text only; verified it compiles and does not change `black` formatting)
- [ ] I have added tests that prove my fix is effective or that my feature works (documentation-only change; no code path is affected)
- [x] I have updated the necessary documentation (if needed)
