### PR TITLE
Fix uniform-initializer docstrings to use the range limit, not sigma

### DIFF
--- a/python/mlx/nn/init.py
+++ b/python/mlx/nn/init.py
@@ -199,7 +199,7 @@ def glorot_uniform(
     units according to:
 
     .. math::
-        \sigma = \gamma \sqrt{\frac{6.0}{\text{fan\_in} + \text{fan\_out}}}
+        \text{limit} = \gamma \sqrt{\frac{6.0}{\text{fan\_in} + \text{fan\_out}}}
 
     For more details see the original reference: `Understanding the difficulty
     of training deep feedforward neural networks
@@ -301,7 +301,7 @@ def he_uniform(
 
     .. math::
 
-        \sigma = \gamma \sqrt{\frac{3.0}{\text{fan}}}
+        \text{limit} = \gamma \sqrt{\frac{3.0}{\text{fan}}}
 
     where :math:`\text{fan}` is either the number of input units when the
     ``mode`` is ``"fan_in"`` or output units when the ``mode`` is


### PR DESCRIPTION
## Proposed changes

`nn.init.glorot_uniform` and `nn.init.he_uniform` sample from a uniform distribution on `[-limit, limit]`: the code computes `limit = gain * math.sqrt(...)` and calls `mx.random.uniform(-limit, limit, ...)`. Their docstring math, however, labels that bound as `\sigma`, the standard-deviation symbol:

```
\sigma = \gamma \sqrt{\frac{6.0}{\text{fan\_in} + \text{fan\_out}}}   # glorot_uniform
\sigma = \gamma \sqrt{\frac{3.0}{\text{fan}}}                        # he_uniform
```

The standard deviation of `U(-limit, limit)` is `limit / sqrt(3)`, not `limit`, so using `\sigma` for the bound is misleading. This renames the symbol to `\text{limit}` in both docstrings so the documented quantity matches the code variable and its true meaning.

`glorot_normal` and `he_normal` are left unchanged: they sample from a normal distribution, where `\sigma` is the correct symbol for the standard deviation.

Documentation-only change; no code paths are affected.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] The change is docstring text only (inside a `.. math::` block), so `black` formatting is unchanged
- [ ] I have added tests (not applicable: documentation-only change, no behavior changed)
- [x] I have updated the necessary documentation