### PR TITLE
Fix Adamax betas docstring and MultiOptimizer filters type

### DIFF
--- a/python/mlx/optimizers/optimizers.py
+++ b/python/mlx/optimizers/optimizers.py
@@ -165,7 +165,7 @@ class MultiOptimizer(Optimizer):
 
     Args:
         optimizers (list[Optimizer]): A list of optimizers to delegate to
-        filters (list[Callable[[str, array], bool]): A list of predicates that
+        filters (list[Callable[[str, array], bool]]): A list of predicates that
             should be one less than the provided optimizers.
     """
 
@@ -606,8 +606,9 @@ class Adamax(Adam):
     Args:
         learning_rate (float or callable): The learning rate :math:`\lambda`.
         betas (Tuple[float, float], optional): The coefficients
-          :math:`(\beta_1, \beta_2)` used for computing running averages of the
-          gradient and its square. Default: ``(0.9, 0.999)``
+          :math:`(\beta_1, \beta_2)` used for computing the running average of
+          the gradient and the exponentially weighted infinity norm.
+          Default: ``(0.9, 0.999)``
         eps (float, optional): The term :math:`\epsilon` added to the
           denominator to improve numerical stability. Default: ``1e-8``
     """


### PR DESCRIPTION
## Proposed changes

Two docstring fixes in `optimizers.py`, no behavior change:

1. `Adamax` betas: the doc says the coefficients compute "running averages of the gradient and its square", but that describes Adam. Adamax's second moment is the exponentially weighted infinity norm (`v = max(beta2 * v, |g|)`, matching the math block and `apply_single`), nothing is squared. Reworded to match.
2. `MultiOptimizer` `filters`: the type had unbalanced brackets `list[Callable[[str, array], bool]` (missing the outer closing `]`).

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

(docstring-only; test_optimizers.py still passes 25/25)

---

honesty note: freshman here, i lean on Claude Code to spot doc/code mismatches but i checked the Adamax update math (max of the infinity norm, not a squared term) against the code myself before writing this. happy to be corrected if i phrased anything poorly.
