### PR TITLE
Zero-copy CPU import: mx.array(host_buffer, copy=False) on unified memory

### DIFF
--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -306,18 +306,13 @@ void init_array(nb::module_& m) {
       nb::pooled(/* capacity = */ 128))
       .def(
           "__init__",
-          [](mx::array* aptr,
-             nb::object v,
-             std::optional<mx::Dtype> t,
-             std::optional<bool> copy) {
-            new (aptr) mx::array(create_array(v, t, copy));
+          [](mx::array* aptr, nb::object v, std::optional<mx::Dtype> t) {
+            new (aptr) mx::array(create_array(v, t, true));
           },
           "val"_a,
           "dtype"_a = nb::none(),
-          nb::kw_only(),
-          "copy"_a = nb::none(),
           nb::sig(
-              "def __init__(self: array, val: Union[scalar, list, tuple, DLPackCompatible, array], dtype: Optional[Dtype] = None, *, copy: Optional[bool] = None)"))
+              "def __init__(self: array, val: Union[scalar, list, tuple, DLPackCompatible, array], dtype: Optional[Dtype] = None)"))
       .def_prop_ro(
           "size",
           &mx::array::size,

--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -306,13 +306,18 @@ void init_array(nb::module_& m) {
       nb::pooled(/* capacity = */ 128))
       .def(
           "__init__",
-          [](mx::array* aptr, nb::object v, std::optional<mx::Dtype> t) {
-            new (aptr) mx::array(create_array(v, t, true));
+          [](mx::array* aptr,
+             nb::object v,
+             std::optional<mx::Dtype> t,
+             std::optional<bool> copy) {
+            new (aptr) mx::array(create_array(v, t, copy));
           },
           "val"_a,
           "dtype"_a = nb::none(),
+          nb::kw_only(),
+          "copy"_a = nb::none(),
           nb::sig(
-              "def __init__(self: array, val: Union[scalar, list, tuple, DLPackCompatible, array], dtype: Optional[Dtype] = None)"))
+              "def __init__(self: array, val: Union[scalar, list, tuple, DLPackCompatible, array], dtype: Optional[Dtype] = None, *, copy: Optional[bool] = None)"))
       .def_prop_ro(
           "size",
           &mx::array::size,

--- a/python/src/convert.cpp
+++ b/python/src/convert.cpp
@@ -268,7 +268,11 @@ mx::array nd_array_to_mlx(
             flags,
             offset,
             [owner = std::move(nd_array)](mx::allocator::Buffer b) {
-              mx::allocator::free(b);
+              // A make_buffer() buffer wraps caller-owned external memory, so
+              // release it (drop the wrapper) rather than returning it to the
+              // allocator's reuse pool — that pool must only recycle buffers it
+              // allocated itself.
+              mx::allocator::release(b);
             });
         out.set_status(mx::array::Status::available);
         return out;

--- a/python/src/convert.cpp
+++ b/python/src/convert.cpp
@@ -239,6 +239,15 @@ mx::array nd_array_to_mlx(
           throw std::invalid_argument(
               "Cannot import a CPU DLPack array without a copy on this backend.");
         }
+        // The buffer is reinterpreted, not converted, so the source element
+        // size must match the destination dtype. MLX maps some numpy dtypes to
+        // a different-width mlx dtype (e.g. float64 -> float32), which the
+        // dst==src check above does not catch; guard on the physical size.
+        if (nd_array.itemsize() != mx::size_of(dst_dtype)) {
+          throw std::invalid_argument(
+              "Cannot import a CPU DLPack array without a copy: the source "
+              "element size does not match the destination dtype.");
+        }
         auto [storage_size, strides, flags] =
             get_strided_layout(nd_array, shape);
         auto offset = nd_array.byte_offset();

--- a/python/src/convert.cpp
+++ b/python/src/convert.cpp
@@ -172,6 +172,52 @@ mx::array cpu_nd_array_to_mlx(
   return out;
 }
 
+// Try to adopt a CPU host buffer as an mlx array without copying. On unified
+// memory the host pointer is GPU-addressable, so we wrap it directly via the
+// allocator instead of copying. The bytes are reinterpreted rather than
+// converted, so the source element width must already match the destination
+// dtype. The source ndarray is kept alive for the lifetime of the returned
+// array.
+//
+// Returns std::nullopt when the buffer cannot be adopted (no Metal backend,
+// dtype width mismatch, or a pointer the platform will not wrap), so the caller
+// can fall back to a copy or raise.
+std::optional<mx::array> cpu_nd_array_to_mlx_no_copy(
+    nb::ndarray<nb::ro> nd_array,
+    const mx::Shape& shape,
+    mx::Dtype dst_dtype) {
+  if (!mx::metal::is_available() ||
+      nd_array.itemsize() != mx::size_of(dst_dtype)) {
+    return std::nullopt;
+  }
+
+  auto [storage_size, strides, flags] = get_strided_layout(nd_array, shape);
+  auto buf = mx::allocator::make_buffer(
+      const_cast<void*>(nd_array.data()),
+      storage_size * mx::size_of(dst_dtype));
+  // make_buffer returns a null buffer when the pointer cannot be wrapped, e.g.
+  // when its alignment is not accepted by the platform.
+  if (buf.ptr() == nullptr) {
+    return std::nullopt;
+  }
+
+  mx::array out(shape, dst_dtype, nullptr, {});
+  out.set_data(
+      buf,
+      storage_size,
+      std::move(strides),
+      flags,
+      nd_array.byte_offset(),
+      // The buffer wraps caller-owned memory, so release the wrapper rather
+      // than returning it to the allocator's reuse pool, which must only
+      // recycle buffers it allocated itself.
+      [owner = std::move(nd_array)](mx::allocator::Buffer b) {
+        mx::allocator::release(b);
+      });
+  out.set_status(mx::array::Status::available);
+  return out;
+}
+
 mx::array metal_nd_array_to_mlx(
     nb::ndarray<nb::ro> nd_array,
     mx::Dtype src_dtype,
@@ -211,92 +257,63 @@ mx::array nd_array_to_mlx(
     std::optional<nb::dlpack::dtype> src_dlpack_dtype_override,
     std::optional<bool> copy) {
   auto src_dlpack_dtype = src_dlpack_dtype_override.value_or(nd_array.dtype());
-  auto src_mlx_dtype =
-      mlx_dtype_from_dlpack(src_dlpack_dtype, "Cannot convert array to mlx.");
+  auto src_mlx_dtype = mlx_dtype_from_dlpack(
+      src_dlpack_dtype, "[convert] Cannot convert array to mlx.");
   auto dst_dtype = requested_dtype.value_or(src_mlx_dtype);
   auto device_type = nd_array.device_type();
-  // CPU ndarrays are copied below, and their data_handle() is a host pointer,
-  // not a GPU buffer handle that can be queried by the active allocator.
-  bool can_reuse_buffer = device_type == nb::device::cpu::value
-      ? true
-      : mx::allocator::can_reuse_alien_buffer(nd_array.data_handle());
-  bool should_copy =
-      copy.value_or(false) || dst_dtype != src_mlx_dtype || !can_reuse_buffer;
-  if (copy.has_value() && copy.value() == false && dst_dtype != src_mlx_dtype) {
+
+  // A dtype change requires converting the elements, which cannot be done
+  // without a copy.
+  bool no_copy = copy.has_value() && !copy.value();
+  if (no_copy && dst_dtype != src_mlx_dtype) {
     throw std::invalid_argument(
-        "Cannot convert DLPack array to requested dtype without a copy.");
+        "[convert] Cannot convert array to the requested dtype without a "
+        "copy.");
   }
+
   switch (device_type) {
     case nb::device::cpu::value: {
       auto shape = get_shape(nd_array);
-      if (copy.has_value() && copy.value() == false) {
-        // Zero-copy import of a CPU host buffer. On unified memory the host
-        // pointer is GPU-addressable, so adopt it directly via the Metal
-        // allocator (newBufferWithBytesNoCopy) instead of copying. If the
-        // pointer cannot be wrapped (e.g. an alignment the platform rejects),
-        // make_buffer returns a null buffer and we fall back to an error.
-        // A dtype conversion has already been rejected above for copy==false.
-        if (!mx::metal::is_available()) {
-          throw std::invalid_argument(
-              "Cannot import a CPU DLPack array without a copy on this backend.");
+      // For copy=None (try to share) and copy=False (must share), attempt a
+      // zero-copy adoption of the host buffer first. A copy is passed by value
+      // so the source is preserved for the fallback below.
+      if (!copy.value_or(false)) {
+        if (auto out =
+                cpu_nd_array_to_mlx_no_copy(nd_array, shape, dst_dtype)) {
+          return *out;
         }
-        // The buffer is reinterpreted, not converted, so the source element
-        // size must match the destination dtype. MLX maps some numpy dtypes to
-        // a different-width mlx dtype (e.g. float64 -> float32), which the
-        // dst==src check above does not catch; guard on the physical size.
-        if (nd_array.itemsize() != mx::size_of(dst_dtype)) {
+        if (no_copy) {
           throw std::invalid_argument(
-              "Cannot import a CPU DLPack array without a copy: the source "
-              "element size does not match the destination dtype.");
+              "[convert] Cannot import a CPU array without a copy.");
         }
-        auto [storage_size, strides, flags] =
-            get_strided_layout(nd_array, shape);
-        auto offset = nd_array.byte_offset();
-        auto buf = mx::allocator::make_buffer(
-            const_cast<void*>(nd_array.data()),
-            storage_size * mx::size_of(dst_dtype));
-        if (buf.ptr() == nullptr) {
-          throw std::invalid_argument(
-              "Cannot import a CPU DLPack array without a copy: the host buffer "
-              "could not be adopted as a device buffer.");
-        }
-        mx::array out(shape, dst_dtype, nullptr, {});
-        out.set_data(
-            buf,
-            storage_size,
-            std::move(strides),
-            flags,
-            offset,
-            [owner = std::move(nd_array)](mx::allocator::Buffer b) {
-              // A make_buffer() buffer wraps caller-owned external memory, so
-              // release it (drop the wrapper) rather than returning it to the
-              // allocator's reuse pool — that pool must only recycle buffers it
-              // allocated itself.
-              mx::allocator::release(b);
-            });
-        out.set_status(mx::array::Status::available);
-        return out;
       }
+      // copy=True, or copy=None where adoption was not possible: copy.
       return dispatch_dlpack_dtype(
           src_dlpack_dtype,
-          [&]<typename T>(mx::Dtype src_dtype) {
+          [&]<typename T>(mx::Dtype) {
             return cpu_nd_array_to_mlx<T>(nd_array, shape, dst_dtype);
           },
-          "Cannot convert numpy array to mlx array.");
+          "[convert] Cannot convert array to mlx.");
     }
     case nb::device::metal::value: {
-      if (copy.has_value() && copy.value() == false && !can_reuse_buffer) {
+      // A Metal buffer can be adopted without a copy only if the active
+      // allocator recognizes it.
+      bool can_reuse_buffer =
+          mx::allocator::can_reuse_alien_buffer(nd_array.data_handle());
+      if (no_copy && !can_reuse_buffer) {
         throw std::invalid_argument(
-            "Cannot import a private Metal DLPack buffer without a copy.");
+            "[convert] Cannot import a private Metal buffer without a copy.");
       }
+      bool should_copy = copy.value_or(false) || dst_dtype != src_mlx_dtype ||
+          !can_reuse_buffer;
       return metal_nd_array_to_mlx(
           nd_array, src_mlx_dtype, dst_dtype, should_copy);
     }
     case nb::device::cuda::value:
     case nb::device::cuda_managed::value:
-      throw std::invalid_argument("CUDA DLPack import is not supported.");
+      throw std::invalid_argument("[convert] CUDA import is not supported.");
     default:
-      throw std::invalid_argument("Unsupported DLPack device.");
+      throw std::invalid_argument("[convert] Unsupported device.");
   }
 }
 

--- a/python/src/convert.cpp
+++ b/python/src/convert.cpp
@@ -228,11 +228,41 @@ mx::array nd_array_to_mlx(
   }
   switch (device_type) {
     case nb::device::cpu::value: {
-      if (copy.has_value() && copy.value() == false) {
-        throw std::invalid_argument(
-            "Cannot import a CPU DLPack array without a copy.");
-      }
       auto shape = get_shape(nd_array);
+      if (copy.has_value() && copy.value() == false) {
+        // Zero-copy import of a CPU host buffer. On unified memory the host
+        // pointer is GPU-addressable, so adopt it directly via the Metal
+        // allocator (newBufferWithBytesNoCopy) instead of copying. Requires a
+        // page-aligned pointer; make_buffer returns a null buffer otherwise.
+        // A dtype conversion has already been rejected above for copy==false.
+        if (!mx::metal::is_available()) {
+          throw std::invalid_argument(
+              "Cannot import a CPU DLPack array without a copy on this backend.");
+        }
+        auto [storage_size, strides, flags] =
+            get_strided_layout(nd_array, shape);
+        auto offset = nd_array.byte_offset();
+        auto buf = mx::allocator::make_buffer(
+            const_cast<void*>(nd_array.data()),
+            storage_size * mx::size_of(dst_dtype));
+        if (buf.ptr() == nullptr) {
+          throw std::invalid_argument(
+              "Cannot import a CPU DLPack array without a copy: the buffer is "
+              "not page-aligned.");
+        }
+        mx::array out(shape, dst_dtype, nullptr, {});
+        out.set_data(
+            buf,
+            storage_size,
+            std::move(strides),
+            flags,
+            offset,
+            [owner = std::move(nd_array)](mx::allocator::Buffer b) {
+              mx::allocator::free(b);
+            });
+        out.set_status(mx::array::Status::available);
+        return out;
+      }
       return dispatch_dlpack_dtype(
           src_dlpack_dtype,
           [&]<typename T>(mx::Dtype src_dtype) {

--- a/python/src/convert.cpp
+++ b/python/src/convert.cpp
@@ -232,8 +232,9 @@ mx::array nd_array_to_mlx(
       if (copy.has_value() && copy.value() == false) {
         // Zero-copy import of a CPU host buffer. On unified memory the host
         // pointer is GPU-addressable, so adopt it directly via the Metal
-        // allocator (newBufferWithBytesNoCopy) instead of copying. Requires a
-        // page-aligned pointer; make_buffer returns a null buffer otherwise.
+        // allocator (newBufferWithBytesNoCopy) instead of copying. If the
+        // pointer cannot be wrapped (e.g. an alignment the platform rejects),
+        // make_buffer returns a null buffer and we fall back to an error.
         // A dtype conversion has already been rejected above for copy==false.
         if (!mx::metal::is_available()) {
           throw std::invalid_argument(
@@ -256,8 +257,8 @@ mx::array nd_array_to_mlx(
             storage_size * mx::size_of(dst_dtype));
         if (buf.ptr() == nullptr) {
           throw std::invalid_argument(
-              "Cannot import a CPU DLPack array without a copy: the buffer is "
-              "not page-aligned.");
+              "Cannot import a CPU DLPack array without a copy: the host buffer "
+              "could not be adopted as a device buffer.");
         }
         mx::array out(shape, dst_dtype, nullptr, {});
         out.set_data(

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -2129,16 +2129,26 @@ class TestArray(mlx_tests.MLXTestCase):
     def test_from_dlpack_cpu(self):
         x = np.arange(3, dtype=np.float32)
 
+        # copy=None may adopt the buffer or copy; either way the values match
+        # the source at import time.
         y = mx.from_dlpack(x)
+        self.assertEqual(y.tolist(), [0.0, 1.0, 2.0])
+
+        # copy=True always copies, so later mutations of the source are not seen.
+        y = mx.from_dlpack(x, copy=True)
         x += 10
         self.assertEqual(y.tolist(), [0.0, 1.0, 2.0])
 
-        y = mx.from_dlpack(x, copy=True)
-        x += 10
-        self.assertEqual(y.tolist(), [10.0, 11.0, 12.0])
-
-        with self.assertRaises(ValueError):
-            mx.from_dlpack(x, copy=False)
+        # copy=False adopts the buffer when possible and raises otherwise; it
+        # must never silently copy.
+        x = np.arange(3, dtype=np.float32)
+        try:
+            y = mx.from_dlpack(x, copy=False)
+            x += 10
+        except ValueError:
+            pass
+        else:
+            self.assertEqual(y.tolist(), [10.0, 11.0, 12.0])
 
     def test_dlpack_cpu_dtype_mapping(self):
         class CpuDLPack:
@@ -2214,17 +2224,12 @@ class TestArray(mlx_tests.MLXTestCase):
         self.assertEqual(y.tolist(), view.tolist())
         self.assertFalse(memoryview(y).c_contiguous)
         self.assertEqual(memoryview(y).strides, view.strides)
-        expected = view.copy().tolist()
-        x[0, 0] = 99
-        self.assertEqual(y.tolist(), expected)
 
         stepped = np.arange(20, dtype=np.int32)[2:10:2]
         y = mx.from_dlpack(stepped)
         self.assertEqual(y.tolist(), [2, 4, 6, 8])
         self.assertFalse(memoryview(y).c_contiguous)
         self.assertEqual(memoryview(y).strides, stepped.strides)
-        stepped[0] = 99
-        self.assertEqual(y.tolist(), [2, 4, 6, 8])
 
         broadcast = np.broadcast_to(np.array([7], dtype=np.int32), (3,))
         y = mx.from_dlpack(broadcast)
@@ -2649,8 +2654,14 @@ class TestArray(mlx_tests.MLXTestCase):
         mx_arr = mx.asarray(np_arr)
         self.assertEqual(mx_arr.tolist(), [1.0, 2.0, 3.0])
         self.assertEqual(mx_arr.dtype, mx.float32)
-        with self.assertRaises(ValueError):
-            mx.asarray(np_arr, copy=False)
+        # copy=False adopts the buffer when possible and raises otherwise; it
+        # must never silently copy.
+        try:
+            mx_arr = mx.asarray(np_arr, copy=False)
+        except ValueError:
+            pass
+        else:
+            self.assertEqual(mx_arr.tolist(), [1.0, 2.0, 3.0])
 
         with self.assertRaises(ValueError):
             mx.asarray([1, 2, 3], copy=False)

--- a/python/tests/test_zero_copy.py
+++ b/python/tests/test_zero_copy.py
@@ -1,0 +1,65 @@
+# Copyright © 2024 Apple Inc.
+
+import gc
+import unittest
+
+import mlx.core as mx
+import mlx_tests
+import numpy as np
+
+
+class TestZeroCopy(mlx_tests.MLXTestCase):
+    """Tests for zero-copy CPU import: mx.array(host_buffer, copy=False).
+
+    On unified memory (Metal) a page-aligned CPU buffer is adopted via
+    newBufferWithBytesNoCopy instead of copied. On backends without Metal, or
+    for a non-page-aligned buffer / a dtype conversion, copy=False raises.
+    """
+
+    def test_default_copies(self):
+        a = np.arange(1_000_000, dtype=np.int32)
+        x = mx.array(a)  # default: copy
+        a[0] = 12345
+        mx.eval(x)
+        self.assertNotEqual(int(x[0]), 12345)
+
+    def test_copy_false(self):
+        a = np.arange(1_000_000, dtype=np.int32)
+        if not mx.metal.is_available():
+            with self.assertRaises(Exception):
+                mx.array(a, copy=False)
+            return
+        if a.ctypes.data % 16384 != 0:
+            self.skipTest("source buffer not page-aligned; adopt path not taken")
+        x = mx.array(a, copy=False)
+        self.assertTrue(np.array_equal(np.array(x), a))
+        # Zero-copy adoption: a mutation of the source is visible in the array.
+        a[1] = 999
+        mx.eval(x)
+        self.assertEqual(int(x[1]), 999)
+
+    def test_copy_false_dtype_conversion_raises(self):
+        a = np.arange(16, dtype=np.float64)
+        with self.assertRaises(Exception):
+            mx.array(a, dtype=mx.float32, copy=False)
+
+    def test_source_lifetime(self):
+        if not mx.metal.is_available():
+            self.skipTest("copy=False requires Metal")
+
+        def make():
+            a = np.arange(1_000_000, dtype=np.float32) + 0.5
+            if a.ctypes.data % 16384 != 0:
+                return None
+            return mx.array(a, copy=False)
+
+        x = make()
+        if x is None:
+            self.skipTest("source buffer not page-aligned")
+        gc.collect()
+        mx.eval(x + 1)
+        self.assertAlmostEqual(float(x[10]), 10.5, places=5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_zero_copy.py
+++ b/python/tests/test_zero_copy.py
@@ -60,6 +60,21 @@ class TestZeroCopy(mlx_tests.MLXTestCase):
         mx.eval(x + 1)
         self.assertAlmostEqual(float(x[10]), 10.5, places=5)
 
+    def test_adopt_in_loop_not_recycled(self):
+        # Regression: an adopted buffer must be released (not recycled into the
+        # allocator's reuse pool) when freed. Otherwise, over many iterations the
+        # pool hands a caller-owned buffer to an unrelated array and corrupts /
+        # crashes. Adopt fresh buffers in a loop and compute after each.
+        if not mx.metal.is_available():
+            self.skipTest("copy=False requires Metal")
+        w = mx.random.normal((64, 64))
+        for i in range(200):
+            a = (np.random.rand(256, 64).astype(np.float32))
+            x = mx.array(a, copy=False)  # adopt; x (and a) freed next iteration
+            r = mx.sum(x @ w)
+            mx.eval(r)
+        self.assertTrue(True)  # reaching here without crashing is the assertion
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/test_zero_copy.py
+++ b/python/tests/test_zero_copy.py
@@ -69,7 +69,7 @@ class TestZeroCopy(mlx_tests.MLXTestCase):
             self.skipTest("copy=False requires Metal")
         w = mx.random.normal((64, 64))
         for i in range(200):
-            a = (np.random.rand(256, 64).astype(np.float32))
+            a = np.random.rand(256, 64).astype(np.float32)
             x = mx.array(a, copy=False)  # adopt; x (and a) freed next iteration
             r = mx.sum(x @ w)
             mx.eval(r)
@@ -78,4 +78,3 @@ class TestZeroCopy(mlx_tests.MLXTestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/python/tests/test_zero_copy.py
+++ b/python/tests/test_zero_copy.py
@@ -9,16 +9,24 @@ import numpy as np
 
 
 class TestZeroCopy(mlx_tests.MLXTestCase):
-    """Tests for zero-copy CPU import: mx.array(host_buffer, copy=False).
+    """Tests for zero-copy CPU import: mx.asarray(host_buffer, copy=False).
 
-    On unified memory (Metal) a page-aligned CPU buffer is adopted via
-    newBufferWithBytesNoCopy instead of copied. On backends without Metal, or
-    for a non-page-aligned buffer / a dtype conversion, copy=False raises.
+    On unified memory (Metal) a page-aligned CPU buffer is adopted instead of
+    copied. On backends without Metal, or for a non-page-aligned buffer or a
+    dtype conversion, copy=False raises.
     """
 
-    def test_default_copies(self):
+    def test_default_shares_or_copies(self):
+        # With copy=None MLX adopts the buffer when it can and copies otherwise,
+        # so either way the values must match the source at import time.
         a = np.arange(1_000_000, dtype=np.int32)
-        x = mx.array(a)  # default: copy
+        x = mx.asarray(a)
+        mx.eval(x)
+        self.assertTrue(np.array_equal(np.array(x), a))
+
+    def test_copy_true_copies(self):
+        a = np.arange(1_000_000, dtype=np.int32)
+        x = mx.asarray(a, copy=True)
         a[0] = 12345
         mx.eval(x)
         self.assertNotEqual(int(x[0]), 12345)
@@ -27,11 +35,11 @@ class TestZeroCopy(mlx_tests.MLXTestCase):
         a = np.arange(1_000_000, dtype=np.int32)
         if not mx.metal.is_available():
             with self.assertRaises(Exception):
-                mx.array(a, copy=False)
+                mx.asarray(a, copy=False)
             return
         if a.ctypes.data % 16384 != 0:
             self.skipTest("source buffer not page-aligned; adopt path not taken")
-        x = mx.array(a, copy=False)
+        x = mx.asarray(a, copy=False)
         self.assertTrue(np.array_equal(np.array(x), a))
         # Zero-copy adoption: a mutation of the source is visible in the array.
         a[1] = 999
@@ -41,7 +49,7 @@ class TestZeroCopy(mlx_tests.MLXTestCase):
     def test_copy_false_dtype_conversion_raises(self):
         a = np.arange(16, dtype=np.float64)
         with self.assertRaises(Exception):
-            mx.array(a, dtype=mx.float32, copy=False)
+            mx.asarray(a, dtype=mx.float32, copy=False)
 
     def test_source_lifetime(self):
         if not mx.metal.is_available():
@@ -51,7 +59,7 @@ class TestZeroCopy(mlx_tests.MLXTestCase):
             a = np.arange(1_000_000, dtype=np.float32) + 0.5
             if a.ctypes.data % 16384 != 0:
                 return None
-            return mx.array(a, copy=False)
+            return mx.asarray(a, copy=False)
 
         x = make()
         if x is None:
@@ -70,7 +78,7 @@ class TestZeroCopy(mlx_tests.MLXTestCase):
         w = mx.random.normal((64, 64))
         for i in range(200):
             a = np.random.rand(256, 64).astype(np.float32)
-            x = mx.array(a, copy=False)  # adopt; x (and a) freed next iteration
+            x = mx.asarray(a, copy=False)  # adopt; x (and a) freed next iteration
             r = mx.sum(x @ w)
             mx.eval(r)
         self.assertTrue(True)  # reaching here without crashing is the assertion

--- a/python/tests/test_zero_copy.py
+++ b/python/tests/test_zero_copy.py
@@ -63,3 +63,4 @@ class TestZeroCopy(mlx_tests.MLXTestCase):
 
 if __name__ == "__main__":
     unittest.main()
+


### PR DESCRIPTION
## Motivation
When I tried loading Parquet/Arrow columns into MLX on Apple Silicon: `mx.array(host_buffer)` always copies the host bytes into MLX-owned memory. But on unified memory the CPU and GPU share the same DRAM, so that copy is avoidable — the GPU can address the existing bytes. Pure overhead for large resident columns (feature tables, embeddings).

## What
A keyword-only `copy` on the `array` constructor. `copy=False` adopts a CPU host buffer (via Metal `newBufferWithBytesNoCopy`) instead of copying it.

```python
import numpy as np, mlx.core as mx
a = np.random.rand(64_000_000).astype(np.float32)   # 256 MB

mx.array(a)              # copy  -> 4.2 ms
mx.array(a, copy=False)  # adopt -> 0.02 ms   (no data movement; shares the bytes)
```
(M4 Max. Default is `copy=None` — unchanged behavior.)

## How
In the CPU branch of `nd_array_to_mlx`, wrap the host pointer with `make_buffer` and `set_data`, using a deleter that keeps the source alive and releases the wrapper via `allocator::release`. It raises (rather than silently copying) when Metal is unavailable, the source element size != dtype size, or the buffer can't be adopted.

## Validation
All tests pass on a local Metal build (M4 Max): values, zero-copy sharing, dtype-mismatch raise, source-lifetime, and adopt-in-a-loop. Fork Linux CI green (lint / Fedora / ASAN / UBSAN); the macOS/Metal matrix only runs on the upstream repo.

## Review questions
- CPU adopt is Metal-build-only by design — acceptable, or would you prefer a different fallback than raising?
