### PR TITLE
Fix JIT preamble header filter matching project paths containing "Xcode"

### DIFF
--- a/mlx/backend/metal/make_compiled_preamble.sh
+++ b/mlx/backend/metal/make_compiled_preamble.sh
@@ -50,8 +50,10 @@ if [ -n "$HDRS" ]; then
   fi
 fi
 
-# Remove any included system frameworks (for MetalPerformancePrimitive headers)
-HDRS=$(echo "$HDRS" | grep -v "Xcode")
+# Remove any included system frameworks (for MetalPerformancePrimitive headers).
+# Match "Xcode.app" rather than bare "Xcode" so project checkouts that live under
+# a directory named Xcode/ are not filtered out along with the SDK headers.
+HDRS=$(echo "$HDRS" | grep -v "Xcode.app")
 
 # Use the header depth to sort the files in order of inclusion
 declare -a HDRS_LIST=()


### PR DESCRIPTION
### The bug

`make_compiled_preamble.sh` removes SDK framework headers from the `metal -E -H` dependency list with `grep -v "Xcode"`. That pattern also matches the checkout's own path when any parent directory is named `Xcode` — a common layout for Apple-platform developers (e.g. `~/Documents/Xcode/mlx`). When it triggers, **every project header is silently dropped** from the generated JIT preambles.

The build completes normally; the failure only appears at runtime, when JIT kernel compilation aborts with errors like:

```
[metal::Device] Unable to build metal library from source
mlx/backend/metal/kernels/utils.h:64:25: error: unknown type name 'bfloat16_t'; did you mean 'float16_t'?
```

because `bf16.h` and the other dependency headers were never spliced into the preamble. Nothing in the error points back at the path filter, which makes this expensive to diagnose.

### The fix

Match `Xcode.app` — the actual SDK path component (`/Applications/Xcode.app/...`) — instead of bare `Xcode`, so project checkouts under a directory named `Xcode/` are no longer filtered out along with the system headers.

### Repro / verification

Clone mlx under any path containing `Xcode` (e.g. `~/Xcode/mlx`), build with Metal enabled, and inspect `build/mlx/backend/metal/jit/utils.cpp`: before this change it contains only the `utils.h` section (no `bf16.h`, `bf16_math.h`, `complex.h`, …) and any JIT-compiled kernel fails at runtime; after, all dependency sections are present and JIT compilation succeeds. Verified on macOS 26 / Metal 4 toolchain with a 31B-parameter model exercising quantized + gather kernels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)