### PR TITLE
Don't reuse a Metal buffer while a command buffer is still using it

### DIFF
--- a/mlx/backend/metal/allocator.cpp
+++ b/mlx/backend/metal/allocator.cpp
@@ -187,6 +187,14 @@ void MetalAllocator::free(Buffer buffer) {
   }
   std::unique_lock lk(mutex_);
   active_memory_ -= buf->length();
+  // Don't hand this buffer back out while a command buffer we haven't seen
+  // finish still uses it, or a concurrent (or cross-stream) allocation could
+  // grab it while a kernel is still reading or writing it. Hold it aside and
+  // let retire_in_flight recycle it once that work completes.
+  if (in_flight_.find(buf) != in_flight_.end()) {
+    deferred_recycle_.insert(buf);
+    return;
+  }
   if (get_cache_memory() < max_pool_size_) {
     buffer_cache_.recycle_to_cache(buf);
   } else {
@@ -197,6 +205,55 @@ void MetalAllocator::free(Buffer buffer) {
     lk.unlock();
     auto pool = metal::new_scoped_memory_pool();
     buf->release();
+  }
+}
+
+void MetalAllocator::mark_in_flight(const std::vector<const void*>& buffers) {
+  std::unique_lock lk(mutex_);
+  for (const auto* ptr : buffers) {
+    if (ptr) {
+      in_flight_[static_cast<MTL::Buffer*>(const_cast<void*>(ptr))]++;
+    }
+  }
+}
+
+void MetalAllocator::retire_in_flight(const std::vector<const void*>& buffers) {
+  std::vector<MTL::Buffer*> to_release;
+  {
+    std::unique_lock lk(mutex_);
+    for (const auto* ptr : buffers) {
+      if (!ptr) {
+        continue;
+      }
+      auto buf = static_cast<MTL::Buffer*>(const_cast<void*>(ptr));
+      auto it = in_flight_.find(buf);
+      if (it == in_flight_.end()) {
+        continue;
+      }
+      if (--(it->second) > 0) {
+        continue;
+      }
+      in_flight_.erase(it);
+      // Only recycle now if it was freed while we were holding it back.
+      if (deferred_recycle_.erase(buf) == 0) {
+        continue;
+      }
+      if (get_cache_memory() < max_pool_size_) {
+        buffer_cache_.recycle_to_cache(buf);
+      } else {
+        num_resources_--;
+        if (!buf->heap()) {
+          residency_set_.erase(buf);
+        }
+        to_release.push_back(buf);
+      }
+    }
+  }
+  if (!to_release.empty()) {
+    auto pool = metal::new_scoped_memory_pool();
+    for (auto* buf : to_release) {
+      buf->release();
+    }
   }
 }
 

--- a/mlx/backend/metal/allocator.h
+++ b/mlx/backend/metal/allocator.h
@@ -4,6 +4,8 @@
 
 #include <map>
 #include <mutex>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "mlx/allocator.h"
@@ -42,6 +44,15 @@ class MetalAllocator : public allocator::Allocator {
   size_t set_wired_limit(size_t limit);
   void clear_cache();
 
+  // We don't track hazards and command buffers can run concurrently across
+  // streams, so a buffer freed on the host while a kernel is still using it
+  // must not be reused yet -- otherwise a later allocation lands on the same
+  // memory mid-kernel (e.g. a bf16 write showing up in an int32 buffer). Mark a
+  // command buffer's buffers when its encoding ends, and retire them from its
+  // completion handler so the allocator knows when they're safe to reuse.
+  void mark_in_flight(const std::vector<const void*>& buffers);
+  void retire_in_flight(const std::vector<const void*>& buffers);
+
  private:
   MTL::Device* device_;
 
@@ -71,6 +82,11 @@ class MetalAllocator : public allocator::Allocator {
   size_t wired_limit_{0};
   size_t num_resources_{0};
   size_t resource_limit_{0};
+
+  // How many in-flight command buffers still reference each buffer, and the
+  // buffers that were freed while in flight and are waiting to be recycled.
+  std::unordered_map<MTL::Buffer*, int> in_flight_;
+  std::unordered_set<MTL::Buffer*> deferred_recycle_;
 
   std::mutex mutex_;
 };

--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -10,6 +10,7 @@
 #define MTL_PRIVATE_IMPLEMENTATION
 
 #include "mlx/backend/common/utils.h"
+#include "mlx/backend/metal/allocator.h"
 #include "mlx/backend/metal/device.h"
 #include "mlx/backend/metal/event.h"
 #include "mlx/backend/metal/metal.h"
@@ -445,6 +446,18 @@ void CommandEncoder::end_encoding() {
     all_inputs_.erase(t.buffer().ptr());
   }
 
+  // Let the allocator know these buffers are in use until this command buffer
+  // finishes, so it won't reuse them out from under a running kernel. The
+  // completion handler below retires them. Temporaries are already held alive
+  // as arrays there, so we leave them out.
+  std::vector<const void*> in_flight_bufs;
+  in_flight_bufs.reserve(all_inputs_.size() + all_outputs_.size());
+  in_flight_bufs.insert(
+      in_flight_bufs.end(), all_inputs_.begin(), all_inputs_.end());
+  in_flight_bufs.insert(
+      in_flight_bufs.end(), all_outputs_.begin(), all_outputs_.end());
+  metal::allocator().mark_in_flight(in_flight_bufs);
+
   // Keep references to the fences we waited on and put them in the completion
   // handler so they are not prematurely released.
   std::unordered_set<NS::SharedPtr<MTL::Fence>> waiting_on;
@@ -469,8 +482,10 @@ void CommandEncoder::end_encoding() {
                                 fence = std::move(fence_),
                                 temporaries = std::move(temporaries_),
                                 all_outputs = std::move(all_outputs_),
+                                in_flight_bufs = std::move(in_flight_bufs),
                                 waiting_on = std::move(waiting_on)](
                                    MTL::CommandBuffer*) mutable {
+    metal::allocator().retire_in_flight(in_flight_bufs);
     std::lock_guard lk(outputs_mtx_);
     for (auto& o : all_outputs) {
       if (auto it = prev_ce_outputs_.find(o); it != prev_ce_outputs_.end()) {


### PR DESCRIPTION
Under continuous batching with `async_eval`, the small int32 KV-cache bookkeeping arrays (`offset` / `left_padding`) sometimes come back as garbage that looks like bf16 bits in int32 slots -- e.g. `16256` (`0x3F80`, bf16 `1.0`). A buffer is being reused while a kernel is still writing it. Full write-up and repro in the linked issue; likely related to #3346.

`MetalAllocator::free` returns a buffer to the reuse pool without knowing which command buffer last used it. Fine on one stream (in order), but `async_eval` adds a second stream, so a buffer freed on one can be reused on the other before the first kernel finishes.

Fix: count how many in-flight command buffers reference each buffer -- marked at `end_encoding`, retired from the completion handler. `free()` holds a still-in-use buffer aside and recycles it once the work is done.