### PR TITLE
[CUDA] Fix grid overflow in gemm conv unfold kernels for >= 65,536 output positions

### DIFF
--- a/mlx/backend/cuda/conv/gemm_conv.cu
+++ b/mlx/backend/cuda/conv/gemm_conv.cu
@@ -25,17 +25,19 @@ __global__ void naive_unfold_nd(
   auto tid = block.group_index();
   auto lid = block.thread_index();
 
-  int index_batch = tid.z / out_pixels; // [0, N)
-  int index_out_spatial = tid.z % out_pixels; // [0, H_out * W_out)
+  // The matrix-row index (N * out_pixels values) rides grid.x, which allows
+  // up to 2^31-1 blocks; grid.y and grid.z are limited to 65,535.
+  int index_batch = tid.x / out_pixels; // [0, N)
+  int index_out_spatial = tid.x % out_pixels; // [0, H_out * W_out)
   int index_wt_spatial =
-      tid.x * block.dim_threads().x + lid.x; // [0, H_wt * W_wt)
+      tid.z * block.dim_threads().x + lid.x; // [0, H_wt * W_wt)
 
   if (index_wt_spatial >= filter_size / params.C) {
     return;
   }
 
   in += tid.y; // [0, C)
-  out += tid.z * filter_size + index_wt_spatial * params.C + tid.y;
+  out += tid.x * filter_size + index_wt_spatial * params.C + tid.y;
 
   bool valid = index_batch < params.N;
 
@@ -106,9 +108,12 @@ array unfold_inputs_nd(
   dim3 block_dims;
   block_dims.x = std::min(std::max(wt_spatial_size, 32), 1024);
   dim3 num_blocks;
-  num_blocks.x = cuda::ceil_div(wt_spatial_size, block_dims.x);
+  // mat_M = N * out_pixels can exceed 65,535 (a 256x256 output already has
+  // 65,536 positions), so it must ride grid.x; the handful of filter-spatial
+  // blocks go on grid.z. grid.y and grid.z are limited to 65,535.
+  num_blocks.x = mat_M;
   num_blocks.y = params.C;
-  num_blocks.z = mat_M;
+  num_blocks.z = cuda::ceil_div(wt_spatial_size, block_dims.x);
 
   encoder.set_input_array(in);
   encoder.set_output_array(unfolded);

--- a/mlx/backend/cuda/conv/gemm_grouped_conv.cu
+++ b/mlx/backend/cuda/conv/gemm_grouped_conv.cu
@@ -25,17 +25,19 @@ __global__ void naive_grouped_unfold_transpose_nd(
   auto tid = block.group_index();
   auto lid = block.thread_index();
 
-  int index_batch = tid.z / out_pixels; // [0, N)
-  int index_out_spatial = tid.z % out_pixels; // [0, H_out * W_out)
+  // The matrix-row index (N * out_pixels values) rides grid.x, which allows
+  // up to 2^31-1 blocks; grid.y and grid.z are limited to 65,535.
+  int index_batch = tid.x / out_pixels; // [0, N)
+  int index_out_spatial = tid.x % out_pixels; // [0, H_out * W_out)
   int index_wt_spatial =
-      tid.x * block.dim_threads().x + lid.x; // [0, H_wt * W_wt)
+      tid.z * block.dim_threads().x + lid.x; // [0, H_wt * W_wt)
 
   if (index_wt_spatial >= filter_size / params.C) {
     return;
   }
 
   in += tid.y; // [0, C)
-  out += tid.z * filter_size + tid.y * (filter_size / params.C);
+  out += tid.x * filter_size + tid.y * (filter_size / params.C);
 
   bool valid = index_batch < params.N;
 
@@ -109,9 +111,12 @@ array grouped_unfold_transpose_inputs_nd(
   dim3 block_dims;
   block_dims.x = std::min(std::max(wt_spatial_size, 32), 1024);
   dim3 num_blocks;
-  num_blocks.x = cuda::ceil_div(wt_spatial_size, block_dims.x);
+  // mat_M = N * out_pixels can exceed 65,535 (a 256x256 output already has
+  // 65,536 positions), so it must ride grid.x; the handful of filter-spatial
+  // blocks go on grid.z. grid.y and grid.z are limited to 65,535.
+  num_blocks.x = mat_M;
   num_blocks.y = params.C;
-  num_blocks.z = mat_M;
+  num_blocks.z = cuda::ceil_div(wt_spatial_size, block_dims.x);
 
   encoder.set_input_array(in);
   encoder.set_output_array(unfolded);


### PR DESCRIPTION
The naive unfold kernels in `backend/cuda/conv/gemm_conv.cu` and `gemm_grouped_conv.cu` launch with

```cpp
num_blocks.x = cuda::ceil_div(wt_spatial_size, block_dims.x);
num_blocks.y = params.C;
num_blocks.z = mat_M;          // mat_M = N * out_pixels
```

`gridDim.z` is limited to 65,535, so any convolution with ≥ 65,536 output positions — e.g. a batch-1 **256×256** image, common in VAE decoders — fails with `cudaGraphAddKernelNode(...): invalid argument` (or `cudaLaunchKernelExC(...): invalid argument` with `MLX_USE_CUDA_GRAPHS=0`). Meanwhile `grid.x` (limit 2³¹−1) carries only `ceil_div(wt_spatial_size, block_dims.x)`, which is 1 for typical filters.

This PR swaps the mapping so the unbounded matrix-row index rides `grid.x` and the filter-spatial blocks ride `grid.z`, updating the two `tid.x`/`tid.z` consumers in each kernel accordingly. Per-block thread layout and memory access patterns are unchanged.

Same bug class as #3858 (batched matvec, batch > 65,535) and the merged #3666 (binary ops).

Repro (before):
```python
import mlx.core as mx
x = mx.zeros((1, 256, 256, 512), dtype=mx.bfloat16)
w = mx.zeros((512, 3, 3, 512), dtype=mx.bfloat16)
mx.eval(mx.conv2d(x, w, stride=1, padding=1))   # invalid argument
# (1, 128, 128, 512) works: 16,384 <= 65,535
```

Found while debugging ollama/ollama#14843 (FLUX.2-klein image generation on Linux/CUDA): the VAE decoder's upsample-to-256 conv is the first launch to cross the limit. Verified indirectly on an NVIDIA L4 (CUDA 13) via an equivalent host-side chunking workaround producing correct 512×512 and 1024×1024 images; the patch itself is a pure grid-axis remap (not compile-tested here — missing local dep tree).

Note: `num_blocks.y = params.C` retains a theoretical >65,535-channel limit, untouched here.
