### PR TITLE
Fix custom metal kernel cache collision for same name, different source

### DIFF
--- a/mlx/backend/metal/custom_kernel.cpp
+++ b/mlx/backend/metal/custom_kernel.cpp
@@ -8,16 +8,6 @@
 
 namespace mlx::core::fast {
 
-struct CustomKernelCache {
-  std::unordered_map<std::string, std::pair<std::string, CompileOptions::Data>>
-      libraries;
-};
-
-static CustomKernelCache& cache() {
-  static CustomKernelCache cache_;
-  return cache_;
-};
-
 void CustomKernel::eval_gpu(
     const std::vector<array>& inputs,
     std::vector<array>& outputs) {
@@ -55,25 +45,15 @@ void CustomKernel::eval_gpu(
 
   auto& d = metal::device(s.device);
 
-  {
-    // Clear kernels from the device library cache if needed
-    auto& kernel_cache = cache();
-    if (auto it = kernel_cache.libraries.find(name_);
-        it != kernel_cache.libraries.end()) {
-      if (it->second.first != source_ ||
-          it->second.second != compile_options_) {
-        auto& d = metal::device(s.device);
-        d.clear_library(name_);
-        it->second = std::make_tuple(source_, compile_options_);
-      }
-    } else {
-      kernel_cache.libraries.emplace(
-          name_, std::make_tuple(source_, compile_options_));
-    }
-  }
-
+  // Key the library by (name, source, compile options) so kernels that differ
+  // in any of those coexist instead of thrashing a single cache slot within one
+  // eval batch (fixes #3832). The map key is never used as a Metal identifier,
+  // so the full source is a collision-free key (a content hash could alias
+  // distinct sources and silently reintroduce the bug).
+  std::string lib_name =
+      name_ + "\n" + source_ + "\n" + std::to_string(compile_options_);
   auto lib = d.get_library(
-      name_, compile_options_, [this] { return metal::utils() + source_; });
+      lib_name, compile_options_, [this] { return metal::utils() + source_; });
   auto kernel = d.get_kernel(name_, lib);
   auto& compute_encoder = metal::get_command_encoder(s);
   compute_encoder.set_compute_pipeline_state(kernel);

--- a/mlx/backend/metal/custom_kernel.cpp
+++ b/mlx/backend/metal/custom_kernel.cpp
@@ -45,13 +45,13 @@ void CustomKernel::eval_gpu(
 
   auto& d = metal::device(s.device);
 
-  // Key the library by (name, source, compile options) so kernels that differ
-  // in any of those coexist instead of thrashing a single cache slot within one
-  // eval batch (fixes #3832). The map key is never used as a Metal identifier,
-  // so the full source is a collision-free key (a content hash could alias
-  // distinct sources and silently reintroduce the bug).
-  std::string lib_name =
-      name_ + "\n" + source_ + "\n" + std::to_string(compile_options_);
+  // Key the library by (name, source hash, compile options) so kernels that
+  // differ in any of those coexist instead of thrashing a single cache slot
+  // within one eval batch (fixes #3832). The source is hashed to keep the key
+  // short.
+  std::string lib_name = name_ + "_" +
+      std::to_string(std::hash<std::string>{}(source_)) + "_" +
+      std::to_string(compile_options_);
   auto lib = d.get_library(
       lib_name, compile_options_, [this] { return metal::utils() + source_; });
   auto kernel = d.get_kernel(name_, lib);

--- a/mlx/backend/metal/custom_kernel.cpp
+++ b/mlx/backend/metal/custom_kernel.cpp
@@ -6,6 +6,8 @@
 #include "mlx/backend/metal/utils.h"
 #include "mlx/fast_primitives.h"
 
+#include <fmt/format.h>
+
 namespace mlx::core::fast {
 
 void CustomKernel::eval_gpu(
@@ -45,13 +47,8 @@ void CustomKernel::eval_gpu(
 
   auto& d = metal::device(s.device);
 
-  // Key the library by (name, source hash, compile options) so kernels that
-  // differ in any of those coexist instead of thrashing a single cache slot
-  // within one eval batch (fixes #3832). The source is hashed to keep the key
-  // short.
-  std::string lib_name = name_ + "_" +
-      std::to_string(std::hash<std::string>{}(source_)) + "_" +
-      std::to_string(compile_options_);
+  std::string lib_name = fmt::format(
+      "{}_{:x}_{}", name_, std::hash<std::string>{}(source_), compile_options_);
   auto lib = d.get_library(
       lib_name, compile_options_, [this] { return metal::utils() + source_; });
   auto kernel = d.get_kernel(name_, lib);

--- a/python/tests/test_fast.py
+++ b/python/tests/test_fast.py
@@ -1027,6 +1027,38 @@ class TestFast(mlx_tests.MLXTestCase):
         self.assertTrue(mx.array_equal(out, mx.ones_like(out)))
 
     @unittest.skipIf(not mx.metal.is_available(), "Metal is not available")
+    def test_custom_kernel_same_name_different_source_one_eval(self):
+        # Regression test for #3832: two kernels sharing a name but with
+        # different sources, dispatched in a SINGLE eval batch, must each run
+        # their own compiled code instead of silently reusing the first's.
+        def call_kernel(a, source):
+            kernel = mx.fast.metal_kernel(
+                name="dup_name",
+                input_names=["inp"],
+                output_names=["out"],
+                source=source,
+            )
+            return kernel(
+                inputs=[a],
+                grid=(a.size, 1, 1),
+                threadgroup=(a.size, 1, 1),
+                output_shapes=[a.shape],
+                output_dtypes=[a.dtype],
+                stream=mx.gpu,
+            )[0]
+
+        a = mx.arange(32, dtype=mx.float32)
+        out_a = call_kernel(
+            a, "uint e = thread_position_in_grid.x; out[e] = inp[e] * 2.0f;"
+        )
+        out_b = call_kernel(
+            a, "uint e = thread_position_in_grid.x; out[e] = inp[e] + 100.0f;"
+        )
+        mx.eval(out_a, out_b)  # one batch — the reported failure case
+        self.assertTrue(mx.array_equal(out_a, a * 2.0))
+        self.assertTrue(mx.array_equal(out_b, a + 100.0))
+
+    @unittest.skipIf(not mx.metal.is_available(), "Metal is not available")
     def test_custom_metal_kernel_math_mode(self):
         with self.assertRaises(ValueError):
             mx.fast.metal_kernel(


### PR DESCRIPTION
## Summary

Fixes #3832. Two `fast.metal_kernel` instances that share a `name` but have different `source`, dispatched before a single `mx.eval`, silently execute the **first** kernel's compiled code for the second — wrong results, no error.

## Cause

The custom-kernel library cache is keyed by `name_` alone (`backend/metal/custom_kernel.cpp`), with a hand-rolled "if the source changed, `clear_library(name_)` and rebuild" invalidation. That is safe *across* `eval` boundaries (the command buffer has completed before the clear) but not *within* one batch: the second kernel clears and rebuilds the shared `name_` slot while the first kernel's dispatch is still pending in the same command buffer, and the second ends up bound to the first's code.

## Fix

Key the library by `name_ + hash(source_) + compile_options_`, so kernels that differ in any of those map to distinct libraries — and therefore distinct pipelines (the pipeline cache is already keyed by `(library, function)`). They now coexist for the whole batch instead of thrashing one slot, and the fragile clear-and-rebuild (with its `CustomKernelCache` bookkeeping) is removed. `compile_options_` is still passed to `get_library`, so a kernel's math mode is honored.

The source is hashed with `std::hash<std::string>` rather than embedded whole, so the key stays short — the same treatment `backend/cpu/compiled.cpp` gives over-long kernel names. A wrong cache hit would need two kernels to share a name, share compile options, *and* collide on the 64-bit hash.

## Test

Adds `test_custom_kernel_same_name_different_source_one_eval`: two same-name / different-source kernels evaluated in a single batch must each return their own result. It fails before this change and passes after.

## Validation

Built against `main`; `python/tests/test_fast.py` passes (27/27, including the new test and the compile-options / caching tests), and the issue's repro now returns the correct `[100, 101, 102]` instead of `[0, 2, 4]`.

Thanks to @Jinge-Wang for the precise report and minimal repro.
