### PR TITLE
Fix triplet_loss docstring to document the reduced output shape

### DIFF
--- a/python/mlx/nn/losses.py
+++ b/python/mlx/nn/losses.py
@@ -416,8 +416,9 @@ def triplet_loss(
           ``'none'`` | ``'mean'`` | ``'sum'``. Default: ``'none'``.
 
     Returns:
-        array: Computed triplet loss. If reduction is "none", returns a tensor of the same shape as input;
-                  if reduction is "mean" or "sum", returns a scalar tensor.
+        array: Computed triplet loss. If reduction is ``"none"``, returns a tensor with the
+          same shape as the inputs but with the ``axis`` dimension removed; if reduction
+          is ``"mean"`` or ``"sum"``, returns a scalar tensor.
     """
     pos_dist = mx.power(
         mx.power(mx.abs(anchors - positives), p).sum(axis) + eps, 1.0 / p


### PR DESCRIPTION
## Proposed changes

The `triplet_loss` Returns section says that with `reduction="none"` the output has "the same shape as input", but the p-norm is summed over `axis` (default -1), so that dimension is always removed. Quick check on main:

```python
import mlx.core as mx
import mlx.nn as nn

a, p, n = (mx.random.normal((4, 8)) for _ in range(3))
nn.losses.triplet_loss(a, p, n, reduction="none").shape  # (4,), not (4, 8)
```

This updates the docstring to say the `axis` dimension is removed. Also normalizes the odd indentation on the continuation line since I was touching it anyway. Doc only, no behavior change. Related: #3613 fixed the p-norm math here but left this line as-is.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

(docstring-only change, existing test_losses.py passes: 14/14)

---

being upfront: i'm a college freshman and i use Claude Code to help me hunt for doc/code mismatches, but i ran the repro above myself on current main and read the loss implementation to make sure the new wording is actually right. corrections welcome if i misread anything :)
