### PR TITLE
Add a fused full-attention path for head_dim 256 on NAX devices

### DIFF
--- a/benchmarks/python/sdpa_bench.py
+++ b/benchmarks/python/sdpa_bench.py
@@ -215,9 +215,18 @@ if __name__ == "__main__":
           (  1,  4096,  5000,      128,   32,     8),
           (  1,  2048,  32121,     128,   32,     8),
     )
+
+    shapes_256 = (
+        # (  B,   qsl,   ksl, head_dim, n_qh, n_kvh)
+          (  1,  1024,  1024,      256,   24,     4),
+          (  1,  2048,  2048,      256,   24,     4),
+          (  1,  4096,  4096,      256,   24,     4),
+          (  1,  4096,  5000,      256,   24,     4),
+          (  1,  2048,  32121,     256,   24,     4),
+    )
     # fmt: on
 
-    shapes = shapes_64 + shapes_72 + shapes_80 + shapes_96 + shapes_128
+    shapes = shapes_64 + shapes_72 + shapes_80 + shapes_96 + shapes_128 + shapes_256
 
     masks = [None, "bool", "causal"]
 

--- a/mlx/backend/metal/jit_kernels.cpp
+++ b/mlx/backend/metal/jit_kernels.cpp
@@ -1330,7 +1330,8 @@ MTL::ComputePipelineState* get_steel_attention_nax_kernel(
     int bd,
     int wm,
     int wn,
-    const array& m) {
+    const array& m,
+    bool split_d) {
   const auto& lib_name = kernel_name;
   auto lib = d.get_library(lib_name, [&]() {
     std::string kernel_source;
@@ -1340,7 +1341,7 @@ MTL::ComputePipelineState* get_steel_attention_nax_kernel(
         metal::steel_attention_nax(),
         get_template_definition(
             lib_name,
-            "attention_nax",
+            split_d ? "attention_nax_dsplit" : "attention_nax",
             get_type_string(q.dtype()),
             bq,
             bk,

--- a/mlx/backend/metal/kernels.h
+++ b/mlx/backend/metal/kernels.h
@@ -426,7 +426,8 @@ MTL::ComputePipelineState* get_steel_attention_nax_kernel(
     int bd,
     int wm,
     int wn,
-    const array& m);
+    const array& m,
+    bool split_d);
 
 // Create a GPU kernel template definition for JIT compilation
 template <typename... Args>

--- a/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention_nax.h
+++ b/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention_nax.h
@@ -127,7 +127,10 @@ template <
   // Prepare MMA tiles
   constexpr short kU = 16;
 
-  constexpr int kNWarps = WM * WN;
+  // With WN == 2 the second warp dimension splits the head dim (each
+  // simdgroup owns half of D for Q@K.T and half of Dv for P@V); only WM
+  // warps split the Q sequence.
+  constexpr int kNWarps = (WN == 2) ? WM : WM * WN;
   static_assert(
       BQ >= (kNWarps * kU) && BQ % (kNWarps * kU) == 0,
       "Each simdgroup must host atleast 1 simdgroup matrix along Q sequence.");
@@ -140,6 +143,346 @@ template <
   constexpr short TK = BK / kU;
 
   static_assert(TQ == 1, "Check TQ");
+
+  if constexpr (WN == 2) {
+    // Head-dim split path. Per simdgroup the accumulator working set is
+    // half of the WN == 1 kernel (TD/2 output fragments), which is the
+    // resource that gates bd=256 throughput. The Q@K.T partial sums over
+    // each half of D are exchanged through threadgroup memory; both halves
+    // then run softmax redundantly on the full S tile and each computes
+    // P@V for its own half of Dv.
+    constexpr int TDh = TD / 2;
+    constexpr int BDh = BD / 2;
+
+    const short row_group = simd_group_id / 2;
+    const short d_half = simd_group_id & 1;
+
+    using otile_t = NAXTile<AccumType, TQ, TDh>;
+    otile_t Otile;
+    Otile.clear();
+
+    const short tm = kU * TQ * row_group;
+    Q += tm * int(params->Q_strides[2]) + d_half * BDh;
+    K += d_half * BDh;
+    V += d_half * BDh;
+    O += tm * int(params->O_strides[2]) + d_half * BDh;
+
+    constexpr short kRowsPT = otile_t::kRowsPerThread;
+
+    metal::vec<AccumType, kRowsPT> max_score;
+    metal::vec<AccumType, kRowsPT> sum_score{0};
+
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < kRowsPT; ++i) {
+      max_score[i] = Limits<AccumType>::finite_min;
+    }
+
+    if (has_sinks) {
+      STEEL_PRAGMA_UNROLL
+      for (short i = 0; i < kRowsPT; ++i) {
+        max_score[i] = M_LOG2E_F * static_cast<AccumType>(sinks[tidl.y]);
+        sum_score[i] = 1;
+      }
+    }
+
+    int kb_lim = params->NK;
+    int kb_min_causal = params->NK;
+
+    if (do_causal) {
+      int q_max = (tid.x + 1) * BQ + params->qL_off;
+      kb_lim = (q_max + BK - 1) / BK;
+      kb_lim = min(params->NK, kb_lim);
+
+      int q_min = tid.x * BQ + params->qL_off;
+      q_min = max(0, q_min);
+      kb_min_causal = (q_min / BK);
+    }
+
+    const bool is_last_q = int(tid.x) == (params->NQ_aligned);
+    const short lim_rows_q = params->qL_rem - tm;
+    const short lim_rows_k = params->kL_rem;
+
+    using stile_t = NAXTile<AccumType, TQ, TK>;
+    constexpr short kEPF = stile_t::NAXFrag_t::kElemsPerFrag;
+
+    // One slot per (row group, half): a fragment pair in per-lane-linear
+    // layout. Both halves share the fragment-to-lane mapping, so the
+    // exchange needs no coordinate math.
+    threadgroup AccumType s_xchg[WM][2][2 * kEPF * 32];
+
+    // Keep the simdgroup's Q half resident in registers for the whole KV
+    // loop (TDh fragments of T are cheap; see the bd=256 notes).
+    NAXTile<T, 1, 1> Qtiles[TDh];
+    STEEL_PRAGMA_UNROLL
+    for (short id = 0; id < TDh; id++) {
+      const int Q_load_off = id * kU;
+      if (!align_Q && is_last_q) {
+        Qtiles[id].load_rows(
+            Q + Q_load_off, int(params->Q_strides[2]), lim_rows_q);
+      } else {
+        Qtiles[id].load(Q + Q_load_off, int(params->Q_strides[2]));
+      }
+    }
+
+    const short2 simd_coord = otile_t::NAXFrag_t::get_coord();
+    const short sm = simd_coord.y;
+    const short sn = simd_coord.x;
+
+    // Loop over KV seq length
+    for (int kb = 0; kb < kb_lim; kb++) {
+      const int is_last_k = (kb == (params->NK_aligned));
+
+      stile_t Stile;
+      Stile.clear();
+
+      // S = Q @ K.T, this half of D only, exchanged pair by pair.
+      STEEL_PRAGMA_UNROLL
+      for (short ik = 0; ik < TK; ik += 2) {
+        STEEL_PRAGMA_UNROLL
+        for (short id = 0; id < TDh; id++) {
+          NAXTile<T, 2, 1> Ktile;
+          const int K_load_off = ik * kU * int(params->K_strides[2]) + id * kU;
+
+          if (!align_K && is_last_k) {
+            Ktile.load_rows(
+                K + K_load_off,
+                int(params->K_strides[2]),
+                lim_rows_k - ik * kU);
+          } else {
+            Ktile.load(K + K_load_off, int(params->K_strides[2]));
+          }
+
+          stile_t::NAXFrag_t::mma(
+              Stile.frag_at(0, ik),
+              Stile.frag_at(0, ik + 1),
+              Qtiles[id].frag_at(0, 0),
+              metal::false_type{},
+              Ktile.frag_at(0, 0),
+              Ktile.frag_at(1, 0),
+              metal::true_type{});
+        }
+
+        // Exchange the partial pair and reduce.
+        threadgroup AccumType* slot = s_xchg[row_group][d_half];
+        thread auto& s0 = Stile.frag_at(0, ik);
+        thread auto& s1 = Stile.frag_at(0, ik + 1);
+        const short base = short(simd_lane_id) * (2 * kEPF);
+        STEEL_PRAGMA_UNROLL
+        for (short i = 0; i < kEPF; i++) {
+          slot[base + i] = s0[i];
+          slot[base + kEPF + i] = s1[i];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        const threadgroup AccumType* peer = s_xchg[row_group][1 - d_half];
+        STEEL_PRAGMA_UNROLL
+        for (short i = 0; i < kEPF; i++) {
+          s0[i] += peer[base + i];
+          s1[i] += peer[base + kEPF + i];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+      }
+
+      // Scale S
+      STEEL_PRAGMA_UNROLL
+      for (short ii = 0; ii < stile_t::kElemsPerTile; ii++) {
+        Stile.elems()[ii] *= float(scale2);
+      }
+
+      // Mask out length sequence
+      if (!align_K && is_last_k) {
+        constexpr auto neg_inf = Limits<AccumType>::finite_min;
+
+        STEEL_PRAGMA_UNROLL
+        for (short ik = 0; ik < TK; ik++) {
+          const short col_pos = ik * kU + sn;
+          thread auto& fg = Stile.frag_at(0, ik);
+
+          STEEL_PRAGMA_UNROLL
+          for (short ii = 0; ii < stile_t::kFragThrRows; ii++) {
+            STEEL_PRAGMA_UNROLL
+            for (short jj = 0; jj < stile_t::kFragThrCols; jj++) {
+              const auto loc = ii * stile_t::kFragThrCols + jj;
+              fg[loc] = ((col_pos + jj) < params->kL_rem) ? fg[loc] : neg_inf;
+            }
+          }
+        }
+      }
+
+      // Mask out if causal
+      if (do_causal && kb >= kb_min_causal) {
+        constexpr auto neg_inf = Limits<AccumType>::finite_min;
+
+        const int base_row = tid.x * BQ + params->qL_off + tm;
+        const int base_col = kb * BK;
+
+        STEEL_PRAGMA_UNROLL
+        for (short ik = 0; ik < TK; ik++) {
+          thread auto& fg = Stile.frag_at(0, ik);
+
+          STEEL_PRAGMA_UNROLL
+          for (short ii = 0; ii < stile_t::kFragThrRows; ii++) {
+            STEEL_PRAGMA_UNROLL
+            for (short jj = 0; jj < stile_t::kFragThrCols; jj++) {
+              const auto r = base_row + ii * stile_t::kFragRowsJump + sm;
+              const auto c = base_col + ik * kU + jj + sn;
+              const auto loc = ii * stile_t::kFragThrCols + jj;
+              fg[loc] = (r < c) ? neg_inf : fg[loc];
+            }
+          }
+        }
+      }
+
+      // Other masking as needed
+      if (has_mask) {
+        constexpr auto neg_inf = Limits<AccumType>::finite_min;
+
+        const int base_row = tid.x * BQ + tm;
+        const int base_col = kb * BK;
+
+        constexpr bool is_bool = is_same_v<MaskType, bool>;
+        using melem_t = typename metal::conditional_t<is_bool, bool, AccumType>;
+        using mtile_t = NAXTile<melem_t, TQ, TK>;
+        using mfrag_t = typename mtile_t::frag_type;
+
+        if (base_row + kU <= params->qL && base_col + BK <= params->kL) {
+          STEEL_PRAGMA_UNROLL
+          for (short ik = 0; ik < TK; ik++) {
+            const int row_pos = base_row;
+            const int col_pos = base_col + ik * kU;
+
+            mfrag_t mfrag;
+            mtile_t::NAXFrag_t::load(
+                mfrag,
+                mask,
+                int64_t(mask_params->M_strides[2]),
+                Int<1>{},
+                row_pos,
+                col_pos);
+
+            thread auto& fg = Stile.frag_at(0, ik);
+
+            STEEL_PRAGMA_UNROLL
+            for (short jj = 0; jj < mtile_t::kElemsPerFrag; jj++) {
+              if constexpr (is_bool) {
+                fg[jj] = mfrag[jj] ? fg[jj] : neg_inf;
+              } else {
+                fg[jj] += M_LOG2E_F * AccumType(mfrag[jj]);
+              }
+            }
+          }
+        } else {
+          STEEL_PRAGMA_UNROLL
+          for (short ik = 0; ik < TK; ik++) {
+            const int row_pos = base_row;
+            const int col_pos = base_col + ik * kU;
+
+            mfrag_t mfrag;
+            mtile_t::NAXFrag_t::load_safe(
+                mfrag,
+                mask,
+                int64_t(mask_params->M_strides[2]),
+                Int<1>{},
+                params->qL,
+                params->kL,
+                row_pos,
+                col_pos);
+
+            thread auto& fg = Stile.frag_at(0, ik);
+
+            STEEL_PRAGMA_UNROLL
+            for (short jj = 0; jj < mtile_t::kElemsPerFrag; jj++) {
+              if constexpr (is_bool) {
+                fg[jj] = mfrag[jj] ? fg[jj] : neg_inf;
+              } else {
+                fg[jj] += M_LOG2E_F * AccumType(mfrag[jj]);
+              }
+            }
+          }
+        }
+      }
+
+      // Do softmax (redundantly per half; the row statistics are cheap)
+      metal::vec<AccumType, kRowsPT> new_max;
+      metal::vec<AccumType, kRowsPT> factor;
+      STEEL_PRAGMA_UNROLL
+      for (short i = 0; i < kRowsPT; ++i) {
+        new_max[i] = max_score[i];
+      }
+
+      Stile.template row_reduce<MaxOp>(new_max);
+      Stile.template row_bin_op<ExpSubOp>(new_max);
+
+      STEEL_PRAGMA_UNROLL
+      for (short i = 0; i < kRowsPT; ++i) {
+        factor[i] = fast::exp2(max_score[i] - new_max[i]);
+        max_score[i] = new_max[i];
+      }
+
+      STEEL_PRAGMA_UNROLL
+      for (short i = 0; i < kRowsPT; ++i) {
+        sum_score[i] = sum_score[i] * factor[i];
+      }
+
+      Stile.template row_reduce<SumOp>(sum_score);
+
+      Otile.template row_bin_op<MulOp>(factor);
+
+      simdgroup_barrier(mem_flags::mem_none);
+
+      // O = P @ V, this half of Dv only.
+      STEEL_PRAGMA_UNROLL
+      for (short id = 0; id < TDh; id += 2) {
+        STEEL_PRAGMA_UNROLL
+        for (short ik = 0; ik < TK; ik++) {
+          NAXTile<T, 1, 2> Vtile;
+
+          const int V_load_off = ik * kU * int(params->V_strides[2]) + id * kU;
+
+          if (!align_K && is_last_k) {
+            Vtile.load_rows(
+                V + V_load_off,
+                int(params->V_strides[2]),
+                lim_rows_k - ik * kU);
+          } else {
+            Vtile.load(V + V_load_off, int(params->V_strides[2]));
+          }
+
+          otile_t::NAXFrag_t::mma(
+              Otile.frag_at(0, id),
+              Otile.frag_at(0, id + 1),
+              Stile.frag_at(0, ik),
+              metal::false_type{},
+              Vtile.frag_at(0, 0),
+              Vtile.frag_at(0, 1),
+              metal::false_type{});
+        }
+      }
+
+      // Next block
+      K += BK * int(params->K_strides[2]);
+      V += BK * int(params->V_strides[2]);
+    }
+
+    // Normalize output
+    threadgroup_barrier(mem_flags::mem_none);
+
+    metal::vec<AccumType, kRowsPT> rcp;
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < kRowsPT; ++i) {
+      rcp[i] = 1.f / sum_score[i];
+    }
+
+    Otile.template row_bin_op<MulOp>(rcp);
+
+    if (!align_Q && is_last_q) {
+      if (lim_rows_q <= 0)
+        return;
+      Otile.store_rows(O, int(params->O_strides[2]), lim_rows_q);
+    } else {
+      Otile.store(O, int(params->O_strides[2]));
+    }
+    return;
+  }
   using otile_t = NAXTile<AccumType, TQ, TD>;
   otile_t Otile;
 

--- a/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention_nax.h
+++ b/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention_nax.h
@@ -127,10 +127,7 @@ template <
   // Prepare MMA tiles
   constexpr short kU = 16;
 
-  // With WN == 2 the second warp dimension splits the head dim (each
-  // simdgroup owns half of D for Q@K.T and half of Dv for P@V); only WM
-  // warps split the Q sequence.
-  constexpr int kNWarps = (WN == 2) ? WM : WM * WN;
+  constexpr int kNWarps = WM * WN;
   static_assert(
       BQ >= (kNWarps * kU) && BQ % (kNWarps * kU) == 0,
       "Each simdgroup must host atleast 1 simdgroup matrix along Q sequence.");
@@ -143,346 +140,6 @@ template <
   constexpr short TK = BK / kU;
 
   static_assert(TQ == 1, "Check TQ");
-
-  if constexpr (WN == 2) {
-    // Head-dim split path. Per simdgroup the accumulator working set is
-    // half of the WN == 1 kernel (TD/2 output fragments), which is the
-    // resource that gates bd=256 throughput. The Q@K.T partial sums over
-    // each half of D are exchanged through threadgroup memory; both halves
-    // then run softmax redundantly on the full S tile and each computes
-    // P@V for its own half of Dv.
-    constexpr int TDh = TD / 2;
-    constexpr int BDh = BD / 2;
-
-    const short row_group = simd_group_id / 2;
-    const short d_half = simd_group_id & 1;
-
-    using otile_t = NAXTile<AccumType, TQ, TDh>;
-    otile_t Otile;
-    Otile.clear();
-
-    const short tm = kU * TQ * row_group;
-    Q += tm * int(params->Q_strides[2]) + d_half * BDh;
-    K += d_half * BDh;
-    V += d_half * BDh;
-    O += tm * int(params->O_strides[2]) + d_half * BDh;
-
-    constexpr short kRowsPT = otile_t::kRowsPerThread;
-
-    metal::vec<AccumType, kRowsPT> max_score;
-    metal::vec<AccumType, kRowsPT> sum_score{0};
-
-    STEEL_PRAGMA_UNROLL
-    for (short i = 0; i < kRowsPT; ++i) {
-      max_score[i] = Limits<AccumType>::finite_min;
-    }
-
-    if (has_sinks) {
-      STEEL_PRAGMA_UNROLL
-      for (short i = 0; i < kRowsPT; ++i) {
-        max_score[i] = M_LOG2E_F * static_cast<AccumType>(sinks[tidl.y]);
-        sum_score[i] = 1;
-      }
-    }
-
-    int kb_lim = params->NK;
-    int kb_min_causal = params->NK;
-
-    if (do_causal) {
-      int q_max = (tid.x + 1) * BQ + params->qL_off;
-      kb_lim = (q_max + BK - 1) / BK;
-      kb_lim = min(params->NK, kb_lim);
-
-      int q_min = tid.x * BQ + params->qL_off;
-      q_min = max(0, q_min);
-      kb_min_causal = (q_min / BK);
-    }
-
-    const bool is_last_q = int(tid.x) == (params->NQ_aligned);
-    const short lim_rows_q = params->qL_rem - tm;
-    const short lim_rows_k = params->kL_rem;
-
-    using stile_t = NAXTile<AccumType, TQ, TK>;
-    constexpr short kEPF = stile_t::NAXFrag_t::kElemsPerFrag;
-
-    // One slot per (row group, half): a fragment pair in per-lane-linear
-    // layout. Both halves share the fragment-to-lane mapping, so the
-    // exchange needs no coordinate math.
-    threadgroup AccumType s_xchg[WM][2][2 * kEPF * 32];
-
-    // Keep the simdgroup's Q half resident in registers for the whole KV
-    // loop (TDh fragments of T are cheap; see the bd=256 notes).
-    NAXTile<T, 1, 1> Qtiles[TDh];
-    STEEL_PRAGMA_UNROLL
-    for (short id = 0; id < TDh; id++) {
-      const int Q_load_off = id * kU;
-      if (!align_Q && is_last_q) {
-        Qtiles[id].load_rows(
-            Q + Q_load_off, int(params->Q_strides[2]), lim_rows_q);
-      } else {
-        Qtiles[id].load(Q + Q_load_off, int(params->Q_strides[2]));
-      }
-    }
-
-    const short2 simd_coord = otile_t::NAXFrag_t::get_coord();
-    const short sm = simd_coord.y;
-    const short sn = simd_coord.x;
-
-    // Loop over KV seq length
-    for (int kb = 0; kb < kb_lim; kb++) {
-      const int is_last_k = (kb == (params->NK_aligned));
-
-      stile_t Stile;
-      Stile.clear();
-
-      // S = Q @ K.T, this half of D only, exchanged pair by pair.
-      STEEL_PRAGMA_UNROLL
-      for (short ik = 0; ik < TK; ik += 2) {
-        STEEL_PRAGMA_UNROLL
-        for (short id = 0; id < TDh; id++) {
-          NAXTile<T, 2, 1> Ktile;
-          const int K_load_off = ik * kU * int(params->K_strides[2]) + id * kU;
-
-          if (!align_K && is_last_k) {
-            Ktile.load_rows(
-                K + K_load_off,
-                int(params->K_strides[2]),
-                lim_rows_k - ik * kU);
-          } else {
-            Ktile.load(K + K_load_off, int(params->K_strides[2]));
-          }
-
-          stile_t::NAXFrag_t::mma(
-              Stile.frag_at(0, ik),
-              Stile.frag_at(0, ik + 1),
-              Qtiles[id].frag_at(0, 0),
-              metal::false_type{},
-              Ktile.frag_at(0, 0),
-              Ktile.frag_at(1, 0),
-              metal::true_type{});
-        }
-
-        // Exchange the partial pair and reduce.
-        threadgroup AccumType* slot = s_xchg[row_group][d_half];
-        thread auto& s0 = Stile.frag_at(0, ik);
-        thread auto& s1 = Stile.frag_at(0, ik + 1);
-        const short base = short(simd_lane_id) * (2 * kEPF);
-        STEEL_PRAGMA_UNROLL
-        for (short i = 0; i < kEPF; i++) {
-          slot[base + i] = s0[i];
-          slot[base + kEPF + i] = s1[i];
-        }
-        threadgroup_barrier(mem_flags::mem_threadgroup);
-        const threadgroup AccumType* peer = s_xchg[row_group][1 - d_half];
-        STEEL_PRAGMA_UNROLL
-        for (short i = 0; i < kEPF; i++) {
-          s0[i] += peer[base + i];
-          s1[i] += peer[base + kEPF + i];
-        }
-        threadgroup_barrier(mem_flags::mem_threadgroup);
-      }
-
-      // Scale S
-      STEEL_PRAGMA_UNROLL
-      for (short ii = 0; ii < stile_t::kElemsPerTile; ii++) {
-        Stile.elems()[ii] *= float(scale2);
-      }
-
-      // Mask out length sequence
-      if (!align_K && is_last_k) {
-        constexpr auto neg_inf = Limits<AccumType>::finite_min;
-
-        STEEL_PRAGMA_UNROLL
-        for (short ik = 0; ik < TK; ik++) {
-          const short col_pos = ik * kU + sn;
-          thread auto& fg = Stile.frag_at(0, ik);
-
-          STEEL_PRAGMA_UNROLL
-          for (short ii = 0; ii < stile_t::kFragThrRows; ii++) {
-            STEEL_PRAGMA_UNROLL
-            for (short jj = 0; jj < stile_t::kFragThrCols; jj++) {
-              const auto loc = ii * stile_t::kFragThrCols + jj;
-              fg[loc] = ((col_pos + jj) < params->kL_rem) ? fg[loc] : neg_inf;
-            }
-          }
-        }
-      }
-
-      // Mask out if causal
-      if (do_causal && kb >= kb_min_causal) {
-        constexpr auto neg_inf = Limits<AccumType>::finite_min;
-
-        const int base_row = tid.x * BQ + params->qL_off + tm;
-        const int base_col = kb * BK;
-
-        STEEL_PRAGMA_UNROLL
-        for (short ik = 0; ik < TK; ik++) {
-          thread auto& fg = Stile.frag_at(0, ik);
-
-          STEEL_PRAGMA_UNROLL
-          for (short ii = 0; ii < stile_t::kFragThrRows; ii++) {
-            STEEL_PRAGMA_UNROLL
-            for (short jj = 0; jj < stile_t::kFragThrCols; jj++) {
-              const auto r = base_row + ii * stile_t::kFragRowsJump + sm;
-              const auto c = base_col + ik * kU + jj + sn;
-              const auto loc = ii * stile_t::kFragThrCols + jj;
-              fg[loc] = (r < c) ? neg_inf : fg[loc];
-            }
-          }
-        }
-      }
-
-      // Other masking as needed
-      if (has_mask) {
-        constexpr auto neg_inf = Limits<AccumType>::finite_min;
-
-        const int base_row = tid.x * BQ + tm;
-        const int base_col = kb * BK;
-
-        constexpr bool is_bool = is_same_v<MaskType, bool>;
-        using melem_t = typename metal::conditional_t<is_bool, bool, AccumType>;
-        using mtile_t = NAXTile<melem_t, TQ, TK>;
-        using mfrag_t = typename mtile_t::frag_type;
-
-        if (base_row + kU <= params->qL && base_col + BK <= params->kL) {
-          STEEL_PRAGMA_UNROLL
-          for (short ik = 0; ik < TK; ik++) {
-            const int row_pos = base_row;
-            const int col_pos = base_col + ik * kU;
-
-            mfrag_t mfrag;
-            mtile_t::NAXFrag_t::load(
-                mfrag,
-                mask,
-                int64_t(mask_params->M_strides[2]),
-                Int<1>{},
-                row_pos,
-                col_pos);
-
-            thread auto& fg = Stile.frag_at(0, ik);
-
-            STEEL_PRAGMA_UNROLL
-            for (short jj = 0; jj < mtile_t::kElemsPerFrag; jj++) {
-              if constexpr (is_bool) {
-                fg[jj] = mfrag[jj] ? fg[jj] : neg_inf;
-              } else {
-                fg[jj] += M_LOG2E_F * AccumType(mfrag[jj]);
-              }
-            }
-          }
-        } else {
-          STEEL_PRAGMA_UNROLL
-          for (short ik = 0; ik < TK; ik++) {
-            const int row_pos = base_row;
-            const int col_pos = base_col + ik * kU;
-
-            mfrag_t mfrag;
-            mtile_t::NAXFrag_t::load_safe(
-                mfrag,
-                mask,
-                int64_t(mask_params->M_strides[2]),
-                Int<1>{},
-                params->qL,
-                params->kL,
-                row_pos,
-                col_pos);
-
-            thread auto& fg = Stile.frag_at(0, ik);
-
-            STEEL_PRAGMA_UNROLL
-            for (short jj = 0; jj < mtile_t::kElemsPerFrag; jj++) {
-              if constexpr (is_bool) {
-                fg[jj] = mfrag[jj] ? fg[jj] : neg_inf;
-              } else {
-                fg[jj] += M_LOG2E_F * AccumType(mfrag[jj]);
-              }
-            }
-          }
-        }
-      }
-
-      // Do softmax (redundantly per half; the row statistics are cheap)
-      metal::vec<AccumType, kRowsPT> new_max;
-      metal::vec<AccumType, kRowsPT> factor;
-      STEEL_PRAGMA_UNROLL
-      for (short i = 0; i < kRowsPT; ++i) {
-        new_max[i] = max_score[i];
-      }
-
-      Stile.template row_reduce<MaxOp>(new_max);
-      Stile.template row_bin_op<ExpSubOp>(new_max);
-
-      STEEL_PRAGMA_UNROLL
-      for (short i = 0; i < kRowsPT; ++i) {
-        factor[i] = fast::exp2(max_score[i] - new_max[i]);
-        max_score[i] = new_max[i];
-      }
-
-      STEEL_PRAGMA_UNROLL
-      for (short i = 0; i < kRowsPT; ++i) {
-        sum_score[i] = sum_score[i] * factor[i];
-      }
-
-      Stile.template row_reduce<SumOp>(sum_score);
-
-      Otile.template row_bin_op<MulOp>(factor);
-
-      simdgroup_barrier(mem_flags::mem_none);
-
-      // O = P @ V, this half of Dv only.
-      STEEL_PRAGMA_UNROLL
-      for (short id = 0; id < TDh; id += 2) {
-        STEEL_PRAGMA_UNROLL
-        for (short ik = 0; ik < TK; ik++) {
-          NAXTile<T, 1, 2> Vtile;
-
-          const int V_load_off = ik * kU * int(params->V_strides[2]) + id * kU;
-
-          if (!align_K && is_last_k) {
-            Vtile.load_rows(
-                V + V_load_off,
-                int(params->V_strides[2]),
-                lim_rows_k - ik * kU);
-          } else {
-            Vtile.load(V + V_load_off, int(params->V_strides[2]));
-          }
-
-          otile_t::NAXFrag_t::mma(
-              Otile.frag_at(0, id),
-              Otile.frag_at(0, id + 1),
-              Stile.frag_at(0, ik),
-              metal::false_type{},
-              Vtile.frag_at(0, 0),
-              Vtile.frag_at(0, 1),
-              metal::false_type{});
-        }
-      }
-
-      // Next block
-      K += BK * int(params->K_strides[2]);
-      V += BK * int(params->V_strides[2]);
-    }
-
-    // Normalize output
-    threadgroup_barrier(mem_flags::mem_none);
-
-    metal::vec<AccumType, kRowsPT> rcp;
-    STEEL_PRAGMA_UNROLL
-    for (short i = 0; i < kRowsPT; ++i) {
-      rcp[i] = 1.f / sum_score[i];
-    }
-
-    Otile.template row_bin_op<MulOp>(rcp);
-
-    if (!align_Q && is_last_q) {
-      if (lim_rows_q <= 0)
-        return;
-      Otile.store_rows(O, int(params->O_strides[2]), lim_rows_q);
-    } else {
-      Otile.store(O, int(params->O_strides[2]));
-    }
-    return;
-  }
   using otile_t = NAXTile<AccumType, TQ, TD>;
   otile_t Otile;
 
@@ -822,6 +479,424 @@ template <
     if (lim_rows_q <= 0)
       return;
 
+    Otile.store_rows(O, int(params->O_strides[2]), lim_rows_q);
+  } else {
+    Otile.store(O, int(params->O_strides[2]));
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Head-dim split attention kernel
+///////////////////////////////////////////////////////////////////////////////
+
+// Variant of attention_nax for wide heads (bd = 256). There, the per-simdgroup
+// accumulator working set of attention_nax (TD output fragments plus the S
+// fragments) is what gates tensor-unit throughput, so this kernel splits the
+// head dim across the two simdgroups of the second warp dimension: each
+// simdgroup of a pair owns one half of D for Q@K.T and one half of Dv for P@V,
+// halving its accumulator set. The pair exchanges its partial Q@K.T sums
+// through threadgroup memory, then both simdgroups run softmax redundantly on
+// the full S tile (the row statistics are cheap) and each accumulates P@V for
+// its own half of Dv.
+
+// clang-format off
+template <
+    typename T,
+    int BQ,
+    int BK,
+    int BD,
+    int WM,
+    int WN,
+    typename MaskType = float,
+    typename AccumType = float>
+[[kernel, max_total_threads_per_threadgroup(WM * WN * 32)]] void attention_nax_dsplit(
+    const device T* Q [[buffer(0)]],
+    const device T* K [[buffer(1)]],
+    const device T* V [[buffer(2)]],
+    device T* O [[buffer(3)]],
+    const constant AttnParams* params [[buffer(4)]],
+    const constant AttnMaskParams* mask_params [[buffer(5), function_constant(has_mask)]],
+    const device MaskType* mask [[buffer(6), function_constant(has_mask)]],
+    const device T* sinks [[buffer(7), function_constant(has_sinks)]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint3 lid [[thread_position_in_threadgroup]]) { // clang-format on
+
+  // Pacifying compiler
+  (void)lid;
+
+  // Move to correct block
+  ulong3 tidl{tid.x, tid.y, tid.z};
+
+  Q += tidl.z * params->Q_strides[0] + // Batch
+      tidl.y * params->Q_strides[1] + // Head
+      tidl.x * BQ * params->Q_strides[2]; // Sequence
+
+  ulong kv_head_idx = int(tid.y) / params->gqa_factor;
+  K += tidl.z * params->K_strides[0] + // Batch
+      kv_head_idx * params->K_strides[1]; // Head
+
+  V += tidl.z * params->V_strides[0] + // Batch
+      kv_head_idx * params->V_strides[1]; // Head
+
+  O += tidl.z * params->O_strides[0] + // Batch
+      tidl.y * params->O_strides[1] + // Head
+      tidl.x * BQ * params->O_strides[2]; // Sequence
+
+  if (has_mask) {
+    mask += tidl.z * mask_params->M_strides[0] + // Batch
+        tidl.y * mask_params->M_strides[1]; // Head
+  }
+
+  const metal::uniform<float> scale2 =
+      make_uniform(params->scale) * make_uniform(1.44269504089f);
+
+  // Prepare MMA tiles
+  constexpr short kU = 16;
+
+  // Only the WM simdgroups along the first warp dimension split the Q
+  // sequence; the WN == 2 simdgroups along the second split the head dim.
+  static_assert(WN == 2, "The head-dim split kernel needs WN == 2");
+  constexpr int kNWarps = WM;
+  static_assert(
+      BQ >= (kNWarps * kU) && BQ % (kNWarps * kU) == 0,
+      "Each simdgroup must host atleast 1 simdgroup matrix along Q sequence.");
+
+  // Q seq frags per warp
+  constexpr int TQ = BQ / (kNWarps * kU);
+  // HeadDim frags over the full head dim
+  constexpr int TD = BD / kU;
+  // KV seq frags per warp
+  constexpr short TK = BK / kU;
+
+  static_assert(TQ == 1, "Check TQ");
+  static_assert(TK % 2 == 0, "S fragments are exchanged pair by pair");
+  static_assert(TD % 4 == 0, "Each head-dim half must hold fragment pairs");
+
+  // HeadDim frags / columns owned by each simdgroup of a pair
+  constexpr int TDh = TD / 2;
+  constexpr int BDh = BD / 2;
+
+  const short row_group = simd_group_id / 2;
+  const short d_half = simd_group_id & 1;
+
+  using otile_t = NAXTile<AccumType, TQ, TDh>;
+  otile_t Otile;
+  Otile.clear();
+
+  const short tm = kU * TQ * row_group;
+  Q += tm * int(params->Q_strides[2]) + d_half * BDh;
+  K += d_half * BDh;
+  V += d_half * BDh;
+  O += tm * int(params->O_strides[2]) + d_half * BDh;
+
+  constexpr short kRowsPT = otile_t::kRowsPerThread;
+
+  metal::vec<AccumType, kRowsPT> max_score;
+  metal::vec<AccumType, kRowsPT> sum_score{0};
+
+  STEEL_PRAGMA_UNROLL
+  for (short i = 0; i < kRowsPT; ++i) {
+    max_score[i] = Limits<AccumType>::finite_min;
+  }
+
+  if (has_sinks) {
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < kRowsPT; ++i) {
+      max_score[i] = M_LOG2E_F * static_cast<AccumType>(sinks[tidl.y]);
+      sum_score[i] = 1;
+    }
+  }
+
+  int kb_lim = params->NK;
+  int kb_min_causal = params->NK;
+
+  if (do_causal) {
+    int q_max = (tid.x + 1) * BQ + params->qL_off;
+    kb_lim = (q_max + BK - 1) / BK;
+    kb_lim = min(params->NK, kb_lim);
+
+    int q_min = tid.x * BQ + params->qL_off;
+    q_min = max(0, q_min);
+    kb_min_causal = (q_min / BK);
+  }
+
+  const bool is_last_q = int(tid.x) == (params->NQ_aligned);
+  const short lim_rows_q = params->qL_rem - tm;
+  const short lim_rows_k = params->kL_rem;
+
+  using stile_t = NAXTile<AccumType, TQ, TK>;
+  constexpr short kEPF = stile_t::NAXFrag_t::kElemsPerFrag;
+
+  // One slot per (row group, half): a fragment pair in per-lane-linear
+  // layout. Both halves share the fragment-to-lane mapping, so the
+  // exchange needs no coordinate math.
+  threadgroup AccumType s_xchg[WM][2][2 * kEPF * 32];
+
+  // Keep the simdgroup's Q half resident in registers for the whole KV
+  // loop: TDh fragments of T are cheap next to the accumulators.
+  NAXTile<T, 1, 1> Qtiles[TDh];
+  STEEL_PRAGMA_UNROLL
+  for (short id = 0; id < TDh; id++) {
+    const int Q_load_off = id * kU;
+    if (!align_Q && is_last_q) {
+      Qtiles[id].load_rows(
+          Q + Q_load_off, int(params->Q_strides[2]), lim_rows_q);
+    } else {
+      Qtiles[id].load(Q + Q_load_off, int(params->Q_strides[2]));
+    }
+  }
+
+  const short2 simd_coord = otile_t::NAXFrag_t::get_coord();
+  const short sm = simd_coord.y;
+  const short sn = simd_coord.x;
+
+  // Loop over KV seq length
+  for (int kb = 0; kb < kb_lim; kb++) {
+    const int is_last_k = (kb == (params->NK_aligned));
+
+    stile_t Stile;
+    Stile.clear();
+
+    // S = Q @ K.T, this half of D only, exchanged pair by pair.
+    STEEL_PRAGMA_UNROLL
+    for (short ik = 0; ik < TK; ik += 2) {
+      STEEL_PRAGMA_UNROLL
+      for (short id = 0; id < TDh; id++) {
+        NAXTile<T, 2, 1> Ktile;
+        const int K_load_off = ik * kU * int(params->K_strides[2]) + id * kU;
+
+        if (!align_K && is_last_k) {
+          Ktile.load_rows(
+              K + K_load_off, int(params->K_strides[2]), lim_rows_k - ik * kU);
+        } else {
+          Ktile.load(K + K_load_off, int(params->K_strides[2]));
+        }
+
+        stile_t::NAXFrag_t::mma(
+            Stile.frag_at(0, ik),
+            Stile.frag_at(0, ik + 1),
+            Qtiles[id].frag_at(0, 0),
+            metal::false_type{},
+            Ktile.frag_at(0, 0),
+            Ktile.frag_at(1, 0),
+            metal::true_type{});
+      }
+
+      // Exchange the partial pair and reduce.
+      threadgroup AccumType* slot = s_xchg[row_group][d_half];
+      thread auto& s0 = Stile.frag_at(0, ik);
+      thread auto& s1 = Stile.frag_at(0, ik + 1);
+      const short base = short(simd_lane_id) * (2 * kEPF);
+      STEEL_PRAGMA_UNROLL
+      for (short i = 0; i < kEPF; i++) {
+        slot[base + i] = s0[i];
+        slot[base + kEPF + i] = s1[i];
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      const threadgroup AccumType* peer = s_xchg[row_group][1 - d_half];
+      STEEL_PRAGMA_UNROLL
+      for (short i = 0; i < kEPF; i++) {
+        s0[i] += peer[base + i];
+        s1[i] += peer[base + kEPF + i];
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    // Scale S
+    STEEL_PRAGMA_UNROLL
+    for (short ii = 0; ii < stile_t::kElemsPerTile; ii++) {
+      Stile.elems()[ii] *= float(scale2);
+    }
+
+    // Mask out length sequence
+    if (!align_K && is_last_k) {
+      constexpr auto neg_inf = Limits<AccumType>::finite_min;
+
+      STEEL_PRAGMA_UNROLL
+      for (short ik = 0; ik < TK; ik++) {
+        const short col_pos = ik * kU + sn;
+        thread auto& fg = Stile.frag_at(0, ik);
+
+        STEEL_PRAGMA_UNROLL
+        for (short ii = 0; ii < stile_t::kFragThrRows; ii++) {
+          STEEL_PRAGMA_UNROLL
+          for (short jj = 0; jj < stile_t::kFragThrCols; jj++) {
+            const auto loc = ii * stile_t::kFragThrCols + jj;
+            fg[loc] = ((col_pos + jj) < params->kL_rem) ? fg[loc] : neg_inf;
+          }
+        }
+      }
+    }
+
+    // Mask out if causal
+    if (do_causal && kb >= kb_min_causal) {
+      constexpr auto neg_inf = Limits<AccumType>::finite_min;
+
+      const int base_row = tid.x * BQ + params->qL_off + tm;
+      const int base_col = kb * BK;
+
+      STEEL_PRAGMA_UNROLL
+      for (short ik = 0; ik < TK; ik++) {
+        thread auto& fg = Stile.frag_at(0, ik);
+
+        STEEL_PRAGMA_UNROLL
+        for (short ii = 0; ii < stile_t::kFragThrRows; ii++) {
+          STEEL_PRAGMA_UNROLL
+          for (short jj = 0; jj < stile_t::kFragThrCols; jj++) {
+            const auto r = base_row + ii * stile_t::kFragRowsJump + sm;
+            const auto c = base_col + ik * kU + jj + sn;
+            const auto loc = ii * stile_t::kFragThrCols + jj;
+            fg[loc] = (r < c) ? neg_inf : fg[loc];
+          }
+        }
+      }
+    }
+
+    // Other masking as needed
+    if (has_mask) {
+      constexpr auto neg_inf = Limits<AccumType>::finite_min;
+
+      const int base_row = tid.x * BQ + tm;
+      const int base_col = kb * BK;
+
+      constexpr bool is_bool = is_same_v<MaskType, bool>;
+      using melem_t = typename metal::conditional_t<is_bool, bool, AccumType>;
+      using mtile_t = NAXTile<melem_t, TQ, TK>;
+      using mfrag_t = typename mtile_t::frag_type;
+
+      if (base_row + kU <= params->qL && base_col + BK <= params->kL) {
+        STEEL_PRAGMA_UNROLL
+        for (short ik = 0; ik < TK; ik++) {
+          const int row_pos = base_row;
+          const int col_pos = base_col + ik * kU;
+
+          mfrag_t mfrag;
+          mtile_t::NAXFrag_t::load(
+              mfrag,
+              mask,
+              int64_t(mask_params->M_strides[2]),
+              Int<1>{},
+              row_pos,
+              col_pos);
+
+          thread auto& fg = Stile.frag_at(0, ik);
+
+          STEEL_PRAGMA_UNROLL
+          for (short jj = 0; jj < mtile_t::kElemsPerFrag; jj++) {
+            if constexpr (is_bool) {
+              fg[jj] = mfrag[jj] ? fg[jj] : neg_inf;
+            } else {
+              fg[jj] += M_LOG2E_F * AccumType(mfrag[jj]);
+            }
+          }
+        }
+      } else {
+        STEEL_PRAGMA_UNROLL
+        for (short ik = 0; ik < TK; ik++) {
+          const int row_pos = base_row;
+          const int col_pos = base_col + ik * kU;
+
+          mfrag_t mfrag;
+          mtile_t::NAXFrag_t::load_safe(
+              mfrag,
+              mask,
+              int64_t(mask_params->M_strides[2]),
+              Int<1>{},
+              params->qL,
+              params->kL,
+              row_pos,
+              col_pos);
+
+          thread auto& fg = Stile.frag_at(0, ik);
+
+          STEEL_PRAGMA_UNROLL
+          for (short jj = 0; jj < mtile_t::kElemsPerFrag; jj++) {
+            if constexpr (is_bool) {
+              fg[jj] = mfrag[jj] ? fg[jj] : neg_inf;
+            } else {
+              fg[jj] += M_LOG2E_F * AccumType(mfrag[jj]);
+            }
+          }
+        }
+      }
+    }
+
+    // Do softmax (redundantly per half; the row statistics are cheap)
+    metal::vec<AccumType, kRowsPT> new_max;
+    metal::vec<AccumType, kRowsPT> factor;
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < kRowsPT; ++i) {
+      new_max[i] = max_score[i];
+    }
+
+    Stile.template row_reduce<MaxOp>(new_max);
+    Stile.template row_bin_op<ExpSubOp>(new_max);
+
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < kRowsPT; ++i) {
+      factor[i] = fast::exp2(max_score[i] - new_max[i]);
+      max_score[i] = new_max[i];
+    }
+
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < kRowsPT; ++i) {
+      sum_score[i] = sum_score[i] * factor[i];
+    }
+
+    Stile.template row_reduce<SumOp>(sum_score);
+
+    Otile.template row_bin_op<MulOp>(factor);
+
+    simdgroup_barrier(mem_flags::mem_none);
+
+    // O = P @ V, this half of Dv only.
+    STEEL_PRAGMA_UNROLL
+    for (short id = 0; id < TDh; id += 2) {
+      STEEL_PRAGMA_UNROLL
+      for (short ik = 0; ik < TK; ik++) {
+        NAXTile<T, 1, 2> Vtile;
+
+        const int V_load_off = ik * kU * int(params->V_strides[2]) + id * kU;
+
+        if (!align_K && is_last_k) {
+          Vtile.load_rows(
+              V + V_load_off, int(params->V_strides[2]), lim_rows_k - ik * kU);
+        } else {
+          Vtile.load(V + V_load_off, int(params->V_strides[2]));
+        }
+
+        otile_t::NAXFrag_t::mma(
+            Otile.frag_at(0, id),
+            Otile.frag_at(0, id + 1),
+            Stile.frag_at(0, ik),
+            metal::false_type{},
+            Vtile.frag_at(0, 0),
+            Vtile.frag_at(0, 1),
+            metal::false_type{});
+      }
+    }
+
+    // Next block
+    K += BK * int(params->K_strides[2]);
+    V += BK * int(params->V_strides[2]);
+  }
+
+  // Normalize output
+  threadgroup_barrier(mem_flags::mem_none);
+
+  metal::vec<AccumType, kRowsPT> rcp;
+  STEEL_PRAGMA_UNROLL
+  for (short i = 0; i < kRowsPT; ++i) {
+    rcp[i] = 1.f / sum_score[i];
+  }
+
+  Otile.template row_bin_op<MulOp>(rcp);
+
+  if (!align_Q && is_last_q) {
+    if (lim_rows_q <= 0)
+      return;
     Otile.store_rows(O, int(params->O_strides[2]), lim_rows_q);
   } else {
     Otile.store(O, int(params->O_strides[2]));

--- a/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention_nax.h
+++ b/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention_nax.h
@@ -492,7 +492,7 @@ template <
 // Variant of attention_nax for wide heads (bd = 256). There, the per-simdgroup
 // accumulator working set of attention_nax (TD output fragments plus the S
 // fragments) is what gates tensor-unit throughput, so this kernel splits the
-// head dim across the two simdgroups of the second warp dimension: each
+// head dim across the WN = 2 simdgroups of the second warp dimension: each
 // simdgroup of a pair owns one half of D for Q@K.T and one half of Dv for P@V,
 // halving its accumulator set. The pair exchanges its partial Q@K.T sums
 // through threadgroup memory, then both simdgroups run softmax redundantly on
@@ -555,8 +555,9 @@ template <
   // Prepare MMA tiles
   constexpr short kU = 16;
 
-  // Only the WM simdgroups along the first warp dimension split the Q
-  // sequence; the WN == 2 simdgroups along the second split the head dim.
+  // The WM simdgroups along the first warp dimension split the Q sequence;
+  // the WN simdgroups along the second split the head dim. The exchange
+  // below reduces exactly one peer, so WN is fixed at 2.
   static_assert(WN == 2, "The head-dim split kernel needs WN == 2");
   constexpr int kNWarps = WM;
   static_assert(
@@ -571,15 +572,17 @@ template <
   constexpr short TK = BK / kU;
 
   static_assert(TQ == 1, "Check TQ");
+  static_assert(TD % WN == 0, "The head dim must split evenly across WN");
+
+  // HeadDim frags / columns owned by each of the WN simdgroups of a row group
+  constexpr int TDh = TD / WN;
+  constexpr int BDh = BD / WN;
+
+  static_assert(TDh % 2 == 0, "P@V accumulates output fragments in pairs");
   static_assert(TK % 2 == 0, "S fragments are exchanged pair by pair");
-  static_assert(TD % 4 == 0, "Each head-dim half must hold fragment pairs");
 
-  // HeadDim frags / columns owned by each simdgroup of a pair
-  constexpr int TDh = TD / 2;
-  constexpr int BDh = BD / 2;
-
-  const short row_group = simd_group_id / 2;
-  const short d_half = simd_group_id & 1;
+  const short row_group = simd_group_id / WN;
+  const short d_half = simd_group_id % WN;
 
   using otile_t = NAXTile<AccumType, TQ, TDh>;
   otile_t Otile;
@@ -632,7 +635,7 @@ template <
   // One slot per (row group, half): a fragment pair in per-lane-linear
   // layout. Both halves share the fragment-to-lane mapping, so the
   // exchange needs no coordinate math.
-  threadgroup AccumType s_xchg[WM][2][2 * kEPF * 32];
+  threadgroup AccumType s_xchg[WM][WN][2 * kEPF * 32];
 
   // Keep the simdgroup's Q half resident in registers for the whole KV
   // loop: TDh fragments of T are cheap next to the accumulators.

--- a/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention_nax.metal
+++ b/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention_nax.metal
@@ -12,6 +12,7 @@
   attention_nax, dtype, bq, bk, bd, wm, wn, mtype, float)
 
 #define instantiate_attn_shapes_helper(iname, itype, mname, mtype)  \
+    instantiate_attn(iname, itype, 64, 32, 256, 4, 2, mname, mtype) \
     instantiate_attn(iname, itype, 64, 32, 128, 4, 1, mname, mtype) \
     instantiate_attn(iname, itype, 64, 32,  64, 4, 1, mname, mtype) \
     instantiate_attn(iname, itype, 64, 64, 128, 4, 1, mname, mtype) \

--- a/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention_nax.metal
+++ b/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention_nax.metal
@@ -11,12 +11,18 @@
       "_wm" #wm "_wn" #wn "_mask" #mname,                                \
   attention_nax, dtype, bq, bk, bd, wm, wn, mtype, float)
 
-#define instantiate_attn_shapes_helper(iname, itype, mname, mtype)  \
-    instantiate_attn(iname, itype, 64, 32, 256, 4, 2, mname, mtype) \
-    instantiate_attn(iname, itype, 64, 32, 128, 4, 1, mname, mtype) \
-    instantiate_attn(iname, itype, 64, 32,  96, 4, 1, mname, mtype) \
-    instantiate_attn(iname, itype, 64, 32,  64, 4, 1, mname, mtype) \
-    instantiate_attn(iname, itype, 64, 64, 128, 4, 1, mname, mtype) \
+#define instantiate_attn_dsplit(tname, dtype, bq, bk, bd, wm, wn, mname, mtype) \
+  instantiate_kernel(                                                           \
+      "steel_attention_dsplit_" #tname "_bq" #bq "_bk" #bk "_bd" #bd            \
+      "_wm" #wm "_wn" #wn "_mask" #mname,                                       \
+  attention_nax_dsplit, dtype, bq, bk, bd, wm, wn, mtype, float)
+
+#define instantiate_attn_shapes_helper(iname, itype, mname, mtype)         \
+    instantiate_attn_dsplit(iname, itype, 64, 32, 256, 4, 2, mname, mtype) \
+    instantiate_attn(iname, itype, 64, 32, 128, 4, 1, mname, mtype)        \
+    instantiate_attn(iname, itype, 64, 32,  96, 4, 1, mname, mtype)        \
+    instantiate_attn(iname, itype, 64, 32,  64, 4, 1, mname, mtype)        \
+    instantiate_attn(iname, itype, 64, 64, 128, 4, 1, mname, mtype)        \
     instantiate_attn(iname, itype, 64, 64,  64, 4, 1, mname, mtype)
 
 #define instantiate_attn_mask_helper(iname, itype) \

--- a/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention_nax.metal
+++ b/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention_nax.metal
@@ -12,6 +12,7 @@
   attention_nax, dtype, bq, bk, bd, wm, wn, mtype, float)
 
 #define instantiate_attn_shapes_helper(iname, itype, mname, mtype)  \
+    instantiate_attn(iname, itype, 64, 32, 256, 4, 2, mname, mtype) \
     instantiate_attn(iname, itype, 64, 32, 128, 4, 1, mname, mtype) \
     instantiate_attn(iname, itype, 64, 32,  96, 4, 1, mname, mtype) \
     instantiate_attn(iname, itype, 64, 32,  64, 4, 1, mname, mtype) \

--- a/mlx/backend/metal/nojit_kernels.cpp
+++ b/mlx/backend/metal/nojit_kernels.cpp
@@ -503,7 +503,8 @@ MTL::ComputePipelineState* get_steel_attention_nax_kernel(
     int,
     int,
     int,
-    const array&) {
+    const array&,
+    bool) {
   return d.get_kernel(kernel_name, hash_name, func_consts);
 }
 

--- a/mlx/backend/metal/scaled_dot_product_attention.cpp
+++ b/mlx/backend/metal/scaled_dot_product_attention.cpp
@@ -18,30 +18,92 @@ namespace {
 void sdpa_full_self_attention_nax(
     const Stream& s,
     metal::Device& d,
-    const array& q,
-    const array& k,
-    const array& v,
+    const array& q_in,
+    const array& k_in,
+    const array& v_in,
     const float scale,
-    array& o,
+    array& o_in,
     bool do_causal_,
     const std::optional<array>& mask,
     const std::optional<array>& sinks) {
   using namespace mlx::steel;
 
+  int bd = q_in.shape(-1);
   int wm = 4;
-  int wn = 1;
+  // bd=256 uses the head-dim-split kernel (wn=2): halving the per-simdgroup
+  // accumulator working set is what recovers tensor-unit throughput at this
+  // head width.
+  int wn = bd == 256 ? 2 : 1;
 
-  int bd = q.shape(-1);
   int bq = 64;
+  // bk=32 everywhere: with the head-dim split at bd=256 this puts the
+  // per-simdgroup accumulator set (S 2 + O 8 fragments) at exact bd=128
+  // parity, which is what restores tensor-unit throughput (42.8 vs
+  // 47.7 TF at 8192^2).
   int bk = 32;
 
-  int B = q.shape(0);
-  int H = q.shape(1);
-  int D = q.shape(3);
-  int gqa_factor = q.shape(1) / k.shape(1);
+  int B = q_in.shape(0);
+  int H = q_in.shape(1);
+  int D = q_in.shape(3);
+  int gqa_factor = q_in.shape(1) / k_in.shape(1);
 
-  int qL = q.shape(2);
-  int kL = k.shape(2);
+  int qL = q_in.shape(2);
+  int kL = k_in.shape(2);
+
+  // The causal offset must keep describing the true diagonal even when the
+  // inputs get padded below.
+  const int qL_off = kL - qL;
+
+  // For head_dim 256 the unaligned pipelines (align_Q/align_K = false)
+  // spill registers and slow every block down ~3x, not just the ragged edge
+  // ones. Pad ragged causal inputs up to the tile sizes and take the
+  // aligned pipeline instead: with qL_off computed from the true lengths,
+  // the causal bound c <= r + qL_off never reaches a padded key column for
+  // any true query row, and the padded query rows are dropped by the copy
+  // back into o. The pads are zero-filled so the padded value rows cannot
+  // poison P @ V with NaNs (their probabilities are exactly zero).
+  std::optional<array> q_pad, k_pad, v_pad, o_pad;
+  if (bd == 256 && do_causal_ && !mask.has_value() &&
+      ((qL % bq) || (kL % bk))) {
+    auto& enc = metal::get_command_encoder(s);
+    auto pad_seq = [&](const array& src, int Lp) {
+      array dst(
+          {src.shape(0), src.shape(1), Lp, src.shape(3)},
+          src.dtype(),
+          nullptr,
+          {});
+      array zero(0, src.dtype());
+      fill_gpu(zero, dst, s);
+      array dst_slice(src.shape(), dst.dtype(), nullptr, {});
+      dst_slice.copy_shared_buffer(
+          dst, dst.strides(), dst.flags(), dst_slice.size(), 0);
+      copy_gpu_inplace(src, dst_slice, CopyType::GeneralGeneral, s);
+      enc.add_temporary(std::move(zero));
+      enc.add_temporary(std::move(dst_slice));
+      enc.add_temporary(dst);
+      return dst;
+    };
+
+    if (qL % bq) {
+      int qLp = bq * ((qL + bq - 1) / bq);
+      q_pad = pad_seq(q_in, qLp);
+      o_pad = array({B, H, qLp, D}, o_in.dtype(), nullptr, {});
+      o_pad->set_data(allocator::malloc(o_pad->nbytes()));
+      enc.add_temporary(*o_pad);
+      qL = qLp;
+    }
+    if (kL % bk) {
+      int kLp = bk * ((kL + bk - 1) / bk);
+      k_pad = pad_seq(k_in, kLp);
+      v_pad = pad_seq(v_in, kLp);
+      kL = kLp;
+    }
+  }
+
+  const array& q = q_pad ? *q_pad : q_in;
+  const array& k = k_pad ? *k_pad : k_in;
+  const array& v = v_pad ? *v_pad : v_in;
+  array& o = o_pad ? *o_pad : o_in;
 
   const bool align_Q = (qL % bq) == 0;
   const bool align_K = (kL % bk) == 0;
@@ -131,7 +193,7 @@ void sdpa_full_self_attention_nax(
 
       /* int qL_rem = */ (qL - NQ_aligned * bq),
       /* int kL_rem = */ (kL - NK_aligned * bk),
-      /* int qL_off = */ (kL - qL),
+      /* int qL_off = */ qL_off,
 
       /* int64_t Q_strides[3] = */ {q.strides(0), q.strides(1), q.strides(2)},
       /* int64_t K_strides[3] = */ {k.strides(0), k.strides(1), k.strides(2)},
@@ -161,6 +223,15 @@ void sdpa_full_self_attention_nax(
   MTL::Size group_dims = MTL::Size(32, wm, wn);
 
   compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+
+  // Drop the padded query rows.
+  if (o_pad) {
+    array o_slice(o_in.shape(), o_pad->dtype(), nullptr, {});
+    o_slice.copy_shared_buffer(
+        *o_pad, o_pad->strides(), o_pad->flags(), o_slice.size(), 0);
+    copy_gpu_inplace(o_slice, o_in, CopyType::GeneralGeneral, s);
+    compute_encoder.add_temporary(std::move(o_slice));
+  }
 }
 
 void sdpa_full_self_attention_metal(
@@ -625,8 +696,25 @@ bool ScaledDotProductAttention::use_fallback(
        (query_head_dim == 64 || query_head_dim == 96 || query_head_dim == 128 ||
         query_head_dim == 256)) ||
       (query_head_dim == 192 && value_head_dim == 128);
+  // head_dim 256 is only instantiated for the NAX kernel, so it must match
+  // the exact condition under which sdpa_full_self_attention_metal routes
+  // to it. It is further gated to the shapes where the fused kernel beats
+  // the unfused graph (measured on M5 Max): large, nearly-square causal
+  // blocks. On offset rectangles (kL >> qL, i.e. chunked prefill against a
+  // long cache) the causal block-skip amortizes away and the unfused
+  // graph's GEMMs win; below ~2k queries there are too few query blocks to
+  // fill the machine.
+  const bool takes_nax_full_path = metal::is_nax_available() &&
+      (env::enable_tf32() || q.dtype() != float32);
+  // The head-dim-split kernel beats the unfused graph on every measured
+  // causal shape with qL >= 1024, rectangles included (M5 Max); below that
+  // there are too few query blocks to fill the machine against a long
+  // cache (512x8192 measures 1.08x of unfused).
+  const bool sdpa_full_supported_256 = takes_nax_full_path && do_causal &&
+      !has_arr_mask && query_sequence_length >= 1024;
   const bool sdpa_full_supported_head_dim = query_head_dim == value_head_dim &&
-      (query_head_dim == 64 || query_head_dim == 80 || query_head_dim == 128);
+      (query_head_dim == 64 || query_head_dim == 80 || query_head_dim == 128 ||
+       (query_head_dim == 256 && sdpa_full_supported_256));
 
   const bool sdpa_full_supported_mask = !has_mask || has_arr_mask ||
       (query_sequence_length <= key_sequence_length && do_causal);

--- a/mlx/backend/metal/scaled_dot_product_attention.cpp
+++ b/mlx/backend/metal/scaled_dot_product_attention.cpp
@@ -704,8 +704,8 @@ bool ScaledDotProductAttention::use_fallback(
   // long cache) the causal block-skip amortizes away and the unfused
   // graph's GEMMs win; below ~2k queries there are too few query blocks to
   // fill the machine.
-  const bool takes_nax_full_path = metal::is_nax_available() &&
-      (env::enable_tf32() || q.dtype() != float32);
+  const bool takes_nax_full_path =
+      metal::is_nax_available() && (env::enable_tf32() || q.dtype() != float32);
   // The head-dim-split kernel beats the unfused graph on every measured
   // causal shape with qL >= 1024, rectangles included (M5 Max); below that
   // there are too few query blocks to fill the machine against a long

--- a/mlx/backend/metal/scaled_dot_product_attention.cpp
+++ b/mlx/backend/metal/scaled_dot_product_attention.cpp
@@ -29,11 +29,13 @@ void sdpa_full_self_attention_nax(
   using namespace mlx::steel;
 
   int bd = q_in.shape(-1);
+  // bd=256 runs the head-dim split kernel (attention_nax_dsplit): the two
+  // simdgroups along the second warp dimension each own half of the head
+  // dim, which halves the per-simdgroup accumulator working set that gates
+  // tensor-unit throughput at this head width.
+  const bool split_d = bd == 256;
   int wm = 4;
-  // bd=256 uses the head-dim-split kernel (wn=2): halving the per-simdgroup
-  // accumulator working set is what recovers tensor-unit throughput at this
-  // head width.
-  int wn = bd == 256 ? 2 : 1;
+  int wn = split_d ? 2 : 1;
 
   int bq = 64;
   // bk=32 everywhere: with the head-dim split at bd=256 this puts the
@@ -63,8 +65,7 @@ void sdpa_full_self_attention_nax(
   // back into o. The pads are zero-filled so the padded value rows cannot
   // poison P @ V with NaNs (their probabilities are exactly zero).
   std::optional<array> q_pad, k_pad, v_pad, o_pad;
-  if (bd == 256 && do_causal_ && !mask.has_value() &&
-      ((qL % bq) || (kL % bk))) {
+  if (split_d && do_causal_ && !mask.has_value() && ((qL % bq) || (kL % bk))) {
     auto& enc = metal::get_command_encoder(s);
     auto pad_seq = [&](const array& src, int Lp) {
       array dst(
@@ -121,7 +122,7 @@ void sdpa_full_self_attention_nax(
   std::string base_name;
   concatenate(
       base_name,
-      "steel_attention_",
+      split_d ? "steel_attention_dsplit_" : "steel_attention_",
       type_to_name(q),
       "_bq",
       bq,
@@ -164,7 +165,8 @@ void sdpa_full_self_attention_nax(
       bd,
       wm,
       wn,
-      (has_mask ? *mask : q));
+      (has_mask ? *mask : q),
+      split_d);
 
   compute_encoder.set_compute_pipeline_state(kernel);
 

--- a/mlx/backend/metal/scaled_dot_product_attention.cpp
+++ b/mlx/backend/metal/scaled_dot_product_attention.cpp
@@ -207,8 +207,16 @@ void sdpa_full_self_attention_metal(
     bool do_causal_,
     const std::optional<array>& mask,
     const std::optional<array>& sinks) {
+  int B = q.shape(0);
+  int H = q.shape(1);
+  int D = q.shape(3);
+  int gqa_factor = q.shape(1) / k.shape(1);
+
+  int qL = q.shape(2);
+  int kL = k.shape(2);
+
   if (metal::is_nax_available() &&
-      (q.shape(3) == 64 || q.shape(3) == 96 || q.shape(3) == 128) &&
+      (D == 64 || D == 96 || D == 128 || D == 256) &&
       (env::enable_tf32() || q.dtype() != float32)) {
     return sdpa_full_self_attention_nax(
         /* const Stream& s = */ s,
@@ -231,14 +239,6 @@ void sdpa_full_self_attention_metal(
   int bd = q.shape(-1);
   int bq = 32;
   int bk = bd < 128 ? 32 : 16;
-
-  int B = q.shape(0);
-  int H = q.shape(1);
-  int D = q.shape(3);
-  int gqa_factor = q.shape(1) / k.shape(1);
-
-  int qL = q.shape(2);
-  int kL = k.shape(2);
 
   const bool align_Q = (qL % bq) == 0;
   const bool align_K = (kL % bk) == 0;

--- a/mlx/backend/metal/scaled_dot_product_attention.cpp
+++ b/mlx/backend/metal/scaled_dot_product_attention.cpp
@@ -18,17 +18,17 @@ namespace {
 void sdpa_full_self_attention_nax(
     const Stream& s,
     metal::Device& d,
-    const array& q_in,
-    const array& k_in,
-    const array& v_in,
+    const array& q,
+    const array& k,
+    const array& v,
     const float scale,
-    array& o_in,
+    array& o,
     bool do_causal_,
     const std::optional<array>& mask,
     const std::optional<array>& sinks) {
   using namespace mlx::steel;
 
-  int bd = q_in.shape(-1);
+  int bd = q.shape(-1);
   // bd=256 runs the head-dim split kernel (attention_nax_dsplit): the two
   // simdgroups along the second warp dimension each own half of the head
   // dim, which halves the per-simdgroup accumulator working set that gates
@@ -44,67 +44,52 @@ void sdpa_full_self_attention_nax(
   // 47.7 TF at 8192^2).
   int bk = 32;
 
-  int B = q_in.shape(0);
-  int H = q_in.shape(1);
-  int D = q_in.shape(3);
-  int gqa_factor = q_in.shape(1) / k_in.shape(1);
+  int B = q.shape(0);
+  int H = q.shape(1);
+  int D = q.shape(3);
+  int gqa_factor = q.shape(1) / k.shape(1);
 
-  int qL = q_in.shape(2);
-  int kL = k_in.shape(2);
+  int qL = q.shape(2);
+  int kL = k.shape(2);
 
-  // The causal offset must keep describing the true diagonal even when the
-  // inputs get padded below.
+  // The causal offset describes the true diagonal even if kL is widened
+  // below.
   const int qL_off = kL - qL;
 
-  // For head_dim 256 the unaligned pipelines (align_Q/align_K = false)
-  // spill registers and slow every block down ~3x, not just the ragged edge
-  // ones. Pad ragged causal inputs up to the tile sizes and take the
-  // aligned pipeline instead: with qL_off computed from the true lengths,
-  // the causal bound c <= r + qL_off never reaches a padded key column for
-  // any true query row, and the padded query rows are dropped by the copy
-  // back into o. The pads are zero-filled so the padded value rows cannot
-  // poison P @ V with NaNs (their probabilities are exactly zero).
-  std::optional<array> q_pad, k_pad, v_pad, o_pad;
-  if (split_d && do_causal_ && !mask.has_value() && ((qL % bq) || (kL % bk))) {
-    auto& enc = metal::get_command_encoder(s);
-    auto pad_seq = [&](const array& src, int Lp) {
-      array dst(
-          {src.shape(0), src.shape(1), Lp, src.shape(3)},
-          src.dtype(),
-          nullptr,
-          {});
-      array zero(0, src.dtype());
-      fill_gpu(zero, dst, s);
-      array dst_slice(src.shape(), dst.dtype(), nullptr, {});
-      dst_slice.copy_shared_buffer(
-          dst, dst.strides(), dst.flags(), dst_slice.size(), 0);
-      copy_gpu_inplace(src, dst_slice, CopyType::GeneralGeneral, s);
-      enc.add_temporary(std::move(zero));
-      enc.add_temporary(std::move(dst_slice));
-      enc.add_temporary(dst);
-      return dst;
-    };
-
-    if (qL % bq) {
-      int qLp = bq * ((qL + bq - 1) / bq);
-      q_pad = pad_seq(q_in, qLp);
-      o_pad = array({B, H, qLp, D}, o_in.dtype(), nullptr, {});
-      o_pad->set_data(allocator::malloc(o_pad->nbytes()));
-      enc.add_temporary(*o_pad);
-      qL = qLp;
+  // K/V that come out of a preallocated KV cache (mlx-lm grows it 256
+  // positions at a time) are slices of a longer buffer, keys[..., :kL, :].
+  // Reading such a slice past its end up to the next bk multiple keeps the
+  // head-dim split kernel on the aligned K pipeline, which is ~13% faster
+  // over the whole KV loop than the unaligned one at bd=256. It is safe
+  // under causal masking with qL_off taken from the true lengths: every
+  // extra key column lies beyond the diagonal of every true query row, so
+  // it is masked to zero probability and its (finite) V row never reaches
+  // the output. Ragged Q needs no such treatment: the kernel loads Q once,
+  // outside the KV loop.
+  auto has_backing_rows = [](const array& kv, int rows) {
+    const auto& st = kv.strides();
+    if (st[0] < 0 || st[1] <= 0 || st[2] <= 0 || st[1] % st[2] != 0) {
+      return false;
     }
-    if (kL % bk) {
-      int kLp = bk * ((kL + bk - 1) / bk);
-      k_pad = pad_seq(k_in, kLp);
-      v_pad = pad_seq(v_in, kLp);
+    const int64_t itemsize = kv.itemsize();
+    // The rows must stay inside the head's row pitch (so they belong to the
+    // cache the slice was taken from) ...
+    const int64_t pitch = st[1] / st[2];
+    const int64_t row0 = ((kv.offset() / itemsize) % st[1]) / st[2];
+    if (row0 + rows > pitch) {
+      return false;
+    }
+    // ... and inside the buffer.
+    const int64_t end = (kv.shape(0) - 1) * st[0] + (kv.shape(1) - 1) * st[1] +
+        (rows - 1) * st[2] + kv.shape(3);
+    return kv.offset() + end * itemsize <= int64_t(kv.buffer_size());
+  };
+  if (split_d && do_causal_ && !mask.has_value() && (kL % bk)) {
+    int kLp = bk * ((kL + bk - 1) / bk);
+    if (has_backing_rows(k, kLp) && has_backing_rows(v, kLp)) {
       kL = kLp;
     }
   }
-
-  const array& q = q_pad ? *q_pad : q_in;
-  const array& k = k_pad ? *k_pad : k_in;
-  const array& v = v_pad ? *v_pad : v_in;
-  array& o = o_pad ? *o_pad : o_in;
 
   const bool align_Q = (qL % bq) == 0;
   const bool align_K = (kL % bk) == 0;
@@ -226,15 +211,6 @@ void sdpa_full_self_attention_nax(
 
   check_kernel_threadgroup_size(kernel, group_dims, hash_name);
   compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
-
-  // Drop the padded query rows.
-  if (o_pad) {
-    array o_slice(o_in.shape(), o_pad->dtype(), nullptr, {});
-    o_slice.copy_shared_buffer(
-        *o_pad, o_pad->strides(), o_pad->flags(), o_slice.size(), 0);
-    copy_gpu_inplace(o_slice, o_in, CopyType::GeneralGeneral, s);
-    compute_encoder.add_temporary(std::move(o_slice));
-  }
 }
 
 void sdpa_full_self_attention_metal(

--- a/mlx/backend/metal/scaled_dot_product_attention.cpp
+++ b/mlx/backend/metal/scaled_dot_product_attention.cpp
@@ -18,30 +18,92 @@ namespace {
 void sdpa_full_self_attention_nax(
     const Stream& s,
     metal::Device& d,
-    const array& q,
-    const array& k,
-    const array& v,
+    const array& q_in,
+    const array& k_in,
+    const array& v_in,
     const float scale,
-    array& o,
+    array& o_in,
     bool do_causal_,
     const std::optional<array>& mask,
     const std::optional<array>& sinks) {
   using namespace mlx::steel;
 
+  int bd = q_in.shape(-1);
   int wm = 4;
-  int wn = 1;
+  // bd=256 uses the head-dim-split kernel (wn=2): halving the per-simdgroup
+  // accumulator working set is what recovers tensor-unit throughput at this
+  // head width.
+  int wn = bd == 256 ? 2 : 1;
 
-  int bd = q.shape(-1);
   int bq = 64;
+  // bk=32 everywhere: with the head-dim split at bd=256 this puts the
+  // per-simdgroup accumulator set (S 2 + O 8 fragments) at exact bd=128
+  // parity, which is what restores tensor-unit throughput (42.8 vs
+  // 47.7 TF at 8192^2).
   int bk = 32;
 
-  int B = q.shape(0);
-  int H = q.shape(1);
-  int D = q.shape(3);
-  int gqa_factor = q.shape(1) / k.shape(1);
+  int B = q_in.shape(0);
+  int H = q_in.shape(1);
+  int D = q_in.shape(3);
+  int gqa_factor = q_in.shape(1) / k_in.shape(1);
 
-  int qL = q.shape(2);
-  int kL = k.shape(2);
+  int qL = q_in.shape(2);
+  int kL = k_in.shape(2);
+
+  // The causal offset must keep describing the true diagonal even when the
+  // inputs get padded below.
+  const int qL_off = kL - qL;
+
+  // For head_dim 256 the unaligned pipelines (align_Q/align_K = false)
+  // spill registers and slow every block down ~3x, not just the ragged edge
+  // ones. Pad ragged causal inputs up to the tile sizes and take the
+  // aligned pipeline instead: with qL_off computed from the true lengths,
+  // the causal bound c <= r + qL_off never reaches a padded key column for
+  // any true query row, and the padded query rows are dropped by the copy
+  // back into o. The pads are zero-filled so the padded value rows cannot
+  // poison P @ V with NaNs (their probabilities are exactly zero).
+  std::optional<array> q_pad, k_pad, v_pad, o_pad;
+  if (bd == 256 && do_causal_ && !mask.has_value() &&
+      ((qL % bq) || (kL % bk))) {
+    auto& enc = metal::get_command_encoder(s);
+    auto pad_seq = [&](const array& src, int Lp) {
+      array dst(
+          {src.shape(0), src.shape(1), Lp, src.shape(3)},
+          src.dtype(),
+          nullptr,
+          {});
+      array zero(0, src.dtype());
+      fill_gpu(zero, dst, s);
+      array dst_slice(src.shape(), dst.dtype(), nullptr, {});
+      dst_slice.copy_shared_buffer(
+          dst, dst.strides(), dst.flags(), dst_slice.size(), 0);
+      copy_gpu_inplace(src, dst_slice, CopyType::GeneralGeneral, s);
+      enc.add_temporary(std::move(zero));
+      enc.add_temporary(std::move(dst_slice));
+      enc.add_temporary(dst);
+      return dst;
+    };
+
+    if (qL % bq) {
+      int qLp = bq * ((qL + bq - 1) / bq);
+      q_pad = pad_seq(q_in, qLp);
+      o_pad = array({B, H, qLp, D}, o_in.dtype(), nullptr, {});
+      o_pad->set_data(allocator::malloc(o_pad->nbytes()));
+      enc.add_temporary(*o_pad);
+      qL = qLp;
+    }
+    if (kL % bk) {
+      int kLp = bk * ((kL + bk - 1) / bk);
+      k_pad = pad_seq(k_in, kLp);
+      v_pad = pad_seq(v_in, kLp);
+      kL = kLp;
+    }
+  }
+
+  const array& q = q_pad ? *q_pad : q_in;
+  const array& k = k_pad ? *k_pad : k_in;
+  const array& v = v_pad ? *v_pad : v_in;
+  array& o = o_pad ? *o_pad : o_in;
 
   const bool align_Q = (qL % bq) == 0;
   const bool align_K = (kL % bk) == 0;
@@ -131,7 +193,7 @@ void sdpa_full_self_attention_nax(
 
       /* int qL_rem = */ (qL - NQ_aligned * bq),
       /* int kL_rem = */ (kL - NK_aligned * bk),
-      /* int qL_off = */ (kL - qL),
+      /* int qL_off = */ qL_off,
 
       /* int64_t Q_strides[3] = */ {q.strides(0), q.strides(1), q.strides(2)},
       /* int64_t K_strides[3] = */ {k.strides(0), k.strides(1), k.strides(2)},
@@ -162,6 +224,15 @@ void sdpa_full_self_attention_nax(
 
   check_kernel_threadgroup_size(kernel, group_dims, hash_name);
   compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+
+  // Drop the padded query rows.
+  if (o_pad) {
+    array o_slice(o_in.shape(), o_pad->dtype(), nullptr, {});
+    o_slice.copy_shared_buffer(
+        *o_pad, o_pad->strides(), o_pad->flags(), o_slice.size(), 0);
+    copy_gpu_inplace(o_slice, o_in, CopyType::GeneralGeneral, s);
+    compute_encoder.add_temporary(std::move(o_slice));
+  }
 }
 
 void sdpa_full_self_attention_metal(
@@ -713,10 +784,20 @@ bool ScaledDotProductAttention::use_fallback(
     return true;
   }
 
-  // Unfused path is faster for following shapes.
   const int query_sequence_length = q.shape(2);
   const int query_head_dim = q.shape(-1);
   const int value_head_dim = v.shape(-1);
+
+  // Use headdim-split kernel when NAX is enabled and there are enough query
+  // blocks to fill the machine.
+  if (metal::is_nax_available() &&
+      (env::enable_tf32() || q.dtype() != float32) &&
+      query_sequence_length >= 1024 && query_head_dim == 256 && do_causal &&
+      !has_arr_mask) {
+    return false;
+  }
+
+  // Unfused path is faster for following shapes.
   if (query_sequence_length > 8) {
     return query_head_dim == 192 || query_head_dim == 256;
   } else {

--- a/mlx/backend/metal/scaled_dot_product_attention.cpp
+++ b/mlx/backend/metal/scaled_dot_product_attention.cpp
@@ -29,20 +29,12 @@ void sdpa_full_self_attention_nax(
   using namespace mlx::steel;
 
   int bd = q.shape(-1);
-  // bd=256 runs the head-dim split kernel (attention_nax_dsplit): the two
-  // simdgroups along the second warp dimension each own half of the head
-  // dim, which halves the per-simdgroup accumulator working set that gates
-  // tensor-unit throughput at this head width.
-  const bool split_d = bd == 256;
+  int bq = 64;
+  int bk = 32;
+
+  bool split_d = bd == 256;
   int wm = 4;
   int wn = split_d ? 2 : 1;
-
-  int bq = 64;
-  // bk=32 everywhere: with the head-dim split at bd=256 this puts the
-  // per-simdgroup accumulator set (S 2 + O 8 fragments) at exact bd=128
-  // parity, which is what restores tensor-unit throughput (42.8 vs
-  // 47.7 TF at 8192^2).
-  int bk = 32;
 
   int B = q.shape(0);
   int H = q.shape(1);
@@ -54,33 +46,24 @@ void sdpa_full_self_attention_nax(
 
   // The causal offset describes the true diagonal even if kL is widened
   // below.
-  const int qL_off = kL - qL;
+  int qL_off = kL - qL;
 
-  // K/V that come out of a preallocated KV cache (mlx-lm grows it 256
-  // positions at a time) are slices of a longer buffer, keys[..., :kL, :].
-  // Reading such a slice past its end up to the next bk multiple keeps the
-  // head-dim split kernel on the aligned K pipeline, which is ~13% faster
-  // over the whole KV loop than the unaligned one at bd=256. It is safe
-  // under causal masking with qL_off taken from the true lengths: every
-  // extra key column lies beyond the diagonal of every true query row, so
-  // it is masked to zero probability and its (finite) V row never reaches
-  // the output. Ragged Q needs no such treatment: the kernel loads Q once,
-  // outside the KV loop.
+  // Check if K/V are from chunked KV cache, and assume aligned K/V if so.
   auto has_backing_rows = [](const array& kv, int rows) {
-    const auto& st = kv.strides();
-    if (st[0] < 0 || st[1] <= 0 || st[2] <= 0 || st[1] % st[2] != 0) {
+    auto& st = kv.strides();
+    if ((st[0] < 0) || (st[1] <= 0) || (st[2] <= 0) || (st[1] % st[2] != 0)) {
       return false;
     }
-    const int64_t itemsize = kv.itemsize();
+    int64_t itemsize = kv.itemsize();
     // The rows must stay inside the head's row pitch (so they belong to the
     // cache the slice was taken from) ...
-    const int64_t pitch = st[1] / st[2];
-    const int64_t row0 = ((kv.offset() / itemsize) % st[1]) / st[2];
+    int64_t pitch = st[1] / st[2];
+    int64_t row0 = ((kv.offset() / itemsize) % st[1]) / st[2];
     if (row0 + rows > pitch) {
       return false;
     }
     // ... and inside the buffer.
-    const int64_t end = (kv.shape(0) - 1) * st[0] + (kv.shape(1) - 1) * st[1] +
+    int64_t end = (kv.shape(0) - 1) * st[0] + (kv.shape(1) - 1) * st[1] +
         (rows - 1) * st[2] + kv.shape(3);
     return kv.offset() + end * itemsize <= int64_t(kv.buffer_size());
   };

--- a/python/tests/test_fast_sdpa.py
+++ b/python/tests/test_fast_sdpa.py
@@ -117,6 +117,80 @@ def mlx_primitives_sdpa(q, k, v, scale, mask=None):
 
 
 class TestFastSDPA(mlx_tests.MLXTestCase):
+    def test_sdpa_full_head_dim_256_tf32_disabled(self):
+        # float32 with tf32 disabled must NOT be routed to the fused path:
+        # only the NAX kernel is instantiated for head_dim 256, so a
+        # predicate mismatch shows up as a kernel-load failure. TF32 is a
+        # process-wide setting, so exercise it in a subprocess.
+        import os
+        import subprocess
+        import sys
+
+        # qL >= 2048 so that, predicate mismatch aside, the shape would
+        # otherwise be routed to the fused path.
+        script = (
+            "import mlx.core as mx\n"
+            "q = mx.random.normal(shape=(1, 4, 2048, 256))\n"
+            "k = mx.random.normal(shape=(1, 2, 2048, 256))\n"
+            "v = mx.random.normal(shape=(1, 2, 2048, 256))\n"
+            "out = mx.fast.scaled_dot_product_attention("
+            "q, k, v, scale=0.0625, mask='causal')\n"
+            "mx.eval(out)\n"
+            "print('ok')\n"
+        )
+        env = dict(os.environ, MLX_ENABLE_TF32="0")
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("ok", result.stdout)
+
+    def test_sdpa_full_head_dim_256(self):
+        # On NAX devices, large nearly-square causal blocks take the fused
+        # path, with ragged lengths padded up to the tile size inside the
+        # dispatch; everything else takes the unfused fallback. All of it
+        # must be correct.
+        D = 256
+        Nq, Nkv = 8, 2
+        scale = D**-0.5
+        mx.random.seed(0)
+        cases = [
+            # (qL, kL, mask): unfused fallback shapes
+            (17, 17, None),
+            (17, 17, "causal"),
+            (128, 128, "causal"),
+            (512, 512, "causal"),
+            # fused on NAX: aligned square, ragged square (padded), aligned
+            # rectangle at the routing boundary, ragged rectangle (padded)
+            (2048, 2048, "causal"),
+            (2049, 2049, "causal"),
+            (2048, 2560, "causal"),
+            (2049, 2560, "causal"),
+        ]
+        for dtype in (mx.float32, mx.bfloat16):
+            for qL, kL, mask in cases:
+                with self.subTest(dtype=dtype, qL=qL, kL=kL, mask=mask):
+                    q = (5e-1 * mx.random.normal(shape=(1, Nq, qL, D))).astype(dtype)
+                    k = (5e-1 * mx.random.normal(shape=(1, Nkv, kL, D))).astype(dtype)
+                    v = (5e-1 * mx.random.normal(shape=(1, Nkv, kL, D))).astype(dtype)
+                    k_rep = mx.repeat(k, Nq // Nkv, axis=1)
+                    v_rep = mx.repeat(v, Nq // Nkv, axis=1)
+                    ref = mlx_primitives_sdpa(q, k_rep, v_rep, scale, mask=mask)
+                    out = mx.fast.scaled_dot_product_attention(
+                        q, k, v, scale=scale, mask=mask
+                    )
+                    self.assertEqual(out.shape, ref.shape)
+                    if dtype == mx.float32:
+                        # The fused shapes run through tf32 tensor ops when
+                        # MLX_ENABLE_TF32 is on (the default).
+                        tol = 1e-3 if qL >= 2048 else 1e-4
+                    else:
+                        tol = 5e-3
+                    self.assertTrue(mx.allclose(ref, out, atol=tol, rtol=tol))
+
     def test_sdpa_vector_kv_transposed_head_seq(self):
         D = 64
         Nq = 4

--- a/python/tests/test_fast_sdpa.py
+++ b/python/tests/test_fast_sdpa.py
@@ -171,6 +171,44 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
                 diff = mx.abs(out - ref) - atol * mx.abs(ref)
                 self.assertLessEqual(mx.max(diff).item(), atol)
 
+    def test_sdpa_full_head_dim_256(self):
+        # On NAX devices, large nearly-square causal blocks take the fused
+        # path, with ragged lengths padded up to the tile size inside the
+        # dispatch; everything else takes the unfused fallback. All of it
+        # must be correct.
+        D = 256
+        Nq, Nkv = 8, 2
+        scale = D**-0.5
+        mx.random.seed(0)
+        cases = [
+            # fused on NAX: aligned square, ragged square (padded), aligned
+            # rectangle at the routing boundary, ragged rectangle (padded)
+            (2048, 2048, "causal"),
+            (2049, 2049, "causal"),
+            (2048, 2560, "causal"),
+            (2049, 2560, "causal"),
+        ]
+        for dtype in (mx.float32, mx.bfloat16):
+            for qL, kL, mask in cases:
+                with self.subTest(dtype=dtype, qL=qL, kL=kL, mask=mask):
+                    q = (5e-1 * mx.random.normal(shape=(1, Nq, qL, D))).astype(dtype)
+                    k = (5e-1 * mx.random.normal(shape=(1, Nkv, kL, D))).astype(dtype)
+                    v = (5e-1 * mx.random.normal(shape=(1, Nkv, kL, D))).astype(dtype)
+                    k_rep = mx.repeat(k, Nq // Nkv, axis=1)
+                    v_rep = mx.repeat(v, Nq // Nkv, axis=1)
+                    ref = mlx_primitives_sdpa(q, k_rep, v_rep, scale, mask=mask)
+                    out = mx.fast.scaled_dot_product_attention(
+                        q, k, v, scale=scale, mask=mask
+                    )
+                    self.assertEqual(out.shape, ref.shape)
+                    if dtype == mx.float32:
+                        # The fused shapes run through tf32 tensor ops when
+                        # MLX_ENABLE_TF32 is on (the default).
+                        tol = 1e-3 if qL >= 2048 else 1e-4
+                    else:
+                        tol = 5e-3
+                    self.assertTrue(mx.allclose(ref, out, atol=tol, rtol=tol))
+
     def test_sdpa_vector_kv_transposed_head_seq(self):
         D = 64
         Nq = 4

--- a/python/tests/test_fast_sdpa.py
+++ b/python/tests/test_fast_sdpa.py
@@ -144,6 +144,34 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
                 diff = mx.abs(out - ref) - atol * mx.abs(ref)
                 self.assertLessEqual(mx.max(diff).item(), atol)
 
+    @unittest.skipIf(not mx.is_available(mx.gpu), "GPU kernel path only")
+    def test_sdpa_head_dim_96(self):
+        B, D, qH, kH = (1, 96, 8, 2)
+        for qL, kL, dtype, mask_str in product(
+            (64, 65),
+            (128, 127),
+            (mx.float16, mx.bfloat16, mx.float32),
+            (None, "additive", "bool", "causal"),
+        ):
+            with self.subTest(qL=qL, kL=kL, dtype=dtype, mask=mask_str):
+                q, k, v, scale, mask = prepare_inputs(
+                    B, qL, kL, D, qH, kH, mask_str, False, dtype
+                )
+                ref = mlx_ref_attn(q, k, v, scale, mask)
+                out = mx.fast.scaled_dot_product_attention(
+                    q, k, v, scale=scale, mask=mask
+                )
+
+                if dtype == mx.float32:
+                    atol = 1e-5
+                elif dtype == mx.bfloat16:
+                    atol = 5e-3
+                else:
+                    atol = 3e-4
+                diff = mx.abs(out - ref) - atol * mx.abs(ref)
+                self.assertLessEqual(mx.max(diff).item(), atol)
+
+    @unittest.skipIf(not mx.is_available(mx.gpu), "GPU kernel path only")
     def test_sdpa_full_head_dim_256(self):
         # On NAX devices, large nearly-square causal blocks take the fused
         # path; everything else takes the unfused fallback. Ragged lengths
@@ -209,33 +237,6 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
                     else:
                         tol = 5e-3
                     self.assertTrue(mx.allclose(ref, out, atol=tol, rtol=tol))
-
-    @unittest.skipIf(not mx.is_available(mx.gpu), "GPU kernel path only")
-    def test_sdpa_head_dim_96(self):
-        B, D, qH, kH = (1, 96, 8, 2)
-        for qL, kL, dtype, mask_str in product(
-            (64, 65),
-            (128, 127),
-            (mx.float16, mx.bfloat16, mx.float32),
-            (None, "additive", "bool", "causal"),
-        ):
-            with self.subTest(qL=qL, kL=kL, dtype=dtype, mask=mask_str):
-                q, k, v, scale, mask = prepare_inputs(
-                    B, qL, kL, D, qH, kH, mask_str, False, dtype
-                )
-                ref = mlx_ref_attn(q, k, v, scale, mask)
-                out = mx.fast.scaled_dot_product_attention(
-                    q, k, v, scale=scale, mask=mask
-                )
-
-                if dtype == mx.float32:
-                    atol = 1e-5
-                elif dtype == mx.bfloat16:
-                    atol = 5e-3
-                else:
-                    atol = 3e-4
-                diff = mx.abs(out - ref) - atol * mx.abs(ref)
-                self.assertLessEqual(mx.max(diff).item(), atol)
 
     def test_sdpa_vector_kv_transposed_head_seq(self):
         D = 64

--- a/python/tests/test_fast_sdpa.py
+++ b/python/tests/test_fast_sdpa.py
@@ -144,6 +144,72 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
                 diff = mx.abs(out - ref) - atol * mx.abs(ref)
                 self.assertLessEqual(mx.max(diff).item(), atol)
 
+    def test_sdpa_full_head_dim_256(self):
+        # On NAX devices, large nearly-square causal blocks take the fused
+        # path; everything else takes the unfused fallback. Ragged lengths
+        # exercise the kernel's unaligned pipelines, and K/V sliced out of a
+        # longer preallocated cache (the way mlx-lm hands them over) exercise
+        # the dispatch reading the slice past its end. All of it must be
+        # correct.
+        D = 256
+        Nq, Nkv = 8, 2
+        scale = D**-0.5
+        mx.random.seed(0)
+        cases = [
+            # fused on NAX: aligned square, ragged square (unaligned Q and
+            # K/V), aligned rectangle at the routing boundary, ragged
+            # rectangle
+            (2048, 2048, "causal", None),
+            (2049, 2049, "causal", None),
+            (2048, 2560, "causal", None),
+            (2049, 2560, "causal", None),
+            # fused on NAX with ragged K/V sliced out of a longer cache: the
+            # rows behind the slice must not leak into the output
+            (2049, 2049, "causal", 2304),
+            (2048, 2500, "causal", 2560),
+            (1031, 2049, "causal", 2304),
+        ]
+        for dtype in (mx.float32, mx.bfloat16):
+            for qL, kL, mask, cache_len in cases:
+                with self.subTest(
+                    dtype=dtype, qL=qL, kL=kL, mask=mask, cache_len=cache_len
+                ):
+                    q = (5e-1 * mx.random.normal(shape=(1, Nq, qL, D))).astype(dtype)
+                    if cache_len is None:
+                        k = (5e-1 * mx.random.normal(shape=(1, Nkv, kL, D))).astype(
+                            dtype
+                        )
+                        v = (5e-1 * mx.random.normal(shape=(1, Nkv, kL, D))).astype(
+                            dtype
+                        )
+                    else:
+                        # Large, finite stale rows behind the slice: any of
+                        # them reaching the output is loud.
+                        k_cache = 1e2 * mx.random.normal(shape=(1, Nkv, cache_len, D))
+                        v_cache = 1e3 * mx.random.normal(shape=(1, Nkv, cache_len, D))
+                        k_cache[..., :kL, :] = 5e-1 * mx.random.normal(
+                            shape=(1, Nkv, kL, D)
+                        )
+                        v_cache[..., :kL, :] = 5e-1 * mx.random.normal(
+                            shape=(1, Nkv, kL, D)
+                        )
+                        k = k_cache.astype(dtype)[..., :kL, :]
+                        v = v_cache.astype(dtype)[..., :kL, :]
+                    k_rep = mx.repeat(k, Nq // Nkv, axis=1)
+                    v_rep = mx.repeat(v, Nq // Nkv, axis=1)
+                    ref = mlx_primitives_sdpa(q, k_rep, v_rep, scale, mask=mask)
+                    out = mx.fast.scaled_dot_product_attention(
+                        q, k, v, scale=scale, mask=mask
+                    )
+                    self.assertEqual(out.shape, ref.shape)
+                    if dtype == mx.float32:
+                        # The fused shapes run through tf32 tensor ops when
+                        # MLX_ENABLE_TF32 is on (the default).
+                        tol = 1e-3 if qL >= 2048 else 1e-4
+                    else:
+                        tol = 5e-3
+                    self.assertTrue(mx.allclose(ref, out, atol=tol, rtol=tol))
+
     @unittest.skipIf(not mx.is_available(mx.gpu), "GPU kernel path only")
     def test_sdpa_head_dim_96(self):
         B, D, qH, kH = (1, 96, 8, 2)

--- a/python/tests/test_fast_sdpa.py
+++ b/python/tests/test_fast_sdpa.py
@@ -237,44 +237,6 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
                 diff = mx.abs(out - ref) - atol * mx.abs(ref)
                 self.assertLessEqual(mx.max(diff).item(), atol)
 
-    def test_sdpa_full_head_dim_256(self):
-        # On NAX devices, large nearly-square causal blocks take the fused
-        # path, with ragged lengths padded up to the tile size inside the
-        # dispatch; everything else takes the unfused fallback. All of it
-        # must be correct.
-        D = 256
-        Nq, Nkv = 8, 2
-        scale = D**-0.5
-        mx.random.seed(0)
-        cases = [
-            # fused on NAX: aligned square, ragged square (padded), aligned
-            # rectangle at the routing boundary, ragged rectangle (padded)
-            (2048, 2048, "causal"),
-            (2049, 2049, "causal"),
-            (2048, 2560, "causal"),
-            (2049, 2560, "causal"),
-        ]
-        for dtype in (mx.float32, mx.bfloat16):
-            for qL, kL, mask in cases:
-                with self.subTest(dtype=dtype, qL=qL, kL=kL, mask=mask):
-                    q = (5e-1 * mx.random.normal(shape=(1, Nq, qL, D))).astype(dtype)
-                    k = (5e-1 * mx.random.normal(shape=(1, Nkv, kL, D))).astype(dtype)
-                    v = (5e-1 * mx.random.normal(shape=(1, Nkv, kL, D))).astype(dtype)
-                    k_rep = mx.repeat(k, Nq // Nkv, axis=1)
-                    v_rep = mx.repeat(v, Nq // Nkv, axis=1)
-                    ref = mlx_primitives_sdpa(q, k_rep, v_rep, scale, mask=mask)
-                    out = mx.fast.scaled_dot_product_attention(
-                        q, k, v, scale=scale, mask=mask
-                    )
-                    self.assertEqual(out.shape, ref.shape)
-                    if dtype == mx.float32:
-                        # The fused shapes run through tf32 tensor ops when
-                        # MLX_ENABLE_TF32 is on (the default).
-                        tol = 1e-3 if qL >= 2048 else 1e-4
-                    else:
-                        tol = 5e-3
-                    self.assertTrue(mx.allclose(ref, out, atol=tol, rtol=tol))
-
     def test_sdpa_vector_kv_transposed_head_seq(self):
         D = 64
         Nq = 4


### PR DESCRIPTION
## Proposed changes

Add a fused NAX full-attention path for `head_dim == 256` without
materializing the `[n_heads, qL, kL]` score tensor.

| Area | Change |
|---|---|
| Kernel configuration | `bq=64`, `bk=32`, `wm=4`, `wn=2` |
| Parallel decomposition | Separate `attention_nax_dsplit` kernel: split `D` and `Dv` across the `WN = 2` simdgroups of the second warp dimension |
| Routing | Causal, no array mask, `qL >= 1024`, NAX-compatible dtype/TF32 mode |
| Ragged inputs | No padding copies. Ragged `qL` runs the kernel's unaligned-Q path (Q is loaded once, outside the KV loop, so it is free). Ragged `kL` from a KV-cache slice is read past its end up to the next `bk` multiple (the extra columns are causally masked); ragged `kL` from a plain array runs the unaligned-K path (~13% slower over the KV loop, still ~2x the unfused graph) |
| Fallback safety | Preserve fallback for unsupported shapes and `float32` with TF32 disabled |

## Motivation

`use_fallback` currently allows fused full attention only for
`head_dim` in `{64, 80, 128}`. Full-attention layers in the Qwen3.5/3.6
family use `head_dim == 256`, so they fall back to an unfused graph that:

- materializes the full score tensor;
- computes the full rectangle before applying the causal mask; and
- becomes increasingly expensive at long context lengths.

A direct `bd=256` instantiation of `steel_attention_nax` reaches only about
half the efficiency of `bd=128` on M5 Max (`22` vs `48 TF`). The limiting
resource is the per-simdgroup accumulator byte budget: the `bd=256` output
and score accumulator set is twice as large. A half-precision-accumulator
probe recovered `+51%`, while register pressure, scheduling fences,
accumulation-chain order, instruction footprint, and Q reload traffic were
ruled out by measurement.

## Design

### Head-dimension split

`attention_nax_dsplit`, a separate kernel from `attention_nax` dispatched
for `bd = 256` with `wn = 2`, assigns each simdgroup one half of `D` and
`Dv`:

1. Each half computes its partial `Q @ K.T` scores.
2. The two halves exchange score fragments pair-by-pair through a `16 KB`
   threadgroup buffer.
3. Both halves run softmax on the complete score tile.
4. Each half accumulates `P @ V` for its owned half of `Dv`.

Both halves use the same fragment-to-lane mapping, so the exchange can use a
per-lane-linear layout without coordinate conversion. Q fragments remain
register-resident across the KV loop.

This reduces the per-simdgroup accumulator set to `2 S + 8 O` fragments
(`320 B/lane`), matching the working set of the existing `bd=128` kernel.

### Ragged causal inputs

There is no padding. Ragged query lengths take the kernel's unaligned-Q
path (`align_Q = false`), which measures within noise of the aligned one:
Q is loaded into registers once, before the KV loop, so raggedness never
touches the hot loop.

Ragged key/value lengths matter more: the unaligned-K pipeline
(`align_K = false`) carries bounds-checked K/V loads and column masking
inside the KV loop and measures ~13% slower over the whole loop on M5 Max.
The dispatch avoids it for the common case without copying anything: K/V
that come out of a preallocated KV cache (mlx-lm's `KVCache` grows its
buffer 256 positions at a time) are slices of a longer buffer,
`keys[..., :kL, :]`. When such a slice can be read past `kL` up to the next
`bk` multiple — the head's row pitch (`strides[1] / strides[2]`) reaches
that far and the buffer bound allows it — the kernel is simply told the
widened `kL`. This is safe under causal masking with `qL_off` computed from
the **true** lengths: every extra key column lies strictly beyond the
diagonal of every real query row, so it receives exactly zero probability
and its (finite) V row never reaches the output.

The check deliberately differs from the CUDA `use_cudnn_for_decoding`
heuristic in two ways: Metal buffers are page-rounded, so it tests
`offset + extent <= buffer_size` instead of equality, and it does not
require the cache capacity to be a multiple of 256 — after a chunked
prefill mlx-lm's cache is e.g. `2049 + 1280 = 3329` positions long, and
only the row pitch reaching the widened length matters. K/V that are not
such slices (a plain array with a ragged `kL`) run the unaligned-K path.

## Routing and fallback behavior

| Condition | Behavior |
|---|---|
| NAX, causal, no array mask, `head_dim == value_head_dim == 256`, `qL >= 1024` | Fused `wn=2` path |
| `qL < 1024` | Existing fallback |
| Array mask present | Existing fallback |
| `float32` with `MLX_ENABLE_TF32=0` | Existing fallback |
| Non-NAX device | Existing fallback |

The `qL >= 1024` threshold is based on measured M5 Max behavior. Below that
point, long-cache rectangles do not provide enough query blocks to fill the
machine (`512 x 8192` measured approximately `1.08x` the unfused time on an
earlier variant).

## Performance

Unless noted otherwise: **M5 Max, 16 Q / 2 KV heads, bf16, causal**.

### Kernel benchmarks

| Shape | Before | After | Improvement |
|---|---:|---:|---:|
| `8192 x 8192` | `24.92 ms` / `22.1 TF` | `12.84 ms` / `42.8 TF` | `1.94x` throughput |
| `4096 x 4096` | `8.87 ms` | `3.45 ms` | `2.57x` faster |
| `2048 x 8192` | `8.92 ms` | `5.77 ms` | `1.55x` faster |
| `1024 x 8192` | `4.65 ms` | `3.58 ms` | `1.30x` faster |
| `2048 x 2048` | `2.39 ms` | `1.19 ms` | `2.01x` faster |

At `8192 x 8192`, the new kernel reaches approximately `90%` of the
`bd=128` kernel's throughput.

### Ragged lengths

M5 Max, 16 Q / 2 KV heads, bf16, causal, min of alternating A/B runs:

| Shape (`qL x kL`) | Path | Time |
|---|---|---:|
| `4096 x 4096` | aligned reference | `3.46 ms` |
| `4064 x 4096` | ragged Q, unaligned-Q path | `3.61 ms` |
| `4096 x 4112` | ragged K sliced from a longer cache (widened, aligned pipeline) | `3.53 ms` |
| `4096 x 4112` | ragged K from a plain array (unaligned-K path) | `4.02 ms` |
| `8192 x 8200` | ragged K, aligned vs unaligned-K path | `15.2 ms` vs `17.2 ms` |

Padding Q instead would have cost more than it saved (`3.84 ms` for
`4064 x 4096`), which is why the earlier padding copies were dropped.

### End-to-end prefill

Qwen3.6-35B-A3B 4-bit, ragged prompts:

| Prompt / chunking | Before | After | Change | Peak memory |
|---|---:|---:|---:|---:|
| 8k, default 2048-token chunks | `4039 tok/s` | `4193 tok/s` | `+3.8%` | — |
| 8k, single chunk | `4209 tok/s` | `4822 tok/s` | `+14.6%` | — |
| 16k, 8k-token chunks | `3457 tok/s` | `4180 tok/s` | `+20.9%` | `29.9 -> 26.1 GB` |
| 32k, 8k-token chunks | `2833 tok/s` | `3598 tok/s` | `+27.0%` | `34.6 -> 26.5 GB` |
| 32k, single chunk | `1771 tok/s` | `2873 tok/s` | `+62.2%` | `72.9 -> 41.8 GB` |

Transient memory for the `4096 x 4096` kernel case drops from `663 MB` to
`75 MB` because the fused path no longer materializes the score tensor.

The end-to-end numbers were taken with an earlier revision that padded
ragged inputs with copies; mlx-lm hands over cache slices, which now run
the same aligned kernel without the pad/copy work.

## Numerical behavior

Against an f32 reference, the fused bf16 output is more accurate than the
previous unfused graph:

| Implementation | Relative L2 error |
|---|---:|
| Unfused bf16 graph | `2.3e-3` |
| Fused NAX kernel | `1.6e-3` |

## Validation

- Fallback and fused shapes checked against the primitives reference in
  `float32` and `bfloat16`.
- Committed coverage includes aligned/ragged squares and rectangles, plus
  ragged K/V sliced out of a longer preallocated cache with large, finite
  stale rows behind the slice (any leak into the output would be loud).
- Verified directly against `mlx_lm.models.cache.KVCache` slices from a
  chunked prefill (`2049` then `1031` tokens) in bf16 and fp32/TF32.
- Additional local boundary checks cover odd lengths `1031` and `2049`, plus
  the exact `qL == 1024` routing boundary.
- A subprocess test with `MLX_ENABLE_TF32=0` verifies that
  `float32 + head_dim 256` remains on the fallback path.
- Full local `test_fast_sdpa.py` result: **20 tests, 1 platform-dependent
  skip, otherwise passing**.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document.
- [x] I have run `pre-commit run --all-files`.
- [x] I have added tests that cover the new fused and fallback behavior.
- [x] No documentation changes are required for this internal kernel path.

