### PR TITLE
Skip non-quantizable modules in nn.quantize with a custom predicate

### DIFF
--- a/python/mlx/nn/layers/quantized.py
+++ b/python/mlx/nn/layers/quantized.py
@@ -50,8 +50,13 @@ def quantize(
         class_predicate (Optional[Callable]): A callable which receives the
            :obj:`Module` path and :obj:`Module` itself and returns ``True`` or a
            dict of params for ``to_quantized`` if it should be quantized and
-           ``False`` otherwise. If ``None``, then all layers that define a
-           ``to_quantized()`` method are quantized. Default: ``None``.
+           ``False`` otherwise. A module selected by the predicate but without a
+           ``to_quantized()`` method (for example a normalization or activation
+           layer) is skipped rather than quantized, so a broad predicate can be
+           applied to a whole model. If the predicate selects *only* such
+           modules and nothing is quantized, a :obj:`ValueError` is raised, since
+           that request cannot be satisfied. If ``None``, then all layers that
+           define a ``to_quantized()`` method are quantized. Default: ``None``.
 
     Example:
         Weight only quantization for all layers that define a ``to_quantized()`` method:
@@ -64,34 +69,55 @@ def quantize(
         >>> predicate = lambda p, m: isinstance(m, nn.Linear)
         >>> nn.quantize(model, mode="nvfp4", quantize_input=True, class_predicate=predicate)
     """
+    # The default predicate only selects quantizable leaves, so it never trips
+    # the "selected only unquantizable modules" diagnostic below.
     class_predicate = class_predicate or (lambda _, m: hasattr(m, "to_quantized"))
 
+    # A broad predicate (e.g. ``lambda p, m: True``) may match leaves that have
+    # no ``to_quantized()`` method, such as norms or activations. Those are
+    # skipped so the predicate can be applied to a whole model. We still want to
+    # flag a predicate that selects *only* such modules, so track whether
+    # anything was quantized and which unquantizable types were selected.
+    quantized_any = False
+    unquantizable_selected = set()
+
     def _maybe_quantize(path, m):
-        if bool_or_params := class_predicate(path, m):
-            if hasattr(m, "to_quantized"):
-                if isinstance(bool_or_params, bool):
-                    kwargs = {"group_size": group_size, "bits": bits, "mode": mode}
-                    if quantize_input:
-                        kwargs["quantize_input"] = quantize_input
-                    return m.to_quantized(**kwargs)
-                elif isinstance(bool_or_params, dict):
-                    if ("quantize_input" in bool_or_params) and not bool_or_params[
-                        "quantize_input"
-                    ]:
-                        bool_or_params.pop("quantize_input")
-                    return m.to_quantized(**bool_or_params)
-                else:
-                    raise ValueError(
-                        "``class_predicate`` must return a bool"
-                        " or a dict of parameters to pass to ``to_quantized``"
-                    )
-            else:
-                raise ValueError(f"Unable to quantize model of type {type(m)}")
-        else:
+        nonlocal quantized_any
+        bool_or_params = class_predicate(path, m)
+        if not bool_or_params:
             return m
+        if not hasattr(m, "to_quantized"):
+            unquantizable_selected.add(type(m).__name__)
+            return m
+
+        if isinstance(bool_or_params, bool):
+            kwargs = {"group_size": group_size, "bits": bits, "mode": mode}
+            if quantize_input:
+                kwargs["quantize_input"] = quantize_input
+        elif isinstance(bool_or_params, dict):
+            # Copy so a predicate returning a shared dict is not mutated.
+            kwargs = dict(bool_or_params)
+            if not kwargs.get("quantize_input", True):
+                kwargs.pop("quantize_input")
+        else:
+            raise ValueError(
+                "``class_predicate`` must return a bool"
+                " or a dict of parameters to pass to ``to_quantized``"
+            )
+
+        quantized_any = True
+        return m.to_quantized(**kwargs)
 
     leaves = model.leaf_modules()
     leaves = tree_map_with_path(_maybe_quantize, leaves, is_leaf=Module.is_module)
+
+    if unquantizable_selected and not quantized_any:
+        types = ", ".join(sorted(unquantizable_selected))
+        raise ValueError(
+            f"``class_predicate`` selected only modules without a "
+            f"``to_quantized()`` method ({types}); nothing could be quantized."
+        )
+
     model.update_modules(leaves)
 
 

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -242,6 +242,106 @@ class TestBase(mlx_tests.MLXTestCase):
         with self.assertRaises(ValueError) as context:
             nn.quantize(m, group_size=32, mode="mxfp8", quantize_input=True)
 
+        # A broad predicate that incidentally matches a module without
+        # to_quantized (a norm, an activation, ...) should skip that module
+        # rather than abort the whole call.
+        class NotQuantizable(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = mx.zeros((8, 64))
+
+        class Block(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.proj = nn.Linear(64, 64)
+                self.gate = NotQuantizable()
+
+        m = Block()
+        nn.quantize(m, group_size=64, bits=4, class_predicate=lambda p, m: True)
+        self.assertTrue(isinstance(m.proj, nn.QuantizedLinear))
+        self.assertTrue(isinstance(m.gate, NotQuantizable))
+        self.assertFalse(isinstance(m.gate, nn.QuantizedLinear))
+
+        # Same when the predicate returns a params dict instead of True.
+        m = Block()
+        nn.quantize(
+            m,
+            class_predicate=lambda p, mod: {"group_size": 64, "bits": 4},
+        )
+        self.assertTrue(isinstance(m.proj, nn.QuantizedLinear))
+        self.assertTrue(isinstance(m.gate, NotQuantizable))
+
+        # A predicate that also selects a quantizable module is fine: the
+        # quantizable one is converted and the rest are skipped, no raise.
+        m = Block()
+        nn.quantize(
+            m,
+            group_size=64,
+            bits=4,
+            class_predicate=lambda p, mod: isinstance(mod, (nn.Linear, NotQuantizable)),
+        )
+        self.assertTrue(isinstance(m.proj, nn.QuantizedLinear))
+        self.assertTrue(isinstance(m.gate, NotQuantizable))
+
+        # A predicate that selects *only* modules without to_quantized asked
+        # for something impossible, so it should raise rather than silently
+        # return an unchanged model. The error names the offending type.
+        m = Block()
+        with self.assertRaises(ValueError) as context:
+            nn.quantize(
+                m, class_predicate=lambda p, mod: isinstance(mod, NotQuantizable)
+            )
+        self.assertIn("NotQuantizable", str(context.exception))
+        # The model must be left unchanged on that error path.
+        self.assertTrue(isinstance(m.proj, nn.Linear))
+        self.assertFalse(isinstance(m.proj, nn.QuantizedLinear))
+        self.assertTrue(isinstance(m.gate, NotQuantizable))
+
+        # A predicate returning neither a bool nor a dict is an error.
+        m = Block()
+        with self.assertRaises(ValueError):
+            nn.quantize(m, class_predicate=lambda p, mod: 3.5)
+
+        # A predicate that selects nothing at all is a no-op, not an error.
+        m = Block()
+        nn.quantize(m, group_size=64, bits=4, class_predicate=lambda p, mod: False)
+        self.assertTrue(isinstance(m.proj, nn.Linear))
+        self.assertTrue(isinstance(m.gate, NotQuantizable))
+
+        # A predicate returning a shared params dict must not have that dict
+        # mutated as it is applied across modules.
+        shared = {"group_size": 64, "bits": 4, "quantize_input": False}
+        m = nn.Sequential(nn.Linear(64, 64), nn.Linear(64, 64))
+        nn.quantize(m, class_predicate=lambda p, mod: shared)
+        self.assertTrue(isinstance(m.layers[0], nn.QuantizedLinear))
+        self.assertTrue(isinstance(m.layers[1], nn.QuantizedLinear))
+        self.assertEqual(shared, {"group_size": 64, "bits": 4, "quantize_input": False})
+
+        # quantize_input passed through a params dict is honored.
+        m = nn.Sequential(nn.Linear(64, 64, bias=False))
+        nn.quantize(
+            m,
+            class_predicate=lambda p, mod: {
+                "group_size": 32,
+                "mode": "mxfp8",
+                "quantize_input": True,
+            },
+        )
+        self.assertTrue(isinstance(m.layers[0], nn.QQLinear))
+
+        # The default predicate stays lenient: a model whose leaves cannot be
+        # quantized is returned unchanged rather than raising.
+        class NoQuantizableLeaves(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.a = NotQuantizable()
+                self.b = NotQuantizable()
+
+        m = NoQuantizableLeaves()
+        nn.quantize(m, group_size=64, bits=4)
+        self.assertTrue(isinstance(m.a, NotQuantizable))
+        self.assertTrue(isinstance(m.b, NotQuantizable))
+
     def test_quantize_freeze(self):
         lin = nn.Linear(512, 512)
         qlin = lin.to_quantized()


### PR DESCRIPTION
Fixes #3865.

With the default predicate, `nn.quantize` skips modules that don't define `to_quantized()`. Passing a custom `class_predicate` loses that behavior: if it returns truthy for such a module, the call raises `Unable to quantize model of type ...` and the whole model load fails.

```python
class Gate(nn.Module):        # has params, no to_quantized()
    def __init__(self):
        super().__init__()
        self.weight = mx.zeros((8, 64))

class Block(nn.Module):
    def __init__(self):
        super().__init__()
        self.proj = nn.Linear(64, 64)
        self.gate = Gate()

nn.quantize(Block(), group_size=64, bits=4)                                  # ok
nn.quantize(Block(), group_size=64, bits=4, class_predicate=lambda p, m: True)  # raises
```

This is why call sites like `mlx_lm` start every predicate with `if not hasattr(m, "to_quantized"): return False`.

The fix checks for `to_quantized()` before calling the predicate, so a module without it is skipped whether the predicate is custom or the default. Standard layers all define `to_quantized()`, so existing calls are unaffected. Updated the docstring and added test coverage for a custom predicate returning `True` and a params dict over a non-quantizable module.