### PR TITLE
Fix log_cosh_loss docstring to document the element-wise loss

### DIFF
--- a/python/mlx/nn/losses.py
+++ b/python/mlx/nn/losses.py
@@ -505,8 +505,7 @@ def log_cosh_loss(
     .. math::
 
        \text{logcosh}(y_{\text{true}}, y_{\text{pred}}) =
-            \frac{1}{n} \sum_{i=1}^{n}
-            \log(\cosh(y_{\text{pred}}^{(i)} - y_{\text{true}}^{(i)}))
+            \log(\cosh(y_{\text{pred}} - y_{\text{true}}))
 
 
     Args:


### PR DESCRIPTION
## Proposed changes

`log_cosh_loss`'s docstring documents the loss as a mean-reduced scalar:

```
logcosh(y_true, y_pred) = (1/n) Σ log(cosh(y_pred - y_true))
```

but the function defaults to `reduction="none"` and returns the per-element `log(cosh(y_pred - y_true))`. The `(1/n) Σ` only corresponds to `reduction="mean"`, so at the default the documented formula doesn't match the output:

```python
>>> import mlx.core as mx, mlx.nn as nn
>>> nn.losses.log_cosh_loss(mx.array([1.0, 2.0]), mx.array([0.0, 0.0]))
array([0.433781, 1.325], dtype=float32)   # per-element, not the scalar 0.87939 the formula implies
```

It's also the only loss in `losses.py` whose math block bakes in the reduction — `huber_loss`, `smooth_l1_loss`, `hinge_loss`, and the others all document the element-wise loss and delegate aggregation to the `reduction` argument. This drops the `(1/n) Σ` so the formula reads the element-wise `log(cosh(y_pred - y_true))`, matching both the code and the rest of the file.

Docs-only; no behavior change.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit` (black + isort) on the changed file
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
