### PR TITLE
Fix JIT build with old macOS SDK

### DIFF
--- a/mlx/backend/metal/CMakeLists.txt
+++ b/mlx/backend/metal/CMakeLists.txt
@@ -84,19 +84,32 @@ if(MLX_METAL_JIT)
 
   make_jit_source(steel/attn/kernels/steel_attention)
 
-  make_jit_source(
-    steel/gemm/gemm_nax kernels/steel/utils.h kernels/steel/gemm/nax.h
-    kernels/steel/gemm/params.h kernels/steel/gemm/transforms.h)
-  make_jit_source(steel/gemm/kernels/steel_gemm_fused_nax)
-  make_jit_source(steel/gemm/kernels/steel_gemm_gather_nax)
-  make_jit_source(steel/gemm/kernels/steel_gemm_splitk_nax)
-  make_jit_source(steel/gemm/kernels/steel_gemm_segmented_nax)
+  if(MLX_METAL_VERSION GREATER_EQUAL 400
+     AND MACOS_SDK_VERSION VERSION_GREATER_EQUAL 26.2
+     AND CMAKE_OSX_DEPLOYMENT_TARGET VERSION_GREATER_EQUAL 26.2)
 
-  make_jit_source(quantized_nax kernels/quantized_utils.h)
-  make_jit_source(fp_quantized_nax kernels/quantized_utils.h kernels/fp8.h
-                  kernels/fp4.h)
+    make_jit_source(
+      steel/gemm/gemm_nax kernels/steel/utils.h kernels/steel/gemm/nax.h
+      kernels/steel/gemm/params.h kernels/steel/gemm/transforms.h)
+    make_jit_source(steel/gemm/kernels/steel_gemm_fused_nax)
+    make_jit_source(steel/gemm/kernels/steel_gemm_gather_nax)
+    make_jit_source(steel/gemm/kernels/steel_gemm_splitk_nax)
+    make_jit_source(steel/gemm/kernels/steel_gemm_segmented_nax)
 
-  make_jit_source(steel/attn/kernels/steel_attention_nax)
+    make_jit_source(quantized_nax kernels/quantized_utils.h)
+    make_jit_source(fp_quantized_nax kernels/quantized_utils.h kernels/fp8.h
+                    kernels/fp4.h)
+
+    make_jit_source(steel/attn/kernels/steel_attention_nax)
+
+  else()
+    message(
+      WARNING "NAX kernels require Metal 4, macOS SDK >= 26.2, and "
+              "MACOSX_DEPLOYMENT_TARGET >= 26.2 (SDK ${MACOS_SDK_VERSION}, "
+              "CMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}). "
+              "Building without NAX kernels.")
+    target_compile_definitions(mlx PRIVATE MLX_METAL_NO_NAX)
+  endif()
 
 else()
   target_sources(mlx PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/nojit_kernels.cpp)

--- a/mlx/backend/metal/jit_kernels.cpp
+++ b/mlx/backend/metal/jit_kernels.cpp
@@ -8,6 +8,40 @@ using namespace fmt::literals;
 
 namespace mlx::core {
 
+#ifdef MLX_METAL_NO_NAX
+// NAX JIT preambles are only generated (via make_jit_source) when the SDK
+// requirement is met. On older SDKs they are skipped and MLX_METAL_NO_NAX is
+// defined, so is_nax_available() returns false and the get_*_nax_kernel entry
+// points below are never reached. These empty definitions only exist to satisfy
+// the linker for this translation unit.
+namespace metal {
+const char* gemm_nax() {
+  return "";
+}
+const char* steel_gemm_fused_nax() {
+  return "";
+}
+const char* steel_gemm_gather_nax() {
+  return "";
+}
+const char* steel_gemm_splitk_nax() {
+  return "";
+}
+const char* steel_gemm_segmented_nax() {
+  return "";
+}
+const char* quantized_nax() {
+  return "";
+}
+const char* fp_quantized_nax() {
+  return "";
+}
+const char* steel_attention_nax() {
+  return "";
+}
+} // namespace metal
+#endif // MLX_METAL_NO_NAX
+
 MTL::ComputePipelineState* get_arange_kernel(
     metal::Device& d,
     const std::string& kernel_name,


### PR DESCRIPTION
### Summary
The NAX kernel headers unconditionally include `<MetalPerformancePrimitives/MetalPerformancePrimitives.h>`, which only ships in the macOS 26 / Xcode 26 SDK. With `MLX_METAL_JIT=ON` on an older SDK, the build fails because the JIT preamble generator preprocesses these headers and the include cannot be resolved.

### Details
`make_jit_source` → `make_compiled_preamble.sh` runs `xcrun -sdk macosx metal -x metal -E -H` over each NAX header to enumerate/inline its dependencies. On an SDK without `MetalPerformancePrimitives`, that step fatals:

```
nax.h:12:10: fatal error: 'MetalPerformancePrimitives/MetalPerformancePrimitives.h' file not found
Error: Metal compiler header resolution failed for .../steel/gemm/gemm_nax.h
```

The **metallib** path already gates NAX on `MLX_METAL_VERSION >= 400 && MACOS_SDK_VERSION >= 26.2 && CMAKE_OSX_DEPLOYMENT_TARGET >= 26.2` (`kernels/CMakeLists.txt`), but the **JIT** path adds the NAX `make_jit_source` entries unconditionally, so a JIT build on a pre-26 SDK always tries to preprocess `nax.h` and fails. `make_compiled_preamble.sh` already intends to tolerate the framework (`grep -v "Xcode"` strips it from the inlined preamble); this only breaks when the header is absent from the SDK entirely.

### Fix
Wrap the framework include in both NAX headers with `#if __has_include(...)`:

```cpp
#if __has_include(<MetalPerformancePrimitives/MetalPerformancePrimitives.h>)
#include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>
#endif
```

On pre-26 SDKs, preprocessing now succeeds and NAX kernels are simply never JIT-compiled (they are runtime-gated by `is_nax_available()`, which is already false on non-NAX hardware). On the macOS 26 SDK the include is kept and NAX is unchanged.

### Testing
- `MLX_METAL_JIT=ON` build with Xcode 16.4 / macOS 15.5 SDK: fails before, succeeds after.
- NAX-capable hardware + macOS 26 SDK: NAX still compiled and used (include present).
