### PR TITLE
metal: add gemv_wide for fp16/bf16 matmuls of a few rows

### DIFF
--- a/mlx/backend/metal/jit_kernels.cpp
+++ b/mlx/backend/metal/jit_kernels.cpp
@@ -803,6 +803,52 @@ MTL::ComputePipelineState* get_gemv_masked_kernel(
   return d.get_kernel(kernel_name, lib);
 }
 
+MTL::ComputePipelineState* get_gemv_wide_kernel(
+    metal::Device& d,
+    const std::string& kernel_name,
+    const std::string& hash_name,
+    const metal::MTLFCList& func_consts,
+    const array& out,
+    int vecs_per_tg,
+    int k_lanes) {
+  const auto& lib_name = kernel_name;
+  auto lib = d.get_library(lib_name, [&]() {
+    std::ostringstream kernel_source;
+    kernel_source << metal::gemv()
+                  << get_template_definition(
+                         lib_name,
+                         "gemv_wide",
+                         get_type_string(out.dtype()),
+                         vecs_per_tg,
+                         k_lanes);
+    return kernel_source.str();
+  });
+  return d.get_kernel(kernel_name, lib, hash_name, func_consts);
+}
+
+MTL::ComputePipelineState* get_gemv_wide_gather_kernel(
+    metal::Device& d,
+    const std::string& kernel_name,
+    const std::string& hash_name,
+    const metal::MTLFCList& func_consts,
+    const array& out,
+    int vecs_per_tg,
+    int k_lanes) {
+  const auto& lib_name = kernel_name;
+  auto lib = d.get_library(lib_name, [&]() {
+    std::ostringstream kernel_source;
+    kernel_source << metal::gemv()
+                  << get_template_definition(
+                         lib_name,
+                         "gemv_wide_gather",
+                         get_type_string(out.dtype()),
+                         vecs_per_tg,
+                         k_lanes);
+    return kernel_source.str();
+  });
+  return d.get_kernel(kernel_name, lib, hash_name, func_consts);
+}
+
 MTL::ComputePipelineState* get_steel_conv_kernel(
     metal::Device& d,
     const std::string& kernel_name,

--- a/mlx/backend/metal/kernels.h
+++ b/mlx/backend/metal/kernels.h
@@ -253,6 +253,24 @@ MTL::ComputePipelineState* get_gemv_masked_kernel(
     int tn,
     bool contiguous);
 
+MTL::ComputePipelineState* get_gemv_wide_kernel(
+    metal::Device& d,
+    const std::string& kernel_name,
+    const std::string& hash_name,
+    const metal::MTLFCList& func_consts,
+    const array& out,
+    int vecs_per_tg,
+    int k_lanes);
+
+MTL::ComputePipelineState* get_gemv_wide_gather_kernel(
+    metal::Device& d,
+    const std::string& kernel_name,
+    const std::string& hash_name,
+    const metal::MTLFCList& func_consts,
+    const array& out,
+    int vecs_per_tg,
+    int k_lanes);
+
 MTL::ComputePipelineState* get_steel_conv_general_kernel(
     metal::Device& d,
     const std::string& kernel_name,

--- a/mlx/backend/metal/kernels/gemv.h
+++ b/mlx/backend/metal/kernels/gemv.h
@@ -764,3 +764,281 @@ template <
       simd_gid,
       simd_lid);
 }
+
+///////////////////////////////////////////////////////////////////////////////
+/// Multi-vector matrix-vector multiplication (wide gemv)
+///////////////////////////////////////////////////////////////////////////////
+
+constant bool gemv_wide_has_batch [[function_constant(0)]];
+constant bool gemv_wide_do_axpby [[function_constant(1)]];
+
+// out[M, N] = x[M, K] @ mat[N, K]^T for small M: each threadgroup streams a
+// block of matrix rows once and applies it to vecs_per_tg input vectors, so
+// the matrix is read ceil(M / vecs_per_tg) times instead of once per padded
+// GEMM tile. k_lanes lanes reduce K for one row, 32 / k_lanes rows per
+// simdgroup, k_lanes / 8 simdgroups per threadgroup.
+template <
+    typename T,
+    const int vecs_per_tg,
+    const int k_lanes,
+    typename AccT = typename DefaultAccT<T>::type>
+struct GemvWide {
+  static constexpr constant int unroll = 8;
+  static constexpr constant int num_simdgroups = k_lanes / 8;
+
+  static METAL_FUNC void run(
+      const device T* mat,
+      const device T* in_vec,
+      const device T* bias,
+      device T* out_vec,
+      int in_vec_size,
+      int out_vec_size,
+      int M,
+      int matrix_ld,
+      int vector_ld,
+      float alpha,
+      float beta,
+      int bias_ld,
+      int bias_fd,
+      uint3 tid [[threadgroup_position_in_grid]],
+      uint3 tgpg [[threadgroups_per_grid]],
+      uint simd_gid [[simdgroup_index_in_threadgroup]],
+      uint simd_lid [[thread_index_in_simdgroup]]) {
+    constexpr int rows_per_simdgroup = 32 / k_lanes;
+    constexpr int rows_per_tg = rows_per_simdgroup * num_simdgroups;
+
+    const short k_lane =
+        simd_lid % k_lanes; // this lane's slot in the K reduction
+    const short sg_row =
+        simd_lid / k_lanes; // which output row of the simdgroup
+
+    const int out_row =
+        tid.y * rows_per_tg + rows_per_simdgroup * simd_gid + sg_row;
+
+    // Clamped tail rows/vectors read valid memory; the guarded writes
+    // below never store them.
+    const int row = min(out_row, out_vec_size - 1);
+    const device T* wrow = mat + int64_t(row) * matrix_ld;
+    const device vec<T, 4>* w4 = (const device vec<T, 4>*)wrow;
+    const int n_v4 = in_vec_size / 4;
+    const int n_main = n_v4 - n_v4 % (k_lanes * unroll);
+
+    // Vector chunks beyond grid.x round-robin onto the same threadgroups:
+    // re-walking the row block hits cache where an extra grid column would
+    // re-stream it from DRAM.
+    const device vec<T, 4>* x4 = (const device vec<T, 4>*)in_vec;
+    const int x_ld4 = vector_ld / 4;
+    const int n_chunks = (M + vecs_per_tg - 1) / vecs_per_tg;
+    for (int chunk = tid.x; chunk < n_chunks; chunk += tgpg.x) {
+      const int vec0 = chunk * vecs_per_tg;
+
+      int x_off4[vecs_per_tg];
+      for (int v = 0; v < vecs_per_tg; v++) {
+        x_off4[v] = min(vec0 + v, M - 1) * x_ld4;
+      }
+
+      AccT result[vecs_per_tg] = {0};
+
+      // Adjacent lanes read adjacent blocks so every transaction lands on
+      // whole cachelines; the unroll keeps loads in flight on short rows.
+      for (int base = 0; base < n_main; base += k_lanes * unroll) {
+        vec<AccT, 4> wf[unroll];
+        MLX_MTL_PRAGMA_UNROLL
+        for (int i = 0; i < unroll; i++) {
+          wf[i] = vec<AccT, 4>(w4[base + i * k_lanes + k_lane]);
+        }
+        MLX_MTL_PRAGMA_UNROLL
+        for (int v = 0; v < vecs_per_tg; v++) {
+          AccT acc = 0;
+          MLX_MTL_PRAGMA_UNROLL
+          for (int i = 0; i < unroll; i++) {
+            acc +=
+                dot(wf[i],
+                    vec<AccT, 4>(x4[x_off4[v] + base + i * k_lanes + k_lane]));
+          }
+          result[v] += acc;
+        }
+      }
+      for (int idx = n_main + k_lane; idx < n_v4; idx += k_lanes) {
+        const vec<AccT, 4> wf = vec<AccT, 4>(w4[idx]);
+        MLX_MTL_PRAGMA_UNROLL
+        for (int v = 0; v < vecs_per_tg; v++) {
+          result[v] += dot(wf, vec<AccT, 4>(x4[x_off4[v] + idx]));
+        }
+      }
+
+      // The halving shuffles reduce each row's k_lanes while rows sharing
+      // the simdgroup stay separate.
+      MLX_MTL_PRAGMA_UNROLL
+      for (int v = 0; v < vecs_per_tg; v++) {
+        MLX_MTL_PRAGMA_UNROLL
+        for (ushort off = k_lanes / 2; off >= 1; off >>= 1) {
+          result[v] += simd_shuffle_down(result[v], off);
+        }
+      }
+
+      if (k_lane == 0 && out_row < out_vec_size) {
+        for (int v = 0; v < vecs_per_tg; v++) {
+          if (vec0 + v < M) {
+            int64_t out_idx = int64_t(vec0 + v) * out_vec_size + out_row;
+            if (gemv_wide_do_axpby) {
+              AccT bias_val = static_cast<AccT>(
+                  bias[int64_t(vec0 + v) * bias_ld + out_row * bias_fd]);
+              out_vec[out_idx] =
+                  static_cast<T>(alpha * result[v] + beta * bias_val);
+            } else {
+              out_vec[out_idx] = static_cast<T>(result[v]);
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+template <typename T, const int vecs_per_tg, const int k_lanes>
+[[kernel]] void gemv_wide(
+    const device T* mat [[buffer(0)]],
+    const device T* in_vec [[buffer(1)]],
+    const device T* bias [[buffer(2), function_constant(gemv_wide_do_axpby)]],
+    device T* out_vec [[buffer(3)]],
+    const constant int& in_vec_size [[buffer(4)]],
+    const constant int& out_vec_size [[buffer(5)]],
+    const constant int& M [[buffer(6)]],
+    const constant int& matrix_ld [[buffer(7)]],
+    const constant int& vector_ld [[buffer(8)]],
+    const constant float& alpha
+    [[buffer(9), function_constant(gemv_wide_do_axpby)]],
+    const constant float& beta
+    [[buffer(10), function_constant(gemv_wide_do_axpby)]],
+    const constant int& batch_ndim [[buffer(11)]],
+    const constant int* batch_shape [[buffer(12)]],
+    const constant int64_t* vector_batch_stride [[buffer(13)]],
+    const constant int64_t* matrix_batch_stride [[buffer(14)]],
+    const constant int64_t* bias_batch_stride
+    [[buffer(15), function_constant(gemv_wide_do_axpby)]],
+    const constant int& bias_ld
+    [[buffer(16), function_constant(gemv_wide_do_axpby)]],
+    const constant int& bias_fd
+    [[buffer(17), function_constant(gemv_wide_do_axpby)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint3 tgpg [[threadgroups_per_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  if (gemv_wide_has_batch) {
+    in_vec += elem_to_loc(tid.z, batch_shape, vector_batch_stride, batch_ndim);
+    mat += elem_to_loc(tid.z, batch_shape, matrix_batch_stride, batch_ndim);
+
+    if (gemv_wide_do_axpby) {
+      bias += elem_to_loc(tid.z, batch_shape, bias_batch_stride, batch_ndim);
+    }
+  } else {
+    in_vec += tid.z * vector_batch_stride[0];
+    mat += tid.z * matrix_batch_stride[0];
+
+    if (gemv_wide_do_axpby) {
+      bias += tid.z * bias_batch_stride[0];
+    }
+  }
+  out_vec += int64_t(tid.z) * M * out_vec_size;
+
+  GemvWide<T, vecs_per_tg, k_lanes>::run(
+      mat,
+      in_vec,
+      bias,
+      out_vec,
+      in_vec_size,
+      out_vec_size,
+      M,
+      matrix_ld,
+      vector_ld,
+      alpha,
+      beta,
+      bias_ld,
+      bias_fd,
+      tid,
+      tgpg,
+      simd_gid,
+      simd_lid);
+}
+
+template <typename T, const int vecs_per_tg, const int k_lanes>
+[[kernel]] void gemv_wide_gather(
+    const device T* mat [[buffer(0)]],
+    const device T* in_vec [[buffer(1)]],
+    const device T* bias [[buffer(2)]],
+    device T* out_vec [[buffer(3)]],
+    const constant int& in_vec_size [[buffer(4)]],
+    const constant int& out_vec_size [[buffer(5)]],
+    const constant int& M [[buffer(6)]],
+    const constant int& matrix_ld [[buffer(7)]],
+    const constant int& vector_ld [[buffer(8)]],
+    const constant int& batch_ndim [[buffer(11)]],
+    const constant int* batch_shape [[buffer(12)]],
+    const constant int64_t* index_batch_strides [[buffer(13)]],
+    const constant int& vector_batch_ndim [[buffer(14)]],
+    const constant int* vector_batch_shape [[buffer(15)]],
+    const constant int64_t* vector_batch_stride [[buffer(16)]],
+    const constant int& matrix_batch_ndim [[buffer(17)]],
+    const constant int* matrix_batch_shape [[buffer(18)]],
+    const constant int64_t* matrix_batch_stride [[buffer(19)]],
+    const constant uint32_t* vec_indices [[buffer(20)]],
+    const constant uint32_t* mat_indices [[buffer(21)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint3 tgpg [[threadgroups_per_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  uint32_t indx_vec;
+  uint32_t indx_mat;
+
+  // Update batch offsets
+  if (batch_ndim > 1) {
+    const constant auto* veci_bstrides = index_batch_strides;
+    const constant auto* mati_bstrides = index_batch_strides + batch_ndim;
+
+    ulong2 batch_offsets = elem_to_loc_broadcast(
+        tid.z, batch_shape, veci_bstrides, mati_bstrides, batch_ndim);
+
+    indx_vec = vec_indices[batch_offsets.x];
+    indx_mat = mat_indices[batch_offsets.y];
+
+  } else {
+    indx_vec = vec_indices[index_batch_strides[0] * tid.z];
+    indx_mat = mat_indices[index_batch_strides[batch_ndim] * tid.z];
+  }
+
+  if (vector_batch_ndim > 1) {
+    in_vec += elem_to_loc(
+        indx_vec, vector_batch_shape, vector_batch_stride, vector_batch_ndim);
+  } else {
+    in_vec += indx_vec * vector_batch_stride[0];
+  }
+
+  if (matrix_batch_ndim > 1) {
+    mat += elem_to_loc(
+        indx_mat, matrix_batch_shape, matrix_batch_stride, matrix_batch_ndim);
+  } else {
+    mat += indx_mat * matrix_batch_stride[0];
+  }
+
+  out_vec += int64_t(tid.z) * M * out_vec_size;
+
+  GemvWide<T, vecs_per_tg, k_lanes>::run(
+      mat,
+      in_vec,
+      bias,
+      out_vec,
+      in_vec_size,
+      out_vec_size,
+      M,
+      matrix_ld,
+      vector_ld,
+      1.0f,
+      0.0f,
+      0,
+      0,
+      tid,
+      tgpg,
+      simd_gid,
+      simd_lid);
+}

--- a/mlx/backend/metal/kernels/gemv.metal
+++ b/mlx/backend/metal/kernels/gemv.metal
@@ -110,3 +110,39 @@ instantiate_gemv_t_bs_blocks(float32, float);
 instantiate_gemv_t_bs_blocks(float16, half);
 instantiate_gemv_t_bs_blocks(bfloat16, bfloat16_t);
 instantiate_gemv_t_bs_blocks(complex64, complex64_t); // clang-format on
+
+// Batch addressing and axpby are function constants. M == 1 stays with
+// gemv, so tiles start at two vectors.
+// clang-format off
+#define instantiate_gemv_wide_helper(name, itype, nv, kl) \
+  instantiate_kernel(                                    \
+      "gemv_wide_" #name "_nv" #nv "_kl" #kl,             \
+      gemv_wide, itype, nv, kl)
+
+#define instantiate_gemv_wide(name, itype, kl) \
+  instantiate_gemv_wide_helper(name, itype, 2, kl)  \
+  instantiate_gemv_wide_helper(name, itype, 3, kl)  \
+  instantiate_gemv_wide_helper(name, itype, 4, kl)  \
+  instantiate_gemv_wide_helper(name, itype, 5, kl) // clang-format on
+
+instantiate_gemv_wide(float16, half, 16);
+instantiate_gemv_wide(bfloat16, bfloat16_t, 16);
+instantiate_gemv_wide(float16, half, 32);
+instantiate_gemv_wide(bfloat16, bfloat16_t, 32);
+
+// clang-format off
+#define instantiate_gemv_wide_gather_helper(name, itype, nv, kl) \
+  instantiate_kernel(                                            \
+      "gemv_wide_gather_" #name "_nv" #nv "_kl" #kl,             \
+      gemv_wide_gather, itype, nv, kl)
+
+#define instantiate_gemv_wide_gather(name, itype, kl) \
+  instantiate_gemv_wide_gather_helper(name, itype, 2, kl)  \
+  instantiate_gemv_wide_gather_helper(name, itype, 3, kl)  \
+  instantiate_gemv_wide_gather_helper(name, itype, 4, kl)  \
+  instantiate_gemv_wide_gather_helper(name, itype, 5, kl) // clang-format on
+
+instantiate_gemv_wide_gather(float16, half, 16);
+instantiate_gemv_wide_gather(bfloat16, bfloat16_t, 16);
+instantiate_gemv_wide_gather(float16, half, 32);
+instantiate_gemv_wide_gather(bfloat16, bfloat16_t, 32);

--- a/mlx/backend/metal/matmul.cpp
+++ b/mlx/backend/metal/matmul.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cassert>
 #include <numeric>
+#include <optional>
 #include <sstream>
 
 #include "mlx/backend/common/broadcasting.h"
@@ -1230,6 +1231,170 @@ inline void gemv(
       /* Strides B_batch_stride = */ B_batch_stride);
 }
 
+struct GemvWideConfig {
+  int vecs_per_tg;
+  int k_lanes;
+  int grid_x;
+};
+
+std::string gemv_wide_kernel_name(
+    const char* prefix,
+    const array& out,
+    const GemvWideConfig& config) {
+  std::ostringstream kname;
+  kname << prefix << type_to_name(out) << "_nv" << config.vecs_per_tg << "_kl"
+        << config.k_lanes;
+  return kname.str();
+}
+
+inline std::optional<GemvWideConfig> gemv_wide_config(
+    metal::Device& d,
+    const array& out,
+    int M,
+    int N,
+    int K,
+    int mat_ld,
+    int vec_ld,
+    int64_t mat_offset,
+    int64_t vec_offset,
+    const Strides& mat_batch_stride,
+    const Strides& vec_batch_stride) {
+  // Pre-M3 generations are limited by load issue rate rather than
+  // bandwidth and do not profit from the amortized stream; they keep the
+  // existing kernels.
+  if (d.get_architecture_gen() < 15) {
+    return std::nullopt;
+  }
+
+  auto all_aligned = [](const Strides& strides, int alignment) {
+    return std::all_of(
+        strides.begin(), strides.end(), [alignment](int64_t stride) {
+          return stride % alignment == 0;
+        });
+  };
+
+  bool vec4_aligned = mat_offset % 8 == 0 && vec_offset % 8 == 0 &&
+      mat_ld % 4 == 0 && vec_ld % 4 == 0 && all_aligned(mat_batch_stride, 4) &&
+      all_aligned(vec_batch_stride, 4);
+
+  // Wide amortizes one matrix stream over several vectors; M == 1 has
+  // nothing to amortize and stays with gemv.
+  if (M <= 1 || N <= 1 || K % 4 != 0 ||
+      (out.dtype() != float16 && out.dtype() != bfloat16) || !vec4_aligned) {
+    return std::nullopt;
+  }
+
+  // A register tile holds at most five vectors (wider collapses occupancy);
+  // M balances across passes that each re-stream the matrix, and a fourth
+  // pass no longer pays.
+  int passes = (M + 4) / 5;
+  if (passes > 3) {
+    return std::nullopt;
+  }
+
+  // Wide enough that the row grid alone saturates the GPU: N/4 threadgroups,
+  // orders of magnitude beyond concurrent execution capacity.
+  bool vocab_wide = N >= 65536;
+
+  // Full rows double the threads per group and halve each lane's K share
+  // — more in flight where the grid is thinnest: one-pass tiles have a
+  // single grid column, and tiny outputs starve every column.
+  bool full_simd = passes == 1 || N <= 64;
+  int grid_x = vocab_wide ? 1 : passes;
+  return GemvWideConfig{(M + passes - 1) / passes, full_simd ? 32 : 16, grid_x};
+}
+
+bool gemv_wide(
+    const Stream& s,
+    metal::Device& d,
+    const array& mat,
+    const array& in_vec,
+    const array* bias,
+    array& out,
+    int M,
+    int N,
+    int K,
+    int mat_ld,
+    int vec_ld,
+    int batch_size_out,
+    const Shape& batch_shape,
+    const Strides& mat_batch_stride,
+    const Strides& vec_batch_stride,
+    std::vector<array>& copies,
+    const Strides* bias_batch_stride,
+    float alpha,
+    float beta) {
+  auto plan = gemv_wide_config(
+      d,
+      out,
+      M,
+      N,
+      K,
+      mat_ld,
+      vec_ld,
+      mat.offset(),
+      in_vec.offset(),
+      mat_batch_stride,
+      vec_batch_stride);
+  if (!plan) {
+    return false;
+  }
+
+  const bool has_batch = batch_shape.size() != 1;
+  const bool do_axpby = bias != nullptr;
+  int batch_ndim = batch_shape.size();
+
+  MTL::Size group_dims(32, plan->k_lanes / 8, 1);
+  MTL::Size grid_dims(plan->grid_x, (N + 3) / 4, batch_size_out);
+
+  std::string base_name = gemv_wide_kernel_name("gemv_wide_", out, *plan);
+  std::ostringstream hash_name;
+  hash_name << base_name << "_nc" << has_batch << "_axpby" << do_axpby;
+  metal::MTLFCList func_consts = {
+      {&has_batch, MTL::DataType::DataTypeBool, 0},
+      {&do_axpby, MTL::DataType::DataTypeBool, 1},
+  };
+
+  auto& compute_encoder = metal::get_command_encoder(s);
+  auto kernel = get_gemv_wide_kernel(
+      d,
+      base_name,
+      hash_name.str(),
+      func_consts,
+      out,
+      plan->vecs_per_tg,
+      plan->k_lanes);
+  compute_encoder.set_compute_pipeline_state(kernel);
+
+  compute_encoder.set_input_array(mat, 0);
+  compute_encoder.set_input_array(in_vec, 1);
+  compute_encoder.set_output_array(out, 3);
+  compute_encoder.set_bytes(K, 4);
+  compute_encoder.set_bytes(N, 5);
+  compute_encoder.set_bytes(M, 6);
+  compute_encoder.set_bytes(mat_ld, 7);
+  compute_encoder.set_bytes(vec_ld, 8);
+  compute_encoder.set_bytes(batch_ndim, 11);
+  compute_encoder.set_vector_bytes(batch_shape, 12);
+  compute_encoder.set_vector_bytes(vec_batch_stride, 13);
+  compute_encoder.set_vector_bytes(mat_batch_stride, 14);
+
+  if (do_axpby) {
+    compute_encoder.set_input_array(*bias, 2);
+    compute_encoder.set_bytes(alpha, 9);
+    compute_encoder.set_bytes(beta, 10);
+    compute_encoder.set_vector_bytes(*bias_batch_stride, 15);
+    int bias_ld = bias->strides()[bias->ndim() - 2];
+    int bias_fd = bias->strides()[bias->ndim() - 1];
+    compute_encoder.set_bytes(bias_ld, 16);
+    compute_encoder.set_bytes(bias_fd, 17);
+  }
+
+  compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+  compute_encoder.add_temporaries(std::move(copies));
+  return true;
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Matmul implementation
 ///////////////////////////////////////////////////////////////////////////////
@@ -1289,6 +1454,32 @@ void Matmul::eval_gpu(const std::vector<array>& inputs, array& out) {
 
   /////////////////////////////////////////////////////////////////////////////
   // Gemv specialization
+
+  // The wide gemv route streams the weight matrix once per <= 5 input
+  // vectors instead of running a row-padded GEMM tile.
+  if (!a_transposed && b_transposed &&
+      gemv_wide(
+          /* const Stream& s = */ s,
+          /* metal::Device& d = */ d,
+          /* const array& mat = */ b,
+          /* const array& in_vec = */ a,
+          /* const array* bias = */ nullptr,
+          /* array& out = */ out,
+          /* int M = */ M,
+          /* int N = */ N,
+          /* int K = */ K,
+          /* int mat_ld = */ b_cols,
+          /* int vec_ld = */ a_cols,
+          /* int batch_size_out = */ static_cast<int>(batch_size_out),
+          /* const Shape& batch_shape = */ batch_shape,
+          /* const Strides& mat_batch_stride = */ B_batch_stride,
+          /* const Strides& vec_batch_stride = */ A_batch_stride,
+          /* std::vector<array>& copies = */ copies,
+          /* const Strides* bias_batch_stride = */ nullptr,
+          /* float alpha = */ 1.0f,
+          /* float beta = */ 0.0f)) {
+    return;
+  }
 
   // Route to gemv if needed
   if (std::min(M, N) == 1) {
@@ -1421,6 +1612,32 @@ void AddMM::eval_gpu(const std::vector<array>& inputs, array& out) {
 
   /////////////////////////////////////////////////////////////////////////////
   // Gemv specialization
+
+  // The wide gemv route streams the weight matrix once per <= 5 input
+  // vectors instead of running a row-padded GEMM tile.
+  if (!transpose_a && transpose_b &&
+      gemv_wide(
+          /* const Stream& s = */ s,
+          /* metal::Device& d = */ d,
+          /* const array& mat = */ b,
+          /* const array& in_vec = */ a,
+          /* const array* bias = */ &c,
+          /* array& out = */ out,
+          /* int M = */ M,
+          /* int N = */ N,
+          /* int K = */ K,
+          /* int mat_ld = */ ldb,
+          /* int vec_ld = */ lda,
+          /* int batch_size_out = */ static_cast<int>(batch_size_out),
+          /* const Shape& batch_shape = */ batch_shape,
+          /* const Strides& mat_batch_stride = */ B_batch_stride,
+          /* const Strides& vec_batch_stride = */ A_batch_stride,
+          /* std::vector<array>& copies = */ copies,
+          /* const Strides* bias_batch_stride = */ &C_batch_stride,
+          /* float alpha = */ alpha_,
+          /* float beta = */ beta_)) {
+    return;
+  }
 
   // Route to gemv if needed
   if (std::min(M, N) == 1) {
@@ -2260,6 +2477,138 @@ void gather_mv(
   compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
 }
 
+// Dispatches gathers whose b is a transposed view (x @ W.T layouts) onto
+// gemv_wide_gather; returns false when the layout or shape wants the existing
+// routes instead. The route is decided from raw strides so no copy is encoded
+// unless it will be dispatched.
+bool gather_mm_wide(
+    const array& a_,
+    const array& b_,
+    const array& vec_indices,
+    const array& mat_indices,
+    array& out,
+    int M,
+    int N,
+    int K,
+    metal::Device& d,
+    const Stream& s) {
+  // b must already be a transposed view (second-to-last dim contiguous,
+  // inner stride != 1). check_transpose can't decide this: it copies any
+  // other layout to row-contiguous and reports it as non-transposed.
+  if (b_.strides()[b_.ndim() - 1] == 1 || b_.strides()[b_.ndim() - 2] != 1) {
+    return false;
+  }
+  int ldb = b_.strides()[b_.ndim() - 1];
+  // a is served directly when row-contiguous, by a contiguous copy when
+  // neither layout matches, and declines when transposed.
+  bool a_direct = a_.strides()[a_.ndim() - 1] == 1;
+  if (!a_direct && a_.strides()[a_.ndim() - 2] == 1) {
+    return false;
+  }
+  int lda;
+  int64_t vec_offset;
+  Strides vec_batch_stride;
+  if (a_direct) {
+    lda = a_.strides()[a_.ndim() - 2];
+    vec_offset = a_.offset();
+    vec_batch_stride = Strides(a_.strides().begin(), a_.strides().end() - 2);
+  } else {
+    lda = a_.shape(-1);
+    vec_offset = 0;
+    vec_batch_stride = Strides(a_.ndim() - 2);
+    int64_t stride = int64_t(a_.shape(-2)) * a_.shape(-1);
+    for (int i = a_.ndim() - 3; i >= 0; --i) {
+      vec_batch_stride[i] = stride;
+      stride *= a_.shape(i);
+    }
+  }
+  Strides mat_batch_stride(b_.strides().begin(), b_.strides().end() - 2);
+
+  auto cfg = gemv_wide_config(
+      d,
+      out,
+      M,
+      N,
+      K,
+      ldb,
+      lda,
+      b_.offset(),
+      vec_offset,
+      mat_batch_stride,
+      vec_batch_stride);
+  if (!cfg) {
+    return false;
+  }
+
+  std::vector<array> copies;
+  array a = a_;
+  if (!a_direct) {
+    a = contiguous_copy_gpu(a_, s);
+    copies.push_back(a);
+  }
+  const array& b = b_;
+
+  int batch_size_out = out.size() / M / N;
+  int batch_ndim = out.ndim() - 2;
+  int batch_ndim_vec = a.ndim() - 2;
+  int batch_ndim_mat = b.ndim() - 2;
+  Strides index_strides = vec_indices.strides();
+  index_strides.insert(
+      index_strides.end(),
+      mat_indices.strides().begin(),
+      mat_indices.strides().end());
+  if (index_strides.empty()) {
+    // Scalar indices: the kernel still loads a stride (scaled by tid.z == 0).
+    index_strides = {0, 0};
+  }
+
+  MTL::Size group_dims(32, cfg->k_lanes / 8, 1);
+  MTL::Size grid_dims(cfg->grid_x, (N + 3) / 4, batch_size_out);
+
+  const bool do_axpby = false;
+  std::string base_name = gemv_wide_kernel_name("gemv_wide_gather_", out, *cfg);
+  std::ostringstream hash_name;
+  hash_name << base_name << "_axpby0";
+  metal::MTLFCList func_consts = {
+      {&do_axpby, MTL::DataType::DataTypeBool, 1},
+  };
+
+  auto& compute_encoder = metal::get_command_encoder(s);
+  auto kernel = get_gemv_wide_gather_kernel(
+      d,
+      base_name,
+      hash_name.str(),
+      func_consts,
+      out,
+      cfg->vecs_per_tg,
+      cfg->k_lanes);
+  compute_encoder.set_compute_pipeline_state(kernel);
+
+  compute_encoder.set_input_array(b, 0);
+  compute_encoder.set_input_array(a, 1);
+  compute_encoder.set_output_array(out, 3);
+  compute_encoder.set_bytes(K, 4);
+  compute_encoder.set_bytes(N, 5);
+  compute_encoder.set_bytes(M, 6);
+  compute_encoder.set_bytes(ldb, 7);
+  compute_encoder.set_bytes(lda, 8);
+  compute_encoder.set_bytes(batch_ndim, 11);
+  compute_encoder.set_vector_bytes(out.shape(), 12);
+  compute_encoder.set_vector_bytes(index_strides, 13);
+  compute_encoder.set_bytes(batch_ndim_vec, 14);
+  compute_encoder.set_vector_bytes(a.shape(), 15);
+  compute_encoder.set_vector_bytes(a.strides(), 16);
+  compute_encoder.set_bytes(batch_ndim_mat, 17);
+  compute_encoder.set_vector_bytes(b.shape(), 18);
+  compute_encoder.set_vector_bytes(b.strides(), 19);
+  compute_encoder.set_input_array(vec_indices, 20);
+  compute_encoder.set_input_array(mat_indices, 21);
+
+  compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+  compute_encoder.add_temporaries(std::move(copies));
+  return true;
+}
+
 void gather_mm(
     const array& a_,
     const array& b_,
@@ -2442,6 +2791,11 @@ void GatherMM::eval_gpu(const std::vector<array>& inputs, array& out) {
   }
   if (N == 1) {
     gather_mv(a, b, lhs_indices, rhs_indices, out, M, K, true, d, s);
+    return;
+  }
+
+  // The wide gather route streams each gathered matrix once per <= 5 rows.
+  if (gather_mm_wide(a, b, lhs_indices, rhs_indices, out, M, N, K, d, s)) {
     return;
   }
 

--- a/mlx/backend/metal/nojit_kernels.cpp
+++ b/mlx/backend/metal/nojit_kernels.cpp
@@ -273,6 +273,28 @@ MTL::ComputePipelineState* get_gemv_masked_kernel(
   return d.get_kernel(kernel_name);
 }
 
+MTL::ComputePipelineState* get_gemv_wide_kernel(
+    metal::Device& d,
+    const std::string& kernel_name,
+    const std::string& hash_name,
+    const metal::MTLFCList& func_consts,
+    const array&,
+    int,
+    int) {
+  return d.get_kernel(kernel_name, hash_name, func_consts);
+}
+
+MTL::ComputePipelineState* get_gemv_wide_gather_kernel(
+    metal::Device& d,
+    const std::string& kernel_name,
+    const std::string& hash_name,
+    const metal::MTLFCList& func_consts,
+    const array&,
+    int,
+    int) {
+  return d.get_kernel(kernel_name, hash_name, func_consts);
+}
+
 MTL::ComputePipelineState* get_steel_conv_kernel(
     metal::Device& d,
     const std::string& kernel_name,

--- a/python/tests/test_blas.py
+++ b/python/tests/test_blas.py
@@ -541,6 +541,7 @@ class TestBlas(mlx_tests.MLXTestCase):
     def test_wide_matmul(self):
         if mx.default_device() == mx.cpu:
             self.skipTest("requires GPU")
+
         # Eligible a @ b.T products of a few rows take the wide gemv route on metal;
         # cover numerical correctness across the routing boundaries: row tails,
         # K not divisible by 4, offset and sliced views, and batching.
@@ -823,6 +824,7 @@ class TestBlas(mlx_tests.MLXTestCase):
     def test_wide_addmm(self):
         if mx.default_device() == mx.cpu:
             self.skipTest("requires GPU")
+
         # Eligible few-row addmm shapes take the wide gemv route on metal; cover
         # the axpby epilogue against bias shapes, scales, and batching.
         def run_test(dtype, B, M, K, N, c_shape, alpha, beta):
@@ -1337,6 +1339,7 @@ class TestBlas(mlx_tests.MLXTestCase):
     def test_gather_mm_blocks(self):
         if mx.default_device() == mx.cpu:
             self.skipTest("requires GPU")
+
         # Eligible gathered products with few-row blocks route to the wide
         # gather on metal; check block indexing against a per-entry reference.
         def run_test(dtype, G, M, K, N, E, idx_shape):

--- a/python/tests/test_blas.py
+++ b/python/tests/test_blas.py
@@ -538,6 +538,91 @@ class TestBlas(mlx_tests.MLXTestCase):
                                     )
                                     self.assertTrue(np.array_equal(c_mlx, c_npy))
 
+    def test_wide_matmul(self):
+        # Eligible a @ b.T products of a few rows take the wide gemv route on metal;
+        # cover numerical correctness across the routing boundaries: row tails,
+        # K not divisible by 4, offset and sliced views, and batching.
+        # Inputs scale as K**-0.5 so outputs stay O(K**-0.5); atol scales
+        # with them, above output rounding for every dtype but below a
+        # dropped reduction block.
+        def run_test(dtype, shape_a, shape_b, f_np_b, f_mx_b):
+            with self.subTest(dtype=str(dtype), shape_a=shape_a, shape_b=shape_b):
+                np.random.seed(7)
+                scale = shape_a[-1] ** -0.5
+                a_mx = mx.array(
+                    np.random.normal(0.0, scale, shape_a).astype(np.float32)
+                ).astype(dtype)
+                b_mx = mx.array(
+                    np.random.normal(0.0, scale, shape_b).astype(np.float32)
+                ).astype(dtype)
+                a_np = np.array(a_mx.astype(mx.float32))
+                b_np = np.array(b_mx.astype(mx.float32))
+
+                out_np = a_np @ f_np_b(b_np)
+                out_mx = (a_mx @ f_mx_b(b_mx)).astype(mx.float32)
+
+                self.assertListEqual(list(out_np.shape), list(out_mx.shape))
+                self.assertTrue(np.allclose(out_mx, out_np, atol=0.05 * scale))
+
+        nt_np = lambda b: b.swapaxes(-1, -2)
+        nt_mx = lambda b: mx.swapaxes(b, -1, -2)
+
+        for dtype in (mx.float32, mx.float16, mx.bfloat16):
+            for M in (1, 2, 3, 5, 8, 11, 16):
+                for K, N in (
+                    (64, 128),
+                    (512, 128),
+                    (2048, 256),
+                    (2048, 32),
+                    (2052, 1000),
+                ):
+                    run_test(dtype, (M, K), (N, K), nt_np, nt_mx)
+
+            # K % 4 != 0 falls back to the general kernels
+            run_test(dtype, (5, 514), (333, 514), nt_np, nt_mx)
+
+            # sliced weights: leading dimension != K, plus offset views at 16-
+            # and 8-byte alignment, and a slice with an odd vec4 tail
+            run_test(
+                dtype,
+                (5, 512),
+                (333, 576),
+                lambda b: b[:, :512].swapaxes(-1, -2),
+                lambda b: mx.swapaxes(b[:, :512], -1, -2),
+            )
+            run_test(
+                dtype,
+                (5, 512),
+                (333, 512),
+                lambda b: b[7:, :].swapaxes(-1, -2),
+                lambda b: mx.swapaxes(b[7:, :], -1, -2),
+            )
+            run_test(
+                dtype,
+                (3, 512),
+                (333, 520),
+                lambda b: b[:, 4:516].swapaxes(-1, -2),
+                lambda b: mx.swapaxes(b[:, 4:516], -1, -2),
+            )
+            run_test(
+                dtype,
+                (3, 2052),
+                (129, 2056),
+                lambda b: b[:, :2052].swapaxes(-1, -2),
+                lambda b: mx.swapaxes(b[:, :2052], -1, -2),
+            )
+
+            # batched: regular, broadcast weights, and multi-dim batch
+            run_test(dtype, (4, 3, 512), (4, 257, 512), nt_np, nt_mx)
+            run_test(
+                dtype,
+                (4, 3, 512),
+                (1, 257, 512),
+                lambda b: np.broadcast_to(b, (4, 257, 512)).swapaxes(-1, -2),
+                lambda b: mx.swapaxes(mx.broadcast_to(b, (4, 257, 512)), -1, -2),
+            )
+            run_test(dtype, (2, 3, 5, 512), (2, 3, 129, 512), nt_np, nt_mx)
+
     def test_mismatch_stride_mm(self):
         np.random.seed(0)
         a_npy = np.random.normal(0.0, 1.0 / 128, (4, 16, 16)).astype(np.float32)
@@ -732,6 +817,58 @@ class TestBlas(mlx_tests.MLXTestCase):
             out = mx.addmm(c, a, b, alpha=0.5, beta=2.0)
             expected = 0.5 * (a @ b) + 2.0 * c
             self.assertTrue(mx.allclose(out, expected, rtol=tol, atol=tol))
+
+    def test_wide_addmm(self):
+        # Eligible few-row addmm shapes take the wide gemv route on metal; cover
+        # the axpby epilogue against bias shapes, scales, and batching.
+        def run_test(dtype, B, M, K, N, c_shape, alpha, beta):
+            with self.subTest(dtype=str(dtype), c_shape=c_shape, alpha=alpha):
+                np.random.seed(3)
+                shape_a = (M, K) if B is None else (B, M, K)
+                shape_b = (N, K) if B is None else (B, N, K)
+                scale = K**-0.5
+                a_mx = mx.array(
+                    np.random.normal(0.0, scale, shape_a).astype(np.float32)
+                ).astype(dtype)
+                b_mx = mx.array(
+                    np.random.normal(0.0, scale, shape_b).astype(np.float32)
+                ).astype(dtype)
+                c_mx = mx.array(
+                    np.random.normal(0.0, scale, c_shape).astype(np.float32)
+                ).astype(dtype)
+                a_np = np.array(a_mx.astype(mx.float32))
+                b_np = np.array(b_mx.astype(mx.float32))
+                c_np = np.array(c_mx.astype(mx.float32))
+
+                out_np = alpha * (a_np @ b_np.swapaxes(-1, -2)) + beta * c_np
+                out_mx = mx.addmm(
+                    c_mx,
+                    a_mx,
+                    mx.swapaxes(b_mx, -1, -2),
+                    alpha,
+                    beta,
+                ).astype(mx.float32)
+
+                self.assertListEqual(list(out_np.shape), list(out_mx.shape))
+                atol = 0.05 * (abs(alpha) + abs(beta)) * scale
+                self.assertTrue(np.allclose(out_mx, out_np, atol=atol))
+
+        for dtype in (mx.float32, mx.float16, mx.bfloat16):
+            for M in (2, 5, 12):
+                for c_shape in ((250,), (1, 250), (M, 250)):
+                    for alpha, beta in ((1.0, 1.0), (2.5, 0.5), (1.0, 0.0)):
+                        run_test(dtype, None, M, 512, 250, c_shape, alpha, beta)
+            run_test(dtype, 3, 4, 512, 250, (3, 4, 250), 1.0, 1.0)
+
+            # the epilogue must scale the accumulator before narrowing: a
+            # product past the fp16 max rescued by alpha stays finite (M = 4
+            # keeps the 2-byte shape routed on every supported generation)
+            with self.subTest(dtype=str(dtype), case="alpha rescue"):
+                a = mx.full((4, 512), 2.0, dtype=dtype)
+                b = mx.full((250, 512), 100.0, dtype=dtype)
+                c = mx.ones((4, 250), dtype=dtype)
+                out = mx.addmm(c, a, mx.swapaxes(b, -1, -2), 0.125, 0.0)
+                self.assertTrue(np.allclose(out.astype(mx.float32), 12800.0))
 
     def test_addmm_grad(self):
         def make_ref_addmm(alpha, beta):
@@ -1192,6 +1329,64 @@ class TestBlas(mlx_tests.MLXTestCase):
         out_mx = mx.gather_mm(a_mx, b_mx_t, lhs_indices_mx, rhs_indices_mx)
 
         self.assertTrue(np.allclose(out_np, out_mx, atol=1e-5))
+
+    def test_gather_mm_blocks(self):
+        # Eligible gathered products with few-row blocks route to the wide
+        # gather on metal; check block indexing against a per-entry reference.
+        def run_test(dtype, G, M, K, N, E, idx_shape):
+            with self.subTest(dtype=str(dtype), G=G, M=M, idx=idx_shape):
+                np.random.seed(11)
+                scale = K**-0.5
+                a_mx = mx.array(
+                    np.random.normal(0.0, scale, (G, M, K)).astype(np.float32)
+                ).astype(dtype)
+                w_mx = mx.array(
+                    np.random.normal(0.0, scale, (E, N, K)).astype(np.float32)
+                ).astype(dtype)
+                a_np = np.array(a_mx.astype(mx.float32))
+                w_np = np.array(w_mx.astype(mx.float32))
+                rhs = np.random.randint(0, E, size=idx_shape).astype(np.uint32)
+
+                out_np = np.stack(
+                    [a_np[i % G] @ w_np[r].T for i, r in enumerate(rhs.reshape(-1))]
+                ).reshape(*idx_shape, M, N)
+                out_mx = mx.gather_mm(
+                    a_mx.reshape(*idx_shape, M, K),
+                    mx.swapaxes(w_mx, -1, -2),
+                    None,
+                    mx.array(rhs),
+                ).astype(mx.float32)
+
+                self.assertListEqual(list(out_np.shape), list(out_mx.shape))
+                self.assertTrue(np.allclose(out_mx, out_np, atol=0.05 * scale))
+
+        for dtype in (mx.float32, mx.float16, mx.bfloat16):
+            for M in (2, 4, 5, 11):
+                run_test(dtype, 6, M, 2048, 1024, 8, (6,))
+            run_test(dtype, 6, 3, 2048, 1024, 8, (2, 3))
+
+            # scalar indices: batch_ndim == 0 must still bind index strides
+            with self.subTest(dtype=str(dtype), idx="scalar"):
+                np.random.seed(11)
+                scale = 512**-0.5
+                a_mx = mx.array(
+                    np.random.normal(0.0, scale, (4, 512)).astype(np.float32)
+                ).astype(dtype)
+                w_mx = mx.array(
+                    np.random.normal(0.0, scale, (8, 129, 512)).astype(np.float32)
+                ).astype(dtype)
+                out_np = (
+                    np.array(a_mx.astype(mx.float32))
+                    @ np.array(w_mx[3].astype(mx.float32)).T
+                )
+                out_mx = mx.gather_mm(
+                    a_mx,
+                    mx.swapaxes(w_mx, -1, -2),
+                    None,
+                    mx.array(3, dtype=mx.uint32),
+                ).astype(mx.float32)
+                self.assertListEqual(list(out_np.shape), list(out_mx.shape))
+                self.assertTrue(np.allclose(out_mx, out_np, atol=0.05 * scale))
 
     def test_gather_matmul_grad(self):
         lhs_indices = mx.array([[7, 6], [4, 1], [0, 2]], dtype=mx.uint32)

--- a/python/tests/test_blas.py
+++ b/python/tests/test_blas.py
@@ -539,6 +539,8 @@ class TestBlas(mlx_tests.MLXTestCase):
                                     self.assertTrue(np.array_equal(c_mlx, c_npy))
 
     def test_wide_matmul(self):
+        if mx.default_device() == mx.cpu:
+            self.skipTest("requires GPU")
         # Eligible a @ b.T products of a few rows take the wide gemv route on metal;
         # cover numerical correctness across the routing boundaries: row tails,
         # K not divisible by 4, offset and sliced views, and batching.
@@ -819,6 +821,8 @@ class TestBlas(mlx_tests.MLXTestCase):
             self.assertTrue(mx.allclose(out, expected, rtol=tol, atol=tol))
 
     def test_wide_addmm(self):
+        if mx.default_device() == mx.cpu:
+            self.skipTest("requires GPU")
         # Eligible few-row addmm shapes take the wide gemv route on metal; cover
         # the axpby epilogue against bias shapes, scales, and batching.
         def run_test(dtype, B, M, K, N, c_shape, alpha, beta):
@@ -1331,6 +1335,8 @@ class TestBlas(mlx_tests.MLXTestCase):
         self.assertTrue(np.allclose(out_np, out_mx, atol=1e-5))
 
     def test_gather_mm_blocks(self):
+        if mx.default_device() == mx.cpu:
+            self.skipTest("requires GPU")
         # Eligible gathered products with few-row blocks route to the wide
         # gather on metal; check block indexing against a per-entry reference.
         def run_test(dtype, G, M, K, N, E, idx_shape):


### PR DESCRIPTION
fp16/bf16 products of a few rows against a large transposed weight matrix
(`x @ w.T` with M = 2..15) route to GEMM tiles that pad M to 64 rows
and leave much of the memory bandwidth unused.

`gemv_wide` streams each block of weight rows once and applies it to up
to five input vectors held in registers; chunks beyond the grid loop
inside one threadgroup, so vocab-width outputs also stream the matrix
once. It covers `Matmul`, `AddMM`, and `GatherMM`, batched or sliced, on
the M3 generation and later.

Speedups are per-kernel GPU time against the stock routing, with
uncached weights. The shapes come from a qwen3.6 deployment (the
layers a quantized model keeps in bf16).

`in_proj_a/b`, `[M, 2048] x [2048, 32]`:

| M | M3 Ultra | M4 Pro | M5 Max |
|---|----------|--------|--------|
| 2 | 3.0x     | 2.3x   | 6.0x   |
| 4 | 2.3x     | 1.8x   | 4.7x   |
| 8 | 2.3x     | 1.7x   | 4.8x   |

`lm_head`, `[M, 2048] x [2048, 248320]`:

| M | M3 Ultra | M4 Pro | M5 Max |
|---|----------|--------|--------|
| 2 | 1.7x     | 2.3x   | 1.4x   |
| 4 | 1.7x     | 2.2x   | 1.4x   |
| 8 | 1.8x     | 2.1x   | 1.3x   |