### PR TITLE
docs: document the reduced-precision float32 default and MLX_ENABLE_TF32

### DIFF
--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -43,6 +43,7 @@ are the CPU and GPU.
    usage/function_transforms
    usage/compile
    usage/numpy
+   usage/precision
    usage/distributed
    usage/using_streams
    usage/export

--- a/docs/src/usage/precision.rst
+++ b/docs/src/usage/precision.rst
@@ -1,0 +1,53 @@
+.. _precision:
+
+Numerical Precision
+===================
+
+By default MLX runs ``float32`` matrix-multiplication family operations
+(matmul, quantized matmul, grouped matmul, convolution, and attention)
+at reduced, TF32-class precision on hardware with dedicated
+matrix-multiplication units:
+
+* On the CUDA backend, cuBLAS and cuDNN are asked for TF32 tensor-core
+  math.
+* On Apple silicon with a neural accelerator (the M5 generation), the
+  Metal backend dispatches these operations to accelerator kernels of
+  comparable precision. Earlier Apple silicon (M1–M4) runs them in full
+  ``float32``.
+
+TF32-class math keeps the ``float32`` exponent range but rounds the
+significand to about 10 bits, so results carry roughly three decimal
+digits instead of seven. For a 512x512 ``float32`` matrix product the
+relative error against a ``float64`` reference is on the order of
+``1e-4`` to ``1e-3``, compared with about ``2e-7`` in full ``float32``
+(measured on both backends). Individual operations still look correct,
+but workloads that compare nearly equal values downstream — for
+example an ``argmax`` over correlation scores, or a kernel-vs-reference
+test with tight tolerances — can change results.
+
+To run these operations in full ``float32`` precision, set the
+environment variable ``MLX_ENABLE_TF32=0``. The variable is read once,
+when the first operation that could use reduced precision runs, and the
+value is latched for the lifetime of the process. Setting it later has
+no effect. Setting it in-process works as long as it happens before the
+first such operation:
+
+.. code-block:: python
+
+  import os
+
+  os.environ["MLX_ENABLE_TF32"] = "0"  # before the first matmul
+
+  import mlx.core as mx
+
+  # float32 matmuls now run at full float32 precision
+
+A few details worth knowing:
+
+* Matrix-vector products (output shapes with ``M == 1`` or ``N == 1``)
+  retain full ``float32`` accuracy on both backends even under the
+  default, so within one program the effect can appear shape-dependent.
+* On the CUDA backend, ``complex64`` matrix products use the same
+  reduced-precision path and are likewise restored to full precision by
+  ``MLX_ENABLE_TF32=0``.
+* ``float16`` and ``bfloat16`` inputs are not affected by this setting.

--- a/docs/src/usage/precision.rst
+++ b/docs/src/usage/precision.rst
@@ -10,10 +10,13 @@ matrix-multiplication units:
 
 * On the CUDA backend, cuBLAS and cuDNN are asked for TF32 tensor-core
   math.
-* On Apple silicon with a neural accelerator (the M5 generation), the
-  Metal backend dispatches these operations to accelerator kernels of
-  comparable precision. Earlier Apple silicon (M1–M4) runs them in full
-  ``float32``.
+* On Apple silicon with a neural accelerator (the M5 generation and
+  newer, on macOS 26.2 or later), the Metal backend dispatches these
+  operations to accelerator kernels of comparable precision. Earlier
+  Apple silicon (M1–M4) always runs them in full ``float32``: on those
+  machines ``MLX_ENABLE_TF32`` has no observable effect because the
+  reduced-precision path is never taken, not because the setting is
+  ignored.
 
 TF32-class math keeps the ``float32`` exponent range but rounds the
 significand to about 10 bits, so results carry roughly three decimal
@@ -50,4 +53,9 @@ A few details worth knowing:
 * On the CUDA backend, ``complex64`` matrix products use the same
   reduced-precision path and are likewise restored to full precision by
   ``MLX_ENABLE_TF32=0``.
+* The default applies to anything that lowers to these operations, not
+  only code that calls ``mx.matmul`` directly. For example, an attention
+  computation that falls back to a composition of ordinary matrix
+  products (rather than a fused kernel) inherits the reduced precision
+  and is likewise restored by ``MLX_ENABLE_TF32=0``.
 * ``float16`` and ``bfloat16`` inputs are not affected by this setting.

--- a/docs/src/usage/precision.rst
+++ b/docs/src/usage/precision.rst
@@ -58,4 +58,7 @@ A few details worth knowing:
   computation that falls back to a composition of ordinary matrix
   products (rather than a fused kernel) inherits the reduced precision
   and is likewise restored by ``MLX_ENABLE_TF32=0``.
-* ``float16`` and ``bfloat16`` inputs are not affected by this setting.
+* ``float16`` and ``bfloat16`` inputs are not affected by this setting:
+  it applies to ``float32`` only. Reduced-precision behaviour involving
+  ``float16`` or ``bfloat16`` inputs, where it exists, has other causes
+  and is not controlled by ``MLX_ENABLE_TF32``.

--- a/docs/src/usage/precision.rst
+++ b/docs/src/usage/precision.rst
@@ -3,62 +3,19 @@
 Numerical Precision
 ===================
 
-By default MLX runs ``float32`` matrix-multiplication family operations
-(matmul, quantized matmul, grouped matmul, convolution, and attention)
-at reduced, TF32-class precision on hardware with dedicated
-matrix-multiplication units:
+By default, MLX may run ``float32`` matrix-multiplication family
+operations (matmul, quantized matmul, grouped matmul, convolution and
+attention) at reduced precision on hardware with dedicated
+matrix-multiplication units. Inputs and outputs stay ``float32``, but
+results can differ from a full-precision reference by several orders of
+magnitude more than ``float32`` rounding alone would explain.
 
-* On the CUDA backend, cuBLAS and cuDNN are asked for TF32 tensor-core
-  math.
-* On Apple silicon with a neural accelerator (the M5 generation and
-  newer, on macOS 26.2 or later), the Metal backend dispatches these
-  operations to accelerator kernels of comparable precision. Earlier
-  Apple silicon (M1–M4) always runs them in full ``float32``: on those
-  machines ``MLX_ENABLE_TF32`` has no observable effect because the
-  reduced-precision path is never taken, not because the setting is
-  ignored.
+To keep these operations in full ``float32``, set ``MLX_ENABLE_TF32=0``
+when launching the process:
 
-TF32-class math keeps the ``float32`` exponent range but rounds the
-significand to about 10 bits, so results carry roughly three decimal
-digits instead of seven. For a 512x512 ``float32`` matrix product the
-relative error against a ``float64`` reference is on the order of
-``1e-4`` to ``1e-3``, compared with about ``2e-7`` in full ``float32``
-(measured on both backends). Individual operations still look correct,
-but workloads that compare nearly equal values downstream — for
-example an ``argmax`` over correlation scores, or a kernel-vs-reference
-test with tight tolerances — can change results.
+.. code-block:: shell
 
-To run these operations in full ``float32`` precision, set the
-environment variable ``MLX_ENABLE_TF32=0``. The variable is read once,
-when the first operation that could use reduced precision runs, and the
-value is latched for the lifetime of the process. Setting it later has
-no effect. Setting it in-process works as long as it happens before the
-first such operation:
+  MLX_ENABLE_TF32=0 python my_script.py
 
-.. code-block:: python
-
-  import os
-
-  os.environ["MLX_ENABLE_TF32"] = "0"  # before the first matmul
-
-  import mlx.core as mx
-
-  # float32 matmuls now run at full float32 precision
-
-A few details worth knowing:
-
-* Matrix-vector products (output shapes with ``M == 1`` or ``N == 1``)
-  retain full ``float32`` accuracy on both backends even under the
-  default, so within one program the effect can appear shape-dependent.
-* On the CUDA backend, ``complex64`` matrix products use the same
-  reduced-precision path and are likewise restored to full precision by
-  ``MLX_ENABLE_TF32=0``.
-* The default applies to anything that lowers to these operations, not
-  only code that calls ``mx.matmul`` directly. For example, an attention
-  computation that falls back to a composition of ordinary matrix
-  products (rather than a fused kernel) inherits the reduced precision
-  and is likewise restored by ``MLX_ENABLE_TF32=0``.
-* ``float16`` and ``bfloat16`` inputs are not affected by this setting:
-  it applies to ``float32`` only. Reduced-precision behaviour involving
-  ``float16`` or ``bfloat16`` inputs, where it exists, has other causes
-  and is not controlled by ``MLX_ENABLE_TF32``.
+Which operations take the reduced-precision path, and how large the
+difference is, depends on the backend and the hardware.


### PR DESCRIPTION
Documents the reduced-precision default discussed in #3860.

Adds a short "Numerical Precision" usage page stating two things:

* float32 matmul-family operations (matmul, quantized matmul, grouped
  matmul, convolution and attention) may run at reduced precision by
  default on hardware with dedicated matrix-multiplication units;
* `MLX_ENABLE_TF32=0` at launch keeps them in full float32.

Per review, per-backend descriptions and implementation-specific
behaviour are left out, so the page does not need updating when either
changes.

### Testing

Built the docs with `sphinx-build -b html` against
`docs/requirements.txt`: the page renders, is reachable from the Usage
toctree, and none of the six build warnings originate from it (they are
the pre-existing `nn.distributed` autosummary imports against the pip
wheel, the doxygen-generated C++ group, and the `printoptions` stub).
