### PR TITLE
[Metal] Avoid regex in custom kernel name generation

### DIFF
--- a/mlx/backend/common/metal_kernel.cpp
+++ b/mlx/backend/common/metal_kernel.cpp
@@ -1,7 +1,6 @@
 // Copyright © 2024 Apple Inc.
 
 #include <iostream>
-#include <regex>
 #include <sstream>
 
 #include "mlx/backend/common/compiled.h"
@@ -197,6 +196,25 @@ std::string write_template(
   return template_def.str();
 }
 
+std::string make_template_hash(const std::string& template_def) {
+  std::string template_hash;
+  template_hash.reserve(template_def.size());
+  for (size_t i = 0; i < template_def.size(); ++i) {
+    auto c = template_def[i];
+    if (c == '<' || c == '>') {
+      template_hash += '_';
+    } else if (
+        c == ',' && i + 1 < template_def.size() && template_def[i + 1] == ' ') {
+      template_hash += '_';
+      ++i;
+    } else {
+      template_hash += c;
+    }
+  }
+  template_hash.pop_back();
+  return template_hash;
+}
+
 } // namespace
 
 CustomKernelFunction metal_kernel(
@@ -290,11 +308,8 @@ CustomKernelFunction metal_kernel(
     std::string kernel_name = "custom_kernel_" + name;
     std::string template_def = "";
     if (!template_args.empty()) {
-      std::regex disallowed_chars("\\<|\\>|(, )");
       template_def = write_template(template_args);
-      auto template_hash =
-          std::regex_replace(template_def, disallowed_chars, "_");
-      template_hash.pop_back();
+      auto template_hash = make_template_hash(template_def);
       kernel_name += "_";
       kernel_name += template_hash;
     }


### PR DESCRIPTION
## Proposed changes

Templated custom Metal kernels generate a specialized kernel name on every invocation. This previously constructed a `std::regex` and called `std::regex_replace` to convert the template definition into a valid kernel-name suffix.

This cost becomes measurable in workloads that repeatedly invoke templated custom kernels. In an Instruments capture of Qwen 3.5 gated-delta decoding, regex processing accounted for approximately 3.5% of the generation worker's sampled CPU cycles.

This change replaces the regex with a single linear pass over the template definition while preserving the generated kernel names byte-for-byte. It also removes the unused `<regex>` dependency.

### Performance

An isolated C++20 `-O3` benchmark using a representative template definition:

`<bfloat16_t, float, 128, 64, 8, 8>`

Results over 20,000 iterations:

- Previous regex implementation: approximately 6.86 µs per call
- New linear implementation: approximately 0.077 µs per call
- Isolated speedup: approximately 88.6×  

This benchmark measures only template-name transformation and does not imply an equivalent end-to-end inference speedup.


## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (not needed: this is an internal performance change with no API or behavior change)