### PR TITLE
Fix broken docstring rendering in Linear and RNN

### DIFF
--- a/python/mlx/nn/layers/linear.py
+++ b/python/mlx/nn/layers/linear.py
@@ -32,7 +32,6 @@ class Linear(Module):
 
         y = x W^\top + b
 
-    where:
     where :math:`W` has shape ``[output_dims, input_dims]`` and :math:`b` has shape ``[output_dims]``.
 
     The values are initialized from the uniform distribution :math:`\mathcal{U}(-{k}, {k})`,

--- a/python/mlx/nn/layers/recurrent.py
+++ b/python/mlx/nn/layers/recurrent.py
@@ -33,7 +33,7 @@ class RNN(Module):
         hidden_size (int): Dimension of the hidden state, ``H``.
         bias (bool, optional): Whether to use a bias. Default: ``True``.
         nonlinearity (callable, optional): Non-linearity to use. If ``None``,
-            then func:`tanh` is used. Default: ``None``.
+            then :func:`tanh` is used. Default: ``None``.
     """
 
     def __init__(


### PR DESCRIPTION
## Proposed changes

Two small docstring rendering fixes, no behavior change:

1. `Linear`: the docstring had a duplicated `where:` line (a bare `where:` immediately followed by `where :math:\`W\` has shape ...`), so it rendered "where:" twice. Removed the stray line.
2. `RNN`: the `nonlinearity` arg wrote `func:\`tanh\`` without the leading colon, so Sphinx rendered it literally instead of as a `:func:` cross-reference. Fixed to `:func:\`tanh\``.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

(docstring-only, no tests needed)

---

small disclaimer: i'm a freshman contributor and i used Claude Code to help me sweep for docstring issues, but i read both docstrings myself to confirm these actually render wrong before opening this. let me know if anything looks off :)
