### PR TITLE
Document default value of p in dropout layer docstrings

### DIFF
--- a/python/mlx/nn/layers/dropout.py
+++ b/python/mlx/nn/layers/dropout.py
@@ -12,7 +12,7 @@ class Dropout(Module):
     expected value of a given element will remain the same.
 
     Args:
-        p (float): The probability to zero an element
+        p (float): The probability to zero an element. Default: ``0.5``.
     """
 
     def __init__(self, p: float = 0.5):
@@ -56,6 +56,7 @@ class Dropout2d(Module):
 
     Args:
         p (float): Probability of zeroing a channel during training.
+            Default: ``0.5``.
     """
 
     def __init__(self, p: float = 0.5):
@@ -105,6 +106,7 @@ class Dropout3d(Module):
 
     Args:
         p (float): Probability of zeroing a channel during training.
+            Default: ``0.5``.
     """
 
     def __init__(self, p: float = 0.5):


### PR DESCRIPTION
## Proposed changes

`Dropout`, `Dropout2d`, and `Dropout3d` all default to `p = 0.5`, but none of their docstrings mention it. This adds the default to each `p` entry, same style as #3819 (normalization layers) and #3811 (conv dilation). Doc-only change, no behavior touched.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

(no tests since this only touches docstrings)

---

small disclosure: i'm a college freshman getting into open source, and i used Claude Code to help me sweep the docstrings for missing defaults, then checked each one against the source myself. if i got anything wrong i'd genuinely like to hear it so i can learn :)
