### PR TITLE
Making JACCL coordinator optional

### DIFF
--- a/docs/src/usage/distributed.rst
+++ b/docs/src/usage/distributed.rst
@@ -347,6 +347,33 @@ of a gigantic model using MLX LM.
    and GPU need to collaborate for some computation and is pretty critical for
    low-latency communication since the communication is done by the CPU.
 
+Custom side channel
+^^^^^^^^^^^^^^^^^^^
+
+During initialization JACCL exchanges RDMA connection metadata between ranks
+over a side channel. By default this is a simple TCP star all-gather, but you
+can provide your own side-channel all-gather via the
+``all_gather_factory`` argument of :func:`mlx.core.distributed.init` when using
+``backend='jaccl'``.
+
+The factory is called once per rank with ``(rank, size)`` and must return a
+callable with signature ``f(src: bytes, n_bytes: int) -> bytes``. The returned
+bytes must have length ``size * n_bytes`` and contain the inputs from all ranks
+concatenated in rank order.
+
+.. code-block:: python
+
+    def make_side_channel(rank, size):
+        def all_gather(src: bytes, n_bytes: int) -> bytes:
+            # Exchange src with all ranks and return size * n_bytes bytes
+            ...
+        return all_gather
+
+    world = mx.distributed.init(
+        backend="jaccl",
+        all_gather_factory=make_side_channel,
+    )
+
 .. _nccl_section:
 
 Getting Started with NCCL

--- a/mlx/distributed/distributed.cpp
+++ b/mlx/distributed/distributed.cpp
@@ -138,9 +138,19 @@ Group Group::split(int color, int key /* = -1 */) const {
   return Group(group_->split(color, key));
 }
 
-Group init(bool strict /* = false */, const std::string& bk /* = "any" */) {
+namespace {
+
+std::unordered_map<std::string, std::shared_ptr<detail::GroupImpl>>&
+get_backends() {
   static std::unordered_map<std::string, std::shared_ptr<detail::GroupImpl>>
       backends;
+  return backends;
+}
+
+} // namespace
+
+Group init(bool strict /* = false */, const std::string& bk /* = "any" */) {
+  auto& backends = get_backends();
 
   // Already initialized so return the group.
   if (auto g = backends.find(bk); g != backends.end()) {
@@ -192,6 +202,10 @@ Group init(bool strict /* = false */, const std::string& bk /* = "any" */) {
   }
   backends.insert({std::move(bk_), group});
   return Group(group);
+}
+
+void clear_backends() {
+  get_backends().clear();
 }
 
 } // namespace mlx::core::distributed

--- a/mlx/distributed/distributed.cpp
+++ b/mlx/distributed/distributed.cpp
@@ -147,6 +147,17 @@ get_backends() {
   return backends;
 }
 
+Group register_group(std::shared_ptr<detail::GroupImpl> group, std::string bk) {
+  auto& backends = get_backends();
+  if (group == nullptr) {
+    group = std::make_shared<detail::EmptyGroup>();
+  } else {
+    backends.insert({"any", group});
+  }
+  backends.insert({std::move(bk), group});
+  return Group(group);
+}
+
 } // namespace
 
 Group init(bool strict /* = false */, const std::string& bk /* = "any" */) {
@@ -195,13 +206,27 @@ Group init(bool strict /* = false */, const std::string& bk /* = "any" */) {
     throw std::invalid_argument(msg.str());
   }
 
-  if (group == nullptr) {
-    group = std::make_shared<detail::EmptyGroup>();
-  } else {
-    backends.insert({"any", group});
+  return register_group(std::move(group), std::move(bk_));
+}
+
+Group init(bool strict, const std::string& bk, AllGatherFactory factory) {
+  if (bk != "jaccl") {
+    std::ostringstream msg;
+    msg << "[distributed] An all gather factory is only supported with the "
+        << "'jaccl' backend but '" << bk << "' was provided.";
+    throw std::invalid_argument(msg.str());
   }
-  backends.insert({std::move(bk_), group});
-  return Group(group);
+
+  auto& backends = get_backends();
+
+  // Already initialized so return the cached group. The factory is ignored in
+  // this case since the backend is already up.
+  if (auto g = backends.find(bk); g != backends.end()) {
+    return Group(g->second);
+  }
+
+  auto group = jaccl::init(strict, std::move(factory));
+  return register_group(std::move(group), bk);
 }
 
 void clear_backends() {

--- a/mlx/distributed/distributed.h
+++ b/mlx/distributed/distributed.h
@@ -58,4 +58,7 @@ struct MLX_API Group {
  */
 MLX_API Group init(bool strict = false, const std::string& bk = "any");
 
+/** Clear the distributed backend cache. */
+MLX_API void clear_backends();
+
 } // namespace mlx::core::distributed

--- a/mlx/distributed/distributed.h
+++ b/mlx/distributed/distributed.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <cstddef>
+#include <functional>
 #include <memory>
 
 #include "mlx/api.h"
@@ -13,7 +15,26 @@ namespace mlx::core::distributed {
 // Forward declaration of the base group implementation.
 namespace detail {
 class GroupImpl;
-};
+}
+
+/**
+ * Byte-level all-gather function used by the JACCL side channel.
+ *
+ * Args:
+ *   src: Pointer to this rank's data of size n_bytes.
+ *   dst: Pointer to an output buffer of size size_ * n_bytes. After the call,
+ *        dst[rank * n_bytes, (rank+1) * n_bytes] contains the data from rank.
+ *   n_bytes: The number of bytes contributed by each rank.
+ */
+using AllGatherFn = std::function<void(const char*, char*, size_t)>;
+
+/**
+ * Factory that produces a per-rank side-channel all-gather function.
+ *
+ * The factory receives the rank and size of the group and returns the
+ * AllGatherFn that will be used for the side channel.
+ */
+using AllGatherFactory = std::function<AllGatherFn(int, int)>;
 
 /* Check if a communication backend is available */
 MLX_API bool is_available();
@@ -57,6 +78,14 @@ struct MLX_API Group {
  * render communication operations as no-op.
  */
 MLX_API Group init(bool strict = false, const std::string& bk = "any");
+
+/**
+ * Initialize the distributed backend using a custom JACCL side channel.
+ *
+ * This behaves like init(strict, bk) but requires bk to be "jaccl".
+ */
+MLX_API Group
+init(bool strict, const std::string& bk, AllGatherFactory factory);
 
 /** Clear the distributed backend cache. */
 MLX_API void clear_backends();

--- a/mlx/distributed/jaccl/jaccl.cpp
+++ b/mlx/distributed/jaccl/jaccl.cpp
@@ -8,6 +8,9 @@
 #include <jaccl/group.h>
 #include <jaccl/jaccl.h>
 
+#include <optional>
+#include <sstream>
+
 using GroupImpl = mlx::core::distributed::detail::GroupImpl;
 
 namespace mlx::core::distributed::jaccl {
@@ -164,6 +167,14 @@ bool is_available() {
 
 std::shared_ptr<GroupImpl> init(bool strict /* = false */) {
   auto group = ::jaccl::init(strict);
+  if (group == nullptr) {
+    return nullptr;
+  }
+  return std::make_shared<JACCLGroup>(std::move(group));
+}
+
+std::shared_ptr<GroupImpl> init(bool strict, AllGatherFactory factory) {
+  auto group = ::jaccl::init(strict, factory);
   if (group == nullptr) {
     return nullptr;
   }

--- a/mlx/distributed/jaccl/jaccl.h
+++ b/mlx/distributed/jaccl/jaccl.h
@@ -2,13 +2,36 @@
 
 #pragma once
 
+#include <cstddef>
+#include <functional>
+
 #include "mlx/distributed/distributed.h"
 
 namespace mlx::core::distributed::jaccl {
 
 using GroupImpl = mlx::core::distributed::detail::GroupImpl;
 
-bool is_available();
-std::shared_ptr<GroupImpl> init(bool strict = false);
+/**
+ * Byte-level all-gather function used by the JACCL side channel.
+ *
+ * Args:
+ *   src: Pointer to this rank's data of size n_bytes.
+ *   dst: Pointer to an output buffer of size size_ * n_bytes. After the call,
+ *        dst[rank * n_bytes, (rank+1) * n_bytes] contains the data from rank.
+ *   n_bytes: The number of bytes contributed by each rank.
+ */
+using AllGatherFn = std::function<void(const char*, char*, size_t)>;
+
+/**
+ * Factory that produces a per-rank side-channel all-gather function.
+ *
+ * The factory receives the rank and size of the group and returns the
+ * AllGatherFn that will be used for the side channel.
+ */
+using AllGatherFactory = std::function<AllGatherFn(int, int)>;
+
+MLX_API bool is_available();
+MLX_API std::shared_ptr<GroupImpl> init(bool strict = false);
+MLX_API std::shared_ptr<GroupImpl> init(bool strict, AllGatherFactory factory);
 
 } // namespace mlx::core::distributed::jaccl

--- a/mlx/distributed/jaccl/jaccl.h
+++ b/mlx/distributed/jaccl/jaccl.h
@@ -2,8 +2,7 @@
 
 #pragma once
 
-#include <cstddef>
-#include <functional>
+#include <memory>
 
 #include "mlx/distributed/distributed.h"
 
@@ -11,27 +10,8 @@ namespace mlx::core::distributed::jaccl {
 
 using GroupImpl = mlx::core::distributed::detail::GroupImpl;
 
-/**
- * Byte-level all-gather function used by the JACCL side channel.
- *
- * Args:
- *   src: Pointer to this rank's data of size n_bytes.
- *   dst: Pointer to an output buffer of size size_ * n_bytes. After the call,
- *        dst[rank * n_bytes, (rank+1) * n_bytes] contains the data from rank.
- *   n_bytes: The number of bytes contributed by each rank.
- */
-using AllGatherFn = std::function<void(const char*, char*, size_t)>;
-
-/**
- * Factory that produces a per-rank side-channel all-gather function.
- *
- * The factory receives the rank and size of the group and returns the
- * AllGatherFn that will be used for the side channel.
- */
-using AllGatherFactory = std::function<AllGatherFn(int, int)>;
-
-MLX_API bool is_available();
-MLX_API std::shared_ptr<GroupImpl> init(bool strict = false);
-MLX_API std::shared_ptr<GroupImpl> init(bool strict, AllGatherFactory factory);
+bool is_available();
+std::shared_ptr<GroupImpl> init(bool strict = false);
+std::shared_ptr<GroupImpl> init(bool strict, AllGatherFactory factory);
 
 } // namespace mlx::core::distributed::jaccl

--- a/mlx/distributed/jaccl/lib/jaccl/jaccl.cpp
+++ b/mlx/distributed/jaccl/lib/jaccl/jaccl.cpp
@@ -1,13 +1,13 @@
 // Copyright © 2025 Apple Inc.
 
 #include <fstream>
+#include <memory>
 #include <sstream>
 
 #include <json.hpp>
 
 #include "jaccl/jaccl.h"
 #include "jaccl/mesh.h"
-#include "jaccl/rdma.h"
 #include "jaccl/ring.h"
 
 using json = nlohmann::json;
@@ -106,6 +106,11 @@ Config& Config::prefer_ring(bool prefer /* = true */) {
   return *this;
 }
 
+Config& Config::set_all_gather(AllGatherFn agf) {
+  all_gather_fn_ = std::move(agf);
+  return *this;
+}
+
 bool Config::is_valid_mesh() const {
   if (size_ < 2) {
     return false;
@@ -166,6 +171,21 @@ Config::get_ring_connectivity() const {
   return std::make_pair(devices_[rank_][left], devices_[rank_][right]);
 }
 
+SideChannel Config::get_side_channel() const {
+  if (all_gather_fn_) {
+    return SideChannel(rank_, size_, all_gather_fn_);
+  }
+
+  auto tcp =
+      std::make_shared<TCPAllGather>(rank_, size_, get_coordinator().c_str());
+  return SideChannel(
+      rank_,
+      size_,
+      [tcp = std::move(tcp)](const char* src, char* dst, size_t n_bytes) {
+        (*tcp)(src, dst, n_bytes);
+      });
+}
+
 std::optional<Config> Config::from_env() {
   const char* dev_file = getenv("JACCL_IBV_DEVICES", "MLX_IBV_DEVICES");
   const char* coordinator =
@@ -209,15 +229,15 @@ std::shared_ptr<Group> init(const Config& cfg, bool strict /* = false */) {
   if (cfg.get_prefer_ring() && cfg.is_valid_ring()) {
     auto [left, right] = cfg.get_ring_connectivity();
     return std::make_shared<RingGroup>(
-        cfg.get_rank(), cfg.get_size(), left, right, cfg.get_coordinator());
+        cfg.get_rank(), cfg.get_size(), left, right, cfg.get_side_channel());
   } else if (cfg.is_valid_mesh()) {
     auto mesh = cfg.get_mesh_connectivity();
     return std::make_shared<MeshGroup>(
-        cfg.get_rank(), mesh, cfg.get_coordinator());
+        cfg.get_rank(), mesh, cfg.get_side_channel());
   } else if (cfg.is_valid_ring()) {
     auto [left, right] = cfg.get_ring_connectivity();
     return std::make_shared<RingGroup>(
-        cfg.get_rank(), cfg.get_size(), left, right, cfg.get_coordinator());
+        cfg.get_rank(), cfg.get_size(), left, right, cfg.get_side_channel());
   } else {
     if (!strict) {
       return nullptr;

--- a/mlx/distributed/jaccl/lib/jaccl/jaccl.cpp
+++ b/mlx/distributed/jaccl/lib/jaccl/jaccl.cpp
@@ -75,13 +75,34 @@ namespace jaccl {
 
 Config::Config() : rank_(0), size_(0) {}
 
+Config& Config::set_rank(const char* rank_str) {
+  if (rank_str) {
+    rank_ = std::atoi(rank_str);
+  }
+  return *this;
+}
+
 Config& Config::set_rank(int rank) {
   rank_ = rank;
   return *this;
 }
 
+Config& Config::set_coordinator(const char* coordinator) {
+  if (coordinator != nullptr) {
+    coordinator_ = coordinator;
+  }
+  return *this;
+}
+
 Config& Config::set_coordinator(std::string coordinator) {
   coordinator_ = std::move(coordinator);
+  return *this;
+}
+
+Config& Config::set_devices_from_file(const char* dev_file) {
+  if (dev_file) {
+    set_devices(parse_devices_json(dev_file));
+  }
   return *this;
 }
 
@@ -108,6 +129,12 @@ Config& Config::prefer_ring(bool prefer /* = true */) {
 
 Config& Config::set_all_gather(AllGatherFn agf) {
   all_gather_fn_ = std::move(agf);
+  return *this;
+}
+
+Config& Config::set_all_gather_factory(
+    std::function<AllGatherFn(int, int)> factory) {
+  all_gather_factory_ = std::move(factory);
   return *this;
 }
 
@@ -147,6 +174,12 @@ bool Config::is_valid_ring() const {
   return true;
 }
 
+bool Config::is_valid() const {
+  return size_ >= 1 && rank_ < size_ && rank_ >= 0 &&
+      (!coordinator_.empty() || all_gather_factory_ || all_gather_fn_) &&
+      (is_valid_mesh() || is_valid_ring());
+}
+
 std::vector<std::string> Config::get_mesh_connectivity() const {
   if (!is_valid_mesh()) {
     throw std::runtime_error("[jaccl] The devices do not form a valid mesh.");
@@ -172,6 +205,10 @@ Config::get_ring_connectivity() const {
 }
 
 SideChannel Config::get_side_channel() const {
+  if (all_gather_factory_) {
+    return SideChannel(rank_, size_, all_gather_factory_(rank_, size_));
+  }
+
   if (all_gather_fn_) {
     return SideChannel(rank_, size_, all_gather_fn_);
   }
@@ -186,21 +223,17 @@ SideChannel Config::get_side_channel() const {
       });
 }
 
-std::optional<Config> Config::from_env() {
+Config Config::from_env() {
   const char* dev_file = getenv("JACCL_IBV_DEVICES", "MLX_IBV_DEVICES");
   const char* coordinator =
       getenv("JACCL_COORDINATOR", "MLX_JACCL_COORDINATOR");
   const char* rank_str = getenv("JACCL_RANK", "MLX_RANK");
   const char* ring = getenv("JACCL_RING", "MLX_JACCL_RING");
 
-  if (!dev_file || !coordinator || !rank_str) {
-    return std::nullopt;
-  }
-
   return Config()
-      .set_rank(std::atoi(rank_str))
+      .set_rank(rank_str)
       .set_coordinator(coordinator)
-      .set_devices(parse_devices_json(dev_file))
+      .set_devices_from_file(dev_file)
       .prefer_ring(ring != nullptr);
 }
 
@@ -210,7 +243,7 @@ bool is_available() {
 
 std::shared_ptr<Group> init(bool strict /* = false */) {
   auto cfg = Config::from_env();
-  if (!cfg.has_value()) {
+  if (!cfg.is_valid()) {
     if (strict) {
       std::ostringstream msg;
       msg << "[jaccl] You need to provide via environment variables a rank "
@@ -222,7 +255,25 @@ std::shared_ptr<Group> init(bool strict /* = false */) {
     return nullptr;
   }
 
-  return init(*cfg, strict);
+  return init(cfg, strict);
+}
+
+std::shared_ptr<Group> init(
+    bool strict,
+    std::function<AllGatherFn(int, int)> factory) {
+  auto cfg = Config::from_env().set_all_gather_factory(factory);
+  if (!cfg.is_valid()) {
+    if (strict) {
+      std::ostringstream msg;
+      msg << "[jaccl] You need to provide via environment variables a rank "
+          << "(JACCL_RANK/MLX_RANK) and a device file "
+          << "(JACCL_IBV_DEVICES/MLX_IBV_DEVICES)";
+      throw std::runtime_error(msg.str());
+    }
+    return nullptr;
+  }
+
+  return init(cfg, strict);
 }
 
 std::shared_ptr<Group> init(const Config& cfg, bool strict /* = false */) {

--- a/mlx/distributed/jaccl/lib/jaccl/jaccl.h
+++ b/mlx/distributed/jaccl/lib/jaccl/jaccl.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "jaccl/group.h"
+#include "jaccl/rdma.h"
 
 namespace jaccl {
 
@@ -18,6 +19,7 @@ class Config {
   Config& set_devices(
       std::vector<std::vector<std::vector<std::string>>> devices);
   Config& prefer_ring(bool prefer = true);
+  Config& set_all_gather(AllGatherFn agf);
 
   bool is_valid_mesh() const;
   bool is_valid_ring() const;
@@ -46,12 +48,14 @@ class Config {
   std::vector<std::string> get_mesh_connectivity() const;
   std::pair<std::vector<std::string>, std::vector<std::string>>
   get_ring_connectivity() const;
+  SideChannel get_side_channel() const;
 
   int rank_;
   int size_;
   std::string coordinator_;
   std::vector<std::vector<std::vector<std::string>>> devices_;
   bool prefer_ring_;
+  AllGatherFn all_gather_fn_;
 };
 
 /**

--- a/mlx/distributed/jaccl/lib/jaccl/jaccl.h
+++ b/mlx/distributed/jaccl/lib/jaccl/jaccl.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <vector>
 
@@ -14,15 +15,20 @@ class Config {
  public:
   Config();
 
+  Config& set_rank(const char* rank_str);
   Config& set_rank(int rank);
+  Config& set_coordinator(const char* coordinator);
   Config& set_coordinator(std::string coordinator);
+  Config& set_devices_from_file(const char* dev_file);
   Config& set_devices(
       std::vector<std::vector<std::vector<std::string>>> devices);
   Config& prefer_ring(bool prefer = true);
   Config& set_all_gather(AllGatherFn agf);
+  Config& set_all_gather_factory(std::function<AllGatherFn(int, int)> factory);
 
   bool is_valid_mesh() const;
   bool is_valid_ring() const;
+  bool is_valid() const;
 
   int get_rank() const {
     return rank_;
@@ -40,7 +46,7 @@ class Config {
     return prefer_ring_;
   }
 
-  static std::optional<Config> from_env();
+  static Config from_env();
 
   friend std::shared_ptr<Group> init(const Config& cfg, bool strict);
 
@@ -56,6 +62,7 @@ class Config {
   std::vector<std::vector<std::vector<std::string>>> devices_;
   bool prefer_ring_;
   AllGatherFn all_gather_fn_;
+  std::function<AllGatherFn(int, int)> all_gather_factory_;
 };
 
 /**
@@ -80,6 +87,18 @@ bool is_available();
  *   A shared_ptr to the Group, or nullptr on failure.
  */
 std::shared_ptr<Group> init(bool strict = false);
+
+/**
+ * Initialize a JACCL communication group from environment variables, using a
+ * custom all-gather factory for the side channel.
+ *
+ * The factory is called once per rank with the rank and group size, and must
+ * return an all-gather function that will be used to exchange RDMA connection
+ * metadata during setup.
+ */
+std::shared_ptr<Group> init(
+    bool strict,
+    std::function<AllGatherFn(int, int)> factory);
 
 /**
  * Initialize a JACCL communication group from an explicit Config object.

--- a/mlx/distributed/jaccl/lib/jaccl/mesh.cpp
+++ b/mlx/distributed/jaccl/lib/jaccl/mesh.cpp
@@ -9,10 +9,10 @@ namespace jaccl {
 MeshGroup::MeshGroup(
     int rank,
     const std::vector<std::string>& device_names,
-    const std::string& coordinator_addr)
+    SideChannel sc)
     : rank_(rank),
       size_(device_names.size()),
-      side_channel_(rank_, size_, coordinator_addr.c_str()),
+      side_channel_(std::move(sc)),
       connections_(create_connections(device_names)) {
   if (size_ > MESH_MAX_PEERS) {
     std::ostringstream msg;

--- a/mlx/distributed/jaccl/lib/jaccl/mesh.h
+++ b/mlx/distributed/jaccl/lib/jaccl/mesh.h
@@ -23,7 +23,7 @@ class MeshGroup : public Group {
   MeshGroup(
       int rank,
       const std::vector<std::string>& device_names,
-      const std::string& coordinator_addr);
+      SideChannel sc);
 
   int rank() override {
     return rank_;

--- a/mlx/distributed/jaccl/lib/jaccl/rdma.cpp
+++ b/mlx/distributed/jaccl/lib/jaccl/rdma.cpp
@@ -329,13 +329,8 @@ TCPAllGather::TCPAllGather(int rank, int size, const char* addr)
   }
 }
 
-TCPAllGather::TCPAllGather(TCPAllGather&& ag)
-    : rank_(ag.rank_), size_(ag.size_), sockets_(std::move(ag.sockets_)) {
-  ag.rank_ = -1;
-  ag.size_ = -1;
-}
-
 void TCPAllGather::operator()(const char* src, char* dst, size_t n_bytes) {
+  std::lock_guard<std::mutex> lock(mutex_);
   if (rank_ == 0) {
     std::copy(src, src + n_bytes, dst);
     for (int i = 1; i < size_; i++) {

--- a/mlx/distributed/jaccl/lib/jaccl/rdma.cpp
+++ b/mlx/distributed/jaccl/lib/jaccl/rdma.cpp
@@ -294,7 +294,7 @@ std::vector<Connection> create_connections(
   return connections;
 }
 
-SideChannel::SideChannel(int rank, int size, const char* addr)
+TCPAllGather::TCPAllGather(int rank, int size, const char* addr)
     : rank_(rank), size_(size) {
   auto address = parse_address(addr);
 
@@ -329,8 +329,34 @@ SideChannel::SideChannel(int rank, int size, const char* addr)
   }
 }
 
+TCPAllGather::TCPAllGather(TCPAllGather&& ag)
+    : rank_(ag.rank_), size_(ag.size_), sockets_(std::move(ag.sockets_)) {
+  ag.rank_ = -1;
+  ag.size_ = -1;
+}
+
+void TCPAllGather::operator()(const char* src, char* dst, size_t n_bytes) {
+  if (rank_ == 0) {
+    std::copy(src, src + n_bytes, dst);
+    for (int i = 1; i < size_; i++) {
+      sockets_[i - 1].recv(IBV_TAG, dst + i * n_bytes, n_bytes);
+    }
+    for (int i = 1; i < size_; i++) {
+      sockets_[i - 1].send(IBV_TAG, dst, size_ * n_bytes);
+    }
+  } else {
+    sockets_[0].send(IBV_TAG, src, n_bytes);
+    sockets_[0].recv(IBV_TAG, dst, size_ * n_bytes);
+  }
+}
+
+SideChannel::SideChannel(int rank, int size, AllGatherFn agf)
+    : rank_(rank), size_(size), all_gather_fn_(std::move(agf)) {}
+
 SideChannel::SideChannel(SideChannel&& sc)
-    : rank_(sc.rank_), size_(sc.size_), sockets_(std::move(sc.sockets_)) {
+    : rank_(sc.rank_),
+      size_(sc.size_),
+      all_gather_fn_(std::move(sc.all_gather_fn_)) {
   sc.rank_ = -1;
   sc.size_ = -1;
 }

--- a/mlx/distributed/jaccl/lib/jaccl/rdma.h
+++ b/mlx/distributed/jaccl/lib/jaccl/rdma.h
@@ -4,6 +4,7 @@
 
 #include <infiniband/verbs.h>
 
+#include <functional>
 #include <span>
 #include <sstream>
 #include <unordered_map>
@@ -258,6 +259,34 @@ inline int poll(
 }
 
 /**
+ * A function that performs an all-gather across ranks.
+ *
+ * Args:
+ *   src: Pointer to this rank's data of size n_bytes.
+ *   dst: Pointer to an output buffer of size size_ * n_bytes. After the call,
+ *        dst[r * n_bytes, (r+1) * n_bytes] contains the data from rank r.
+ *   n_bytes: The number of bytes contributed by each rank.
+ */
+using AllGatherFn =
+    std::function<void(const char* src, char* dst, size_t n_bytes)>;
+
+class TCPAllGather {
+ public:
+  TCPAllGather(int rank, int size, const char* addr);
+  TCPAllGather(TCPAllGather&& ag);
+
+  TCPAllGather(const TCPAllGather&) = delete;
+  TCPAllGather operator=(const TCPAllGather&) = delete;
+
+  void operator()(const char* src, char* dst, size_t n_bytes);
+
+ private:
+  int rank_;
+  int size_;
+  std::vector<TCPSocket> sockets_;
+};
+
+/**
  * Implement a TCP side channel to exchange information about the RDMA
  * connections.
  *
@@ -266,7 +295,7 @@ inline int poll(
  */
 class SideChannel {
  public:
-  SideChannel(int rank, int size, const char* addr);
+  SideChannel(int rank, int size, AllGatherFn agf);
   SideChannel(SideChannel&& sc);
 
   SideChannel(const SideChannel&) = delete;
@@ -280,54 +309,37 @@ class SideChannel {
     if constexpr (is_container<T>::value) {
       using U = typename T::value_type;
 
-      // Share the lengths first and set the communication size to be the
+      // Share the lengths first to set the communication size to be the
       // maximum length of the containers.
       auto lengths = all_gather<int>(v.size());
       auto max_len = *std::max_element(lengths.begin(), lengths.end());
-      for (auto& s : result) {
-        s.resize(max_len);
-      }
 
-      // All gather of length max_len
-      if (rank_ == 0) {
-        std::copy(v.begin(), v.end(), result[rank_].begin());
-        for (int i = 1; i < size_; i++) {
-          sockets_[i - 1].recv(IBV_TAG, result[i].data(), sizeof(U) * max_len);
-        }
-        for (int i = 1; i < size_; i++) {
-          for (int j = 0; j < size_; j++) {
-            sockets_[i - 1].send(
-                IBV_TAG, result[j].data(), sizeof(U) * max_len);
-          }
-        }
-      } else {
-        std::copy(v.begin(), v.end(), result[rank_].begin());
-        sockets_[0].send(IBV_TAG, result[rank_].data(), sizeof(U) * max_len);
-        for (int i = 0; i < size_; i++) {
-          sockets_[0].recv(IBV_TAG, result[i].data(), sizeof(U) * max_len);
-        }
-      }
+      // Allocate flat memory for the all gather
+      std::vector<U> buffer;
+      buffer.resize(max_len * (size_ + 1));
 
-      // Resize the outputs back to the original length
+      // Copy our value and share it
+      std::copy(v.begin(), v.end(), buffer.begin());
+      all_gather_fn_(
+          reinterpret_cast<const char*>(&buffer[0]),
+          reinterpret_cast<char*>(&buffer[max_len]),
+          max_len * sizeof(U));
+
+      // Put the values into the individual containers
       for (int i = 0; i < size_; i++) {
-        result[i].resize(lengths[i]);
+        std::copy(
+            buffer.begin() + (i + 1) * max_len,
+            buffer.begin() + (i + 1) * max_len + lengths[i],
+            std::inserter(result[i], result[i].end()));
       }
     }
 
     // T is a scalar
     else {
-      if (rank_ == 0) {
-        result[rank_] = v;
-        for (int i = 1; i < size_; i++) {
-          sockets_[i - 1].recv(IBV_TAG, &result[i], sizeof(T));
-        }
-        for (int i = 1; i < size_; i++) {
-          sockets_[i - 1].send(IBV_TAG, result.data(), size_ * sizeof(T));
-        }
-      } else {
-        sockets_[0].send(IBV_TAG, &v, sizeof(T));
-        sockets_[0].recv(IBV_TAG, result.data(), size_ * sizeof(T));
-      }
+      all_gather_fn_(
+          reinterpret_cast<const char*>(&v),
+          reinterpret_cast<char*>(result.data()),
+          sizeof(T));
     }
 
     return result;
@@ -342,7 +354,7 @@ class SideChannel {
  private:
   int rank_;
   int size_;
-  std::vector<TCPSocket> sockets_;
+  AllGatherFn all_gather_fn_;
 };
 
 } // namespace jaccl

--- a/mlx/distributed/jaccl/lib/jaccl/rdma.h
+++ b/mlx/distributed/jaccl/lib/jaccl/rdma.h
@@ -5,6 +5,7 @@
 #include <infiniband/verbs.h>
 
 #include <functional>
+#include <mutex>
 #include <span>
 #include <sstream>
 #include <unordered_map>
@@ -273,10 +274,11 @@ using AllGatherFn =
 class TCPAllGather {
  public:
   TCPAllGather(int rank, int size, const char* addr);
-  TCPAllGather(TCPAllGather&& ag);
 
   TCPAllGather(const TCPAllGather&) = delete;
-  TCPAllGather operator=(const TCPAllGather&) = delete;
+  TCPAllGather(TCPAllGather&&) = delete;
+  TCPAllGather& operator=(const TCPAllGather&) = delete;
+  TCPAllGather& operator=(TCPAllGather&&) = delete;
 
   void operator()(const char* src, char* dst, size_t n_bytes);
 
@@ -284,6 +286,7 @@ class TCPAllGather {
   int rank_;
   int size_;
   std::vector<TCPSocket> sockets_;
+  std::mutex mutex_;
 };
 
 /**

--- a/mlx/distributed/jaccl/lib/jaccl/ring.cpp
+++ b/mlx/distributed/jaccl/lib/jaccl/ring.cpp
@@ -11,11 +11,11 @@ RingGroup::RingGroup(
     int size,
     const std::vector<std::string>& left_devices,
     const std::vector<std::string>& right_devices,
-    const std::string& coordinator_addr)
+    SideChannel sc)
     : rank_(rank),
       size_(size),
       n_conns_(left_devices.size()),
-      side_channel_(rank_, size_, coordinator_addr.c_str()),
+      side_channel_(std::move(sc)),
       left_(create_connections(left_devices)),
       right_(create_connections(right_devices)) {
   if (left_.size() > RING_MAX_CONNS || right_.size() > RING_MAX_CONNS) {

--- a/mlx/distributed/jaccl/lib/jaccl/ring.h
+++ b/mlx/distributed/jaccl/lib/jaccl/ring.h
@@ -24,7 +24,7 @@ class RingGroup : public Group {
       int size,
       const std::vector<std::string>& left_devices,
       const std::vector<std::string>& right_devices,
-      const std::string& coordinator_addr);
+      SideChannel sc);
 
   int rank() override {
     return rank_;

--- a/mlx/distributed/jaccl/no_jaccl.cpp
+++ b/mlx/distributed/jaccl/no_jaccl.cpp
@@ -17,4 +17,18 @@ std::shared_ptr<GroupImpl> init(bool strict /* = false */) {
   return nullptr;
 }
 
+std::shared_ptr<GroupImpl> init(bool strict, AllGatherFn /* fn */) {
+  if (strict) {
+    throw std::runtime_error("Cannot initialize jaccl distributed backend.");
+  }
+  return nullptr;
+}
+
+std::shared_ptr<GroupImpl> init(bool strict, AllGatherFactory /* factory */) {
+  if (strict) {
+    throw std::runtime_error("Cannot initialize jaccl distributed backend.");
+  }
+  return nullptr;
+}
+
 } // namespace mlx::core::distributed::jaccl

--- a/mlx/distributed/jaccl/no_jaccl.cpp
+++ b/mlx/distributed/jaccl/no_jaccl.cpp
@@ -17,13 +17,6 @@ std::shared_ptr<GroupImpl> init(bool strict /* = false */) {
   return nullptr;
 }
 
-std::shared_ptr<GroupImpl> init(bool strict, AllGatherFn /* fn */) {
-  if (strict) {
-    throw std::runtime_error("Cannot initialize jaccl distributed backend.");
-  }
-  return nullptr;
-}
-
 std::shared_ptr<GroupImpl> init(bool strict, AllGatherFactory /* factory */) {
   if (strict) {
     throw std::runtime_error("Cannot initialize jaccl distributed backend.");

--- a/python/src/distributed.cpp
+++ b/python/src/distributed.cpp
@@ -8,9 +8,13 @@
 #include <nanobind/stl/vector.h>
 
 #include "mlx/distributed/distributed.h"
+#include "mlx/distributed/jaccl/jaccl.h"
 #include "mlx/distributed/ops.h"
 #include "python/src/small_vector.h"
 #include "python/src/utils.h"
+
+#include <cstring>
+#include <sstream>
 
 namespace mx = mlx::core;
 namespace nb = nanobind;
@@ -75,10 +79,60 @@ void init_distributed(nb::module_& parent_module) {
 
   m.def(
       "init",
-      &mx::distributed::init,
+      [](bool strict,
+         const std::string& backend,
+         std::optional<nb::callable> all_gather_factory)
+          -> mx::distributed::Group {
+        if (!all_gather_factory.has_value()) {
+          return mx::distributed::init(strict, backend);
+        }
+
+        if (backend != "jaccl") {
+          throw std::invalid_argument(
+              "all_gather_factory is only supported with backend='jaccl'.");
+        }
+
+        auto py_factory = std::move(*all_gather_factory);
+        auto cpp_factory =
+            [py_factory = std::move(py_factory)](
+                int rank, int size) -> mx::distributed::jaccl::AllGatherFn {
+          nb::gil_scoped_acquire gil;
+          nb::object py_inner = py_factory(rank, size);
+          if (!PyCallable_Check(py_inner.ptr())) {
+            throw std::invalid_argument(
+                "all_gather_factory must return a callable");
+          }
+          return [py_inner = std::move(py_inner), size](
+                     const void* src, void* dst, size_t n_bytes) {
+            nb::gil_scoped_acquire gil;
+            nb::bytes src_bytes(src, n_bytes);
+            nb::object result_obj = py_inner(src_bytes, n_bytes);
+            nb::bytes result = nb::cast<nb::bytes>(result_obj);
+            size_t expected = static_cast<size_t>(size) * n_bytes;
+            if (result.size() != expected) {
+              std::ostringstream msg;
+              msg << "Custom all-gather returned " << result.size()
+                  << " bytes but expected " << expected;
+              throw std::runtime_error(msg.str());
+            }
+            std::memcpy(dst, result.data(), expected);
+          };
+        };
+
+        auto group =
+            mx::distributed::jaccl::init(strict, std::move(cpp_factory));
+        if (group == nullptr) {
+          throw std::runtime_error(
+              "Failed to initialize the jaccl backend with a custom side channel.");
+        }
+        return mx::distributed::Group(std::move(group));
+      },
       "strict"_a = false,
       "backend"_a = "any",
-      nb::sig("def init(strict: bool = False, backend: str = 'any') -> Group"),
+      nb::kw_only(),
+      "all_gather_factory"_a = nb::none(),
+      nb::sig(
+          "def init(strict: bool = False, backend: str = 'any', *, all_gather_factory: Optional[Callable[[int, int], Callable[[bytes, int], bytes]]] = None) -> Group"),
       R"pbdoc(
         Initialize the communication backend and create the global communication group.
 
@@ -99,6 +153,13 @@ void init_distributed(nb::module_& parent_module) {
             set to ``any`` all available backends are tried and the first one
             that succeeds becomes the global group which will be returned in
             subsequent calls. Default: ``any``
+          all_gather_factory (Callable, optional): A factory used only with the
+            ``jaccl`` backend. It is called once per rank with ``(rank, size)``
+            and must return a callable with signature
+            ``f(src: bytes, n_bytes: int) -> bytes``. The returned callable
+            performs a byte-level all-gather used as the JACCL side channel
+            when exchanging RDMA connection metadata. The returned bytes must
+            have length ``size * n_bytes``.
 
         Returns:
           Group: The group representing all the launched processes.
@@ -349,4 +410,10 @@ void init_distributed(nb::module_& parent_module) {
       Returns:
         array: The output array with shape ``[x.shape[0] // group.size(), *x.shape[1:]]``.
     )pbdoc");
+
+  // Ensure the distributed backend cache is cleared before the interpreter
+  // goes away, so that any Python objects held by cached groups are released
+  // while Python is still alive.
+  auto atexit = nb::module_::import_("atexit");
+  atexit.attr("register")(nb::cpp_function(&mx::distributed::clear_backends));
 }

--- a/python/src/distributed.cpp
+++ b/python/src/distributed.cpp
@@ -8,7 +8,6 @@
 #include <nanobind/stl/vector.h>
 
 #include "mlx/distributed/distributed.h"
-#include "mlx/distributed/jaccl/jaccl.h"
 #include "mlx/distributed/ops.h"
 #include "python/src/small_vector.h"
 #include "python/src/utils.h"
@@ -93,9 +92,9 @@ void init_distributed(nb::module_& parent_module) {
         }
 
         auto py_factory = std::move(*all_gather_factory);
-        auto cpp_factory =
-            [py_factory = std::move(py_factory)](
-                int rank, int size) -> mx::distributed::jaccl::AllGatherFn {
+        auto cpp_factory = [py_factory = std::move(py_factory)](
+                               int rank,
+                               int size) -> mx::distributed::AllGatherFn {
           nb::gil_scoped_acquire gil;
           nb::object py_inner = py_factory(rank, size);
           if (!PyCallable_Check(py_inner.ptr())) {
@@ -119,13 +118,7 @@ void init_distributed(nb::module_& parent_module) {
           };
         };
 
-        auto group =
-            mx::distributed::jaccl::init(strict, std::move(cpp_factory));
-        if (group == nullptr) {
-          throw std::runtime_error(
-              "Failed to initialize the jaccl backend with a custom side channel.");
-        }
-        return mx::distributed::Group(std::move(group));
+        return mx::distributed::init(strict, backend, std::move(cpp_factory));
       },
       "strict"_a = false,
       "backend"_a = "any",

--- a/python/tests/mlx_distributed_tests.py
+++ b/python/tests/mlx_distributed_tests.py
@@ -360,3 +360,15 @@ class MLXDistributedCommonTestCase(mlx_tests.MLXTestCase):
                     clipped[k], grads_slice[k] * scale, atol=self.atol, rtol=self.rtol
                 )
             )
+
+    def test_jaccl_all_gather_factory_validation(self):
+        # A custom side-channel factory is only valid with the jaccl backend.
+        with self.assertRaises(ValueError):
+            mx.distributed.init(
+                backend="ring",
+                all_gather_factory=lambda rank, size: lambda src, n_bytes: b"",
+            )
+
+        # The factory must be callable.
+        with self.assertRaises(TypeError):
+            mx.distributed.init(backend="jaccl", all_gather_factory="not_callable")


### PR DESCRIPTION
This allows the user to define their own side channel used to exchange RDMA metadata to initialize the connection.

This can be used for apps that have a different way to establish a slow connection between the nodes that can be used to exchange metadata. It avoids the need for opening a port and listening for connections etc. It could use a shared filesystem or iCloud or any centralized service etc

Here is an example I asked Claude to write that uses ZeroMQ to handle connection retries etc.

<details>
<summary>ZeroMQ all gather example</summary>

```python
# Copyright © 2025 Apple Inc.

"""A minimal ZeroMQ based all-gather side channel for the jaccl backend.

The jaccl backend bootstraps its RDMA connections by performing a couple of
byte-level all-gathers to exchange connection metadata. This module provides a
simple :func:`zmq_all_gather_factory` that implements that all-gather over TCP
using ZeroMQ. Rank 0 acts as a coordinator: every other rank connects to it,
sends its chunk and receives the fully assembled buffer back.

Usage:

    import mlx.core as mx
    from mlx._distributed_utils.zmq_all_gather import zmq_all_gather_factory

    group = mx.distributed.init(
        backend="jaccl",
        all_gather_factory=zmq_all_gather_factory(),
    )
"""

import os
import struct

import zmq

# The environment variable set by ``mlx.launch`` that holds the ``ip:port`` of
# rank 0 which acts as the all-gather coordinator.
_COORDINATOR_ENV = ("JACCL_COORDINATOR", "MLX_JACCL_COORDINATOR")


def _coordinator_address(coordinator):
    if coordinator is not None:
        return coordinator
    for name in _COORDINATOR_ENV:
        value = os.environ.get(name)
        if value:
            return value
    raise RuntimeError(
        "No coordinator address provided and neither of "
        f"{_COORDINATOR_ENV} is set in the environment."
    )


def zmq_all_gather_factory(coordinator=None):
    """Create an all-gather factory for the jaccl backend backed by ZeroMQ.

    Args:
        coordinator (str, optional): The ``ip:port`` of rank 0. If ``None`` it
            is read from the ``MLX_JACCL_COORDINATOR`` environment variable.

    Returns:
        Callable[[int, int], Callable[[bytes, int], bytes]]: A factory that
        ``mx.distributed.init`` calls once per rank with ``(rank, size)`` and
        returns the actual all-gather callable.
    """
    ip, port = _coordinator_address(coordinator).rsplit(":", 1)
    endpoint = f"tcp://{ip}:{port}"

    def factory(rank, size):
        context = zmq.Context.instance()

        if rank == 0:
            # The coordinator uses a ROUTER socket so it can gather every
            # rank's chunk before replying with the assembled buffer.
            socket = context.socket(zmq.ROUTER)
            socket.bind(f"tcp://*:{port}")

            def all_gather(src, n_bytes):
                chunks = [None] * size
                chunks[0] = src
                envelopes = []
                for _ in range(size - 1):
                    frames = socket.recv_multipart()
                    # REQ sockets add an empty delimiter frame; everything
                    # before the payload is the routing envelope.
                    envelope, msg = frames[:-1], frames[-1]
                    peer = struct.unpack("<i", msg[:4])[0]
                    chunks[peer] = msg[4:]
                    envelopes.append(envelope)
                assembled = b"".join(chunks)
                for envelope in envelopes:
                    socket.send_multipart(envelope + [assembled])
                return assembled

            return all_gather

        # Non-coordinator ranks send their chunk and receive the full buffer.
        socket = context.socket(zmq.REQ)
        socket.connect(endpoint)

        def all_gather(src, n_bytes):
            socket.send(struct.pack("<i", rank) + src)
            return socket.recv()

        return all_gather

    return factory
```

</details>