### PR TITLE
Fix eigh UPLO and zero-size eigh/svd on the CPU

### DIFF
--- a/mlx/backend/cpu/eigh.cpp
+++ b/mlx/backend/cpu/eigh.cpp
@@ -155,10 +155,12 @@ void eigh_impl(
   auto& encoder = cpu::get_command_encoder(stream);
   encoder.set_output_array(vectors);
   encoder.set_output_array(values);
+  // LAPACK reads the row-major input as its (conjugate) transpose, so the
+  // requested triangle is the opposite one in LAPACK's view.
   encoder.dispatch([vec_ptr,
                     eig_ptr,
                     jobz,
-                    uplo = uplo[0],
+                    uplo = uplo[0] == 'L' ? 'U' : 'L',
                     N = vectors.shape(-1),
                     size = vectors.size()]() mutable {
     // Work query
@@ -201,6 +203,15 @@ void Eigh::eval_cpu(
       vectors,
       a.flags().row_contiguous ? CopyType::Vector : CopyType::General,
       stream());
+
+  // Nothing to decompose for n = 0; LAPACK rejects lda = 0.
+  if (a.shape(-1) == 0) {
+    if (!compute_eigenvectors_) {
+      auto& encoder = cpu::get_command_encoder(stream());
+      encoder.add_temporary(vectors);
+    }
+    return;
+  }
 
   if (compute_eigenvectors_) {
     // Set the strides and flags so the eigenvectors

--- a/mlx/backend/cpu/eigh.cpp
+++ b/mlx/backend/cpu/eigh.cpp
@@ -192,28 +192,26 @@ void Eigh::eval_cpu(
   const auto& a = inputs[0];
   auto& values = outputs[0];
 
+  values.set_data(allocator::malloc(values.nbytes()));
+
+  // Nothing to decompose for n = 0; LAPACK rejects lda = 0. The input is
+  // square, so both outputs are empty and there is nothing to write.
+  if (a.shape(-1) == 0) {
+    if (compute_eigenvectors_) {
+      outputs[1].set_data(allocator::malloc(outputs[1].nbytes()));
+    }
+    return;
+  }
+
   auto vectors = compute_eigenvectors_
       ? outputs[1]
       : array(a.shape(), a.dtype(), nullptr, {});
-
-  values.set_data(allocator::malloc(values.nbytes()));
 
   copy_cpu(
       a,
       vectors,
       a.flags().row_contiguous ? CopyType::Vector : CopyType::General,
       stream());
-
-  // Nothing to decompose for n = 0; LAPACK rejects lda = 0. The input is
-  // square, so both outputs are empty here and the copy above has already
-  // initialized the eigenvectors.
-  if (a.shape(-1) == 0) {
-    if (!compute_eigenvectors_) {
-      auto& encoder = cpu::get_command_encoder(stream());
-      encoder.add_temporary(vectors);
-    }
-    return;
-  }
 
   if (compute_eigenvectors_) {
     // Set the strides and flags so the eigenvectors

--- a/mlx/backend/cpu/eigh.cpp
+++ b/mlx/backend/cpu/eigh.cpp
@@ -204,7 +204,9 @@ void Eigh::eval_cpu(
       a.flags().row_contiguous ? CopyType::Vector : CopyType::General,
       stream());
 
-  // Nothing to decompose for n = 0; LAPACK rejects lda = 0.
+  // Nothing to decompose for n = 0; LAPACK rejects lda = 0. The input is
+  // square, so both outputs are empty here and the copy above has already
+  // initialized the eigenvectors.
   if (a.shape(-1) == 0) {
     if (!compute_eigenvectors_) {
       auto& encoder = cpu::get_command_encoder(stream());

--- a/mlx/backend/cpu/svd.cpp
+++ b/mlx/backend/cpu/svd.cpp
@@ -206,6 +206,14 @@ void svd_impl(
 
   using R = typename SVDWork<T>::R;
 
+  // Nothing to decompose for empty matrices; LAPACK rejects lda = 0.
+  if (M == 0 || N == 0) {
+    for (auto& o : outputs) {
+      o.set_data(allocator::malloc(o.nbytes()));
+    }
+    return;
+  }
+
   size_t num_matrices = a.size() / (M * N);
 
   // lapack clobbers the input, so we have to make a copy.

--- a/mlx/backend/cpu/svd.cpp
+++ b/mlx/backend/cpu/svd.cpp
@@ -1,5 +1,7 @@
 // Copyright © 2024 Apple Inc.
 
+#include <algorithm>
+
 #include "mlx/allocator.h"
 #include "mlx/backend/cpu/copy.h"
 #include "mlx/backend/cpu/encoder.h"
@@ -206,10 +208,26 @@ void svd_impl(
 
   using R = typename SVDWork<T>::R;
 
-  // Nothing to decompose for empty matrices; LAPACK rejects lda = 0.
+  // Nothing to decompose when either dimension is zero; LAPACK rejects
+  // lda = 0. The singular values are empty but the factors are not when only
+  // one of the dimensions is zero, so fill them with the identity like LAPACK
+  // does, which keeps them orthonormal.
   if (M == 0 || N == 0) {
+    auto& encoder = cpu::get_command_encoder(stream);
     for (auto& o : outputs) {
       o.set_data(allocator::malloc(o.nbytes()));
+      if (o.size() == 0) {
+        continue;
+      }
+      encoder.set_output_array(o);
+      encoder.dispatch([ptr = o.data<T>(), size = o.size(), n = o.shape(-1)]() {
+        std::fill_n(ptr, size, T(0));
+        for (size_t i = 0; i < size; i += static_cast<size_t>(n) * n) {
+          for (int j = 0; j < n; ++j) {
+            ptr[i + static_cast<size_t>(j) * n + j] = T(1);
+          }
+        }
+      });
     }
     return;
   }

--- a/mlx/backend/cpu/svd.cpp
+++ b/mlx/backend/cpu/svd.cpp
@@ -220,7 +220,10 @@ void svd_impl(
         continue;
       }
       encoder.set_output_array(o);
-      encoder.dispatch([ptr = o.data<T>(), size = o.size(), n = o.shape(-1)]() {
+      encoder.dispatch([o = array::unsafe_weak_copy(o)]() mutable {
+        auto ptr = o.data<T>();
+        const size_t size = o.size();
+        const int n = o.shape(-1);
         std::fill_n(ptr, size, T(0));
         for (size_t i = 0; i < size; i += static_cast<size_t>(n) * n) {
           for (int j = 0; j < n; ++j) {

--- a/python/tests/test_linalg.py
+++ b/python/tests/test_linalg.py
@@ -188,6 +188,13 @@ class TestLinalg(mlx_tests.MLXTestCase):
                 )
             )
 
+        # Zero-size inputs
+        for shape in [(0, 4, 4), (3, 0, 0)]:
+            U, S, Vt = mx.linalg.svd(mx.zeros(shape), stream=mx.cpu)
+            mx.eval(U, S, Vt)
+            self.assertEqual(S.shape, shape[:-1])
+            self.assertEqual(U.shape, shape)
+
         # Test float64 - use CPU stream since float64 is not supported on GPU
         with mx.stream(mx.cpu):
             A_f64 = mx.array(
@@ -492,6 +499,21 @@ class TestLinalg(mlx_tests.MLXTestCase):
         )
         A_np = A_np + A_np.T.conj()
         check_eigs_and_vecs(A_np)
+
+        # UPLO picks the triangle like numpy; only observable when the two
+        # triangles disagree
+        A_np = np.array([[1.0, 999.0], [2.0, 3.0]], dtype=np.float32)
+        for uplo in ("L", "U"):
+            w = mx.linalg.eigvalsh(mx.array(A_np), UPLO=uplo, stream=mx.cpu)
+            w_np = np.linalg.eigvalsh(A_np, UPLO=uplo)
+            self.assertTrue(np.allclose(w, w_np, atol=1e-5))
+
+        # Zero-size inputs
+        for shape in [(0, 4, 4), (3, 0, 0)]:
+            w, v = mx.linalg.eigh(mx.zeros(shape), stream=mx.cpu)
+            mx.eval(w, v)
+            self.assertEqual(w.shape, shape[:-1])
+            self.assertEqual(v.shape, shape)
 
         # Test error cases
         with self.assertRaises(ValueError):

--- a/python/tests/test_linalg.py
+++ b/python/tests/test_linalg.py
@@ -188,12 +188,22 @@ class TestLinalg(mlx_tests.MLXTestCase):
                 )
             )
 
-        # Zero-size inputs
-        for shape in [(0, 4, 4), (3, 0, 0)]:
-            U, S, Vt = mx.linalg.svd(mx.zeros(shape), stream=mx.cpu)
+        # Zero-size inputs. When only one of the dimensions is zero the
+        # factors are not empty and hold the identity, like numpy.
+        for shape in [(0, 4, 4), (3, 0, 0), (2, 5, 0), (2, 0, 5), (5, 0), (0, 5)]:
+            a_np = np.zeros(shape, dtype=np.float32)
+            U, S, Vt = mx.linalg.svd(mx.array(a_np), stream=mx.cpu)
             mx.eval(U, S, Vt)
-            self.assertEqual(S.shape, shape[:-1])
-            self.assertEqual(U.shape, shape)
+            U_np, S_np, Vt_np = np.linalg.svd(a_np)
+            self.assertEqual(U.shape, U_np.shape)
+            self.assertEqual(S.shape, S_np.shape)
+            self.assertEqual(Vt.shape, Vt_np.shape)
+            self.assertTrue(np.array_equal(np.array(U), U_np))
+            self.assertTrue(np.array_equal(np.array(Vt), Vt_np))
+
+            S_only = mx.linalg.svd(mx.array(a_np), compute_uv=False, stream=mx.cpu)
+            mx.eval(S_only)
+            self.assertEqual(S_only.shape, S_np.shape)
 
         # Test float64 - use CPU stream since float64 is not supported on GPU
         with mx.stream(mx.cpu):
@@ -509,11 +519,19 @@ class TestLinalg(mlx_tests.MLXTestCase):
             self.assertTrue(np.allclose(w, w_np, atol=1e-5))
 
         # Zero-size inputs
-        for shape in [(0, 4, 4), (3, 0, 0)]:
-            w, v = mx.linalg.eigh(mx.zeros(shape), stream=mx.cpu)
+        for shape in [(0, 4, 4), (3, 0, 0), (0, 0)]:
+            a_np = np.zeros(shape, dtype=np.float32)
+            w, v = mx.linalg.eigh(mx.array(a_np), stream=mx.cpu)
             mx.eval(w, v)
-            self.assertEqual(w.shape, shape[:-1])
-            self.assertEqual(v.shape, shape)
+            w_np, v_np = np.linalg.eigh(a_np)
+            self.assertEqual(w.shape, w_np.shape)
+            self.assertEqual(v.shape, v_np.shape)
+            self.assertTrue(np.array_equal(np.array(w), w_np))
+            self.assertTrue(np.array_equal(np.array(v), v_np))
+
+            w_only = mx.linalg.eigvalsh(mx.array(a_np), stream=mx.cpu)
+            mx.eval(w_only)
+            self.assertEqual(w_only.shape, w_np.shape)
 
         # Test error cases
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Proposed changes

`eigh`/`eigvalsh` read the opposite triangle from what `UPLO` asks for.
The row-major buffer is handed to LAPACK, which reads it as its transpose,
so `UPLO="L"` actually used the upper triangle. Only observable when the
two triangles differ:

```python
>>> a = mx.array([[1.0, 999.0], [2.0, 3.0]])
>>> mx.linalg.eigvalsh(a, UPLO="L", stream=mx.cpu)
array([-997.001, 1001], dtype=float32)     # before (upper triangle)
array([-0.236068, 4.23607], dtype=float32) # after, matches numpy
```

Also fixes crashes for zero-size inputs to `eigh` and `svd`: LAPACK
rejects `lda = 0` and the batch-count division was by zero.

No behavior change for inputs with consistent triangles (symmetric or
Hermitian), which is why the existing tests didn't catch it.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
