### PR TITLE
Avoid unaligned writes in CPU RandomBits

### DIFF
--- a/mlx/backend/cpu/primitives.cpp
+++ b/mlx/backend/cpu/primitives.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <cstring>
 #include <numeric>
 #include <sstream>
 
@@ -291,9 +292,12 @@ void RandomBits::eval_cpu(const std::vector<array>& inputs, array& out) {
                     num_keys,
                     kshape = keys.shape(),
                     kstrides = keys.strides()]() mutable {
+    auto copy_word = [](char* dst, uint32_t value) {
+      std::memcpy(dst, &value, sizeof(value));
+    };
     auto copy_remaining = [&](char* cptr, size_t loc, uint32_t v) {
       if (4 * loc + 4 <= bytes_per_key) {
-        reinterpret_cast<uint32_t*>(cptr)[loc] = v;
+        copy_word(cptr + 4 * loc, v);
       } else {
         std::copy(
             reinterpret_cast<char*>(&v),
@@ -306,7 +310,6 @@ void RandomBits::eval_cpu(const std::vector<array>& inputs, array& out) {
     auto half_size = out_skip / 2;
     bool even = out_skip % 2 == 0;
     for (int i = 0; i < num_keys; ++i, cptr += bytes_per_key) {
-      auto ptr = reinterpret_cast<uint32_t*>(cptr);
       // Get ith key
       auto kidx = 2 * i;
       auto k1_elem = elem_to_loc(kidx, kshape, kstrides);
@@ -315,12 +318,13 @@ void RandomBits::eval_cpu(const std::vector<array>& inputs, array& out) {
 
       std::pair<uintptr_t, uintptr_t> count{0, half_size + !even};
       for (; count.first + 1 < half_size; count.first++, count.second++) {
-        std::tie(ptr[count.first], ptr[count.second]) =
-            random::threefry2x32_hash(key, count);
+        auto [first, second] = random::threefry2x32_hash(key, count);
+        copy_word(cptr + 4 * count.first, first);
+        copy_word(cptr + 4 * count.second, second);
       }
       if (count.first < half_size) {
         auto rb = random::threefry2x32_hash(key, count);
-        ptr[count.first++] = rb.first;
+        copy_word(cptr + 4 * count.first++, rb.first);
         copy_remaining(cptr, count.second, rb.second);
       }
       if (!even) {


### PR DESCRIPTION
## Summary

- avoid unaligned 32-bit stores in the CPU `RandomBits` implementation
- preserve the generated bytes and Threefry sequence by using `memcpy` for complete words
- leave the existing partial-word copy path unchanged

## Root cause

For batched keys, each key's output begins `bytes_per_key` bytes after the
previous one. When that stride is not divisible by four, casting the start of a
later key's output to `uint32_t*` and writing through it is undefined behavior.

The existing `test random bits` case covers an affected layout: vmapping five
`uint16` values over two keys makes each per-key output 10 bytes wide. Before
this change, that test aborts under UBSan with a misaligned `uint32_t` store.

## Validation

- `UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 build-ubsan/tests/tests -tc='test random bits'` (1 test, 28 assertions)
- release C++ suite (244 tests, 3,238 assertions)
- UBSan suite excluding two unrelated pre-existing GGUF alignment failures (242 tests, 3,187 assertions)
- `clang-format --dry-run --Werror mlx/backend/cpu/primitives.cpp`
- `git diff --check`
