### PR TITLE
Fix installed static MLX package on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,7 +261,15 @@ if(WIN32)
   FetchContent_MakeAvailable(dlfcn-win32)
   endblock()
   target_include_directories(mlx PRIVATE "${dlfcn-win32_SOURCE_DIR}/src")
-  target_link_libraries(mlx PRIVATE dl)
+  if(BUILD_SHARED_LIBS)
+    target_link_libraries(mlx PRIVATE dl)
+  else()
+    # A static MLX package must not expose the FetchContent-only dlfcn-win32::dl
+    # target to installed consumers. Compile the small Windows implementation
+    # directly into mlx.lib and propagate its system library.
+    target_sources(mlx PRIVATE "${dlfcn-win32_SOURCE_DIR}/src/dlfcn.c")
+    target_link_libraries(mlx PRIVATE Psapi.lib)
+  endif()
 endif()
 
 if(MLX_BUILD_CPU)
@@ -296,8 +304,12 @@ if(MLX_BUILD_CPU)
       URL "https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.33/${OPENBLAS_ZIP}"
     )
     FetchContent_MakeAvailable(openblas)
-    target_link_libraries(
-      mlx PRIVATE "${openblas_SOURCE_DIR}/lib/${OPENBLAS_LIB}.lib")
+    set(OPENBLAS_IMPORT_LIBRARY
+        "${openblas_SOURCE_DIR}/lib/${OPENBLAS_LIB}.lib")
+    add_library(MLX::OpenBLAS UNKNOWN IMPORTED GLOBAL)
+    set_target_properties(MLX::OpenBLAS PROPERTIES IMPORTED_LOCATION
+                                                   "${OPENBLAS_IMPORT_LIBRARY}")
+    target_link_libraries(mlx PRIVATE MLX::OpenBLAS)
     target_include_directories(mlx
                                PRIVATE "${openblas_SOURCE_DIR}/${OPENBLAS_INC}")
     # Make sure the DLL file is placed in the same dir with executables.
@@ -417,6 +429,8 @@ if(WIN32)
   if(MLX_BUILD_CPU)
     # Install OpenBLAS.
     install(FILES ${OPENBLAS_DLL_FILE} TYPE BIN)
+    install(FILES ${OPENBLAS_IMPORT_LIBRARY}
+            DESTINATION ${CMAKE_INSTALL_LIBDIR})
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,7 +262,15 @@ if(WIN32)
   FetchContent_MakeAvailable(dlfcn-win32)
   endblock()
   target_include_directories(mlx PRIVATE "${dlfcn-win32_SOURCE_DIR}/src")
-  target_link_libraries(mlx PRIVATE dl)
+  if(BUILD_SHARED_LIBS)
+    target_link_libraries(mlx PRIVATE dl)
+  else()
+    # A static MLX package must not expose the FetchContent-only dlfcn-win32::dl
+    # target to installed consumers. Compile the small Windows implementation
+    # directly into mlx.lib and propagate its system library.
+    target_sources(mlx PRIVATE "${dlfcn-win32_SOURCE_DIR}/src/dlfcn.c")
+    target_link_libraries(mlx PRIVATE Psapi.lib)
+  endif()
 endif()
 
 if(MLX_BUILD_CPU)
@@ -297,8 +305,12 @@ if(MLX_BUILD_CPU)
       URL "https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.33/${OPENBLAS_ZIP}"
     )
     FetchContent_MakeAvailable(openblas)
-    target_link_libraries(
-      mlx PRIVATE "${openblas_SOURCE_DIR}/lib/${OPENBLAS_LIB}.lib")
+    set(OPENBLAS_IMPORT_LIBRARY
+        "${openblas_SOURCE_DIR}/lib/${OPENBLAS_LIB}.lib")
+    add_library(MLX::OpenBLAS UNKNOWN IMPORTED GLOBAL)
+    set_target_properties(MLX::OpenBLAS PROPERTIES IMPORTED_LOCATION
+                                                   "${OPENBLAS_IMPORT_LIBRARY}")
+    target_link_libraries(mlx PRIVATE MLX::OpenBLAS)
     target_include_directories(mlx
                                PRIVATE "${openblas_SOURCE_DIR}/${OPENBLAS_INC}")
     # Make sure the DLL file is placed in the same dir with executables.
@@ -418,6 +430,8 @@ if(WIN32)
   if(MLX_BUILD_CPU)
     # Install OpenBLAS.
     install(FILES ${OPENBLAS_DLL_FILE} TYPE BIN)
+    install(FILES ${OPENBLAS_IMPORT_LIBRARY}
+            DESTINATION ${CMAKE_INSTALL_LIBDIR})
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,15 +262,8 @@ if(WIN32)
   FetchContent_MakeAvailable(dlfcn-win32)
   endblock()
   target_include_directories(mlx PRIVATE "${dlfcn-win32_SOURCE_DIR}/src")
-  if(BUILD_SHARED_LIBS)
-    target_link_libraries(mlx PRIVATE dl)
-  else()
-    # A static MLX package must not expose the FetchContent-only dlfcn-win32::dl
-    # target to installed consumers. Compile the small Windows implementation
-    # directly into mlx.lib and propagate its system library.
-    target_sources(mlx PRIVATE "${dlfcn-win32_SOURCE_DIR}/src/dlfcn.c")
-    target_link_libraries(mlx PRIVATE Psapi.lib)
-  endif()
+  target_sources(mlx PRIVATE "${dlfcn-win32_SOURCE_DIR}/src/dlfcn.c")
+  target_link_libraries(mlx PRIVATE Psapi.lib)
 endif()
 
 if(MLX_BUILD_CPU)
@@ -305,14 +298,15 @@ if(MLX_BUILD_CPU)
       URL "https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.33/${OPENBLAS_ZIP}"
     )
     FetchContent_MakeAvailable(openblas)
+    target_include_directories(mlx
+                               PRIVATE "${openblas_SOURCE_DIR}/${OPENBLAS_INC}")
+    # Make openblas importable by dependencies when built as static library.
     set(OPENBLAS_IMPORT_LIBRARY
         "${openblas_SOURCE_DIR}/lib/${OPENBLAS_LIB}.lib")
     add_library(MLX::OpenBLAS UNKNOWN IMPORTED GLOBAL)
     set_target_properties(MLX::OpenBLAS PROPERTIES IMPORTED_LOCATION
                                                    "${OPENBLAS_IMPORT_LIBRARY}")
     target_link_libraries(mlx PRIVATE MLX::OpenBLAS)
-    target_include_directories(mlx
-                               PRIVATE "${openblas_SOURCE_DIR}/${OPENBLAS_INC}")
     # Make sure the DLL file is placed in the same dir with executables.
     set(OPENBLAS_DLL_FILE "${openblas_SOURCE_DIR}/bin/${OPENBLAS_LIB}.dll")
     add_custom_command(

--- a/mlx.pc.in
+++ b/mlx.pc.in
@@ -11,6 +11,25 @@
 
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+
+if(WIN32 AND @MLX_BUILD_CPU@ AND NOT TARGET MLX::OpenBLAS)
+    add_library(MLX::OpenBLAS UNKNOWN IMPORTED)
+    set_target_properties(MLX::OpenBLAS PROPERTIES
+        IMPORTED_LOCATION "@PACKAGE_CMAKE_INSTALL_LIBDIR@/@OPENBLAS_LIB@.lib"
+    )
+endif()
+
+if(@MLX_BUILD_CUDA@)
+    find_dependency(CUDAToolkit REQUIRED)
+
+    set(_MLX_SAVED_CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}")
+    list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+    find_dependency(CUDNN REQUIRED)
+    set(CMAKE_MODULE_PATH "${_MLX_SAVED_CMAKE_MODULE_PATH}")
+    unset(_MLX_SAVED_CMAKE_MODULE_PATH)
+endif()
+
 include(@PACKAGE_MLX_CMAKE_INSTALL_MODULE_DIR@/MLXTargets.cmake)
 include(@PACKAGE_MLX_CMAKE_INSTALL_MODULE_DIR@/extension.cmake)
 

--- a/mlx/backend/cuda/CMakeLists.txt
+++ b/mlx/backend/cuda/CMakeLists.txt
@@ -277,7 +277,9 @@ set(CUDNN_FRONTEND_BUILD_SAMPLES OFF)
 set(CUDNN_FRONTEND_BUILD_TESTS OFF)
 set(CUDNN_FRONTEND_BUILD_PYTHON_BINDINGS OFF)
 FetchContent_MakeAvailable(cudnn)
-target_link_libraries(mlx PRIVATE cudnn_frontend)
+# cudnn_frontend is header-only and is only needed while compiling MLX. Do not
+# leak its FetchContent target into the installed static link interface.
+target_link_libraries(mlx PRIVATE $<BUILD_INTERFACE:cudnn_frontend>)
 # Link with the actual cuDNN libraries.
 target_link_libraries(mlx PRIVATE CUDNN::cudnn_all)
 

--- a/mlx/backend/cuda/CMakeLists.txt
+++ b/mlx/backend/cuda/CMakeLists.txt
@@ -277,8 +277,6 @@ set(CUDNN_FRONTEND_BUILD_SAMPLES OFF)
 set(CUDNN_FRONTEND_BUILD_TESTS OFF)
 set(CUDNN_FRONTEND_BUILD_PYTHON_BINDINGS OFF)
 FetchContent_MakeAvailable(cudnn)
-# cudnn_frontend is header-only and is only needed while compiling MLX. Do not
-# leak its FetchContent target into the installed static link interface.
 target_link_libraries(mlx PRIVATE $<BUILD_INTERFACE:cudnn_frontend>)
 # Link with the actual cuDNN libraries.
 target_link_libraries(mlx PRIVATE CUDNN::cudnn_all)


### PR DESCRIPTION
## Proposed changes

Fix the installed static MLX package on Windows so downstream CMake
projects can link against `mlx.lib` without requiring `mlx.dll`.

The changes:

- Compile the dlfcn-win32 implementation directly into the static MLX
  library instead of exposing a FetchContent-only target to installed
  consumers.
- Link the required Windows `Psapi.lib` system library.
- Represent the downloaded OpenBLAS import library as an imported CMake
  target and install the `.lib` file.
- Keep `cudnn_frontend` as a build-only dependency.
- Reconstruct the required CUDA, cuDNN, and OpenBLAS dependencies in the
  installed MLX CMake package.

## Testing

Manually verified on Windows using MSVC, Ninja, CUDA 13.0, and cuDNN 9.19:

- Configured and built MLX with `BUILD_SHARED_LIBS=OFF`
- Installed MLX successfully
- Verified that `mlx.lib` is installed without requiring `mlx.dll`
- Rebuilt and ran the downstream `mlx_cpp_inference` project against the
  installed static MLX package
- Ran `pre-commit run --all-files` successfully

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)