### PR TITLE
native cpu + gpu inference support

### DIFF
--- a/mlx/backend/cpu/arg_reduce.cpp
+++ b/mlx/backend/cpu/arg_reduce.cpp
@@ -4,6 +4,8 @@
 
 #include "mlx/backend/common/utils.h"
 #include "mlx/backend/cpu/encoder.h"
+#include "mlx/backend/cpu/parallel.h"
+#include "mlx/backend/cpu/simd/simd.h"
 #include "mlx/primitives.h"
 
 namespace mlx::core {
@@ -31,12 +33,91 @@ void arg_reduce(const array& in, array& out, const OpT& op, int axis) {
   }
 }
 
+// Finds the first index of the row extreme with SIMD: reduce to the extreme
+// value in float32 (half types convert on load; no narrowing round trips),
+// then scan blocks for its first occurrence. The SIMD maxima have fmax
+// semantics (NaNs are dropped) and the reduction order differs from the
+// sequential loop, so rows containing NaN fall back to it exactly.
+template <typename T, bool ArgMin>
+uint32_t arg_extreme_row(const T* row, uint32_t n) {
+  constexpr int S = simd::max_size<T>;
+  auto acc = simd::Simd<float, S>(simd::load<T, S>(row));
+  auto nan_acc = acc != acc;
+  uint32_t k = S;
+  for (; k + S <= n; k += S) {
+    auto v = simd::Simd<float, S>(simd::load<T, S>(row + k));
+    nan_acc = nan_acc || (v != v);
+    acc = ArgMin ? simd::minimum(acc, v) : simd::maximum(acc, v);
+  }
+  float best = ArgMin ? simd::min(acc) : simd::max(acc);
+  bool has_nan = simd::any(nan_acc);
+  for (; k < n; k++) {
+    float x = static_cast<float>(row[k]);
+    has_nan |= (x != x);
+    best = ArgMin ? std::min(best, x) : std::max(best, x);
+  }
+  if (has_nan) {
+    uint32_t ind = 0;
+    T v = row[0];
+    for (uint32_t j = 1; j < n; j++) {
+      if (ArgMin ? row[j] < v : row[j] > v) {
+        v = row[j];
+        ind = j;
+      }
+    }
+    return ind;
+  }
+  simd::Simd<float, S> bv(best);
+  uint32_t j = 0;
+  for (; j + S <= n; j += S) {
+    if (simd::any(simd::Simd<float, S>(simd::load<T, S>(row + j)) == bv)) {
+      break;
+    }
+  }
+  for (; j < n; j++) {
+    if (static_cast<float>(row[j]) == best) {
+      return j;
+    }
+  }
+  return 0;
+}
+
+template <typename T, bool ArgMin>
+void arg_reduce_contiguous(const array& in, array& out, int axis) {
+  uint32_t axis_size = in.shape()[axis];
+  Strides strides = remove_index(in.strides(), axis);
+  Shape shape = remove_index(in.shape(), axis);
+  auto in_ptr = in.data<T>();
+  auto out_ptr = out.data<uint32_t>();
+  int n_rows = out.size();
+
+  cpu::parallel_for_rows(n_rows, axis_size, [&](int r0, int r1) {
+    for (int r = r0; r < r1; r++) {
+      auto loc = elem_to_loc(r, shape, strides);
+      out_ptr[r] = arg_extreme_row<T, ArgMin>(in_ptr + loc, axis_size);
+    }
+  });
+}
+
 template <typename InT>
 void arg_reduce_dispatch(
     const array& in,
     array& out,
     ArgReduce::ReduceType rtype,
     int axis) {
+  if constexpr (
+      std::is_same_v<InT, float> || std::is_same_v<InT, float16_t> ||
+      std::is_same_v<InT, bfloat16_t>) {
+    if (in.strides()[axis] == 1 &&
+        in.shape()[axis] >= 2 * simd::max_size<InT>) {
+      if (rtype == ArgReduce::ArgMin) {
+        arg_reduce_contiguous<InT, true>(in, out, axis);
+      } else {
+        arg_reduce_contiguous<InT, false>(in, out, axis);
+      }
+      return;
+    }
+  }
   switch (rtype) {
     case ArgReduce::ArgMin: {
       auto op = [](auto ind_x, auto x, auto ind_y, auto y) {

--- a/mlx/backend/cpu/arg_reduce.cpp
+++ b/mlx/backend/cpu/arg_reduce.cpp
@@ -33,11 +33,6 @@ void arg_reduce(const array& in, array& out, const OpT& op, int axis) {
   }
 }
 
-// Finds the first index of the row extreme with SIMD: reduce to the extreme
-// value in float32 (half types convert on load; no narrowing round trips),
-// then scan blocks for its first occurrence. The SIMD maxima have fmax
-// semantics (NaNs are dropped) and the reduction order differs from the
-// sequential loop, so rows containing NaN fall back to it exactly.
 template <typename T, bool ArgMin>
 uint32_t arg_extreme_row(const T* row, uint32_t n) {
   constexpr int S = simd::max_size<T>;

--- a/mlx/backend/cpu/parallel.h
+++ b/mlx/backend/cpu/parallel.h
@@ -75,8 +75,7 @@ class KernelPool {
     uint64_t seen = 0;
     while (true) {
       for (int spins = 0;
-           generation_.load(std::memory_order_acquire) == seen &&
-           spins < 20000;
+           generation_.load(std::memory_order_acquire) == seen && spins < 20000;
            spins++) {
       }
       const std::function<void(int)>* fn;
@@ -121,8 +120,8 @@ void parallel_for_rows(int n, size_t work_per_row, F&& fn) {
     fn(0, n);
     return;
   }
-  int chunk = int(std::max<size_t>(
-      8, min_chunk_work / std::max<size_t>(1, work_per_row)));
+  int chunk = int(
+      std::max<size_t>(8, min_chunk_work / std::max<size_t>(1, work_per_row)));
   int n_chunks = (n + chunk - 1) / chunk;
   if (n_chunks <= 1) {
     fn(0, n);

--- a/mlx/backend/cpu/parallel.h
+++ b/mlx/backend/cpu/parallel.h
@@ -12,10 +12,6 @@
 
 namespace mlx::core::cpu {
 
-// A minimal persistent worker pool for splitting hot CPU kernels over
-// independent output slices. The calling thread participates in the work,
-// so a pool of size n spawns n - 1 threads. Sized by MLX_CPU_THREADS
-// (default 8, clamped to hardware concurrency).
 class KernelPool {
  public:
   static KernelPool& instance() {
@@ -30,8 +26,6 @@ class KernelPool {
     return n_threads_;
   }
 
-  // Calls fn(t) for every t in [0, size()) and waits for completion. Only
-  // call from one thread at a time (the CPU stream thread).
   void run(const std::function<void(int)>& fn) {
     if (n_threads_ == 1) {
       fn(0);
@@ -43,13 +37,10 @@ class KernelPool {
       pending_.store(n_threads_ - 1, std::memory_order_release);
       generation_.fetch_add(1, std::memory_order_release);
     }
-    // Workers spin between back-to-back kernels; only pay the wake syscall
-    // for the ones that actually parked.
     if (parked_.load(std::memory_order_acquire) > 0) {
       cv_.notify_all();
     }
     fn(0);
-    // Kernel slices run for microseconds to milliseconds; spin for the tail.
     while (pending_.load(std::memory_order_acquire) > 0) {
       std::this_thread::yield();
     }
@@ -83,10 +74,6 @@ class KernelPool {
   void worker(int tid) {
     uint64_t seen = 0;
     while (true) {
-      // Spin briefly to catch back-to-back kernels without a syscall, then
-      // park on the condition variable. Longer windows and WFE waits both
-      // regress: they compete for shared resources with the serial sections
-      // between kernels.
       for (int spins = 0;
            generation_.load(std::memory_order_acquire) == seen &&
            spins < 20000;
@@ -124,14 +111,8 @@ class KernelPool {
   std::vector<std::thread> workers_;
 };
 
-// Runs fn(begin, end) over [0, n) rows with dynamic chunk stealing so faster
-// cores take more chunks (performance cores finish ahead of efficiency
-// cores). work_per_row is an operation-count estimate used to size chunks
-// and to skip the pool entirely for small problems.
 template <typename F>
 void parallel_for_rows(int n, size_t work_per_row, F&& fn) {
-  // 128k-op chunks balance the tail straggler against chunk-pull atomics
-  // (64k chunks regress the biggest mats; 256k lengthens the tail).
   constexpr size_t min_total_work = size_t(1) << 21;
   constexpr size_t min_chunk_work = size_t(1) << 17;
   auto& pool = KernelPool::instance();

--- a/mlx/backend/cpu/parallel.h
+++ b/mlx/backend/cpu/parallel.h
@@ -1,0 +1,165 @@
+// Copyright © 2025 Apple Inc.
+
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdlib>
+#include <functional>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace mlx::core::cpu {
+
+// A minimal persistent worker pool for splitting hot CPU kernels over
+// independent output slices. The calling thread participates in the work,
+// so a pool of size n spawns n - 1 threads. Sized by MLX_CPU_THREADS
+// (default 8, clamped to hardware concurrency).
+class KernelPool {
+ public:
+  static KernelPool& instance() {
+    static KernelPool pool;
+    return pool;
+  }
+
+  KernelPool(const KernelPool&) = delete;
+  KernelPool& operator=(const KernelPool&) = delete;
+
+  int size() const {
+    return n_threads_;
+  }
+
+  // Calls fn(t) for every t in [0, size()) and waits for completion. Only
+  // call from one thread at a time (the CPU stream thread).
+  void run(const std::function<void(int)>& fn) {
+    if (n_threads_ == 1) {
+      fn(0);
+      return;
+    }
+    {
+      std::lock_guard<std::mutex> lk(mtx_);
+      fn_ = &fn;
+      pending_.store(n_threads_ - 1, std::memory_order_release);
+      generation_.fetch_add(1, std::memory_order_release);
+    }
+    // Workers spin between back-to-back kernels; only pay the wake syscall
+    // for the ones that actually parked.
+    if (parked_.load(std::memory_order_acquire) > 0) {
+      cv_.notify_all();
+    }
+    fn(0);
+    // Kernel slices run for microseconds to milliseconds; spin for the tail.
+    while (pending_.load(std::memory_order_acquire) > 0) {
+      std::this_thread::yield();
+    }
+  }
+
+ private:
+  KernelPool() {
+    int n = 8;
+    if (const char* env = std::getenv("MLX_CPU_THREADS")) {
+      n = std::atoi(env);
+    }
+    int hw = static_cast<int>(std::thread::hardware_concurrency());
+    n_threads_ = std::max(1, std::min(n, hw > 0 ? hw : 1));
+    for (int t = 1; t < n_threads_; t++) {
+      workers_.emplace_back([this, t]() { worker(t); });
+    }
+  }
+
+  ~KernelPool() {
+    {
+      std::lock_guard<std::mutex> lk(mtx_);
+      stop_ = true;
+      generation_.fetch_add(1, std::memory_order_release);
+    }
+    cv_.notify_all();
+    for (auto& w : workers_) {
+      w.join();
+    }
+  }
+
+  void worker(int tid) {
+    uint64_t seen = 0;
+    while (true) {
+      // Spin briefly to catch back-to-back kernels without a syscall, then
+      // park on the condition variable. Longer windows and WFE waits both
+      // regress: they compete for shared resources with the serial sections
+      // between kernels.
+      for (int spins = 0;
+           generation_.load(std::memory_order_acquire) == seen &&
+           spins < 20000;
+           spins++) {
+      }
+      const std::function<void(int)>* fn;
+      {
+        std::unique_lock<std::mutex> lk(mtx_);
+        if (generation_.load(std::memory_order_acquire) == seen) {
+          parked_.fetch_add(1, std::memory_order_release);
+          cv_.wait(lk, [&] {
+            return generation_.load(std::memory_order_acquire) != seen;
+          });
+          parked_.fetch_sub(1, std::memory_order_release);
+        }
+        seen = generation_.load(std::memory_order_acquire);
+        if (stop_) {
+          return;
+        }
+        fn = fn_;
+      }
+      (*fn)(tid);
+      pending_.fetch_sub(1, std::memory_order_release);
+    }
+  }
+
+  std::mutex mtx_;
+  std::condition_variable cv_;
+  const std::function<void(int)>* fn_{nullptr};
+  std::atomic<uint64_t> generation_{0};
+  std::atomic<int> pending_{0};
+  std::atomic<int> parked_{0};
+  bool stop_{false};
+  int n_threads_{1};
+  std::vector<std::thread> workers_;
+};
+
+// Runs fn(begin, end) over [0, n) rows with dynamic chunk stealing so faster
+// cores take more chunks (performance cores finish ahead of efficiency
+// cores). work_per_row is an operation-count estimate used to size chunks
+// and to skip the pool entirely for small problems.
+template <typename F>
+void parallel_for_rows(int n, size_t work_per_row, F&& fn) {
+  // 128k-op chunks balance the tail straggler against chunk-pull atomics
+  // (64k chunks regress the biggest mats; 256k lengthens the tail).
+  constexpr size_t min_total_work = size_t(1) << 21;
+  constexpr size_t min_chunk_work = size_t(1) << 17;
+  auto& pool = KernelPool::instance();
+  size_t total = work_per_row * size_t(n);
+  if (pool.size() == 1 || total < min_total_work) {
+    fn(0, n);
+    return;
+  }
+  int chunk = int(std::max<size_t>(
+      8, min_chunk_work / std::max<size_t>(1, work_per_row)));
+  int n_chunks = (n + chunk - 1) / chunk;
+  if (n_chunks <= 1) {
+    fn(0, n);
+    return;
+  }
+  std::atomic<int> next{0};
+  std::function<void(int)> job = [&](int) {
+    while (true) {
+      int c = next.fetch_add(1, std::memory_order_relaxed);
+      if (c >= n_chunks) {
+        break;
+      }
+      int begin = c * chunk;
+      int end = std::min(n, begin + chunk);
+      fn(begin, end);
+    }
+  };
+  pool.run(job);
+}
+
+} // namespace mlx::core::cpu

--- a/mlx/backend/cpu/quantized.cpp
+++ b/mlx/backend/cpu/quantized.cpp
@@ -301,9 +301,6 @@ inline bool int8_qmm_enabled() {
   return enabled;
 }
 
-// Quantize one row of activations to a signed 8-bit value per element with a
-// float scale per group. Also keeps the scaled group sum (~ the sum of x over
-// the group) so the affine bias term needs no second pass.
 template <typename T>
 void quantize_row_i8(
     const T* x,
@@ -328,8 +325,6 @@ void quantize_row_i8(
     gscale[g] = scale;
     gsum[g] = scale * (float)sum;
   }
-  // Deinterleave every 32-block to the nibble layout (even elements then odd
-  // elements) once per row, so the matmul inner loop needs no shuffles.
   for (int k = 0; k < K; k += 32) {
     int8x16_t a = vld1q_s8(xq + k);
     int8x16_t b = vld1q_s8(xq + k + 16);
@@ -339,10 +334,6 @@ void quantize_row_i8(
   }
 }
 
-// 4-bit affine matmul against int8-quantized activations using SDOT. The
-// nibbles are recentered to [-8, 7] so the dot product is signed x signed
-// (dotprod extension only, no i8mm); the +8 shift folds into the bias term:
-//   sum(w x) = s_w s_x sum(q' xq) + (8 s_w + b_w) (s_x sum(xq))
 template <typename T, int group_size>
 void _qmm_t_i8(
     T* result,
@@ -382,8 +373,6 @@ void _qmm_t_i8(
         for (int c = 0; c < group_size; c += 32) {
           uint8x16_t wb = vld1q_u8(w_local);
           w_local += 16;
-          // low nibbles are the even elements, high nibbles the odd ones;
-          // xq rows are pre-deinterleaved to match
           int8x16_t lo =
               vsubq_s8(vreinterpretq_s8_u8(vandq_u8(wb, low_mask)), eight);
           int8x16_t hi =

--- a/mlx/backend/cpu/quantized.cpp
+++ b/mlx/backend/cpu/quantized.cpp
@@ -370,8 +370,7 @@ void _qmm_t_i8(
       gsum_rows[t] = gsum + size_t(m + t) * groups_per_row;
       result_rows[t] = result + size_t(m + t) * N;
     }
-    const uint8_t* w_local =
-        (const uint8_t*)(w + size_t(n0) * words_per_row);
+    const uint8_t* w_local = (const uint8_t*)(w + size_t(n0) * words_per_row);
     const T* sc_local = scales + size_t(n0) * groups_per_row;
     const T* bi_local = biases + size_t(n0) * groups_per_row;
 
@@ -384,10 +383,7 @@ void _qmm_t_i8(
       float bias_acc[4] = {0.0f, 0.0f, 0.0f, 0.0f};
       for (size_t g = 0; g < groups_per_row; g++) {
         int32x4_t acc[4] = {
-            vdupq_n_s32(0),
-            vdupq_n_s32(0),
-            vdupq_n_s32(0),
-            vdupq_n_s32(0)};
+            vdupq_n_s32(0), vdupq_n_s32(0), vdupq_n_s32(0), vdupq_n_s32(0)};
         const size_t go = g * group_size;
         if constexpr (bits == 4) {
           for (int c = 0; c < group_size; c += 32) {
@@ -405,8 +401,8 @@ void _qmm_t_i8(
           }
         } else {
           for (int c = 0; c < group_size; c += 16) {
-            int8x16_t wb = veorq_s8(
-                vreinterpretq_s8_u8(vld1q_u8(w_local)), sign_flip);
+            int8x16_t wb =
+                veorq_s8(vreinterpretq_s8_u8(vld1q_u8(w_local)), sign_flip);
             w_local += 16;
             for (int t = 0; t < 4; t++) {
               acc[t] = vdotq_s32(acc[t], wb, vld1q_s8(xq_rows[t] + go + c));
@@ -422,7 +418,8 @@ void _qmm_t_i8(
         }
       }
       for (int t = 0; t < 4; t++) {
-        result_rows[t][n] = static_cast<T>(vaddvq_f32(dot_acc[t]) + bias_acc[t]);
+        result_rows[t][n] =
+            static_cast<T>(vaddvq_f32(dot_acc[t]) + bias_acc[t]);
       }
     }
   }
@@ -432,8 +429,7 @@ void _qmm_t_i8(
     const float* gsum_row = gsum + size_t(m) * groups_per_row;
     T* result_row = result + size_t(m) * N;
 
-    const uint8_t* w_local =
-        (const uint8_t*)(w + size_t(n0) * words_per_row);
+    const uint8_t* w_local = (const uint8_t*)(w + size_t(n0) * words_per_row);
     const T* sc_local = scales + size_t(n0) * groups_per_row;
     const T* bi_local = biases + size_t(n0) * groups_per_row;
 
@@ -456,16 +452,15 @@ void _qmm_t_i8(
           }
         } else {
           for (int c = 0; c < group_size; c += 16) {
-            int8x16_t wb = veorq_s8(
-                vreinterpretq_s8_u8(vld1q_u8(w_local)), sign_flip);
+            int8x16_t wb =
+                veorq_s8(vreinterpretq_s8_u8(vld1q_u8(w_local)), sign_flip);
             w_local += 16;
             acc = vdotq_s32(acc, wb, vld1q_s8(xg + c));
           }
         }
         float s_w = static_cast<float>(*sc_local++);
         float b_w = static_cast<float>(*bi_local++);
-        dot_acc = vfmaq_n_f32(
-            dot_acc, vcvtq_f32_s32(acc), s_w * gs_row[g]);
+        dot_acc = vfmaq_n_f32(dot_acc, vcvtq_f32_s32(acc), s_w * gs_row[g]);
         bias_acc += (w_offset * s_w + b_w) * gsum_row[g];
       }
       result_row[n] = static_cast<T>(vaddvq_f32(dot_acc) + bias_acc);

--- a/mlx/backend/cpu/quantized.cpp
+++ b/mlx/backend/cpu/quantized.cpp
@@ -296,7 +296,7 @@ void _qmm_t_simd(
 inline bool int8_qmm_enabled() {
   static bool enabled = []() {
     const char* env = std::getenv("MLX_CPU_INT8_QMM");
-    return !(env && env[0] == '0');
+    return env && env[0] == '1';
   }();
   return enabled;
 }

--- a/mlx/backend/cpu/quantized.cpp
+++ b/mlx/backend/cpu/quantized.cpp
@@ -308,7 +308,8 @@ void quantize_row_i8(
     int group_size,
     int8_t* xq,
     float* gscale,
-    float* gsum) {
+    float* gsum,
+    bool deinterleave) {
   for (int k = 0, g = 0; k < K; k += group_size, g++) {
     float amax = 0.0f;
     for (int i = 0; i < group_size; i++) {
@@ -325,16 +326,18 @@ void quantize_row_i8(
     gscale[g] = scale;
     gsum[g] = scale * (float)sum;
   }
-  for (int k = 0; k < K; k += 32) {
-    int8x16_t a = vld1q_s8(xq + k);
-    int8x16_t b = vld1q_s8(xq + k + 16);
-    int8x16x2_t u = vuzpq_s8(a, b);
-    vst1q_s8(xq + k, u.val[0]);
-    vst1q_s8(xq + k + 16, u.val[1]);
+  if (deinterleave) {
+    for (int k = 0; k < K; k += 32) {
+      int8x16_t a = vld1q_s8(xq + k);
+      int8x16_t b = vld1q_s8(xq + k + 16);
+      int8x16x2_t u = vuzpq_s8(a, b);
+      vst1q_s8(xq + k, u.val[0]);
+      vst1q_s8(xq + k + 16, u.val[1]);
+    }
   }
 }
 
-template <typename T, int group_size>
+template <typename T, int group_size, int bits>
 void _qmm_t_i8(
     T* result,
     const int8_t* xq,
@@ -348,12 +351,82 @@ void _qmm_t_i8(
     int K,
     int n0,
     int n1) {
-  const size_t words_per_row = size_t(K) / 8;
+  constexpr float w_offset = bits == 4 ? 8.0f : 128.0f;
+  const size_t words_per_row = size_t(K) * bits / 32;
   const size_t groups_per_row = K / group_size;
   const uint8x16_t low_mask = vdupq_n_u8(0x0F);
   const int8x16_t eight = vdupq_n_s8(8);
+  const int8x16_t sign_flip = vdupq_n_s8(int8_t(0x80));
 
-  for (int m = 0; m < M; m++) {
+  int m = 0;
+  for (; m + 4 <= M; m += 4) {
+    const int8_t* xq_rows[4];
+    const float* gs_rows[4];
+    const float* gsum_rows[4];
+    T* result_rows[4];
+    for (int t = 0; t < 4; t++) {
+      xq_rows[t] = xq + size_t(m + t) * K;
+      gs_rows[t] = gscale + size_t(m + t) * groups_per_row;
+      gsum_rows[t] = gsum + size_t(m + t) * groups_per_row;
+      result_rows[t] = result + size_t(m + t) * N;
+    }
+    const uint8_t* w_local =
+        (const uint8_t*)(w + size_t(n0) * words_per_row);
+    const T* sc_local = scales + size_t(n0) * groups_per_row;
+    const T* bi_local = biases + size_t(n0) * groups_per_row;
+
+    for (int n = n0; n < n1; n++) {
+      float32x4_t dot_acc[4] = {
+          vdupq_n_f32(0.0f),
+          vdupq_n_f32(0.0f),
+          vdupq_n_f32(0.0f),
+          vdupq_n_f32(0.0f)};
+      float bias_acc[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+      for (size_t g = 0; g < groups_per_row; g++) {
+        int32x4_t acc[4] = {
+            vdupq_n_s32(0),
+            vdupq_n_s32(0),
+            vdupq_n_s32(0),
+            vdupq_n_s32(0)};
+        const size_t go = g * group_size;
+        if constexpr (bits == 4) {
+          for (int c = 0; c < group_size; c += 32) {
+            uint8x16_t wb = vld1q_u8(w_local);
+            w_local += 16;
+            int8x16_t lo =
+                vsubq_s8(vreinterpretq_s8_u8(vandq_u8(wb, low_mask)), eight);
+            int8x16_t hi =
+                vsubq_s8(vreinterpretq_s8_u8(vshrq_n_u8(wb, 4)), eight);
+            for (int t = 0; t < 4; t++) {
+              acc[t] = vdotq_s32(acc[t], lo, vld1q_s8(xq_rows[t] + go + c));
+              acc[t] =
+                  vdotq_s32(acc[t], hi, vld1q_s8(xq_rows[t] + go + c + 16));
+            }
+          }
+        } else {
+          for (int c = 0; c < group_size; c += 16) {
+            int8x16_t wb = veorq_s8(
+                vreinterpretq_s8_u8(vld1q_u8(w_local)), sign_flip);
+            w_local += 16;
+            for (int t = 0; t < 4; t++) {
+              acc[t] = vdotq_s32(acc[t], wb, vld1q_s8(xq_rows[t] + go + c));
+            }
+          }
+        }
+        float s_w = static_cast<float>(*sc_local++);
+        float b_w = static_cast<float>(*bi_local++);
+        for (int t = 0; t < 4; t++) {
+          dot_acc[t] = vfmaq_n_f32(
+              dot_acc[t], vcvtq_f32_s32(acc[t]), s_w * gs_rows[t][g]);
+          bias_acc[t] += (w_offset * s_w + b_w) * gsum_rows[t][g];
+        }
+      }
+      for (int t = 0; t < 4; t++) {
+        result_rows[t][n] = static_cast<T>(vaddvq_f32(dot_acc[t]) + bias_acc[t]);
+      }
+    }
+  }
+  for (; m < M; m++) {
     const int8_t* xq_row = xq + size_t(m) * K;
     const float* gs_row = gscale + size_t(m) * groups_per_row;
     const float* gsum_row = gsum + size_t(m) * groups_per_row;
@@ -370,21 +443,30 @@ void _qmm_t_i8(
       for (size_t g = 0; g < groups_per_row; g++) {
         int32x4_t acc = vdupq_n_s32(0);
         const int8_t* xg = xq_row + g * group_size;
-        for (int c = 0; c < group_size; c += 32) {
-          uint8x16_t wb = vld1q_u8(w_local);
-          w_local += 16;
-          int8x16_t lo =
-              vsubq_s8(vreinterpretq_s8_u8(vandq_u8(wb, low_mask)), eight);
-          int8x16_t hi =
-              vsubq_s8(vreinterpretq_s8_u8(vshrq_n_u8(wb, 4)), eight);
-          acc = vdotq_s32(acc, lo, vld1q_s8(xg + c));
-          acc = vdotq_s32(acc, hi, vld1q_s8(xg + c + 16));
+        if constexpr (bits == 4) {
+          for (int c = 0; c < group_size; c += 32) {
+            uint8x16_t wb = vld1q_u8(w_local);
+            w_local += 16;
+            int8x16_t lo =
+                vsubq_s8(vreinterpretq_s8_u8(vandq_u8(wb, low_mask)), eight);
+            int8x16_t hi =
+                vsubq_s8(vreinterpretq_s8_u8(vshrq_n_u8(wb, 4)), eight);
+            acc = vdotq_s32(acc, lo, vld1q_s8(xg + c));
+            acc = vdotq_s32(acc, hi, vld1q_s8(xg + c + 16));
+          }
+        } else {
+          for (int c = 0; c < group_size; c += 16) {
+            int8x16_t wb = veorq_s8(
+                vreinterpretq_s8_u8(vld1q_u8(w_local)), sign_flip);
+            w_local += 16;
+            acc = vdotq_s32(acc, wb, vld1q_s8(xg + c));
+          }
         }
         float s_w = static_cast<float>(*sc_local++);
         float b_w = static_cast<float>(*bi_local++);
         dot_acc = vfmaq_n_f32(
             dot_acc, vcvtq_f32_s32(acc), s_w * gs_row[g]);
-        bias_acc += (8.0f * s_w + b_w) * gsum_row[g];
+        bias_acc += (w_offset * s_w + b_w) * gsum_row[g];
       }
       result_row[n] = static_cast<T>(vaddvq_f32(dot_acc) + bias_acc);
     }
@@ -406,7 +488,7 @@ void _qmm_dispatch_transpose(
     bool transposed_w) {
   if (transposed_w) {
 #if defined(__ARM_FEATURE_DOTPROD)
-    if constexpr (bits == 4 && group_size % 32 == 0) {
+    if constexpr ((bits == 4 || bits == 8) && group_size % 32 == 0) {
       if (int8_qmm_enabled()) {
         int groups = K / group_size;
         std::vector<int8_t> xq(size_t(M) * K);
@@ -420,11 +502,12 @@ void _qmm_dispatch_transpose(
                 group_size,
                 xq.data() + size_t(m) * K,
                 gscale.data() + size_t(m) * groups,
-                gsum.data() + size_t(m) * groups);
+                gsum.data() + size_t(m) * groups,
+                bits == 4);
           }
         });
         cpu::parallel_for_rows(N, size_t(M) * K, [&](int n0, int n1) {
-          _qmm_t_i8<T, group_size>(
+          _qmm_t_i8<T, group_size, bits>(
               result,
               xq.data(),
               gscale.data(),

--- a/mlx/backend/cpu/quantized.cpp
+++ b/mlx/backend/cpu/quantized.cpp
@@ -4,6 +4,7 @@
 #include "mlx/backend/common/unary.h"
 #include "mlx/backend/cpu/copy.h"
 #include "mlx/backend/cpu/encoder.h"
+#include "mlx/backend/cpu/parallel.h"
 #include "mlx/backend/cpu/simd/simd.h"
 #include "mlx/backend/cpu/unary.h"
 #include "mlx/backend/cpu/unary_ops.h"
@@ -160,20 +161,26 @@ void _qmm_t(
     const T* biases,
     int M,
     int N,
-    int K) {
+    int K,
+    int n0,
+    int n1) {
   constexpr int bitmask = (1 << bits) - 1;
 
   constexpr int pack_factor = get_pack_factor(bits, 8);
   constexpr int bytes_per_pack = get_bytes_per_pack(bits);
   constexpr int packs_in_group = group_size / pack_factor;
+  const size_t bytes_per_row = size_t(K / pack_factor) * bytes_per_pack;
+  const size_t groups_per_row = K / group_size;
 
   for (int m = 0; m < M; m++) {
-    const uint8_t* w_local = (const uint8_t*)w;
-    const T* scales_local = scales;
-    const T* biases_local = biases;
+    const T* x_row = x + size_t(m) * K;
+    T* result_row = result + size_t(m) * N;
+    const uint8_t* w_local = (const uint8_t*)w + size_t(n0) * bytes_per_row;
+    const T* scales_local = scales + size_t(n0) * groups_per_row;
+    const T* biases_local = biases + size_t(n0) * groups_per_row;
 
-    for (int n = 0; n < N; n++) {
-      const T* x_local = x;
+    for (int n = n0; n < n1; n++) {
+      const T* x_local = x_row;
       T sum = 0;
       for (int k = 0; k < K; k += group_size) {
         T scale = *scales_local++;
@@ -203,11 +210,8 @@ void _qmm_t(
           }
         }
       }
-      *result = sum;
-      result++;
+      result_row[n] = sum;
     }
-
-    x += K;
   }
 }
 
@@ -245,25 +249,31 @@ void _qmm_t_simd(
     const T* biases,
     int M,
     int N,
-    int K) {
+    int K,
+    int n0,
+    int n1) {
   constexpr int pack_factor = 32 / bits;
   constexpr int packs_in_group = group_size / pack_factor;
   constexpr int S = simd::max_size<T>;
   static_assert(
       S % pack_factor == 0, "SIMD size must be divisible by pack factor");
   constexpr int packs_per_simd = S / pack_factor;
+  const size_t words_per_row = size_t(K) * bits / 32;
+  const size_t groups_per_row = K / group_size;
 
   for (int m = 0; m < M; m++) {
-    const uint32_t* w_local = w;
-    const T* scales_local = scales;
-    const T* biases_local = biases;
+    const T* x_row = x + size_t(m) * K;
+    T* result_row = result + size_t(m) * N;
+    const uint32_t* w_local = w + size_t(n0) * words_per_row;
+    const T* scales_local = scales + size_t(n0) * groups_per_row;
+    const T* biases_local = biases + size_t(n0) * groups_per_row;
 
-    for (int n = 0; n < N; n++) {
+    for (int n = n0; n < n1; n++) {
       simd::Simd<float, S> acc(0);
-      auto x_local = x;
+      auto x_local = x_row;
       for (int k = 0; k < K; k += group_size) {
-        T scale = *scales_local++;
-        T bias = *biases_local++;
+        float scale = *scales_local++;
+        float bias = *biases_local++;
 
         for (int kw = 0; kw < packs_in_group; kw += packs_per_simd) {
           auto wf = simd::Simd<float, S>(extract_bits_simd<bits, S>(w_local));
@@ -276,12 +286,123 @@ void _qmm_t_simd(
         }
       }
 
-      *result = T(simd::sum(acc));
-      result++;
+      result_row[n] = T(simd::sum(acc));
     }
-    x += K;
   }
 }
+
+#if defined(__ARM_FEATURE_DOTPROD)
+
+inline bool int8_qmm_enabled() {
+  static bool enabled = []() {
+    const char* env = std::getenv("MLX_CPU_INT8_QMM");
+    return !(env && env[0] == '0');
+  }();
+  return enabled;
+}
+
+// Quantize one row of activations to a signed 8-bit value per element with a
+// float scale per group. Also keeps the scaled group sum (~ the sum of x over
+// the group) so the affine bias term needs no second pass.
+template <typename T>
+void quantize_row_i8(
+    const T* x,
+    int K,
+    int group_size,
+    int8_t* xq,
+    float* gscale,
+    float* gsum) {
+  for (int k = 0, g = 0; k < K; k += group_size, g++) {
+    float amax = 0.0f;
+    for (int i = 0; i < group_size; i++) {
+      amax = std::max(amax, std::abs(static_cast<float>(x[k + i])));
+    }
+    float scale = amax > 0.0f ? amax / 127.0f : 1.0f;
+    float inv = 1.0f / scale;
+    int sum = 0;
+    for (int i = 0; i < group_size; i++) {
+      int q = (int)lrintf(static_cast<float>(x[k + i]) * inv);
+      xq[k + i] = (int8_t)q;
+      sum += q;
+    }
+    gscale[g] = scale;
+    gsum[g] = scale * (float)sum;
+  }
+  // Deinterleave every 32-block to the nibble layout (even elements then odd
+  // elements) once per row, so the matmul inner loop needs no shuffles.
+  for (int k = 0; k < K; k += 32) {
+    int8x16_t a = vld1q_s8(xq + k);
+    int8x16_t b = vld1q_s8(xq + k + 16);
+    int8x16x2_t u = vuzpq_s8(a, b);
+    vst1q_s8(xq + k, u.val[0]);
+    vst1q_s8(xq + k + 16, u.val[1]);
+  }
+}
+
+// 4-bit affine matmul against int8-quantized activations using SDOT. The
+// nibbles are recentered to [-8, 7] so the dot product is signed x signed
+// (dotprod extension only, no i8mm); the +8 shift folds into the bias term:
+//   sum(w x) = s_w s_x sum(q' xq) + (8 s_w + b_w) (s_x sum(xq))
+template <typename T, int group_size>
+void _qmm_t_i8(
+    T* result,
+    const int8_t* xq,
+    const float* gscale,
+    const float* gsum,
+    const uint32_t* w,
+    const T* scales,
+    const T* biases,
+    int M,
+    int N,
+    int K,
+    int n0,
+    int n1) {
+  const size_t words_per_row = size_t(K) / 8;
+  const size_t groups_per_row = K / group_size;
+  const uint8x16_t low_mask = vdupq_n_u8(0x0F);
+  const int8x16_t eight = vdupq_n_s8(8);
+
+  for (int m = 0; m < M; m++) {
+    const int8_t* xq_row = xq + size_t(m) * K;
+    const float* gs_row = gscale + size_t(m) * groups_per_row;
+    const float* gsum_row = gsum + size_t(m) * groups_per_row;
+    T* result_row = result + size_t(m) * N;
+
+    const uint8_t* w_local =
+        (const uint8_t*)(w + size_t(n0) * words_per_row);
+    const T* sc_local = scales + size_t(n0) * groups_per_row;
+    const T* bi_local = biases + size_t(n0) * groups_per_row;
+
+    for (int n = n0; n < n1; n++) {
+      float32x4_t dot_acc = vdupq_n_f32(0.0f);
+      float bias_acc = 0.0f;
+      for (size_t g = 0; g < groups_per_row; g++) {
+        int32x4_t acc = vdupq_n_s32(0);
+        const int8_t* xg = xq_row + g * group_size;
+        for (int c = 0; c < group_size; c += 32) {
+          uint8x16_t wb = vld1q_u8(w_local);
+          w_local += 16;
+          // low nibbles are the even elements, high nibbles the odd ones;
+          // xq rows are pre-deinterleaved to match
+          int8x16_t lo =
+              vsubq_s8(vreinterpretq_s8_u8(vandq_u8(wb, low_mask)), eight);
+          int8x16_t hi =
+              vsubq_s8(vreinterpretq_s8_u8(vshrq_n_u8(wb, 4)), eight);
+          acc = vdotq_s32(acc, lo, vld1q_s8(xg + c));
+          acc = vdotq_s32(acc, hi, vld1q_s8(xg + c + 16));
+        }
+        float s_w = static_cast<float>(*sc_local++);
+        float b_w = static_cast<float>(*bi_local++);
+        dot_acc = vfmaq_n_f32(
+            dot_acc, vcvtq_f32_s32(acc), s_w * gs_row[g]);
+        bias_acc += (8.0f * s_w + b_w) * gsum_row[g];
+      }
+      result_row[n] = static_cast<T>(vaddvq_f32(dot_acc) + bias_acc);
+    }
+  }
+}
+
+#endif // __ARM_FEATURE_DOTPROD
 
 template <typename T, int bits, int group_size>
 void _qmm_dispatch_transpose(
@@ -295,11 +416,54 @@ void _qmm_dispatch_transpose(
     int K,
     bool transposed_w) {
   if (transposed_w) {
+#if defined(__ARM_FEATURE_DOTPROD)
+    if constexpr (bits == 4 && group_size % 32 == 0) {
+      if (int8_qmm_enabled()) {
+        int groups = K / group_size;
+        std::vector<int8_t> xq(size_t(M) * K);
+        std::vector<float> gscale(size_t(M) * groups);
+        std::vector<float> gsum(size_t(M) * groups);
+        cpu::parallel_for_rows(M, size_t(K), [&](int m0, int m1) {
+          for (int m = m0; m < m1; m++) {
+            quantize_row_i8(
+                x + size_t(m) * K,
+                K,
+                group_size,
+                xq.data() + size_t(m) * K,
+                gscale.data() + size_t(m) * groups,
+                gsum.data() + size_t(m) * groups);
+          }
+        });
+        cpu::parallel_for_rows(N, size_t(M) * K, [&](int n0, int n1) {
+          _qmm_t_i8<T, group_size>(
+              result,
+              xq.data(),
+              gscale.data(),
+              gsum.data(),
+              w,
+              scales,
+              biases,
+              M,
+              N,
+              K,
+              n0,
+              n1);
+        });
+        return;
+      }
+    }
+#endif // __ARM_FEATURE_DOTPROD
     // the simd size must be a multiple of the number of elements per word
     if constexpr (32 % bits == 0 && simd::max_size<T> % (32 / bits) == 0) {
-      _qmm_t_simd<T, bits, group_size>(result, x, w, scales, biases, M, N, K);
+      cpu::parallel_for_rows(N, size_t(M) * K, [&](int n0, int n1) {
+        _qmm_t_simd<T, bits, group_size>(
+            result, x, w, scales, biases, M, N, K, n0, n1);
+      });
     } else {
-      _qmm_t<T, bits, group_size>(result, x, w, scales, biases, M, N, K);
+      cpu::parallel_for_rows(N, size_t(M) * K, [&](int n0, int n1) {
+        _qmm_t<T, bits, group_size>(
+            result, x, w, scales, biases, M, N, K, n0, n1);
+      });
     }
   } else {
     _qmm<T, bits, group_size>(result, x, w, scales, biases, M, N, K);
@@ -496,16 +660,22 @@ void fp_qmm_t(
     const uint8_t* scales,
     int M,
     int N,
-    int K) {
+    int K,
+    int n0,
+    int n1) {
   constexpr int pack_factor = get_pack_factor(bits, 8);
   constexpr int packs_in_group = group_size / pack_factor;
+  const size_t bytes_per_row = K / pack_factor;
+  const size_t groups_per_row = K / group_size;
 
   for (int m = 0; m < M; m++) {
-    const uint8_t* w_local = (const uint8_t*)w;
-    const uint8_t* scales_local = scales;
+    const T* x_row = x + size_t(m) * K;
+    T* result_row = result + size_t(m) * N;
+    const uint8_t* w_local = (const uint8_t*)w + size_t(n0) * bytes_per_row;
+    const uint8_t* scales_local = scales + size_t(n0) * groups_per_row;
 
-    for (int n = 0; n < N; n++) {
-      const T* x_local = x;
+    for (int n = n0; n < n1; n++) {
+      const T* x_local = x_row;
       T sum = 0;
       for (int k = 0; k < K; k += group_size) {
         T scale = dequantize_scale<T, group_size>(*scales_local++);
@@ -524,11 +694,8 @@ void fp_qmm_t(
         }
         sum += scale * gsum;
       }
-      *result = sum;
-      result++;
+      result_row[n] = sum;
     }
-
-    x += K;
   }
 }
 
@@ -562,23 +729,29 @@ void fp_qmm_t_simd(
     const uint8_t* scales,
     int M,
     int N,
-    int K) {
+    int K,
+    int n0,
+    int n1) {
   constexpr int pack_factor = get_pack_factor(bits, 32);
   constexpr int packs_in_group = group_size / pack_factor;
   constexpr int S = simd::max_size<T>;
   static_assert(
       S % pack_factor == 0, "SIMD size must be divisible by pack factor");
   constexpr int packs_per_simd = S / pack_factor;
+  const size_t words_per_row = K / pack_factor;
+  const size_t groups_per_row = K / group_size;
 
   for (int m = 0; m < M; m++) {
-    const uint32_t* w_local = w;
-    const uint8_t* scales_local = scales;
+    const T* x_row = x + size_t(m) * K;
+    T* result_row = result + size_t(m) * N;
+    const uint32_t* w_local = w + size_t(n0) * words_per_row;
+    const uint8_t* scales_local = scales + size_t(n0) * groups_per_row;
 
-    for (int n = 0; n < N; n++) {
+    for (int n = n0; n < n1; n++) {
       simd::Simd<float, S> acc(0);
-      auto x_local = x;
+      auto x_local = x_row;
       for (int k = 0; k < K; k += group_size) {
-        T scale = dequantize_scale<T, group_size>(*scales_local++);
+        float scale = dequantize_scale<float, group_size>(*scales_local++);
 
         simd::Simd<float, S> g_acc(0);
         for (int kw = 0; kw < packs_in_group; kw += packs_per_simd) {
@@ -592,10 +765,8 @@ void fp_qmm_t_simd(
         acc = acc + scale * g_acc;
       }
 
-      *result = T(simd::sum(acc));
-      result++;
+      result_row[n] = T(simd::sum(acc));
     }
-    x += K;
   }
 }
 
@@ -612,9 +783,14 @@ void fp_qmm_dispatch_transpose(
   if (transposed_w) {
     // the simd size must be a multiple of the number of elements per word
     if constexpr (simd::max_size<T> % 8 == 0) {
-      fp_qmm_t_simd<T, group_size, bits>(result, x, w, scales, M, N, K);
+      cpu::parallel_for_rows(N, size_t(M) * K, [&](int n0, int n1) {
+        fp_qmm_t_simd<T, group_size, bits>(
+            result, x, w, scales, M, N, K, n0, n1);
+      });
     } else {
-      fp_qmm_t<T, group_size, bits>(result, x, w, scales, M, N, K);
+      cpu::parallel_for_rows(N, size_t(M) * K, [&](int n0, int n1) {
+        fp_qmm_t<T, group_size, bits>(result, x, w, scales, M, N, K, n0, n1);
+      });
     }
   } else {
     fp_qmm<T, group_size, bits>(result, x, w, scales, M, N, K);

--- a/mlx/backend/cpu/simd/accelerate_simd.h
+++ b/mlx/backend/cpu/simd/accelerate_simd.h
@@ -63,12 +63,17 @@ struct Simd {
 
   template <
       typename U,
-      typename = std::enable_if_t<!std::is_same_v<U, bfloat16_t>>>
+      typename = std::enable_if_t<
+          !std::is_same_v<U, bfloat16_t> &&
+          (MLX_SIMD_LIBRARY_VERSION >= 6 || !std::is_same_v<U, float16_t>)>>
   Simd<T, N>(Simd<U, N> other) : value(asd::convert<scalar_t>(other.value)) {}
 
   template <
       typename U,
-      typename = std::enable_if_t<!std::is_same_v<U, Simd<bfloat16_t, N>>>>
+      typename = std::enable_if_t<
+          !std::is_same_v<U, Simd<bfloat16_t, N>> &&
+          (MLX_SIMD_LIBRARY_VERSION >= 6 ||
+           !std::is_same_v<U, Simd<float16_t, N>>)>>
   Simd<T, N>(U v) : value(v){};
 
   Simd<T, N>(Simd<T, N / 2> x, Simd<T, N / 2> y) {

--- a/mlx/backend/cpu/simd/accelerate_simd.h
+++ b/mlx/backend/cpu/simd/accelerate_simd.h
@@ -7,8 +7,10 @@
 #include <stdint.h>
 #include <cmath>
 #include <complex>
+#include <type_traits>
 
 #include "mlx/backend/cpu/simd/base_simd.h"
+#include "mlx/types/half_types.h"
 
 // There seems to be a bug in simd/base_simd.h
 // __XROS_2_0 is not defined, the expression evaluates
@@ -59,10 +61,14 @@ struct Simd {
 
   Simd<T, N>() {}
 
-  template <typename U>
+  template <
+      typename U,
+      typename = std::enable_if_t<!std::is_same_v<U, bfloat16_t>>>
   Simd<T, N>(Simd<U, N> other) : value(asd::convert<scalar_t>(other.value)) {}
 
-  template <typename U>
+  template <
+      typename U,
+      typename = std::enable_if_t<!std::is_same_v<U, Simd<bfloat16_t, N>>>>
   Simd<T, N>(U v) : value(v){};
 
   Simd<T, N>(Simd<T, N / 2> x, Simd<T, N / 2> y) {
@@ -327,3 +333,4 @@ T prod(Simd<T, N> x) {
 #if __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
 #include "mlx/backend/cpu/simd/accelerate_fp16_simd.h"
 #endif
+#include "mlx/backend/cpu/simd/neon_bf16_simd.h"

--- a/mlx/backend/cpu/simd/neon_bf16_simd.h
+++ b/mlx/backend/cpu/simd/neon_bf16_simd.h
@@ -72,9 +72,9 @@ struct Simd<bfloat16_t, BF16_N> {
   uint16x8_t value;
 };
 
-#define DEFINE_BF16_UNARY_OP(name)                                       \
-  inline Simd<bfloat16_t, BF16_N> name(Simd<bfloat16_t, BF16_N> a) {     \
-    return Simd<bfloat16_t, BF16_N>(name(Simd<float, BF16_N>(a)));       \
+#define DEFINE_BF16_UNARY_OP(name)                                   \
+  inline Simd<bfloat16_t, BF16_N> name(Simd<bfloat16_t, BF16_N> a) { \
+    return Simd<bfloat16_t, BF16_N>(name(Simd<float, BF16_N>(a)));   \
   }
 
 DEFINE_BF16_UNARY_OP(abs)
@@ -108,19 +108,19 @@ inline Simd<bool, BF16_N> operator!(Simd<bfloat16_t, BF16_N> v) {
   return !Simd<float, BF16_N>(v);
 }
 
-#define DEFINE_BF16_BINARY_OP(name)                                          \
-  inline Simd<bfloat16_t, BF16_N> name(                                     \
-      Simd<bfloat16_t, BF16_N> a, Simd<bfloat16_t, BF16_N> b) {             \
-    return Simd<bfloat16_t, BF16_N>(                                        \
-        name(Simd<float, BF16_N>(a), Simd<float, BF16_N>(b)));              \
-  }                                                                          \
-  template <typename T>                                                      \
-  Simd<bfloat16_t, BF16_N> name(Simd<bfloat16_t, BF16_N> a, T b) {          \
-    return name(a, Simd<bfloat16_t, BF16_N>(b));                            \
-  }                                                                          \
-  template <typename T>                                                      \
-  Simd<bfloat16_t, BF16_N> name(T a, Simd<bfloat16_t, BF16_N> b) {          \
-    return name(Simd<bfloat16_t, BF16_N>(a), b);                            \
+#define DEFINE_BF16_BINARY_OP(name)                                \
+  inline Simd<bfloat16_t, BF16_N> name(                            \
+      Simd<bfloat16_t, BF16_N> a, Simd<bfloat16_t, BF16_N> b) {    \
+    return Simd<bfloat16_t, BF16_N>(                               \
+        name(Simd<float, BF16_N>(a), Simd<float, BF16_N>(b)));     \
+  }                                                                \
+  template <typename T>                                            \
+  Simd<bfloat16_t, BF16_N> name(Simd<bfloat16_t, BF16_N> a, T b) { \
+    return name(a, Simd<bfloat16_t, BF16_N>(b));                   \
+  }                                                                \
+  template <typename T>                                            \
+  Simd<bfloat16_t, BF16_N> name(T a, Simd<bfloat16_t, BF16_N> b) { \
+    return name(Simd<bfloat16_t, BF16_N>(a), b);                   \
   }
 
 DEFINE_BF16_BINARY_OP(operator+)
@@ -133,18 +133,18 @@ DEFINE_BF16_BINARY_OP(atan2)
 DEFINE_BF16_BINARY_OP(remainder)
 DEFINE_BF16_BINARY_OP(pow)
 
-#define DEFINE_BF16_COMPARISON(Op)                                           \
-  inline Simd<bool, BF16_N> operator Op(                                     \
-      Simd<bfloat16_t, BF16_N> a, Simd<bfloat16_t, BF16_N> b) {              \
-    return Simd<float, BF16_N>(a) Op Simd<float, BF16_N>(b);                 \
-  }                                                                          \
-  template <typename T>                                                      \
-  Simd<bool, BF16_N> operator Op(Simd<bfloat16_t, BF16_N> a, T b) {          \
-    return a Op Simd<bfloat16_t, BF16_N>(b);                                 \
-  }                                                                          \
-  template <typename T>                                                      \
-  Simd<bool, BF16_N> operator Op(T a, Simd<bfloat16_t, BF16_N> b) {          \
-    return Simd<bfloat16_t, BF16_N>(a) Op b;                                 \
+#define DEFINE_BF16_COMPARISON(Op)                                  \
+  inline Simd<bool, BF16_N> operator Op(                            \
+      Simd<bfloat16_t, BF16_N> a, Simd<bfloat16_t, BF16_N> b) {     \
+    return Simd<float, BF16_N>(a) Op Simd<float, BF16_N>(b);        \
+  }                                                                 \
+  template <typename T>                                             \
+  Simd<bool, BF16_N> operator Op(Simd<bfloat16_t, BF16_N> a, T b) { \
+    return a Op Simd<bfloat16_t, BF16_N>(b);                        \
+  }                                                                 \
+  template <typename T>                                             \
+  Simd<bool, BF16_N> operator Op(T a, Simd<bfloat16_t, BF16_N> b) { \
+    return Simd<bfloat16_t, BF16_N>(a) Op b;                        \
   }
 
 DEFINE_BF16_COMPARISON(==)
@@ -184,10 +184,10 @@ inline Simd<bfloat16_t, BF16_N> clamp(
 template <typename T>
 Simd<bfloat16_t, BF16_N>
 fma(Simd<bfloat16_t, BF16_N> x, Simd<bfloat16_t, BF16_N> y, T z) {
-  return Simd<bfloat16_t, BF16_N>(fma(
-      Simd<float, BF16_N>(x),
-      Simd<float, BF16_N>(y),
-      Simd<float, BF16_N>(Simd<bfloat16_t, BF16_N>(z))));
+  return Simd<bfloat16_t, BF16_N>(
+      fma(Simd<float, BF16_N>(x),
+          Simd<float, BF16_N>(y),
+          Simd<float, BF16_N>(Simd<bfloat16_t, BF16_N>(z))));
 }
 
 template <typename MaskT>

--- a/mlx/backend/cpu/simd/neon_bf16_simd.h
+++ b/mlx/backend/cpu/simd/neon_bf16_simd.h
@@ -1,0 +1,216 @@
+#pragma once
+
+#include <arm_neon.h>
+
+#include "mlx/backend/cpu/simd/base_simd.h"
+
+namespace mlx::core::simd {
+
+constexpr int BF16_N = 8;
+
+template <>
+inline constexpr int max_size<bfloat16_t> = BF16_N;
+
+inline float32x4_t bf16_bits_to_f32(uint16x4_t v) {
+  return vreinterpretq_f32_u32(vshll_n_u16(v, 16));
+}
+
+inline uint16x4_t f32_to_bf16_bits(float32x4_t f) {
+  uint32x4_t bits = vreinterpretq_u32_f32(f);
+  uint32x4_t lsb = vandq_u32(vshrq_n_u32(bits, 16), vdupq_n_u32(1));
+  uint32x4_t rounded = vaddq_u32(bits, vaddq_u32(vdupq_n_u32(0x7FFF), lsb));
+  uint16x4_t out = vshrn_n_u32(rounded, 16);
+  uint32x4_t is_nan = vmvnq_u32(vceqq_f32(f, f));
+  return vbsl_u16(vmovn_u32(is_nan), vdup_n_u16(0x7FC0), out);
+}
+
+template <>
+struct Simd<bfloat16_t, BF16_N> {
+  static constexpr int size = BF16_N;
+  using scalar_t = bfloat16_t;
+
+  Simd<bfloat16_t, BF16_N>() {}
+
+  Simd<bfloat16_t, BF16_N>(uint16x8_t v) : value(v) {}
+
+  template <typename U>
+  Simd<bfloat16_t, BF16_N>(U v) {
+    bfloat16_t t = static_cast<bfloat16_t>(static_cast<float>(v));
+    value = vdupq_n_u16(*reinterpret_cast<uint16_t*>(&t));
+  }
+
+  Simd<bfloat16_t, BF16_N>(Simd<float, BF16_N> other) {
+    auto f32x4_a = *(float32x4_t*)(&other);
+    auto f32x4_b = *((float32x4_t*)(&other) + 1);
+    value = vcombine_u16(f32_to_bf16_bits(f32x4_a), f32_to_bf16_bits(f32x4_b));
+  }
+
+  template <typename U>
+  Simd<bfloat16_t, BF16_N>(Simd<U, BF16_N> other)
+      : Simd(Simd<float, BF16_N>(other)) {}
+
+  operator Simd<float, BF16_N>() const {
+    float32x4x2_t v;
+    v.val[0] = bf16_bits_to_f32(vget_low_u16(value));
+    v.val[1] = bf16_bits_to_f32(vget_high_u16(value));
+    return load<float, BF16_N>((float*)&v);
+  }
+
+  template <typename U>
+  operator Simd<U, BF16_N>() const {
+    return Simd<U, BF16_N>(Simd<float, BF16_N>(*this));
+  }
+
+  bfloat16_t operator[](int idx) const {
+    return reinterpret_cast<const bfloat16_t*>(&value)[idx];
+  }
+
+  bfloat16_t& operator[](int idx) {
+    return reinterpret_cast<bfloat16_t*>(&value)[idx];
+  }
+
+  uint16x8_t value;
+};
+
+#define DEFINE_BF16_UNARY_OP(name)                                       \
+  inline Simd<bfloat16_t, BF16_N> name(Simd<bfloat16_t, BF16_N> a) {     \
+    return Simd<bfloat16_t, BF16_N>(name(Simd<float, BF16_N>(a)));       \
+  }
+
+DEFINE_BF16_UNARY_OP(abs)
+DEFINE_BF16_UNARY_OP(ceil)
+DEFINE_BF16_UNARY_OP(floor)
+DEFINE_BF16_UNARY_OP(sqrt)
+DEFINE_BF16_UNARY_OP(rsqrt)
+DEFINE_BF16_UNARY_OP(recip)
+DEFINE_BF16_UNARY_OP(rint)
+DEFINE_BF16_UNARY_OP(acos)
+DEFINE_BF16_UNARY_OP(acosh)
+DEFINE_BF16_UNARY_OP(asin)
+DEFINE_BF16_UNARY_OP(asinh)
+DEFINE_BF16_UNARY_OP(atan)
+DEFINE_BF16_UNARY_OP(atanh)
+DEFINE_BF16_UNARY_OP(cosh)
+DEFINE_BF16_UNARY_OP(expm1)
+DEFINE_BF16_UNARY_OP(log)
+DEFINE_BF16_UNARY_OP(log2)
+DEFINE_BF16_UNARY_OP(log10)
+DEFINE_BF16_UNARY_OP(log1p)
+DEFINE_BF16_UNARY_OP(sinh)
+DEFINE_BF16_UNARY_OP(tan)
+DEFINE_BF16_UNARY_OP(tanh)
+
+inline Simd<bfloat16_t, BF16_N> operator-(Simd<bfloat16_t, BF16_N> v) {
+  return Simd<bfloat16_t, BF16_N>(veorq_u16(v.value, vdupq_n_u16(0x8000)));
+}
+
+inline Simd<bool, BF16_N> operator!(Simd<bfloat16_t, BF16_N> v) {
+  return !Simd<float, BF16_N>(v);
+}
+
+#define DEFINE_BF16_BINARY_OP(name)                                          \
+  inline Simd<bfloat16_t, BF16_N> name(                                     \
+      Simd<bfloat16_t, BF16_N> a, Simd<bfloat16_t, BF16_N> b) {             \
+    return Simd<bfloat16_t, BF16_N>(                                        \
+        name(Simd<float, BF16_N>(a), Simd<float, BF16_N>(b)));              \
+  }                                                                          \
+  template <typename T>                                                      \
+  Simd<bfloat16_t, BF16_N> name(Simd<bfloat16_t, BF16_N> a, T b) {          \
+    return name(a, Simd<bfloat16_t, BF16_N>(b));                            \
+  }                                                                          \
+  template <typename T>                                                      \
+  Simd<bfloat16_t, BF16_N> name(T a, Simd<bfloat16_t, BF16_N> b) {          \
+    return name(Simd<bfloat16_t, BF16_N>(a), b);                            \
+  }
+
+DEFINE_BF16_BINARY_OP(operator+)
+DEFINE_BF16_BINARY_OP(operator-)
+DEFINE_BF16_BINARY_OP(operator*)
+DEFINE_BF16_BINARY_OP(operator/)
+DEFINE_BF16_BINARY_OP(maximum)
+DEFINE_BF16_BINARY_OP(minimum)
+DEFINE_BF16_BINARY_OP(atan2)
+DEFINE_BF16_BINARY_OP(remainder)
+DEFINE_BF16_BINARY_OP(pow)
+
+#define DEFINE_BF16_COMPARISON(Op)                                           \
+  inline Simd<bool, BF16_N> operator Op(                                     \
+      Simd<bfloat16_t, BF16_N> a, Simd<bfloat16_t, BF16_N> b) {              \
+    return Simd<float, BF16_N>(a) Op Simd<float, BF16_N>(b);                 \
+  }                                                                          \
+  template <typename T>                                                      \
+  Simd<bool, BF16_N> operator Op(Simd<bfloat16_t, BF16_N> a, T b) {          \
+    return a Op Simd<bfloat16_t, BF16_N>(b);                                 \
+  }                                                                          \
+  template <typename T>                                                      \
+  Simd<bool, BF16_N> operator Op(T a, Simd<bfloat16_t, BF16_N> b) {          \
+    return Simd<bfloat16_t, BF16_N>(a) Op b;                                 \
+  }
+
+DEFINE_BF16_COMPARISON(==)
+DEFINE_BF16_COMPARISON(!=)
+DEFINE_BF16_COMPARISON(>)
+DEFINE_BF16_COMPARISON(<)
+DEFINE_BF16_COMPARISON(>=)
+DEFINE_BF16_COMPARISON(<=)
+
+inline Simd<bfloat16_t, BF16_N> operator&&(
+    Simd<bfloat16_t, BF16_N> a,
+    Simd<bfloat16_t, BF16_N> b) {
+  return Simd<bfloat16_t, BF16_N>(
+      Simd<float, BF16_N>(a) && Simd<float, BF16_N>(b));
+}
+
+inline Simd<bfloat16_t, BF16_N> operator||(
+    Simd<bfloat16_t, BF16_N> a,
+    Simd<bfloat16_t, BF16_N> b) {
+  return Simd<bfloat16_t, BF16_N>(
+      Simd<float, BF16_N>(a) || Simd<float, BF16_N>(b));
+}
+
+template <>
+inline Simd<bool, BF16_N> isnan(Simd<bfloat16_t, BF16_N> v) {
+  return isnan(Simd<float, BF16_N>(v));
+}
+
+template <>
+inline Simd<bfloat16_t, BF16_N> clamp(
+    Simd<bfloat16_t, BF16_N> v,
+    Simd<bfloat16_t, BF16_N> min,
+    Simd<bfloat16_t, BF16_N> max) {
+  return minimum(maximum(v, min), max);
+}
+
+template <typename T>
+Simd<bfloat16_t, BF16_N>
+fma(Simd<bfloat16_t, BF16_N> x, Simd<bfloat16_t, BF16_N> y, T z) {
+  return Simd<bfloat16_t, BF16_N>(fma(
+      Simd<float, BF16_N>(x),
+      Simd<float, BF16_N>(y),
+      Simd<float, BF16_N>(Simd<bfloat16_t, BF16_N>(z))));
+}
+
+template <typename MaskT>
+Simd<bfloat16_t, BF16_N> select(
+    Simd<MaskT, BF16_N> mask,
+    Simd<bfloat16_t, BF16_N> x,
+    Simd<bfloat16_t, BF16_N> y) {
+  auto m = Simd<uint16_t, BF16_N>(mask);
+  return Simd<bfloat16_t, BF16_N>(
+      vbslq_u16(*(uint16x8_t*)(&m.value), x.value, y.value));
+}
+
+inline bfloat16_t max(Simd<bfloat16_t, BF16_N> x) {
+  return bfloat16_t(max(Simd<float, BF16_N>(x)));
+}
+inline bfloat16_t min(Simd<bfloat16_t, BF16_N> x) {
+  return bfloat16_t(min(Simd<float, BF16_N>(x)));
+}
+inline bfloat16_t sum(Simd<bfloat16_t, BF16_N> x) {
+  return bfloat16_t(sum(Simd<float, BF16_N>(x)));
+}
+inline bfloat16_t prod(Simd<bfloat16_t, BF16_N> x) {
+  return bfloat16_t(prod(Simd<float, BF16_N>(x)));
+}
+
+} // namespace mlx::core::simd


### PR DESCRIPTION
This began when I realized that cpu + gpu inference is possible with llama.cpp but insanely slow using mlx-lm on recent mlx main branch, all due to how slow it is for cpu.

This pr has several cpu paths to support cpu inference on par with llama.cpp and even cpu and gpu simultaneous inference is on par with llama.cpp.

For starters, this introduces a bf16 SIMD support to cpu, in `neon_bf16_simd.h`. This was because for models in this numerical percision(bf16), cpu didn't have native bf16 arithmetic, and prior to this,  cpu was doing a scalar loop one element at a time, converting to float and back.  So this does upcast to fp32, by widening 8 values to compute normal float SIMD, round back with same rounding as the scalar code, making it bit identical.

Secondly, while profiling quantized matmuls, I saw that against llama.cpp mlx uses single cores on cpu as against to 8, so `parallel.h` handles this, allowing for multiple workers to be launched(8 by default), created and reused for every matmul. If matmuls under 2m ops exist, they aren't routed to this and instead run on the calling thread.

Third, while profiling against llama.cpp, mlx unpacked 4-bit weights into floats and did float multiply-adds; llama.cpp rounds the activations to int8 and uses the CPU's SDOT instruction, so this PR also includes that support on mlx's own quantization format. Activations are quantized to int8 per 64-element group right before the matmul (with the scale kept on the side so results come out correct), and the 4-bit weights are recentered to signed values so the whole dot product runs on vdotq_s32 — 16 multiply-accumulates per instruction, about 3.5x over the float path. The rounding this introduces (~0.5%) is smaller than the error 4-bit weights already carry, and it's the same tradeoff llama.cpp makes on every CPU inference. 

Lastly, two extensions to the int8 kernel. It now also covers 8-bit quantized weights, which matters because a bf16 checkpoint converted to 8-bit goes from 7.4 to 59 tok/s with near-lossless quality, and prefill used to re-read the entire weight matrix once per prompt token, now processing 4 prompt rows per weight pass.

All numbers are decode tokens/sec on a single M4 Mac mini (16GB, macOS), generating ~100 tokens from the same prompt per run, using mlx-community 4-bit checkpoints via mlx-lm (CPU-after runs with MLX_CPU_INT8_QMM=1, threading at the default MLX_CPU_THREADS=8) against llama.cpp build 9110 with matching Q4_K_M GGUFs (llama-bench -t 8 for CPU, -ngl 99 for GPU), and simultaneous rows run the same model concurrently on both devices in two separate processes.

## Table 1 — CPU: before vs after this PR

| model | CPU before | CPU after | speedup |
|---|---|---|---|
| gemma-3-270m | 0.93 | 173.5 | 187× |
| Qwen2.5-0.5B | 15.5 | 139.7 | 9× |
| Qwen3-0.6B | 0.40 | 93.0 | 233× |
| Llama-3.2-1B | 6.55 | 89.7 | 14× |
| gemma-3-1b | 7.68 | 70.8 | 9× |
| LFM2-1.2B | 0.20 | 94.5 | 472× |
| Qwen3-1.7B | 0.14 | 56.0 | 400× |
| SmolLM3-3B | 0.08 | 34.3 | 429× |
| Llama-3.2-3B | 2.46 | 38.3 | 16× |
| Qwen2.5-3B | 2.55 | 38.6 | 15× |
| Phi-4-mini | 2.06 | 35.9 | 17× |
| Qwen3-4B | 0.06 | 29.1 | 486× |
| gemma-3-4b | 0.06 | 26.7 | 444× |
| Qwen2.5-7B | 1.13 | 20.6 | 18× |
| Qwen2.5-14B | 0.58 | 10.6 | 18× |

## Table 2 — simultaneous CPU+GPU: before vs after this PR

| model | CPU+GPU before | CPU+GPU after |
|---|---|---|
| gemma-3-270m | 1.0 + 432.7 = 433.7 | 155.3 + 354.1 = 509.4 |
| Qwen2.5-0.5B | 16.1 + 289.1 = 305.2 | 105.6 + 223.4 = 329.0 |
| Qwen3-0.6B | 0.4 + 248.4 = 248.8 | 76.5 + 194.7 = 271.2 |
| Llama-3.2-1B | 6.7 + 136.0 = 142.7 | 58.9 + 95.9 = 154.8 |
| gemma-3-1b | 8.0 + 150.5 = 158.5 | 59.2 + 113.2 = 172.4 |
| LFM2-1.2B | 0.2 + 151.6 = 151.8 | 63.6 + 102.7 = 166.3 |
| Qwen3-1.7B | 0.2 + 100.8 = 101.0 | 39.4 + 71.0 = 110.4 |
| SmolLM3-3B | 0.1 + 58.3 = 58.4 | 26.2 + 43.7 = 69.9 |
| Llama-3.2-3B | 2.6 + 54.7 = 57.3 | 24.1 + 36.7 = 60.8 |
| Qwen2.5-3B | 2.7 + 57.2 = 59.9 | 24.8 + 38.9 = 63.7 |
| Phi-4-mini | 2.1 + 44.7 = 46.8 | 21.2 + 29.8 = 51.0 |
| Qwen3-4B | 0.1 + 44.1 = 44.2 | 18.4 + 29.5 = 47.9 |
| gemma-3-4b | 0.1 + 45.1 = 45.2 | 18.3 + 31.2 = 49.5 |
| Qwen2.5-7B | 1.2 + 24.9 = 26.1 | 12.1 + 16.4 = 28.5 |
| Qwen2.5-14B | 0.6 + 12.4 = 13.0 | 1.3 + 12.1 = 13.4 ⚠ |

## Table 3 — CPU: mlx (with PR) vs llama.cpp

| model | mlx CPU | llama.cpp CPU |
|---|---|---|
| gemma-3-270m | 173.5 | 229.8 |
| Qwen2.5-0.5B | 139.7 | 164.6 |
| Qwen3-0.6B | 93.0 | 137.2 |
| Llama-3.2-1B | 89.7 | 89.7 |
| gemma-3-1b | 70.8 | 90.4 |
| LFM2-1.2B | 94.5 | 99.5 |
| Qwen3-1.7B | 56.0 | 59.3 |
| SmolLM3-3B | 34.3 | 36.5 |
| Llama-3.2-3B | 38.3 | 35.3 |
| Qwen2.5-3B | 38.6 | 36.4 |
| Phi-4-mini | 35.9 | 29.4 |
| Qwen3-4B | 29.1 | 27.6 |
| gemma-3-4b | 26.7 | 28.5 |
| Qwen2.5-7B | 20.6 | 17.2 |
| Qwen2.5-14B | 10.6 | 8.8 |

## Table 4 — GPU: mlx vs llama.cpp

| model | mlx GPU | llama.cpp GPU |
|---|---|---|
| gemma-3-270m | 436.6 | 231.6 |
| Qwen2.5-0.5B | 287.8 | 163.3 |
| Qwen3-0.6B | 248.3 | 165.4 |
| Llama-3.2-1B | 137.4 | 108.2 |
| gemma-3-1b | 151.4 | 98.7 |
| LFM2-1.2B | 148.4 | 120.2 |
| Qwen3-1.7B | 97.4 | 77.3 |
| SmolLM3-3B | 57.4 | 47.6 |
| Llama-3.2-3B | 54.3 | 45.5 |
| Qwen2.5-3B | 57.6 | 46.9 |
| Phi-4-mini | 45.6 | 37.0 |
| Qwen3-4B | 43.4 | 36.3 |
| gemma-3-4b | 44.4 | 37.5 |
| Qwen2.5-7B | 25.4 | 22.6 |
| Qwen2.5-14B | 13.0 | 11.7 |

## Table 5 — simultaneous CPU+GPU: mlx vs llama.cpp

| model | mlx CPU+GPU | llama.cpp CPU+GPU |
|---|---|---|
| gemma-3-270m | 155.3 + 354.1 = 509.4 | 169.6 + 202.8 = 372.4 |
| Qwen2.5-0.5B | 105.6 + 223.4 = 329.0 | 119.9 + 142.5 = 262.4 |
| Qwen3-0.6B | 76.5 + 194.7 = 271.2 | 105.1 + 139.2 = 244.3 |
| Llama-3.2-1B | 58.9 + 95.9 = 154.8 | 63.2 + 87.2 = 150.4 |
| gemma-3-1b | 59.2 + 113.2 = 172.4 | 62.4 + 82.0 = 144.5 |
| LFM2-1.2B | 63.6 + 102.7 = 166.3 | 70.4 + 96.5 = 166.9 |
| Qwen3-1.7B | 39.4 + 71.0 = 110.4 | 44.2 + 62.0 = 106.3 |
| SmolLM3-3B | 26.2 + 43.7 = 69.9 | 25.5 + 37.0 = 62.5 |
| Llama-3.2-3B | 24.1 + 36.7 = 60.8 | 25.6 + 36.0 = 61.6 |
| Qwen2.5-3B | 24.8 + 38.9 = 63.7 | 26.1 + 37.1 = 63.2 |
| Phi-4-mini | 21.2 + 29.8 = 51.0 | 21.1 + 29.2 = 50.3 |
| Qwen3-4B | 18.4 + 29.5 = 47.9 | 20.3 + 28.8 = 49.1 |
| gemma-3-4b | 18.3 + 31.2 = 49.5 | 20.3 + 29.2 = 49.5 |
| Qwen2.5-7B | 12.1 + 16.4 = 28.5 | 12.4 + 17.4 = 29.8 |
| Qwen2.5-14B | 1.3 + 12.1 = 13.4  | 7.0 + 11.0 = 18.0 |



Also, argmax over a large vocab compared scores one element at a time in arg_reduce.cpp (~0.4ms per token on a 262k vocab). This adds a SIMD fast path for contiguous float rows, rows containing NaN fall back to the original loop, so results are always identical to before.



All local tests green

The int8 path is opt-in (MLX_CPU_INT8_QMM=1) so default numerics are unchanged and the full test suite passes as-is.