### PR TITLE
Fix prod dtype promotion when reducing a size-1 axis

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -2397,7 +2397,7 @@ array prod(
     out_type = int32;
   }
   auto out = (is_noop)
-      ? a
+      ? astype(a, out_type, s)
       : array(
             std::move(out_shape),
             out_type,

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -724,6 +724,19 @@ class TestOps(mlx_tests.MLXTestCase):
         self.assertEqual(mx.prod(x, axis=0).tolist(), [3, 6])
         self.assertEqual(mx.prod(x, axis=1).tolist(), [2, 9])
 
+        # dtype should not depend on the length of the reduced axis
+        for dtype, expected in (
+            (mx.bool_, mx.int32),
+            (mx.int8, mx.int32),
+            (mx.uint8, mx.uint32),
+        ):
+            self.assertEqual(
+                mx.prod(mx.array([2], dtype=dtype), axis=0).dtype, expected
+            )
+            self.assertEqual(
+                mx.prod(mx.array([2, 2], dtype=dtype), axis=0).dtype, expected
+            )
+
     def test_min_and_max(self):
         x = mx.array(
             [


### PR DESCRIPTION
## Proposed changes

`prod` computes its promoted output type but discards it on the no-op branch, so the result dtype depends on the length of the reduced axis. Reducing a size-1 axis returns the input dtype while a size-2 axis promotes:

```python
mx.prod(mx.array([2], dtype=mx.int8), axis=0).dtype     # int8   (before)
mx.prod(mx.array([2, 2], dtype=mx.int8), axis=0).dtype  # int32
```

`sum` casts on the same branch (`is_noop ? astype(a, out_type, s) : ...`), but `prod` returned bare `a`. The fix applies the same `astype`, so `prod` matches `sum` and the other promoting reductions. The promotion is there to keep the product from overflowing the narrow input type, so the size-1 case was also silently keeping a narrow accumulator.

Added a test that the output dtype does not depend on the reduced axis length.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
