### PR TITLE
Warn once when float32 ops silently run at TF32 precision

### DIFF
--- a/mlx/backend/cuda/conv.cpp
+++ b/mlx/backend/cuda/conv.cpp
@@ -136,7 +136,7 @@ std::optional<DnnGraph> build_conv_graph(
     return std::nullopt;
   }
   graph.deselect_numeric_notes({fe::NumericalNote_t::DOWN_CONVERT_INPUTS});
-  if (dtype == float32 && !env::tf32_active_for_fp32()) {
+  if (dtype == float32 && !env::tf32_active_for_fp32("convolution")) {
     graph.deselect_numeric_notes({fe::NumericalNote_t::TENSOR_CORE});
   }
   CHECK_CUDNN_ERROR(graph.build());

--- a/mlx/backend/cuda/conv.cpp
+++ b/mlx/backend/cuda/conv.cpp
@@ -136,7 +136,7 @@ std::optional<DnnGraph> build_conv_graph(
     return std::nullopt;
   }
   graph.deselect_numeric_notes({fe::NumericalNote_t::DOWN_CONVERT_INPUTS});
-  if (dtype == float32 && !env::enable_tf32()) {
+  if (dtype == float32 && !env::tf32_active_for_fp32()) {
     graph.deselect_numeric_notes({fe::NumericalNote_t::TENSOR_CORE});
   }
   CHECK_CUDNN_ERROR(graph.build());

--- a/mlx/backend/cuda/gemms/cublas_gemm.cpp
+++ b/mlx/backend/cuda/gemms/cublas_gemm.cpp
@@ -19,8 +19,9 @@ cublasComputeType_t dtype_to_compute_type(Dtype dtype) {
     case bfloat16:
       return CUBLAS_COMPUTE_32F;
     case float32:
-      return mlx::core::env::enable_tf32() ? CUBLAS_COMPUTE_32F_FAST_TF32
-                                           : CUBLAS_COMPUTE_32F;
+      return mlx::core::env::tf32_active_for_fp32()
+          ? CUBLAS_COMPUTE_32F_FAST_TF32
+          : CUBLAS_COMPUTE_32F;
     case float64:
       return CUBLAS_COMPUTE_64F;
     case complex64:

--- a/mlx/backend/cuda/gemms/cublas_gemm.cpp
+++ b/mlx/backend/cuda/gemms/cublas_gemm.cpp
@@ -19,9 +19,11 @@ cublasComputeType_t dtype_to_compute_type(Dtype dtype) {
     case bfloat16:
       return CUBLAS_COMPUTE_32F;
     case float32:
-      return mlx::core::env::tf32_active_for_fp32()
-          ? CUBLAS_COMPUTE_32F_FAST_TF32
-          : CUBLAS_COMPUTE_32F;
+      // Compute-type selection only; the once-per-process TF32 warning is
+      // emitted from the CublasGemm constructor, where the shape is known and
+      // rank-1 (matvec) false positives can be suppressed.
+      return mlx::core::env::enable_tf32() ? CUBLAS_COMPUTE_32F_FAST_TF32
+                                           : CUBLAS_COMPUTE_32F;
     case float64:
       return CUBLAS_COMPUTE_64F;
     case complex64:
@@ -82,6 +84,18 @@ CublasGemm::CublasGemm(
       CUBLASLT_MATMUL_DESC_POINTER_MODE,
       &pointer_mode,
       sizeof(pointer_mode)));
+
+  // Warn once (see mlx/utils.h) that fp32 is running at reduced TF32 precision,
+  // but only for a genuine matrix-matrix product. cuBLASLt leaves rank-1 shapes
+  // (M == 1 || N == 1 -- e.g. a matvec whose layout missed the dedicated GEMV
+  // path and fell through to cuBLAS) numerically exact even when FAST_TF32 is
+  // requested, so warning on them is a false positive. Every cuBLAS fp32 entry
+  // -- plain matmul, AddMM (both constructors), and the GEMM-conv fallbacks --
+  // funnels through this constructor, so coverage matches the previous
+  // dtype-only gate in dtype_to_compute_type() while dropping the matvec noise.
+  if (dtype == float32 && M_ > 1 && N_ > 1) {
+    env::tf32_active_for_fp32();
+  }
 }
 
 CublasGemm::CublasGemm(

--- a/mlx/backend/cuda/gemms/grouped_gemm_unaligned.cu
+++ b/mlx/backend/cuda/gemms/grouped_gemm_unaligned.cu
@@ -302,10 +302,12 @@ auto* get_grouped_mm_funcion(Dtype dtype, int N, cu::Device& device) {
       using Arch = MLX_GET_TYPE(arch_tag);
       dispatch_bool(N % 8 == 0, [&](auto is_out_aligned) {
         constexpr int kAlignmentC = is_out_aligned ? 8 : 1;
-        dispatch_bool(env::enable_tf32(), [&](auto kEnableTF32) {
-          fun = grouped_gemm_v2<
-              GemmConfiguration<DataType, Arch, kAlignmentC, kEnableTF32>>;
-        });
+        dispatch_bool(
+            dtype == float32 ? env::tf32_active_for_fp32() : env::enable_tf32(),
+            [&](auto kEnableTF32) {
+              fun = grouped_gemm_v2<
+                  GemmConfiguration<DataType, Arch, kAlignmentC, kEnableTF32>>;
+            });
       });
     });
   });

--- a/mlx/backend/cuda/gemms/grouped_gemm_unaligned.cu
+++ b/mlx/backend/cuda/gemms/grouped_gemm_unaligned.cu
@@ -303,7 +303,7 @@ auto* get_grouped_mm_funcion(Dtype dtype, int N, cu::Device& device) {
       dispatch_bool(N % 8 == 0, [&](auto is_out_aligned) {
         constexpr int kAlignmentC = is_out_aligned ? 8 : 1;
         dispatch_bool(
-            dtype == float32 ? env::tf32_active_for_fp32() : env::enable_tf32(),
+            dtype == float32 ? env::tf32_active_for_fp32("grouped matmul") : env::enable_tf32(),
             [&](auto kEnableTF32) {
               fun = grouped_gemm_v2<
                   GemmConfiguration<DataType, Arch, kAlignmentC, kEnableTF32>>;

--- a/mlx/backend/metal/matmul.cpp
+++ b/mlx/backend/metal/matmul.cpp
@@ -914,7 +914,7 @@ void steel_matmul_axpby(
   int64_t matrix_size = static_cast<int64_t>(M) * N;
   bool use_nax = metal::is_nax_available() &&
       !issubdtype(a.dtype(), complexfloating) &&
-      (env::enable_tf32() || a.dtype() != float32);
+      (a.dtype() != float32 || env::tf32_active_for_fp32());
   char devc = d.get_architecture().back();
   int min_tmn_threshold = (devc == 's' || devc == 'd') ? 2048 : 1024;
 
@@ -2428,7 +2428,7 @@ void GatherMM::eval_gpu(const std::vector<array>& inputs, array& out) {
   // matmuls and reuse reading a and b.
   if (M == 1 && right_sorted_ == true) {
     if (metal::is_nax_available() &&
-        (env::enable_tf32() || a.dtype() != float32)) {
+        (a.dtype() != float32 || env::tf32_active_for_fp32())) {
       return gather_mm_rhs_nax(a, b, rhs_indices, out, d, s);
     }
     gather_mm_rhs(a, b, rhs_indices, out, d, s);
@@ -2502,7 +2502,7 @@ void segmented_mm(
   GEMM_TPARAM_MACRO(devc)
 
   bool use_nax = metal::is_nax_available() &&
-      (env::enable_tf32() || out.dtype() != float32);
+      (out.dtype() != float32 || env::tf32_active_for_fp32());
 
   const bool align_M = (M % bm) == 0;
   const bool align_N = (N % bn) == 0;

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -785,7 +785,7 @@ void qmm(
     const Stream& s,
     const std::string& mode) {
   if (metal::is_nax_available() && transpose && (K % 64 == 0) &&
-      (x.dtype() != float32 || env::tf32_active_for_fp32())) {
+      (x.dtype() != float32 || env::tf32_active_for_fp32("quantized matmul"))) {
     return qmm_nax(
         /* const array& x = */ x,
         /* const array& w = */ w,
@@ -976,7 +976,7 @@ void gather_qmm(
     const Stream& s,
     const std::string& mode) {
   if (metal::is_nax_available() && transpose && (K % 64 == 0) &&
-      (x.dtype() != float32 || env::tf32_active_for_fp32())) {
+      (x.dtype() != float32 || env::tf32_active_for_fp32("quantized matmul"))) {
     return gather_qmm_nax(
         /* const array& x = */ x,
         /* const array& w = */ w,
@@ -1321,7 +1321,7 @@ void gather_qmm_rhs(
     const Stream& s,
     const std::string mode) {
   if (metal::is_nax_available() && transpose &&
-      (x_.dtype() != float32 || env::tf32_active_for_fp32())) {
+      (x_.dtype() != float32 || env::tf32_active_for_fp32("quantized matmul"))) {
     return gather_qmm_rhs_nax(
         /* const array& x_ = */ x_,
         /* const array& w_ = */ w_,

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -785,7 +785,7 @@ void qmm(
     const Stream& s,
     const std::string& mode) {
   if (metal::is_nax_available() && transpose && (K % 64 == 0) &&
-      (env::enable_tf32() || x.dtype() != float32)) {
+      (x.dtype() != float32 || env::tf32_active_for_fp32())) {
     return qmm_nax(
         /* const array& x = */ x,
         /* const array& w = */ w,
@@ -976,7 +976,7 @@ void gather_qmm(
     const Stream& s,
     const std::string& mode) {
   if (metal::is_nax_available() && transpose && (K % 64 == 0) &&
-      (env::enable_tf32() || x.dtype() != float32)) {
+      (x.dtype() != float32 || env::tf32_active_for_fp32())) {
     return gather_qmm_nax(
         /* const array& x = */ x,
         /* const array& w = */ w,
@@ -1321,7 +1321,7 @@ void gather_qmm_rhs(
     const Stream& s,
     const std::string mode) {
   if (metal::is_nax_available() && transpose &&
-      (env::enable_tf32() || x_.dtype() != float32)) {
+      (x_.dtype() != float32 || env::tf32_active_for_fp32())) {
     return gather_qmm_rhs_nax(
         /* const array& x_ = */ x_,
         /* const array& w_ = */ w_,

--- a/mlx/backend/metal/scaled_dot_product_attention.cpp
+++ b/mlx/backend/metal/scaled_dot_product_attention.cpp
@@ -175,7 +175,7 @@ void sdpa_full_self_attention_metal(
     const std::optional<array>& mask,
     const std::optional<array>& sinks) {
   if (metal::is_nax_available() && q.shape(3) != 80 &&
-      (env::enable_tf32() || q.dtype() != float32)) {
+      (q.dtype() != float32 || env::tf32_active_for_fp32())) {
     return sdpa_full_self_attention_nax(
         /* const Stream& s = */ s,
         /* metal::Device& d = */ d,

--- a/mlx/backend/metal/scaled_dot_product_attention.cpp
+++ b/mlx/backend/metal/scaled_dot_product_attention.cpp
@@ -175,7 +175,7 @@ void sdpa_full_self_attention_metal(
     const std::optional<array>& mask,
     const std::optional<array>& sinks) {
   if (metal::is_nax_available() && q.shape(3) != 80 &&
-      (q.dtype() != float32 || env::tf32_active_for_fp32())) {
+      (q.dtype() != float32 || env::tf32_active_for_fp32("attention"))) {
     return sdpa_full_self_attention_nax(
         /* const Stream& s = */ s,
         /* metal::Device& d = */ d,

--- a/mlx/utils.cpp
+++ b/mlx/utils.cpp
@@ -301,14 +301,15 @@ std::string get_var(const char* name, const char* default_value) {
   }
 }
 
-bool tf32_active_for_fp32() {
+bool tf32_active_for_fp32(const char* op_family) {
   if (!enable_tf32()) {
     return false;
   }
-  static bool warned = []() {
+  static bool warned = [op_family]() {
     if (std::getenv("MLX_ENABLE_TF32") == nullptr) {
       std::cerr
-          << "[mlx] float32 matmul-family ops are running at reduced (TF32) "
+          << "[mlx] float32 " << op_family
+          << " ops are running at reduced (TF32) "
              "precision, which is the default when MLX_ENABLE_TF32 is unset. "
              "Set MLX_ENABLE_TF32=0 before the first operation for full "
              "float32 precision, or set MLX_ENABLE_TF32=1 explicitly to "

--- a/mlx/utils.cpp
+++ b/mlx/utils.cpp
@@ -301,6 +301,26 @@ std::string get_var(const char* name, const char* default_value) {
   }
 }
 
+bool tf32_active_for_fp32() {
+  if (!enable_tf32()) {
+    return false;
+  }
+  static bool warned = []() {
+    if (std::getenv("MLX_ENABLE_TF32") == nullptr) {
+      std::cerr
+          << "[mlx] float32 matmul-family ops are running at reduced (TF32) "
+             "precision, which is the default when MLX_ENABLE_TF32 is unset. "
+             "Set MLX_ENABLE_TF32=0 before the first operation for full "
+             "float32 precision, or set MLX_ENABLE_TF32=1 explicitly to "
+             "silence this warning."
+          << std::endl;
+    }
+    return true;
+  }();
+  (void)warned;
+  return true;
+}
+
 } // namespace env
 
 template <typename T>

--- a/mlx/utils.h
+++ b/mlx/utils.h
@@ -197,6 +197,12 @@ inline bool enable_tf32() {
   return enable_tf32_;
 }
 
+// Same as enable_tf32(), but for use at the point where a float32 op actually
+// takes the reduced-precision route: warns once per process when TF32 is on
+// by default (i.e. MLX_ENABLE_TF32 is unset). Setting MLX_ENABLE_TF32=0 or =1
+// explicitly keeps it silent.
+bool tf32_active_for_fp32();
+
 inline int nccl_timeout(int default_value) {
   static int nccl_timeout = get_var("MLX_NCCL_TIMEOUT", default_value);
   return nccl_timeout;

--- a/mlx/utils.h
+++ b/mlx/utils.h
@@ -201,7 +201,7 @@ inline bool enable_tf32() {
 // takes the reduced-precision route: warns once per process when TF32 is on
 // by default (i.e. MLX_ENABLE_TF32 is unset). Setting MLX_ENABLE_TF32=0 or =1
 // explicitly keeps it silent.
-bool tf32_active_for_fp32();
+bool tf32_active_for_fp32(const char* op_family = "matmul");
 
 inline int nccl_timeout(int default_value) {
   static int nccl_timeout = get_var("MLX_NCCL_TIMEOUT", default_value);


### PR DESCRIPTION
Addresses the diagnostic half of #3860.

float32 matmul-family ops default to TF32-class reduced precision (`MLX_ENABLE_TF32` defaults to 1) on both backends on current hardware — CUDA tensor cores and the M5 Metal NAX route — and the default is undocumented. #3860 has two independent downstream reports of the resulting failure mode: op-level tests stay green while downstream results shift (near-tie argmax flips on sm_120; mlx-lm's `test_ssm` state comparison on M5), and the bisection points at hardware/environment rather than any commit. This repo's own test harness already pins `MLX_ENABLE_TF32=0` (`python/tests/mlx_tests.py`) for the same reason.

This adds `env::tf32_active_for_fp32()`: returns exactly `env::enable_tf32()`, but prints a one-line warning to stderr, once per process, and **only when `MLX_ENABLE_TF32` is unset** — anyone who set `=1` or `=0` explicitly has already made the choice and never sees it:

> [mlx] float32 matmul-family ops are running at reduced (TF32) precision, which is the default when MLX_ENABLE_TF32 is unset. Set MLX_ENABLE_TF32=0 before the first operation for full float32 precision, or set MLX_ENABLE_TF32=1 explicitly to silence this warning.

It is called at exactly the points where a float32 op takes the reduced-precision route, by reordering the existing short-circuit `(env::enable_tf32() || dtype != float32)` → `(dtype != float32 || env::tf32_active_for_fp32())`, so processes that never engage TF32 (matvec-only, non-fp32, opted out) never print:

- **Metal:** the NAX gates in steel matmul, gather_mm_rhs, segmented_mm, qmm, gather_qmm, gather_qmm_rhs, and SDPA full attention
- **CUDA:** cuBLAS compute type (float32 case), cuDNN conv graph, grouped CUTLASS GEMM

No behavior change beyond the log — every gate computes the same boolean as before. The `complex64` cuBLAS case (also `FAST_TF32` today) is intentionally left untouched; probably worth folding into the docs follow-up discussed in #3860.

### Testing

On M5 Max (macOS 26.5), source build with NAX kernels active:

| scenario | warnings |
|---|---|
| default env, fp32 GEMM ×2 in one process | exactly 1 |
| default env, fp32 matvec only | 0 |
| default env, bf16 GEMM | 0 |
| `MLX_ENABLE_TF32=0`, fp32 GEMM | 0 |
| explicit `MLX_ENABLE_TF32=1`, fp32 GEMM | 0 |
| default env, fp32 quantized_matmul (NAX qmm route) | exactly 1 |
| default env, fp32 quantized_matmul (split-K route, not reduced) | 0 |

Numerics unchanged: default fp32 GEMM max rel err vs an fp64 reference is 8.3e-4 (TF32 signature), and 2.5e-7 with `MLX_ENABLE_TF32=0`. `test_blas.py` (24 tests), `test_quantized.py` (32), and `test_fast_sdpa.py` (16) all pass.

The CUDA side compiles the same helper but I have no NVIDIA hardware to run it — @stoyoda0012-cyber offered an sm_120 review in #3860.

🤖 Generated with [Claude Code](https://claude.com/claude-code)