### PR TITLE
Reuse Metal WAR tracking hash tables

### DIFF
--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -392,9 +392,9 @@ void CommandEncoder::maybeInsertBarrier() {
   if (needs_barrier_) {
     get_command_encoder()->memoryBarrier(MTL::BarrierScopeBuffers);
     needs_barrier_ = false;
-    // Preserve both hash tables' buckets for reuse across barrier epochs.
+    // Preserve the hash tables' buckets for reuse across barrier epochs.
     prev_inputs_.swap(next_inputs_);
-    prev_outputs_ = std::move(next_outputs_);
+    prev_outputs_.swap(next_outputs_);
   } else {
     prev_inputs_.insert(next_inputs_.begin(), next_inputs_.end());
     prev_outputs_.insert(next_outputs_.begin(), next_outputs_.end());

--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -392,7 +392,8 @@ void CommandEncoder::maybeInsertBarrier() {
   if (needs_barrier_) {
     get_command_encoder()->memoryBarrier(MTL::BarrierScopeBuffers);
     needs_barrier_ = false;
-    prev_inputs_ = std::move(next_inputs_);
+    // Preserve both hash tables' buckets for reuse across barrier epochs.
+    prev_inputs_.swap(next_inputs_);
     prev_outputs_ = std::move(next_outputs_);
   } else {
     prev_inputs_.insert(next_inputs_.begin(), next_inputs_.end());


### PR DESCRIPTION
## Proposed changes

Metal’s write-after-read tracking moves `next_inputs_` and `next_outputs_` into the previous sets at every barrier. This discards the old hash tables, so the next sets must rebuild their bucket lists during the following barrier epoch. This change was introduced in this PR https://github.com/ml-explore/mlx/pull/3630.

Qwen 35B hits this path 1,056 times per decoded token. The input side alone caused 1,859 bucket-table growths per token, while output tracking followed the same allocation pattern.

This change swaps both pairs of sets instead. The existing `clear()` calls remove old entries while keeping all four bucket tables for reuse. Synchronization behavior and tracked resources are unchanged.

Controlled Qwen runs with input-table reuse improved throughput by about 1.9%, with identical output and unchanged peak memory. MLX’s RoPE benchmark also showed no regression. The output-table reuse applies the same optimization but was not benchmarked separately.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
