### PR TITLE
Add metadata to exported functions

### DIFF
--- a/docs/src/usage/export.rst
+++ b/docs/src/usage/export.rst
@@ -109,6 +109,33 @@ keyword arguments when calling the imported function.
   out, = imported_fun(x, z=y)
 
 
+Saving Metadata
+---------------
+
+You can save metadata, such as a model configuration, alongside an exported
+function. The metadata is a dictionary of string keys with string, integer, or
+float values:
+
+.. code-block:: python
+
+  def fun(x, y):
+    return x + y
+
+  x = mx.array(1.0)
+  y = mx.array(1.0)
+  metadata = {"description": "adds two arrays", "version": 1, "scale": 0.5}
+  mx.export_function("add.mlxfn", fun, x, y, metadata=metadata)
+
+Pass ``return_metadata=True`` to read the metadata back when importing:
+
+.. code-block:: python
+
+  imported_fun, metadata = mx.import_function("add.mlxfn", return_metadata=True)
+
+  # Prints: adds two arrays
+  print(metadata["description"])
+
+
 Exporting Modules
 -----------------
 

--- a/docs/src/usage/export.rst
+++ b/docs/src/usage/export.rst
@@ -109,6 +109,35 @@ keyword arguments when calling the imported function.
   out, = imported_fun(x, z=y)
 
 
+Saving Metadata
+---------------
+
+You can save metadata, such as a model configuration, alongside an exported
+function. The metadata is a string, so structured data can be encoded with
+JSON:
+
+.. code-block:: python
+
+  import json
+
+  def fun(x, y):
+    return x + y
+
+  x = mx.array(1.0)
+  y = mx.array(1.0)
+  config = {"description": "adds two arrays", "version": 1}
+  mx.export_function("add.mlxfn", fun, x, y, metadata=json.dumps(config))
+
+Pass ``return_metadata=True`` to read the metadata back when importing:
+
+.. code-block:: python
+
+  imported_fun, metadata = mx.import_function("add.mlxfn", return_metadata=True)
+
+  # Prints: adds two arrays
+  print(json.loads(metadata)["description"])
+
+
 Exporting Modules
 -----------------
 

--- a/mlx/export.cpp
+++ b/mlx/export.cpp
@@ -260,6 +260,55 @@ array deserialize(Reader& is) {
   return array(std::move(shape), type, nullptr, std::vector<array>{});
 }
 
+enum class MetadataValueType { String = 0, Int = 1, Float = 2 };
+
+void serialize(
+    Writer& os,
+    const std::unordered_map<std::string, MetadataValue>& metadata) {
+  serialize(os, static_cast<uint64_t>(metadata.size()));
+  for (auto& [key, value] : metadata) {
+    serialize(os, key);
+    std::visit(
+        [&os](auto&& v) {
+          using T = std::decay_t<decltype(v)>;
+          if constexpr (std::is_same_v<T, std::string>) {
+            serialize(os, MetadataValueType::String);
+          } else if constexpr (std::is_same_v<T, int64_t>) {
+            serialize(os, MetadataValueType::Int);
+          } else if constexpr (std::is_same_v<T, double>) {
+            serialize(os, MetadataValueType::Float);
+          }
+          serialize(os, v);
+        },
+        value);
+  }
+}
+
+template <>
+std::unordered_map<std::string, MetadataValue> deserialize(Reader& is) {
+  std::unordered_map<std::string, MetadataValue> metadata;
+  auto size = deserialize<uint64_t>(is);
+  metadata.reserve(size);
+  for (uint64_t i = 0; i < size; ++i) {
+    auto key = deserialize<std::string>(is);
+    switch (deserialize<MetadataValueType>(is)) {
+      case MetadataValueType::String:
+        metadata.emplace(std::move(key), deserialize<std::string>(is));
+        break;
+      case MetadataValueType::Int:
+        metadata.emplace(std::move(key), deserialize<int64_t>(is));
+        break;
+      case MetadataValueType::Float:
+        metadata.emplace(std::move(key), deserialize<double>(is));
+        break;
+      default:
+        throw std::runtime_error(
+            "[import_function] Unknown metadata value type.");
+    }
+  }
+  return metadata;
+}
+
 template <typename, typename = void>
 constexpr bool has_state = false;
 
@@ -521,10 +570,15 @@ struct PrimitiveFactory {
   };
 };
 
-void write_header(Writer& os, int count, bool shapeless) {
+void write_header(
+    Writer& os,
+    int count,
+    bool shapeless,
+    const std::unordered_map<std::string, MetadataValue>& metadata) {
   serialize(os, std::string(version()));
   serialize(os, count);
   serialize(os, shapeless);
+  serialize(os, metadata);
 }
 
 // A struct to hold and retrieve the graphs that are exported / imported
@@ -674,14 +728,16 @@ FunctionTable::Function* FunctionTable::find(
 FunctionExporter::FunctionExporter(
     const std::string& file,
     std::function<std::vector<array>(const Args&, const Kwargs&)> fun,
-    bool shapeless)
+    bool shapeless,
+    std::unordered_map<std::string, MetadataValue> metadata)
     : os(file),
       fun(std::move(fun)),
-      ftable(std::make_shared<FunctionTable>(shapeless)) {
+      ftable(std::make_shared<FunctionTable>(shapeless)),
+      metadata_(std::move(metadata)) {
   if (!os.is_open()) {
     throw std::runtime_error("[export_function] Failed to open " + file);
   }
-  write_header(os, count, shapeless);
+  write_header(os, count, shapeless, metadata_);
 }
 
 FunctionExporter::FunctionExporter(
@@ -819,7 +875,7 @@ void FunctionExporter::export_function(const Args& args, const Kwargs& kwargs) {
   // Update the header
   auto pos = os.tell();
   os.seek(0);
-  write_header(os, count, ftable->shapeless);
+  write_header(os, count, ftable->shapeless, metadata_);
   os.seek(pos);
   serialize(os, kwarg_keys);
 
@@ -898,44 +954,51 @@ void FunctionExporter::operator()(const Args& args, const Kwargs& kwargs) {
 FunctionExporter exporter(
     const std::string& file,
     const std::function<std::vector<array>(const Args&)>& fun,
-    bool shapeless /* = false */) {
+    bool shapeless /* = false */,
+    const std::unordered_map<std::string, MetadataValue>& metadata /* = {} */) {
   return FunctionExporter{
       file,
       [fun](const Args& args, const Kwargs&) { return fun(args); },
-      shapeless};
+      shapeless,
+      metadata};
 }
 
 FunctionExporter exporter(
     const std::string& file,
     const std::function<std::vector<array>(const Kwargs&)>& fun,
-    bool shapeless /* = false */) {
+    bool shapeless /* = false */,
+    const std::unordered_map<std::string, MetadataValue>& metadata /* = {} */) {
   return exporter(
       file,
       [fun](const Args&, const Kwargs kwargs) { return fun(kwargs); },
-      shapeless);
+      shapeless,
+      metadata);
 }
 
 FunctionExporter exporter(
     const std::string& file,
     const std::function<std::vector<array>(const Args&, const Kwargs&)>& fun,
-    bool shapeless /* = false */) {
-  return FunctionExporter{file, fun, shapeless};
+    bool shapeless /* = false */,
+    const std::unordered_map<std::string, MetadataValue>& metadata /* = {} */) {
+  return FunctionExporter{file, fun, shapeless, metadata};
 }
 
 void export_function(
     const std::string& file,
     const std::function<std::vector<array>(const Args&)>& fun,
     const Args& args,
-    bool shapeless /* = false */) {
-  exporter(file, fun, shapeless)(args);
+    bool shapeless /* = false */,
+    const std::unordered_map<std::string, MetadataValue>& metadata /* = {} */) {
+  exporter(file, fun, shapeless, metadata)(args);
 }
 
 void export_function(
     const std::string& file,
     const std::function<std::vector<array>(const Kwargs&)>& fun,
     const Kwargs& kwargs,
-    bool shapeless /* = false */) {
-  exporter(file, fun, shapeless)(kwargs);
+    bool shapeless /* = false */,
+    const std::unordered_map<std::string, MetadataValue>& metadata /* = {} */) {
+  exporter(file, fun, shapeless, metadata)(kwargs);
 }
 
 void export_function(
@@ -943,8 +1006,9 @@ void export_function(
     const std::function<std::vector<array>(const Args&, const Kwargs&)>& fun,
     const Args& args,
     const Kwargs& kwargs,
-    bool shapeless /* = false */) {
-  exporter(file, fun, shapeless)(args, kwargs);
+    bool shapeless /* = false */,
+    const std::unordered_map<std::string, MetadataValue>& metadata /* = {} */) {
+  exporter(file, fun, shapeless, metadata)(args, kwargs);
 }
 
 FunctionExporter exporter(
@@ -1054,6 +1118,7 @@ ImportedFunction::ImportedFunction(const std::string& file)
   auto mlx_version = deserialize<std::string>(is);
   auto function_count = deserialize<int>(is);
   ftable->shapeless = deserialize<bool>(is);
+  metadata_ = deserialize<std::unordered_map<std::string, MetadataValue>>(is);
   std::unordered_map<std::uintptr_t, array> constants;
 
   auto import_one = [&]() {

--- a/mlx/export.cpp
+++ b/mlx/export.cpp
@@ -121,6 +121,9 @@ void serialize(Writer& os, T v) {
   } else if constexpr (std::is_enum_v<T>) {
     serialize(os, static_cast<int>(v));
   } else if constexpr (std::is_same_v<T, std::nullptr_t>) {
+  } else if constexpr (std::is_same_v<T, std::string>) {
+    serialize(os, static_cast<uint64_t>(v.size()));
+    os.write(v.data(), v.size());
   } else if constexpr (is_iterable<T>) {
     serialize(os, static_cast<uint64_t>(v.size()));
     for (const auto& t : v) {
@@ -156,6 +159,19 @@ T deserialize(Reader& is) {
     return static_cast<T>(deserialize<int>(is));
   } else if constexpr (std::is_same_v<T, std::nullptr_t>) {
     return nullptr;
+  } else if constexpr (std::is_same_v<T, std::string>) {
+    auto size = deserialize<uint64_t>(is);
+    // Bound the allocation by what the file can still contain
+    auto pos = is.tell();
+    is.seek(0, std::ios_base::end);
+    auto remaining = static_cast<uint64_t>(is.tell() - pos);
+    is.seek(pos);
+    if (size > remaining) {
+      throw std::runtime_error("[import_function] Invalid string size.");
+    }
+    T v(size, '\0');
+    is.read(v.data(), size);
+    return v;
   } else if constexpr (is_iterable<T>) {
     T v;
     auto size = deserialize<uint64_t>(is);
@@ -521,10 +537,15 @@ struct PrimitiveFactory {
   };
 };
 
-void write_header(Writer& os, int count, bool shapeless) {
+void write_header(
+    Writer& os,
+    int count,
+    bool shapeless,
+    const std::string& metadata) {
   serialize(os, std::string(version()));
   serialize(os, count);
   serialize(os, shapeless);
+  serialize(os, metadata);
 }
 
 // A struct to hold and retrieve the graphs that are exported / imported
@@ -674,14 +695,16 @@ FunctionTable::Function* FunctionTable::find(
 FunctionExporter::FunctionExporter(
     const std::string& file,
     std::function<std::vector<array>(const Args&, const Kwargs&)> fun,
-    bool shapeless)
+    bool shapeless,
+    std::string metadata)
     : os(file),
       fun(std::move(fun)),
-      ftable(std::make_shared<FunctionTable>(shapeless)) {
+      ftable(std::make_shared<FunctionTable>(shapeless)),
+      metadata_(std::move(metadata)) {
   if (!os.is_open()) {
     throw std::runtime_error("[export_function] Failed to open " + file);
   }
-  write_header(os, count, shapeless);
+  write_header(os, count, shapeless, metadata_);
 }
 
 FunctionExporter::FunctionExporter(
@@ -819,7 +842,7 @@ void FunctionExporter::export_function(const Args& args, const Kwargs& kwargs) {
   // Update the header
   auto pos = os.tell();
   os.seek(0);
-  write_header(os, count, ftable->shapeless);
+  write_header(os, count, ftable->shapeless, metadata_);
   os.seek(pos);
   serialize(os, kwarg_keys);
 
@@ -898,44 +921,51 @@ void FunctionExporter::operator()(const Args& args, const Kwargs& kwargs) {
 FunctionExporter exporter(
     const std::string& file,
     const std::function<std::vector<array>(const Args&)>& fun,
-    bool shapeless /* = false */) {
+    bool shapeless /* = false */,
+    const std::string& metadata /* = "" */) {
   return FunctionExporter{
       file,
       [fun](const Args& args, const Kwargs&) { return fun(args); },
-      shapeless};
+      shapeless,
+      metadata};
 }
 
 FunctionExporter exporter(
     const std::string& file,
     const std::function<std::vector<array>(const Kwargs&)>& fun,
-    bool shapeless /* = false */) {
+    bool shapeless /* = false */,
+    const std::string& metadata /* = "" */) {
   return exporter(
       file,
       [fun](const Args&, const Kwargs kwargs) { return fun(kwargs); },
-      shapeless);
+      shapeless,
+      metadata);
 }
 
 FunctionExporter exporter(
     const std::string& file,
     const std::function<std::vector<array>(const Args&, const Kwargs&)>& fun,
-    bool shapeless /* = false */) {
-  return FunctionExporter{file, fun, shapeless};
+    bool shapeless /* = false */,
+    const std::string& metadata /* = "" */) {
+  return FunctionExporter{file, fun, shapeless, metadata};
 }
 
 void export_function(
     const std::string& file,
     const std::function<std::vector<array>(const Args&)>& fun,
     const Args& args,
-    bool shapeless /* = false */) {
-  exporter(file, fun, shapeless)(args);
+    bool shapeless /* = false */,
+    const std::string& metadata /* = "" */) {
+  exporter(file, fun, shapeless, metadata)(args);
 }
 
 void export_function(
     const std::string& file,
     const std::function<std::vector<array>(const Kwargs&)>& fun,
     const Kwargs& kwargs,
-    bool shapeless /* = false */) {
-  exporter(file, fun, shapeless)(kwargs);
+    bool shapeless /* = false */,
+    const std::string& metadata /* = "" */) {
+  exporter(file, fun, shapeless, metadata)(kwargs);
 }
 
 void export_function(
@@ -943,8 +973,9 @@ void export_function(
     const std::function<std::vector<array>(const Args&, const Kwargs&)>& fun,
     const Args& args,
     const Kwargs& kwargs,
-    bool shapeless /* = false */) {
-  exporter(file, fun, shapeless)(args, kwargs);
+    bool shapeless /* = false */,
+    const std::string& metadata /* = "" */) {
+  exporter(file, fun, shapeless, metadata)(args, kwargs);
 }
 
 FunctionExporter exporter(
@@ -1054,6 +1085,7 @@ ImportedFunction::ImportedFunction(const std::string& file)
   auto mlx_version = deserialize<std::string>(is);
   auto function_count = deserialize<int>(is);
   ftable->shapeless = deserialize<bool>(is);
+  metadata_ = deserialize<std::string>(is);
   std::unordered_map<std::uintptr_t, array> constants;
 
   auto import_one = [&]() {

--- a/mlx/export.h
+++ b/mlx/export.h
@@ -14,6 +14,11 @@ namespace mlx::core {
 using Args = std::vector<array>;
 using Kwargs = std::unordered_map<std::string, array>;
 
+// Metadata values saved alongside an exported function. The integer and
+// floating point alternatives are 64-bit to hold Python int and float without
+// narrowing (e.g. a parameter count above 2^31, or a non-power-of-two float).
+using MetadataValue = std::variant<std::string, int64_t, double>;
+
 // Possible types for a Primitive's state
 using StateT = std::variant<
     bool,
@@ -50,17 +55,20 @@ struct FunctionExporter;
 MLX_API FunctionExporter exporter(
     const std::string& file,
     const std::function<std::vector<array>(const Args&)>& fun,
-    bool shapeless = false);
+    bool shapeless = false,
+    const std::unordered_map<std::string, MetadataValue>& metadata = {});
 
 MLX_API FunctionExporter exporter(
     const std::string& file,
     const std::function<std::vector<array>(const Kwargs&)>& fun,
-    bool shapeless = false);
+    bool shapeless = false,
+    const std::unordered_map<std::string, MetadataValue>& metadata = {});
 
 MLX_API FunctionExporter exporter(
     const std::string& path,
     const std::function<std::vector<array>(const Args&, const Kwargs&)>& fun,
-    bool shapeless = false);
+    bool shapeless = false,
+    const std::unordered_map<std::string, MetadataValue>& metadata = {});
 
 /**
  * Export a function to a file.
@@ -69,20 +77,23 @@ MLX_API void export_function(
     const std::string& file,
     const std::function<std::vector<array>(const Args&)>& fun,
     const Args& args,
-    bool shapeless = false);
+    bool shapeless = false,
+    const std::unordered_map<std::string, MetadataValue>& metadata = {});
 
 MLX_API void export_function(
     const std::string& file,
     const std::function<std::vector<array>(const Kwargs&)>& fun,
     const Kwargs& kwargs,
-    bool shapeless = false);
+    bool shapeless = false,
+    const std::unordered_map<std::string, MetadataValue>& metadata = {});
 
 MLX_API void export_function(
     const std::string& file,
     const std::function<std::vector<array>(const Args&, const Kwargs&)>& fun,
     const Args& args,
     const Kwargs& kwargs,
-    bool shapeless = false);
+    bool shapeless = false,
+    const std::unordered_map<std::string, MetadataValue>& metadata = {});
 
 struct ImportedFunction;
 

--- a/mlx/export.h
+++ b/mlx/export.h
@@ -50,17 +50,20 @@ struct FunctionExporter;
 MLX_API FunctionExporter exporter(
     const std::string& file,
     const std::function<std::vector<array>(const Args&)>& fun,
-    bool shapeless = false);
+    bool shapeless = false,
+    const std::string& metadata = "");
 
 MLX_API FunctionExporter exporter(
     const std::string& file,
     const std::function<std::vector<array>(const Kwargs&)>& fun,
-    bool shapeless = false);
+    bool shapeless = false,
+    const std::string& metadata = "");
 
 MLX_API FunctionExporter exporter(
     const std::string& path,
     const std::function<std::vector<array>(const Args&, const Kwargs&)>& fun,
-    bool shapeless = false);
+    bool shapeless = false,
+    const std::string& metadata = "");
 
 /**
  * Export a function to a file.
@@ -69,20 +72,23 @@ MLX_API void export_function(
     const std::string& file,
     const std::function<std::vector<array>(const Args&)>& fun,
     const Args& args,
-    bool shapeless = false);
+    bool shapeless = false,
+    const std::string& metadata = "");
 
 MLX_API void export_function(
     const std::string& file,
     const std::function<std::vector<array>(const Kwargs&)>& fun,
     const Kwargs& kwargs,
-    bool shapeless = false);
+    bool shapeless = false,
+    const std::string& metadata = "");
 
 MLX_API void export_function(
     const std::string& file,
     const std::function<std::vector<array>(const Args&, const Kwargs&)>& fun,
     const Args& args,
     const Kwargs& kwargs,
-    bool shapeless = false);
+    bool shapeless = false,
+    const std::string& metadata = "");
 
 struct ImportedFunction;
 

--- a/mlx/export_impl.h
+++ b/mlx/export_impl.h
@@ -27,17 +27,20 @@ struct MLX_API FunctionExporter {
   friend MLX_API FunctionExporter exporter(
       const std::string&,
       const std::function<std::vector<array>(const Args&)>&,
-      bool shapeless);
+      bool shapeless,
+      const std::unordered_map<std::string, MetadataValue>& metadata);
 
   friend MLX_API FunctionExporter exporter(
       const std::string&,
       const std::function<std::vector<array>(const Kwargs&)>&,
-      bool shapeless);
+      bool shapeless,
+      const std::unordered_map<std::string, MetadataValue>& metadata);
 
   friend MLX_API FunctionExporter exporter(
       const std::string&,
       const std::function<std::vector<array>(const Args&, const Kwargs&)>&,
-      bool shapeless);
+      bool shapeless,
+      const std::unordered_map<std::string, MetadataValue>& metadata);
 
   friend MLX_API FunctionExporter exporter(
       const ExportCallback&,
@@ -57,7 +60,8 @@ struct MLX_API FunctionExporter {
   FunctionExporter(
       const std::string& file,
       std::function<std::vector<array>(const Args&, const Kwargs&)> fun,
-      bool shapeless);
+      bool shapeless,
+      std::unordered_map<std::string, MetadataValue> metadata);
 
   FunctionExporter(
       const ExportCallback& callback,
@@ -77,6 +81,7 @@ struct MLX_API FunctionExporter {
   int count{0};
   bool closed{false};
   std::shared_ptr<FunctionTable> ftable;
+  std::unordered_map<std::string, MetadataValue> metadata_;
 };
 
 struct MLX_API ImportedFunction {
@@ -88,12 +93,18 @@ struct MLX_API ImportedFunction {
   std::vector<array> operator()(const Kwargs& kwargs) const;
   std::vector<array> operator()(const Args& args, const Kwargs& kwargs) const;
 
+  // The metadata saved with the function when it was exported.
+  const std::unordered_map<std::string, MetadataValue>& metadata() const {
+    return metadata_;
+  }
+
  private:
   ImportedFunction(const std::string& file);
   friend MLX_API ImportedFunction import_function(const std::string&);
   ImportedFunction();
 
   std::shared_ptr<FunctionTable> ftable;
+  std::unordered_map<std::string, MetadataValue> metadata_;
 };
 
 } // namespace mlx::core

--- a/mlx/export_impl.h
+++ b/mlx/export_impl.h
@@ -27,17 +27,20 @@ struct MLX_API FunctionExporter {
   friend MLX_API FunctionExporter exporter(
       const std::string&,
       const std::function<std::vector<array>(const Args&)>&,
-      bool shapeless);
+      bool shapeless,
+      const std::string& metadata);
 
   friend MLX_API FunctionExporter exporter(
       const std::string&,
       const std::function<std::vector<array>(const Kwargs&)>&,
-      bool shapeless);
+      bool shapeless,
+      const std::string& metadata);
 
   friend MLX_API FunctionExporter exporter(
       const std::string&,
       const std::function<std::vector<array>(const Args&, const Kwargs&)>&,
-      bool shapeless);
+      bool shapeless,
+      const std::string& metadata);
 
   friend MLX_API FunctionExporter exporter(
       const ExportCallback&,
@@ -57,7 +60,8 @@ struct MLX_API FunctionExporter {
   FunctionExporter(
       const std::string& file,
       std::function<std::vector<array>(const Args&, const Kwargs&)> fun,
-      bool shapeless);
+      bool shapeless,
+      std::string metadata);
 
   FunctionExporter(
       const ExportCallback& callback,
@@ -77,6 +81,7 @@ struct MLX_API FunctionExporter {
   int count{0};
   bool closed{false};
   std::shared_ptr<FunctionTable> ftable;
+  std::string metadata_;
 };
 
 struct MLX_API ImportedFunction {
@@ -88,12 +93,18 @@ struct MLX_API ImportedFunction {
   std::vector<array> operator()(const Kwargs& kwargs) const;
   std::vector<array> operator()(const Args& args, const Kwargs& kwargs) const;
 
+  // The metadata saved with the function when it was exported.
+  const std::string& metadata() const {
+    return metadata_;
+  }
+
  private:
   ImportedFunction(const std::string& file);
   friend MLX_API ImportedFunction import_function(const std::string&);
   ImportedFunction();
 
   std::shared_ptr<FunctionTable> ftable;
+  std::string metadata_;
 };
 
 } // namespace mlx::core

--- a/python/src/export.cpp
+++ b/python/src/export.cpp
@@ -138,6 +138,8 @@ void init_export(nb::module_& m) {
          const nb::callable& fun,
          const nb::args& args,
          bool shapeless,
+         const std::optional<
+             std::unordered_map<std::string, mx::MetadataValue>>& metadata,
          const nb::kwargs& kwargs) {
         auto [args_, kwargs_] =
             validate_and_extract_inputs(args, kwargs, "[export_function]");
@@ -147,8 +149,15 @@ void init_export(nb::module_& m) {
               wrap_export_function(fun),
               args_,
               kwargs_,
-              shapeless);
+              shapeless,
+              metadata.value_or(
+                  std::unordered_map<std::string, mx::MetadataValue>{}));
         } else {
+          if (metadata && !metadata->empty()) {
+            throw std::invalid_argument(
+                "[export_function] The metadata argument is only supported "
+                "when exporting to a file, not when using a callback.");
+          }
           auto callback = nb::cast<nb::callable>(file_or_callback);
           auto wrapped_callback =
               [callback](const mx::ExportCallbackInput& input) {
@@ -163,9 +172,10 @@ void init_export(nb::module_& m) {
       "args"_a,
       nb::kw_only(),
       "shapeless"_a = false,
+      "metadata"_a = nb::none(),
       "kwargs"_a,
       nb::sig(
-          "def export_function(file_or_callback: Union[str, Callable], fun: Callable, *args, shapeless: bool = False, **kwargs) -> None"),
+          "def export_function(file_or_callback: Union[str, Callable], fun: Callable, *args, shapeless: bool = False, metadata: Optional[dict[str, Union[str, int, float]]] = None, **kwargs) -> None"),
       R"pbdoc(
         Export an MLX function.
 
@@ -187,6 +197,10 @@ void init_export(nb::module_& m) {
             *args (array): Example array inputs to the function.
             shapeless (bool, optional): Whether or not the function allows
               inputs with variable shapes. Default: ``False``.
+            metadata (dict, optional): A dictionary of string keys and string,
+              integer, or float values to save alongside the function. Only
+              supported when exporting to a file. Read it back with
+              :func:`import_function`. Default: ``None``.
             **kwargs (array): Additional example keyword array inputs to the
               function.
 
@@ -203,17 +217,25 @@ void init_export(nb::module_& m) {
       )pbdoc");
   m.def(
       "import_function",
-      [](const std::string& file) {
-        return nb::cpp_function(
-            [fn = mx::import_function(file)](
+      [](const std::string& file, bool return_metadata) -> nb::object {
+        auto imported = mx::import_function(file);
+        auto metadata = imported.metadata();
+        auto fn = nb::cpp_function(
+            [imported = std::move(imported)](
                 const nb::args& args, const nb::kwargs& kwargs) {
               auto [args_, kwargs_] = validate_and_extract_inputs(
                   args, kwargs, "[import_function::call]");
-              return nb::tuple(nb::cast(fn(args_, kwargs_)));
+              return nb::tuple(nb::cast(imported(args_, kwargs_)));
             });
+        if (return_metadata) {
+          return nb::make_tuple(fn, nb::cast(metadata));
+        }
+        return fn;
       },
       "file"_a,
-      nb::sig("def import_function(file: str) -> Callable"),
+      "return_metadata"_a = false,
+      nb::sig(
+          "def import_function(file: str, return_metadata: bool = False) -> Union[Callable, tuple[Callable, dict[str, Union[str, int, float]]]]"),
       R"pbdoc(
         Import a function from a file.
 
@@ -230,9 +252,14 @@ void init_export(nb::module_& m) {
 
         Args:
             file (str): The file path to import the function from.
+            return_metadata (bool, optional): If ``True`` also return the
+              metadata saved with the function as a dictionary. Default:
+              ``False``.
 
         Returns:
-            Callable: The imported function.
+            Callable: The imported function. If ``return_metadata`` is ``True``
+            a tuple of the imported function and the metadata dictionary is
+            returned instead.
 
         Example:
           >>> fn = mx.import_function("function.mlxfn")
@@ -274,14 +301,25 @@ void init_export(nb::module_& m) {
 
   m.def(
       "exporter",
-      [](const std::string& file, nb::callable fun, bool shapeless) {
+      [](const std::string& file,
+         nb::callable fun,
+         bool shapeless,
+         const std::optional<
+             std::unordered_map<std::string, mx::MetadataValue>>& metadata) {
         return PyFunctionExporter{
-            mx::exporter(file, wrap_export_function(fun), shapeless), fun};
+            mx::exporter(
+                file,
+                wrap_export_function(fun),
+                shapeless,
+                metadata.value_or(
+                    std::unordered_map<std::string, mx::MetadataValue>{})),
+            fun};
       },
       "file"_a,
       "fun"_a,
       nb::kw_only(),
       "shapeless"_a = false,
+      "metadata"_a = nb::none(),
       R"pbdoc(
         Make a callable object to export multiple traces of a function to a file.
 
@@ -295,6 +333,9 @@ void init_export(nb::module_& m) {
             file (str): File path to export the function to.
             shapeless (bool, optional): Whether or not the function allows
               inputs with variable shapes. Default: ``False``.
+            metadata (dict, optional): A dictionary of string keys and string,
+              integer, or float values to save alongside the function. Read it
+              back with :func:`import_function`. Default: ``None``.
 
         Example:
 

--- a/python/src/export.cpp
+++ b/python/src/export.cpp
@@ -138,6 +138,7 @@ void init_export(nb::module_& m) {
          const nb::callable& fun,
          const nb::args& args,
          bool shapeless,
+         const std::optional<std::string>& metadata,
          const nb::kwargs& kwargs) {
         auto [args_, kwargs_] =
             validate_and_extract_inputs(args, kwargs, "[export_function]");
@@ -147,8 +148,14 @@ void init_export(nb::module_& m) {
               wrap_export_function(fun),
               args_,
               kwargs_,
-              shapeless);
+              shapeless,
+              metadata.value_or(""));
         } else {
+          if (metadata && !metadata->empty()) {
+            throw std::invalid_argument(
+                "[export_function] The metadata argument is only supported "
+                "when exporting to a file, not when using a callback.");
+          }
           auto callback = nb::cast<nb::callable>(file_or_callback);
           auto wrapped_callback =
               [callback](const mx::ExportCallbackInput& input) {
@@ -163,9 +170,10 @@ void init_export(nb::module_& m) {
       "args"_a,
       nb::kw_only(),
       "shapeless"_a = false,
+      "metadata"_a = nb::none(),
       "kwargs"_a,
       nb::sig(
-          "def export_function(file_or_callback: Union[str, Callable], fun: Callable, *args, shapeless: bool = False, **kwargs) -> None"),
+          "def export_function(file_or_callback: Union[str, Callable], fun: Callable, *args, shapeless: bool = False, metadata: Optional[str] = None, **kwargs) -> None"),
       R"pbdoc(
         Export an MLX function.
 
@@ -187,8 +195,15 @@ void init_export(nb::module_& m) {
             *args (array): Example array inputs to the function.
             shapeless (bool, optional): Whether or not the function allows
               inputs with variable shapes. Default: ``False``.
+            metadata (str, optional): A string to save alongside the
+              function, for example a JSON encoded model configuration. Only
+              supported when exporting to a file. Read it back with
+              :func:`import_function`. Default: ``None``.
             **kwargs (array): Additional example keyword array inputs to the
               function.
+
+        Raises:
+            ValueError: If ``metadata`` is given when exporting with a callback.
 
         Example:
 
@@ -203,17 +218,25 @@ void init_export(nb::module_& m) {
       )pbdoc");
   m.def(
       "import_function",
-      [](const std::string& file) {
-        return nb::cpp_function(
-            [fn = mx::import_function(file)](
+      [](const std::string& file, bool return_metadata) -> nb::object {
+        auto imported = mx::import_function(file);
+        auto metadata = imported.metadata();
+        auto fn = nb::cpp_function(
+            [imported = std::move(imported)](
                 const nb::args& args, const nb::kwargs& kwargs) {
               auto [args_, kwargs_] = validate_and_extract_inputs(
                   args, kwargs, "[import_function::call]");
-              return nb::tuple(nb::cast(fn(args_, kwargs_)));
+              return nb::tuple(nb::cast(imported(args_, kwargs_)));
             });
+        if (return_metadata) {
+          return nb::make_tuple(fn, nb::cast(metadata));
+        }
+        return fn;
       },
       "file"_a,
-      nb::sig("def import_function(file: str) -> Callable"),
+      "return_metadata"_a = false,
+      nb::sig(
+          "def import_function(file: str, return_metadata: bool = False) -> Union[Callable, tuple[Callable, str]]"),
       R"pbdoc(
         Import a function from a file.
 
@@ -230,15 +253,20 @@ void init_export(nb::module_& m) {
 
         Args:
             file (str): The file path to import the function from.
+            return_metadata (bool, optional): If ``True`` also return the
+              metadata string saved with the function. Default: ``False``.
 
         Returns:
-            Callable: The imported function.
+            Callable or tuple:
+                The imported function. If ``return_metadata`` is ``True`` a
+                tuple of the imported function and the metadata string is
+                returned instead.
 
         Example:
           >>> fn = mx.import_function("function.mlxfn")
           >>> out = fn(a, b, x=x, y=y)[0]
           >>>
-          >>> out = fn((a, b), {"x": x, "y": y}[0]
+          >>> out = fn((a, b), {"x": x, "y": y})[0]
       )pbdoc");
 
   nb::class_<PyFunctionExporter>(
@@ -274,14 +302,23 @@ void init_export(nb::module_& m) {
 
   m.def(
       "exporter",
-      [](const std::string& file, nb::callable fun, bool shapeless) {
+      [](const std::string& file,
+         nb::callable fun,
+         bool shapeless,
+         const std::optional<std::string>& metadata) {
         return PyFunctionExporter{
-            mx::exporter(file, wrap_export_function(fun), shapeless), fun};
+            mx::exporter(
+                file,
+                wrap_export_function(fun),
+                shapeless,
+                metadata.value_or("")),
+            fun};
       },
       "file"_a,
       "fun"_a,
       nb::kw_only(),
       "shapeless"_a = false,
+      "metadata"_a = nb::none(),
       R"pbdoc(
         Make a callable object to export multiple traces of a function to a file.
 
@@ -295,6 +332,9 @@ void init_export(nb::module_& m) {
             file (str): File path to export the function to.
             shapeless (bool, optional): Whether or not the function allows
               inputs with variable shapes. Default: ``False``.
+            metadata (str, optional): A string to save alongside the
+              function, for example a JSON encoded model configuration. Read
+              it back with :func:`import_function`. Default: ``None``.
 
         Example:
 

--- a/python/tests/test_export_import.py
+++ b/python/tests/test_export_import.py
@@ -704,6 +704,50 @@ class TestExportImport(mlx_tests.MLXTestCase):
         imported = mx.import_function(path)
         self.assertTrue(mx.array_equal(imported(x, y, z)[0], fun(x, y, z)))
 
+    def test_export_import_metadata(self):
+        path = os.path.join(self.test_dir, "fn.mlxfn")
+
+        def fun(x):
+            return mx.abs(x)
+
+        x = mx.array([1.0, -2.0, 3.0])
+        # A value above 2**31 and a non-exact float, to catch narrowing
+        metadata = {"name": "model", "params": 7_000_000_000, "lr": 0.1}
+
+        mx.export_function(path, fun, x, metadata=metadata)
+
+        # No metadata returned by default, callable still works
+        imported = mx.import_function(path)
+        self.assertTrue(mx.array_equal(imported(x)[0], fun(x)))
+
+        # Metadata read back with value types and exact values preserved
+        imported, imported_metadata = mx.import_function(path, return_metadata=True)
+        self.assertEqual(imported_metadata, metadata)
+        self.assertIsInstance(imported_metadata["name"], str)
+        self.assertIsInstance(imported_metadata["params"], int)
+        self.assertIsInstance(imported_metadata["lr"], float)
+        self.assertTrue(mx.array_equal(imported(x)[0], fun(x)))
+
+        # No metadata gives an empty dict
+        mx.export_function(path, fun, x)
+        _, imported_metadata = mx.import_function(path, return_metadata=True)
+        self.assertEqual(imported_metadata, {})
+
+        # Metadata survives the per-trace header rewrite of a multi-trace export
+        with mx.exporter(path, fun, metadata=metadata) as exporter:
+            exporter(mx.array([1.0]))
+            exporter(mx.array([1.0, 2.0]))
+        _, imported_metadata = mx.import_function(path, return_metadata=True)
+        self.assertEqual(imported_metadata, metadata)
+
+        # Unsupported value types are rejected
+        with self.assertRaises(TypeError):
+            mx.export_function(path, fun, x, metadata={"bad": [1, 2]})
+
+        # Metadata is not supported with a callback
+        with self.assertRaises(ValueError):
+            mx.export_function(lambda x: None, fun, x, metadata=metadata)
+
 
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner()

--- a/python/tests/test_export_import.py
+++ b/python/tests/test_export_import.py
@@ -1,6 +1,7 @@
 # Copyright © 2024 Apple Inc.
 
 import gc
+import json
 import os
 import tempfile
 import unittest
@@ -747,6 +748,42 @@ class TestExportImport(mlx_tests.MLXTestCase):
                 (y,) = imported(x)
                 self.assertEqual(y.shape, (B, seq_len, H))
                 self.assertTrue(mx.allclose(y, expected))
+
+    def test_export_import_metadata(self):
+        path = os.path.join(self.test_dir, "fn.mlxfn")
+
+        def fun(x):
+            return mx.abs(x)
+
+        x = mx.array([1.0, -2.0, 3.0])
+        metadata = json.dumps({"name": "model", "params": 7_000_000_000, "lr": 0.1})
+
+        mx.export_function(path, fun, x, metadata=metadata)
+
+        imported = mx.import_function(path)
+        self.assertTrue(mx.array_equal(imported(x)[0], fun(x)))
+
+        imported, imported_metadata = mx.import_function(path, return_metadata=True)
+        self.assertEqual(imported_metadata, metadata)
+        self.assertEqual(json.loads(imported_metadata)["params"], 7_000_000_000)
+        self.assertTrue(mx.array_equal(imported(x)[0], fun(x)))
+
+        mx.export_function(path, fun, x)
+        _, imported_metadata = mx.import_function(path, return_metadata=True)
+        self.assertEqual(imported_metadata, "")
+
+        # Metadata survives the per-trace header rewrite of a multi-trace export
+        with mx.exporter(path, fun, metadata=metadata) as exporter:
+            exporter(mx.array([1.0]))
+            exporter(mx.array([1.0, 2.0]))
+        _, imported_metadata = mx.import_function(path, return_metadata=True)
+        self.assertEqual(imported_metadata, metadata)
+
+        with self.assertRaises(TypeError):
+            mx.export_function(path, fun, x, metadata={"name": "model"})
+
+        with self.assertRaises(ValueError):
+            mx.export_function(lambda x: None, fun, x, metadata=metadata)
 
 
 if __name__ == "__main__":

--- a/tests/export_import_tests.cpp
+++ b/tests/export_import_tests.cpp
@@ -161,3 +161,38 @@ TEST_CASE("test export function on different stream") {
   // Should make a new stream that we can run computation on
   eval(import_function(file_path)({array({0, 1, 2})}));
 }
+
+TEST_CASE("test export import with metadata") {
+  std::string file_path = get_temp_file("model.mlxfn");
+
+  auto fun = [](const std::vector<array>& args) -> std::vector<array> {
+    return {abs(args[0])};
+  };
+
+  // A value above 2^31 and a non-power-of-two float, to catch narrowing
+  std::unordered_map<std::string, MetadataValue> metadata = {
+      {"name", std::string("model")},
+      {"params", int64_t(7000000000)},
+      {"lr", 0.1}};
+
+  export_function(file_path, fun, {array({0, 1, 2})}, false, metadata);
+
+  auto imported = import_function(file_path);
+  CHECK(imported.metadata() == metadata);
+  CHECK(std::get<std::string>(imported.metadata().at("name")) == "model");
+  CHECK(std::get<int64_t>(imported.metadata().at("params")) == 7000000000);
+  CHECK(std::get<double>(imported.metadata().at("lr")) == 0.1);
+  eval(imported({array({0, 1, 2})}));
+
+  // No metadata gives an empty map
+  export_function(file_path, fun, {array({0, 1, 2})});
+  CHECK(import_function(file_path).metadata().empty());
+
+  // Metadata survives the per-trace header rewrite of a multi-trace export
+  {
+    auto fn_exporter = exporter(file_path, fun, false, metadata);
+    fn_exporter({array({0, 1})});
+    fn_exporter({array({0, 1, 2})});
+  }
+  CHECK(import_function(file_path).metadata() == metadata);
+}

--- a/tests/export_import_tests.cpp
+++ b/tests/export_import_tests.cpp
@@ -161,3 +161,31 @@ TEST_CASE("test export function on different stream") {
   // Should make a new stream that we can run computation on
   eval(import_function(file_path)({array({0, 1, 2})}));
 }
+
+TEST_CASE("test export import with metadata") {
+  std::string file_path = get_temp_file("model.mlxfn");
+
+  auto fun = [](const std::vector<array>& args) -> std::vector<array> {
+    return {abs(args[0])};
+  };
+
+  std::string metadata = "{\"name\": \"model\", \"params\": 7000000000}";
+
+  export_function(file_path, fun, {array({0, 1, 2})}, false, metadata);
+
+  auto imported = import_function(file_path);
+  CHECK(imported.metadata() == metadata);
+  eval(imported({array({0, 1, 2})}));
+
+  // No metadata gives an empty string
+  export_function(file_path, fun, {array({0, 1, 2})});
+  CHECK(import_function(file_path).metadata().empty());
+
+  // Metadata survives the per-trace header rewrite of a multi-trace export
+  {
+    auto fn_exporter = exporter(file_path, fun, false, metadata);
+    fn_exporter({array({0, 1})});
+    fn_exporter({array({0, 1, 2})});
+  }
+  CHECK(import_function(file_path).metadata() == metadata);
+}


### PR DESCRIPTION
Closes #2410. Exported `.mlxfn` files can now store a metadata string, so a model's config can live with the function instead of in a separate JSON file.

`export_function` and `exporter` take an optional `metadata` string and `import_function(file, return_metadata=True)` returns the function along with it. Structured config can go into the string as JSON, which is what the docs example does. Metadata is only supported when exporting to a file. Passing it with a callback raises.

String fields in the header are now written in one bulk write instead of a write per byte. Without that, a 1 MB metadata string took seconds per trace in a multi-trace export.

The metadata lives in the file header, so a `.mlxfn` written before this change has no metadata section and won't load in a metadata-aware build. That matches the existing note that exported functions aren't compatible across MLX versions.
