### PR TITLE
Refactor the JACCL ring and add threads for the multiple rings

### DIFF
--- a/mlx/distributed/jaccl/lib/jaccl/reduction_ops.h
+++ b/mlx/distributed/jaccl/lib/jaccl/reduction_ops.h
@@ -8,11 +8,24 @@
 
 namespace jaccl {
 
+// Each reduction op has an in place form out[i] OP= in[i] and an out of place
+// form out[i] = a[i] OP b[i]. The out of place pointers are __restrict, so
+// callers must only use it when a, b and output are distinct buffers.
+
 template <typename T>
 struct SumOp {
   void operator()(const T* input, T* output, size_t N) const {
     for (size_t i = 0; i < N; i++) {
       output[i] = output[i] + input[i];
+    }
+  }
+  void operator()(
+      const T* __restrict a,
+      const T* __restrict b,
+      T* __restrict output,
+      size_t N) const {
+    for (size_t i = 0; i < N; i++) {
+      output[i] = a[i] + b[i];
     }
   }
 };
@@ -24,6 +37,15 @@ struct MaxOp {
       output[i] = (output[i] > input[i]) ? output[i] : input[i];
     }
   }
+  void operator()(
+      const T* __restrict a,
+      const T* __restrict b,
+      T* __restrict output,
+      size_t N) const {
+    for (size_t i = 0; i < N; i++) {
+      output[i] = (a[i] > b[i]) ? a[i] : b[i];
+    }
+  }
 };
 
 template <typename T>
@@ -31,6 +53,15 @@ struct MinOp {
   void operator()(const T* input, T* output, size_t N) const {
     for (size_t i = 0; i < N; i++) {
       output[i] = (output[i] < input[i]) ? output[i] : input[i];
+    }
+  }
+  void operator()(
+      const T* __restrict a,
+      const T* __restrict b,
+      T* __restrict output,
+      size_t N) const {
+    for (size_t i = 0; i < N; i++) {
+      output[i] = (a[i] < b[i]) ? a[i] : b[i];
     }
   }
 };
@@ -73,6 +104,36 @@ native_bf16_min(const void* input, void* output, size_t N) {
   }
 }
 
+__attribute__((target("arch=armv8.6-a"))) inline void
+native_bf16_sum(const void* a, const void* b, void* output, size_t N) {
+  auto pa = reinterpret_cast<const __bf16* __restrict>(a);
+  auto pb = reinterpret_cast<const __bf16* __restrict>(b);
+  auto out = reinterpret_cast<__bf16* __restrict>(output);
+  for (size_t i = 0; i < N; i++) {
+    out[i] = pa[i] + pb[i];
+  }
+}
+
+__attribute__((target("arch=armv8.6-a"))) inline void
+native_bf16_max(const void* a, const void* b, void* output, size_t N) {
+  auto pa = reinterpret_cast<const __bf16* __restrict>(a);
+  auto pb = reinterpret_cast<const __bf16* __restrict>(b);
+  auto out = reinterpret_cast<__bf16* __restrict>(output);
+  for (size_t i = 0; i < N; i++) {
+    out[i] = (pa[i] > pb[i]) ? pa[i] : pb[i];
+  }
+}
+
+__attribute__((target("arch=armv8.6-a"))) inline void
+native_bf16_min(const void* a, const void* b, void* output, size_t N) {
+  auto pa = reinterpret_cast<const __bf16* __restrict>(a);
+  auto pb = reinterpret_cast<const __bf16* __restrict>(b);
+  auto out = reinterpret_cast<__bf16* __restrict>(output);
+  for (size_t i = 0; i < N; i++) {
+    out[i] = (pa[i] < pb[i]) ? pa[i] : pb[i];
+  }
+}
+
 template <>
 struct SumOp<bfloat16_t> {
   void operator()(const bfloat16_t* input, bfloat16_t* output, size_t N) const {
@@ -81,6 +142,19 @@ struct SumOp<bfloat16_t> {
     } else {
       for (size_t i = 0; i < N; i++) {
         output[i] = output[i] + input[i];
+      }
+    }
+  }
+  void operator()(
+      const bfloat16_t* __restrict a,
+      const bfloat16_t* __restrict b,
+      bfloat16_t* __restrict output,
+      size_t N) const {
+    if (has_native_bf16_support()) {
+      native_bf16_sum(a, b, output, N);
+    } else {
+      for (size_t i = 0; i < N; i++) {
+        output[i] = a[i] + b[i];
       }
     }
   }
@@ -97,6 +171,19 @@ struct MaxOp<bfloat16_t> {
       }
     }
   }
+  void operator()(
+      const bfloat16_t* __restrict a,
+      const bfloat16_t* __restrict b,
+      bfloat16_t* __restrict output,
+      size_t N) const {
+    if (has_native_bf16_support()) {
+      native_bf16_max(a, b, output, N);
+    } else {
+      for (size_t i = 0; i < N; i++) {
+        output[i] = (a[i] > b[i]) ? a[i] : b[i];
+      }
+    }
+  }
 };
 
 template <>
@@ -107,6 +194,19 @@ struct MinOp<bfloat16_t> {
     } else {
       for (size_t i = 0; i < N; i++) {
         output[i] = (output[i] < input[i]) ? output[i] : input[i];
+      }
+    }
+  }
+  void operator()(
+      const bfloat16_t* __restrict a,
+      const bfloat16_t* __restrict b,
+      bfloat16_t* __restrict output,
+      size_t N) const {
+    if (has_native_bf16_support()) {
+      native_bf16_min(a, b, output, N);
+    } else {
+      for (size_t i = 0; i < N; i++) {
+        output[i] = (a[i] < b[i]) ? a[i] : b[i];
       }
     }
   }

--- a/mlx/distributed/jaccl/lib/jaccl/ring.cpp
+++ b/mlx/distributed/jaccl/lib/jaccl/ring.cpp
@@ -17,7 +17,8 @@ RingGroup::RingGroup(
       n_conns_(left_devices.size()),
       side_channel_(std::move(sc)),
       left_(create_connections(left_devices)),
-      right_(create_connections(right_devices)) {
+      right_(create_connections(right_devices)),
+      pool_(n_conns_ > 0 ? n_conns_ - 1 : 0) {
   if (left_.size() > RING_MAX_CONNS || right_.size() > RING_MAX_CONNS) {
     std::ostringstream msg;
     msg << "[jaccl] Up to " << RING_MAX_CONNS << " per direction supported but "
@@ -32,7 +33,8 @@ RingGroup::RingGroup(
   side_channel_.barrier();
 
   // Create the ring implementation object
-  ring_ = RingImpl(rank_, size_, left_, right_, send_buffers_, recv_buffers_);
+  ring_ = RingImpl(
+      rank_, size_, left_, right_, send_buffers_, recv_buffers_, &pool_);
 }
 
 void RingGroup::initialize() {

--- a/mlx/distributed/jaccl/lib/jaccl/ring.cpp
+++ b/mlx/distributed/jaccl/lib/jaccl/ring.cpp
@@ -206,13 +206,9 @@ void RingGroup::all_reduce(
   auto in_ptr = static_cast<const T*>(input);
   auto out_ptr = static_cast<T*>(output);
   int64_t count = n_bytes / sizeof(T);
-  if (count < size_ * 2 * n_conns_) {
-    ring_.all_reduce<1, T, ReduceOp>(in_ptr, out_ptr, count, 1, reduce_op);
-    return;
-  }
 
-  if (n_bytes <= 65536) {
-    ring_.all_reduce<2, T, ReduceOp>(in_ptr, out_ptr, count, 1, reduce_op);
+  if (n_bytes <= 32768 || count < size_ * 2 * n_conns_) {
+    ring_.all_reduce<1, T, ReduceOp>(in_ptr, out_ptr, count, 1, reduce_op);
     return;
   }
 

--- a/mlx/distributed/jaccl/lib/jaccl/ring.h
+++ b/mlx/distributed/jaccl/lib/jaccl/ring.h
@@ -78,6 +78,8 @@ class RingGroup : public Group {
   std::vector<Connection> right_;
   std::vector<SharedBuffer> send_buffers_;
   std::vector<SharedBuffer> recv_buffers_;
+  // Declared before ring_ so it outlives the RingImpl that points at it.
+  ThreadPool pool_;
   RingImpl ring_;
 };
 

--- a/mlx/distributed/jaccl/lib/jaccl/ring_impl.h
+++ b/mlx/distributed/jaccl/lib/jaccl/ring_impl.h
@@ -45,6 +45,26 @@ class RingImpl {
 
   RingImpl() : rank_(0), size_(1), n_conns_(0) {}
 
+  // Copy the received chunk straight into the output. Used by the all gather
+  // pass of the all reduce and by the standalone all gather.
+  struct CopyOp {
+    template <typename T>
+    inline void operator()(const T* recv, T* out, int64_t n) const {
+      std::copy(recv, recv + std::max<int64_t>(0, n), out);
+    }
+  };
+
+  // Adapts a reduction op (SumOp/MaxOp/...) to the recv handler signature used
+  // by ring_pass. Reduces the received chunk into the output in place.
+  template <typename ReduceOp>
+  struct ReduceRecvOp {
+    ReduceOp reduce_op;
+    template <typename T>
+    inline void operator()(const T* recv, T* out, int64_t n) const {
+      reduce_op(recv, out, std::max<int64_t>(0, n));
+    }
+  };
+
   template <int MAX_DIR, typename T, typename ReduceOp>
   void all_reduce(
       const T* in_ptr,
@@ -73,13 +93,13 @@ class RingImpl {
   }
 
   // Perform the ring all reduce (reduce scatter followed by all gather) for a
-  // single wire `lw`.
+  // single wire lw.
   //
-  // Every chunk of `chunk_size` elements is divided into `MAX_DIR` directional
-  // regions and each region is further split into `n_wires` contiguous slices
-  // of `size_per_wire` elements. This function is responsible for slice `lw` in
-  // every direction and only touches `left_[lw]` / `right_[lw]` and the buffers
-  // that belong to wire `lw`, so several wires can run concurrently.
+  // Every chunk of chunk_size elements is divided into MAX_DIR directional
+  // regions and each region is further split into n_wires contiguous slices of
+  // size_per_wire elements. This function is responsible for slice lw in every
+  // direction and only touches left_[lw] / right_[lw] and the buffers that
+  // belong to wire lw, so several wires can run concurrently.
   template <int MAX_DIR, typename T, typename ReduceOp>
   void all_reduce_wire(
       T* out_ptr,
@@ -89,222 +109,54 @@ class RingImpl {
       int n_wires,
       int lw,
       ReduceOp reduce_op) {
-    constexpr int PIPELINE = 2;
-    constexpr int WC_NUM = PIPELINE * 2 * MAX_DIR;
-    auto [sz, N] = buffer_size_from_message(size_per_wire * sizeof(T));
-    N /= sizeof(T);
-    int64_t n_steps = (size_per_wire + N - 1) / N;
-
     // The element offset (within a chunk) of this wire's slice in each
     // direction and the end of each direction's region. Wire slices are
-    // contiguous rather than interleaved. Direction `lr` owns the chunk region
+    // contiguous rather than interleaved. Direction lr owns the chunk region
     // [lr * n_wires * size_per_wire, (lr + 1) * n_wires * size_per_wire) (the
     // last region is clamped to chunk_size).
     int64_t wire_offset[MAX_DIR];
     int64_t region_end[MAX_DIR];
+    int64_t send_offset[MAX_DIR];
+    int64_t recv_offset[MAX_DIR];
     for (int lr = 0; lr < MAX_DIR; lr++) {
       wire_offset[lr] = lr * n_wires * size_per_wire +
           static_cast<int64_t>(lw) * size_per_wire;
       region_end[lr] = std::min(chunk_size, (lr + 1) * n_wires * size_per_wire);
+      send_offset[lr] = rank_ * chunk_size;
     }
-
-    // Counters to maintain the state of transfers
-    int in_flight = 0;
-    int64_t chunk_multiple_size = size_ * chunk_size;
-    int64_t send_offset[MAX_DIR];
-    int64_t recv_offset[MAX_DIR];
-    int64_t send_limits[MAX_DIR];
-    int64_t recv_limits[MAX_DIR];
-    int send_count[MAX_DIR] = {0};
-    int recv_count[MAX_DIR] = {0};
-    send_offset[0] = rank_ * chunk_size;
     recv_offset[0] = ((rank_ + size_ - 1) % size_) * chunk_size;
-    send_limits[0] =
-        std::min(region_end[0], std::max<int64_t>(0, size - send_offset[0]));
-    recv_limits[0] =
-        std::min(region_end[0], std::max<int64_t>(0, size - recv_offset[0]));
     if constexpr (MAX_DIR == 2) {
-      send_offset[1] = rank_ * chunk_size;
       recv_offset[1] = ((rank_ + 1) % size_) * chunk_size;
-      send_limits[1] =
-          std::min(region_end[1], std::max<int64_t>(0, size - send_offset[1]));
-      recv_limits[1] =
-          std::min(region_end[1], std::max<int64_t>(0, size - recv_offset[1]));
     }
 
-    // First reduce scatter
-    //
-    // Possible perf improvement by not syncing at every step but running ahead
-    // as needed.
-    for (int k = 0; k < size_ - 1; k++) {
-      // Prefill the pipeline
-      int buff = 0;
-      while (buff < n_steps && buff < PIPELINE) {
-        for (int lr = 0; lr < MAX_DIR; lr++) {
-          recv_from(sz, buff, lr, lw);
-        }
-        for (int lr = 0; lr < MAX_DIR; lr++) {
-          int64_t offset = wire_offset[lr] + send_count[lr] * N;
-          std::copy(
-              out_ptr + send_offset[lr] + offset,
-              out_ptr + send_offset[lr] +
-                  std::max(offset, std::min(offset + N, send_limits[lr])),
-              send_buffer(sz, buff, lr, lw).begin<T>());
-          send_count[lr]++;
-          send_to(sz, buff, lr, lw);
-        }
-
-        buff++;
-        in_flight += 2 * MAX_DIR;
-      }
-
-      // Main loop
-      //
-      // Keep going until we have no longer data in flight.
-      while (in_flight > 0) {
-        ibv_wc wc[WC_NUM];
-        int n = poll_wire(lw, WC_NUM, wc);
-        for (int i = 0; i < n; i++) {
-          int work_type = wc[i].wr_id >> 16;
-          int buff = (wc[i].wr_id >> 8) & 0xff;
-          int lr = wc[i].wr_id & 0xff;
-
-          in_flight--;
-
-          if (work_type == SEND_WR && send_count[lr] < n_steps) {
-            int64_t offset = wire_offset[lr] + send_count[lr] * N;
-            std::copy(
-                out_ptr + send_offset[lr] + offset,
-                out_ptr + send_offset[lr] +
-                    std::max(offset, std::min(offset + N, send_limits[lr])),
-                send_buffer(sz, buff, lr, lw).begin<T>());
-            send_to(sz, buff, lr, lw);
-            in_flight++;
-            send_count[lr]++;
-          }
-
-          else if (work_type == RECV_WR) {
-            int64_t offset = wire_offset[lr] + recv_count[lr] * N;
-            reduce_op(
-                recv_buffer(sz, buff, lr, lw).begin<T>(),
-                out_ptr + recv_offset[lr] + offset,
-                std::max<int64_t>(0, std::min(N, recv_limits[lr] - offset)));
-            recv_count[lr]++;
-            if (recv_count[lr] + (PIPELINE - 1) < n_steps) {
-              recv_from(sz, buff, lr, lw);
-              in_flight++;
-            }
-          }
-        }
-      }
-
-      send_offset[0] = (send_offset[0] + chunk_multiple_size - chunk_size) %
-          chunk_multiple_size;
-      recv_offset[0] = (recv_offset[0] + chunk_multiple_size - chunk_size) %
-          chunk_multiple_size;
-      send_limits[0] =
-          std::min(region_end[0], std::max<int64_t>(0, size - send_offset[0]));
-      recv_limits[0] =
-          std::min(region_end[0], std::max<int64_t>(0, size - recv_offset[0]));
-      if constexpr (MAX_DIR == 2) {
-        send_offset[1] = (send_offset[1] + chunk_size) % chunk_multiple_size;
-        recv_offset[1] = (recv_offset[1] + chunk_size) % chunk_multiple_size;
-        send_limits[1] = std::min(
-            region_end[1], std::max<int64_t>(0, size - send_offset[1]));
-        recv_limits[1] = std::min(
-            region_end[1], std::max<int64_t>(0, size - recv_offset[1]));
-      }
-      for (int lr = 0; lr < MAX_DIR; lr++) {
-        send_count[lr] = recv_count[lr] = 0;
-      }
-    }
-
-    // Secondly all gather
-    //
-    // The offsets are correct from the scatter reduce
-    for (int k = 0; k < size_ - 1; k++) {
-      // Prefill the pipeline
-      int buff = 0;
-      while (buff < n_steps && buff < PIPELINE) {
-        for (int lr = 0; lr < MAX_DIR; lr++) {
-          recv_from(sz, buff, lr, lw);
-        }
-        for (int lr = 0; lr < MAX_DIR; lr++) {
-          int64_t offset = wire_offset[lr] + send_count[lr] * N;
-          std::copy(
-              out_ptr + send_offset[lr] + offset,
-              out_ptr + send_offset[lr] +
-                  std::max(offset, std::min(offset + N, send_limits[lr])),
-              send_buffer(sz, buff, lr, lw).begin<T>());
-          send_count[lr]++;
-          send_to(sz, buff, lr, lw);
-        }
-
-        buff++;
-        in_flight += 2 * MAX_DIR;
-      }
-
-      // Main loop
-      //
-      // Keep going until we have no longer data in flight.
-      while (in_flight > 0) {
-        ibv_wc wc[WC_NUM];
-        int n = poll_wire(lw, WC_NUM, wc);
-        for (int i = 0; i < n; i++) {
-          int work_type = wc[i].wr_id >> 16;
-          int buff = (wc[i].wr_id >> 8) & 0xff;
-          int lr = wc[i].wr_id & 0xff;
-
-          in_flight--;
-
-          if (work_type == SEND_WR && send_count[lr] < n_steps) {
-            int64_t offset = wire_offset[lr] + send_count[lr] * N;
-            std::copy(
-                out_ptr + send_offset[lr] + offset,
-                out_ptr + send_offset[lr] +
-                    std::max(offset, std::min(offset + N, send_limits[lr])),
-                send_buffer(sz, buff, lr, lw).begin<T>());
-            send_to(sz, buff, lr, lw);
-            in_flight++;
-            send_count[lr]++;
-          }
-
-          else if (work_type == RECV_WR) {
-            int64_t offset = wire_offset[lr] + recv_count[lr] * N;
-            std::copy(
-                recv_buffer(sz, buff, lr, lw).begin<T>(),
-                recv_buffer(sz, buff, lr, lw).begin<T>() +
-                    std::max<int64_t>(0, std::min(N, recv_limits[lr] - offset)),
-                out_ptr + recv_offset[lr] + offset);
-            recv_count[lr]++;
-            if (recv_count[lr] + (PIPELINE - 1) < n_steps) {
-              recv_from(sz, buff, lr, lw);
-              in_flight++;
-            }
-          }
-        }
-      }
-
-      send_offset[0] = (send_offset[0] + chunk_multiple_size - chunk_size) %
-          chunk_multiple_size;
-      recv_offset[0] = (recv_offset[0] + chunk_multiple_size - chunk_size) %
-          chunk_multiple_size;
-      send_limits[0] =
-          std::min(region_end[0], std::max<int64_t>(0, size - send_offset[0]));
-      recv_limits[0] =
-          std::min(region_end[0], std::max<int64_t>(0, size - recv_offset[0]));
-      if constexpr (MAX_DIR == 2) {
-        send_offset[1] = (send_offset[1] + chunk_size) % chunk_multiple_size;
-        recv_offset[1] = (recv_offset[1] + chunk_size) % chunk_multiple_size;
-        send_limits[1] = std::min(
-            region_end[1], std::max<int64_t>(0, size - send_offset[1]));
-        recv_limits[1] = std::min(
-            region_end[1], std::max<int64_t>(0, size - recv_offset[1]));
-      }
-      for (int lr = 0; lr < MAX_DIR; lr++) {
-        send_count[lr] = recv_count[lr] = 0;
-      }
-    }
+    // First reduce scatter, then all gather. The offsets carry over from the
+    // reduce scatter into the all gather. The only difference between the two
+    // passes is what the recv handler does with the received chunk: reduce it
+    // in place vs. copy it out.
+    ring_pass<MAX_DIR, T>(
+        lw,
+        size,
+        chunk_size,
+        size_ * chunk_size,
+        size_per_wire,
+        wire_offset,
+        region_end,
+        send_offset,
+        recv_offset,
+        out_ptr,
+        ReduceRecvOp<ReduceOp>{reduce_op});
+    ring_pass<MAX_DIR, T>(
+        lw,
+        size,
+        chunk_size,
+        size_ * chunk_size,
+        size_per_wire,
+        wire_offset,
+        region_end,
+        send_offset,
+        recv_offset,
+        out_ptr,
+        CopyOp{});
   }
 
   void
@@ -319,68 +171,117 @@ class RingImpl {
     // threadpool and run concurrently instead of sequentially.
     size_t n_bytes_per_wire = (n_bytes + (2 * n_wires) - 1) / (2 * n_wires);
     for (int lw = 0; lw < n_wires; lw++) {
-      all_gather_wire(out_ptr, n_bytes, n_bytes_per_wire, lw);
+      all_gather_wire(
+          out_ptr, n_bytes, static_cast<int64_t>(n_bytes_per_wire), lw);
     }
   }
 
-  // Perform the ring all gather for a single wire `lw`.
+  // Perform the ring all gather for a single wire lw.
   //
   // The wire is responsible for the contiguous slice
   //   [lw * n_bytes_per_wire, (lw + 1) * n_bytes_per_wire)
-  // of every rank's `n_bytes` region, sent in the left direction (lr == 0),
-  // and the mirrored slice sent in the right direction (lr == 1).
+  // of every rank's n_bytes region, sent in the left direction (lr == 0), and
+  // the mirrored slice sent in the right direction (lr == 1).
   //
-  // This function only ever touches `left_[lw]` / `right_[lw]` and the buffers
-  // that belong to wire `lw` so several wires can run concurrently.
+  // This function only ever touches left_[lw] / right_[lw] and the buffers that
+  // belong to wire lw so several wires can run concurrently.
   void all_gather_wire(
       char* out_ptr,
       int64_t n_bytes,
-      size_t n_bytes_per_wire,
+      int64_t n_bytes_per_wire,
       int lw) {
+    // Both directions send the same contiguous slice of each rank's region.
+    int64_t slice = static_cast<int64_t>(lw) * n_bytes_per_wire;
+    int64_t wire_offset[2] = {slice, slice};
+    int64_t region_end[2] = {n_bytes, n_bytes};
+    int64_t send_offset[2] = {rank_ * n_bytes, rank_ * n_bytes};
+    int64_t recv_offset[2] = {
+        ((rank_ + size_ - 1) % size_) * n_bytes,
+        ((rank_ + 1) % size_) * n_bytes};
+
+    ring_pass<2, char>(
+        lw,
+        n_bytes,
+        n_bytes,
+        n_bytes * size_,
+        n_bytes_per_wire,
+        wire_offset,
+        region_end,
+        send_offset,
+        recv_offset,
+        out_ptr,
+        CopyOp{});
+  }
+
+  // Run size_ - 1 pipelined ring steps for a single wire in every direction.
+  //
+  // At every step each direction sends its current slice to a neighbor and
+  // receives the neighbor's slice, which recv_op either reduces into or copies
+  // into out_ptr. After each step the send and recv windows rotate around the
+  // ring (direction 0 backward, direction 1 forward). This is the shared engine
+  // behind both all reduce passes and all gather.
+  //
+  // wire_offset is the element offset of this wire's slice within a chunk and
+  // region_end is the element end (within a chunk) of each direction's region.
+  // send_offset and recv_offset are the starting window offsets and are updated
+  // in place so callers can chain passes (the all reduce reuses them). stride
+  // is how many elements a window moves per step (chunk_size for the all
+  // reduce, n_bytes for the all gather) and total is the wrap around modulus.
+  template <int MAX_DIR, typename T, typename RecvOp>
+  inline void ring_pass(
+      int lw,
+      int64_t size,
+      int64_t stride,
+      int64_t total,
+      int64_t size_per_wire,
+      const int64_t (&wire_offset)[MAX_DIR],
+      const int64_t (&region_end)[MAX_DIR],
+      int64_t (&send_offset)[MAX_DIR],
+      int64_t (&recv_offset)[MAX_DIR],
+      T* out_ptr,
+      RecvOp recv_op) {
     constexpr int PIPELINE = 2;
-    constexpr int WC_NUM = PIPELINE * 2;
-    size_t out_bytes = n_bytes * size_;
-    auto [sz, N] = buffer_size_from_message(n_bytes_per_wire);
-    int n_steps = (n_bytes_per_wire + N - 1) / N;
+    constexpr int WC_NUM = PIPELINE * 2 * MAX_DIR;
+    auto [sz, buffer_bytes] =
+        buffer_size_from_message(size_per_wire * sizeof(T));
+    int64_t N = buffer_bytes / sizeof(T);
+    int64_t n_steps = (size_per_wire + N - 1) / N;
 
-    // The byte offset (within a rank's region) that this wire is responsible
-    // for. Wire slices are contiguous rather than interleaved.
-    int64_t wire_offset = static_cast<int64_t>(lw) * n_bytes_per_wire;
-
-    // Counters to maintain the state of transfers
     int in_flight = 0;
-    int64_t send_offset[2];
-    int64_t recv_offset[2];
-    int64_t limits[2];
-    int send_count[2] = {0};
-    int recv_count[2] = {0};
-    send_offset[0] = send_offset[1] = rank_ * n_bytes;
-    recv_offset[0] = ((rank_ + size_ - 1) % size_) * n_bytes;
-    recv_offset[1] = ((rank_ + 1) % size_) * n_bytes;
-    limits[0] = limits[1] = n_bytes;
+    int64_t send_limits[MAX_DIR];
+    int64_t recv_limits[MAX_DIR];
+    int send_count[MAX_DIR] = {0};
+    int recv_count[MAX_DIR] = {0};
+    auto set_limits = [&]() {
+      for (int lr = 0; lr < MAX_DIR; lr++) {
+        send_limits[lr] = std::min(
+            region_end[lr], std::max<int64_t>(0, size - send_offset[lr]));
+        recv_limits[lr] = std::min(
+            region_end[lr], std::max<int64_t>(0, size - recv_offset[lr]));
+      }
+    };
+    set_limits();
 
-    // Possible perf improvement by not syncing at every step but running ahead
-    // as needed.
     for (int k = 0; k < size_ - 1; k++) {
       // Prefill the pipeline
       int buff = 0;
       while (buff < n_steps && buff < PIPELINE) {
-        for (int lr = 0; lr < 2; lr++) {
+        for (int lr = 0; lr < MAX_DIR; lr++) {
           recv_from(sz, buff, lr, lw);
         }
-        for (int lr = 0; lr < 2; lr++) {
-          int64_t offset = wire_offset + send_count[lr] * N;
+        for (int lr = 0; lr < MAX_DIR; lr++) {
+          int64_t offset = wire_offset[lr] + send_count[lr] * N;
           std::copy(
               out_ptr + send_offset[lr] + offset,
               out_ptr + send_offset[lr] +
-                  std::max(offset, std::min(offset + N, limits[lr])),
-              send_buffer(sz, buff, lr, lw).begin<char>());
+                  std::max(offset, std::min(offset + N, send_limits[lr])),
+              send_buffer(sz, buff, lr, lw).template begin<T>());
           send_count[lr]++;
           send_to(sz, buff, lr, lw);
         }
 
         buff++;
-        in_flight += 2 * 2;
+        in_flight += 2 * MAX_DIR;
       }
 
       // Main loop
@@ -397,24 +298,23 @@ class RingImpl {
           in_flight--;
 
           if (work_type == SEND_WR && send_count[lr] < n_steps) {
-            int64_t offset = wire_offset + send_count[lr] * N;
+            int64_t offset = wire_offset[lr] + send_count[lr] * N;
             std::copy(
                 out_ptr + send_offset[lr] + offset,
                 out_ptr + send_offset[lr] +
-                    std::max(offset, std::min(offset + N, limits[lr])),
-                send_buffer(sz, buff, lr, lw).begin<char>());
+                    std::max(offset, std::min(offset + N, send_limits[lr])),
+                send_buffer(sz, buff, lr, lw).template begin<T>());
             send_to(sz, buff, lr, lw);
             in_flight++;
             send_count[lr]++;
           }
 
           else if (work_type == RECV_WR) {
-            int64_t offset = wire_offset + recv_count[lr] * N;
-            std::copy(
-                recv_buffer(sz, buff, lr, lw).begin<char>(),
-                recv_buffer(sz, buff, lr, lw).begin<char>() +
-                    std::max<int64_t>(0, std::min(N, limits[lr] - offset)),
-                out_ptr + recv_offset[lr] + offset);
+            int64_t offset = wire_offset[lr] + recv_count[lr] * N;
+            recv_op(
+                recv_buffer(sz, buff, lr, lw).template begin<T>(),
+                out_ptr + recv_offset[lr] + offset,
+                std::min(N, recv_limits[lr] - offset));
             recv_count[lr]++;
             if (recv_count[lr] + (PIPELINE - 1) < n_steps) {
               recv_from(sz, buff, lr, lw);
@@ -424,12 +324,17 @@ class RingImpl {
         }
       }
 
-      send_offset[0] = (send_offset[0] + out_bytes - n_bytes) % out_bytes;
-      recv_offset[0] = (recv_offset[0] + out_bytes - n_bytes) % out_bytes;
-      send_offset[1] = (send_offset[1] + n_bytes) % out_bytes;
-      recv_offset[1] = (recv_offset[1] + n_bytes) % out_bytes;
-      send_count[0] = send_count[1] = 0;
-      recv_count[0] = recv_count[1] = 0;
+      // Rotate the windows around the ring for the next step.
+      send_offset[0] = (send_offset[0] + total - stride) % total;
+      recv_offset[0] = (recv_offset[0] + total - stride) % total;
+      if constexpr (MAX_DIR == 2) {
+        send_offset[1] = (send_offset[1] + stride) % total;
+        recv_offset[1] = (recv_offset[1] + stride) % total;
+      }
+      set_limits();
+      for (int lr = 0; lr < MAX_DIR; lr++) {
+        send_count[lr] = recv_count[lr] = 0;
+      }
     }
   }
 
@@ -453,9 +358,9 @@ class RingImpl {
     }
   }
 
-  // Perform a point-to-point send for a single wire `lw`.
+  // Perform a point-to-point send for a single wire lw.
   //
-  // Only touches the connection / buffers of wire `lw` so several wires can run
+  // Only touches the connection and buffers of wire lw so several wires can run
   // concurrently.
   void send_wire(
       const char* in_ptr,
@@ -535,9 +440,9 @@ class RingImpl {
     }
   }
 
-  // Perform a point-to-point recv for a single wire `lw`.
+  // Perform a point-to-point recv for a single wire lw.
   //
-  // Only touches the connection / buffers of wire `lw` so several wires can run
+  // Only touches the connection and buffers of wire lw so several wires can run
   // concurrently.
   void recv_wire(
       char* out_ptr,

--- a/mlx/distributed/jaccl/lib/jaccl/ring_impl.h
+++ b/mlx/distributed/jaccl/lib/jaccl/ring_impl.h
@@ -2,9 +2,11 @@
 
 #pragma once
 
+#include <future>
 #include <span>
 
 #include "jaccl/rdma.h"
+#include "jaccl/threadpool.h"
 
 constexpr int RING_MAX_CONNS = 4;
 
@@ -18,14 +20,16 @@ class RingImpl {
       std::vector<Connection>& left,
       std::vector<Connection>& right,
       std::vector<SharedBuffer>& send_buffers,
-      std::vector<SharedBuffer>& recv_buffers)
+      std::vector<SharedBuffer>& recv_buffers,
+      ThreadPool* pool = nullptr)
       : rank_(rank),
         size_(size),
         n_conns_(left.size()),
         left_(left),
         right_(right),
         send_buffers_(send_buffers),
-        recv_buffers_(recv_buffers) {}
+        recv_buffers_(recv_buffers),
+        pool_(pool) {}
 
   RingImpl(
       int rank,
@@ -34,16 +38,18 @@ class RingImpl {
       Connection* right_begin,
       size_t n_conns,
       std::vector<SharedBuffer>& send_buffers,
-      std::vector<SharedBuffer>& recv_buffers)
+      std::vector<SharedBuffer>& recv_buffers,
+      ThreadPool* pool = nullptr)
       : rank_(rank),
         size_(size),
         n_conns_(n_conns),
         left_(left_begin, n_conns),
         right_(right_begin, n_conns),
         send_buffers_(send_buffers),
-        recv_buffers_(recv_buffers) {}
+        recv_buffers_(recv_buffers),
+        pool_(pool) {}
 
-  RingImpl() : rank_(0), size_(1), n_conns_(0) {}
+  RingImpl() : rank_(0), size_(1), n_conns_(0), pool_(nullptr) {}
 
   // Copy the received chunk into the output. Used by the all gather passes.
   struct CopyOp {
@@ -84,10 +90,7 @@ class RingImpl {
 
     // Split the reduce scatter + all gather across the available wires. Each
     // wire handles a contiguous slice of each chunk in every direction.
-    //
-    // TODO: These calls are independent so they should be dispatched to a
-    // threadpool and run concurrently instead of sequentially.
-    for (int lw = 0; lw < n_wires; lw++) {
+    dispatch_wires(n_wires, [&](int lw) {
       all_reduce_wire<MAX_DIR>(
           in_ptr,
           out_ptr,
@@ -97,7 +100,7 @@ class RingImpl {
           n_wires,
           lw,
           reduce_op);
-    }
+    });
   }
 
   // Perform the ring all reduce (reduce scatter followed by all gather) for a
@@ -192,14 +195,11 @@ class RingImpl {
 
     // Split the all gather across the available wires. Each wire handles a
     // contiguous slice of every rank's data in both directions.
-    //
-    // TODO: These calls are independent so they should be dispatched to a
-    // threadpool and run concurrently instead of sequentially.
     size_t n_bytes_per_wire = (n_bytes + (2 * n_wires) - 1) / (2 * n_wires);
-    for (int lw = 0; lw < n_wires; lw++) {
+    dispatch_wires(n_wires, [&](int lw) {
       all_gather_wire(
           out_ptr, n_bytes, static_cast<int64_t>(n_bytes_per_wire), lw);
-    }
+    });
   }
 
   // Perform the ring all gather for a single wire lw.
@@ -386,12 +386,9 @@ class RingImpl {
 
     // Split the send across the available wires. Each wire handles the
     // contiguous slice [lw * bytes_per_wire, (lw + 1) * bytes_per_wire).
-    //
-    // TODO: These calls are independent so they should be dispatched to a
-    // threadpool and run concurrently instead of sequentially.
-    for (int lw = 0; lw < n_wires; lw++) {
+    dispatch_wires(n_wires, [&](int lw) {
       send_wire(in_ptr, n_bytes, dir, bytes_per_wire, lw);
-    }
+    });
   }
 
   // Perform a point-to-point send for a single wire lw.
@@ -468,12 +465,9 @@ class RingImpl {
 
     // Split the recv across the available wires. Each wire handles the
     // contiguous slice [lw * bytes_per_wire, (lw + 1) * bytes_per_wire).
-    //
-    // TODO: These calls are independent so they should be dispatched to a
-    // threadpool and run concurrently instead of sequentially.
-    for (int lw = 0; lw < n_wires; lw++) {
+    dispatch_wires(n_wires, [&](int lw) {
       recv_wire(out_ptr, n_bytes, dir, bytes_per_wire, lw);
-    }
+    });
   }
 
   // Perform a point-to-point recv for a single wire lw.
@@ -577,6 +571,38 @@ class RingImpl {
         work_completions);
   }
 
+  // Run fn(lw) for each wire, the first n_wires - 1 on the pool and the last
+  // inline, then wait for the pool calls before returning.
+  template <typename Fn>
+  void dispatch_wires(int n_wires, Fn&& fn) {
+    if (n_wires <= 1 || pool_ == nullptr) {
+      for (int lw = 0; lw < n_wires; lw++) {
+        fn(lw);
+      }
+      return;
+    }
+
+    std::vector<std::future<void>> futures;
+    futures.reserve(n_wires - 1);
+    for (int lw = 0; lw < n_wires - 1; lw++) {
+      futures.emplace_back(pool_->enqueue(fn, lw));
+    }
+
+    // Wait for the pool calls even if the inline one throws, so they never
+    // outlive this frame.
+    try {
+      fn(n_wires - 1);
+    } catch (...) {
+      for (auto& f : futures) {
+        f.wait();
+      }
+      throw;
+    }
+    for (auto& f : futures) {
+      f.wait();
+    }
+  }
+
   int rank_;
   int size_;
   int n_conns_;
@@ -584,6 +610,7 @@ class RingImpl {
   std::span<Connection> right_;
   std::span<SharedBuffer> send_buffers_;
   std::span<SharedBuffer> recv_buffers_;
+  ThreadPool* pool_;
 };
 
 } // namespace jaccl

--- a/mlx/distributed/jaccl/lib/jaccl/ring_impl.h
+++ b/mlx/distributed/jaccl/lib/jaccl/ring_impl.h
@@ -45,23 +45,29 @@ class RingImpl {
 
   RingImpl() : rank_(0), size_(1), n_conns_(0) {}
 
-  // Copy the received chunk straight into the output. Used by the all gather
-  // pass of the all reduce and by the standalone all gather.
+  // Copy the received chunk into the output. Used by the all gather passes.
   struct CopyOp {
     template <typename T>
-    inline void operator()(const T* recv, T* out, int64_t n) const {
+    inline void operator()(const T* recv, const T*, T* out, int64_t n) const {
       std::copy(recv, recv + std::max<int64_t>(0, n), out);
     }
   };
 
-  // Adapts a reduction op (SumOp/MaxOp/...) to the recv handler signature used
-  // by ring_pass. Reduces the received chunk into the output in place.
-  template <typename ReduceOp>
+  // Reduce the received chunk with this rank's own input for the chunk. When
+  // in place (input aliases output) we use the fast two argument kernel;
+  // otherwise the fused out of place kernel seeds the output from the input.
+  template <typename ReduceOp, bool INPLACE>
   struct ReduceRecvOp {
     ReduceOp reduce_op;
     template <typename T>
-    inline void operator()(const T* recv, T* out, int64_t n) const {
-      reduce_op(recv, out, std::max<int64_t>(0, n));
+    inline void operator()(const T* recv, const T* base, T* out, int64_t n)
+        const {
+      n = std::max<int64_t>(0, n);
+      if constexpr (INPLACE) {
+        reduce_op(recv, out, n);
+      } else {
+        reduce_op(base, recv, out, n);
+      }
     }
   };
 
@@ -72,11 +78,6 @@ class RingImpl {
       int64_t size,
       int n_wires,
       ReduceOp reduce_op) {
-    // If not inplace all reduce then copy the input to the output first
-    if (in_ptr != out_ptr) {
-      std::memcpy(out_ptr, in_ptr, size * sizeof(T));
-    }
-
     int64_t chunk_size = (size + size_ - 1) / size_;
     int64_t size_per_wire =
         (chunk_size + (MAX_DIR * n_wires) - 1) / (MAX_DIR * n_wires);
@@ -88,7 +89,14 @@ class RingImpl {
     // threadpool and run concurrently instead of sequentially.
     for (int lw = 0; lw < n_wires; lw++) {
       all_reduce_wire<MAX_DIR>(
-          out_ptr, size, chunk_size, size_per_wire, n_wires, lw, reduce_op);
+          in_ptr,
+          out_ptr,
+          size,
+          chunk_size,
+          size_per_wire,
+          n_wires,
+          lw,
+          reduce_op);
     }
   }
 
@@ -102,6 +110,7 @@ class RingImpl {
   // belong to wire lw, so several wires can run concurrently.
   template <int MAX_DIR, typename T, typename ReduceOp>
   void all_reduce_wire(
+      const T* in_ptr,
       T* out_ptr,
       int64_t size,
       int64_t chunk_size,
@@ -130,9 +139,37 @@ class RingImpl {
     }
 
     // First reduce scatter, then all gather. The offsets carry over from the
-    // reduce scatter into the all gather. The only difference between the two
-    // passes is what the recv handler does with the received chunk: reduce it
-    // in place vs. copy it out.
+    // reduce scatter into the all gather. Pick the in place vs out of place
+    // reduction kernel once so the hot loop stays branch free.
+    if (in_ptr == out_ptr) {
+      ring_pass<MAX_DIR, T>(
+          lw,
+          size,
+          chunk_size,
+          size_ * chunk_size,
+          size_per_wire,
+          wire_offset,
+          region_end,
+          send_offset,
+          recv_offset,
+          in_ptr,
+          out_ptr,
+          ReduceRecvOp<ReduceOp, true>{reduce_op});
+    } else {
+      ring_pass<MAX_DIR, T>(
+          lw,
+          size,
+          chunk_size,
+          size_ * chunk_size,
+          size_per_wire,
+          wire_offset,
+          region_end,
+          send_offset,
+          recv_offset,
+          in_ptr,
+          out_ptr,
+          ReduceRecvOp<ReduceOp, false>{reduce_op});
+    }
     ring_pass<MAX_DIR, T>(
         lw,
         size,
@@ -144,17 +181,6 @@ class RingImpl {
         send_offset,
         recv_offset,
         out_ptr,
-        ReduceRecvOp<ReduceOp>{reduce_op});
-    ring_pass<MAX_DIR, T>(
-        lw,
-        size,
-        chunk_size,
-        size_ * chunk_size,
-        size_per_wire,
-        wire_offset,
-        region_end,
-        send_offset,
-        recv_offset,
         out_ptr,
         CopyOp{});
   }
@@ -210,23 +236,25 @@ class RingImpl {
         send_offset,
         recv_offset,
         out_ptr,
+        out_ptr,
         CopyOp{});
   }
 
   // Run size_ - 1 pipelined ring steps for a single wire in every direction.
   //
   // At every step each direction sends its current slice to a neighbor and
-  // receives the neighbor's slice, which recv_op either reduces into or copies
-  // into out_ptr. After each step the send and recv windows rotate around the
-  // ring (direction 0 backward, direction 1 forward). This is the shared engine
+  // receives the neighbor's slice, which recv_op either reduces or copies into
+  // out_ptr. After each step the send and recv windows rotate around the ring
+  // (direction 0 backward, direction 1 forward). This is the shared engine
   // behind both all reduce passes and all gather.
   //
-  // wire_offset is the element offset of this wire's slice within a chunk and
-  // region_end is the element end (within a chunk) of each direction's region.
-  // send_offset and recv_offset are the starting window offsets and are updated
-  // in place so callers can chain passes (the all reduce reuses them). stride
-  // is how many elements a window moves per step (chunk_size for the all
-  // reduce, n_bytes for the all gather) and total is the wrap around modulus.
+  // The first step sends from in_ptr, later steps from out_ptr; this lets the
+  // all reduce seed its output without an up front copy. Callers that stage
+  // into out_ptr (both all gather paths) pass out_ptr for in_ptr. wire_offset
+  // is this wire's element offset within a chunk, region_end the end of each
+  // direction's region. send_offset and recv_offset are the starting windows,
+  // updated in place so callers can chain passes. stride is the elements a
+  // window moves per step and total is the wrap around modulus.
   template <int MAX_DIR, typename T, typename RecvOp>
   inline void ring_pass(
       int lw,
@@ -238,6 +266,7 @@ class RingImpl {
       const int64_t (&region_end)[MAX_DIR],
       int64_t (&send_offset)[MAX_DIR],
       int64_t (&recv_offset)[MAX_DIR],
+      const T* in_ptr,
       T* out_ptr,
       RecvOp recv_op) {
     constexpr int PIPELINE = 2;
@@ -263,6 +292,10 @@ class RingImpl {
     set_limits();
 
     for (int k = 0; k < size_ - 1; k++) {
+      // Step 0 sends this rank's own input; later steps send the accumulated
+      // partial from out_ptr.
+      const T* send_base = (k == 0) ? in_ptr : out_ptr;
+
       // Prefill the pipeline
       int buff = 0;
       while (buff < n_steps && buff < PIPELINE) {
@@ -272,8 +305,8 @@ class RingImpl {
         for (int lr = 0; lr < MAX_DIR; lr++) {
           int64_t offset = wire_offset[lr] + send_count[lr] * N;
           std::copy(
-              out_ptr + send_offset[lr] + offset,
-              out_ptr + send_offset[lr] +
+              send_base + send_offset[lr] + offset,
+              send_base + send_offset[lr] +
                   std::max(offset, std::min(offset + N, send_limits[lr])),
               send_buffer(sz, buff, lr, lw).template begin<T>());
           send_count[lr]++;
@@ -300,8 +333,8 @@ class RingImpl {
           if (work_type == SEND_WR && send_count[lr] < n_steps) {
             int64_t offset = wire_offset[lr] + send_count[lr] * N;
             std::copy(
-                out_ptr + send_offset[lr] + offset,
-                out_ptr + send_offset[lr] +
+                send_base + send_offset[lr] + offset,
+                send_base + send_offset[lr] +
                     std::max(offset, std::min(offset + N, send_limits[lr])),
                 send_buffer(sz, buff, lr, lw).template begin<T>());
             send_to(sz, buff, lr, lw);
@@ -311,8 +344,11 @@ class RingImpl {
 
           else if (work_type == RECV_WR) {
             int64_t offset = wire_offset[lr] + recv_count[lr] * N;
+            // The base operand is this rank's own input for the chunk; the all
+            // gather passes copy and ignore it.
             recv_op(
                 recv_buffer(sz, buff, lr, lw).template begin<T>(),
+                in_ptr + recv_offset[lr] + offset,
                 out_ptr + recv_offset[lr] + offset,
                 std::min(N, recv_limits[lr] - offset));
             recv_count[lr]++;

--- a/mlx/distributed/jaccl/lib/jaccl/ring_impl.h
+++ b/mlx/distributed/jaccl/lib/jaccl/ring_impl.h
@@ -57,14 +57,56 @@ class RingImpl {
       std::memcpy(out_ptr, in_ptr, size * sizeof(T));
     }
 
-    constexpr int PIPELINE = 2;
-    constexpr int WC_NUM = PIPELINE * RING_MAX_CONNS * 2 * MAX_DIR;
     int64_t chunk_size = (size + size_ - 1) / size_;
     int64_t size_per_wire =
         (chunk_size + (MAX_DIR * n_wires) - 1) / (MAX_DIR * n_wires);
+
+    // Split the reduce scatter + all gather across the available wires. Each
+    // wire handles a contiguous slice of each chunk in every direction.
+    //
+    // TODO: These calls are independent so they should be dispatched to a
+    // threadpool and run concurrently instead of sequentially.
+    for (int lw = 0; lw < n_wires; lw++) {
+      all_reduce_wire<MAX_DIR>(
+          out_ptr, size, chunk_size, size_per_wire, n_wires, lw, reduce_op);
+    }
+  }
+
+  // Perform the ring all reduce (reduce scatter followed by all gather) for a
+  // single wire `lw`.
+  //
+  // Every chunk of `chunk_size` elements is divided into `MAX_DIR` directional
+  // regions and each region is further split into `n_wires` contiguous slices
+  // of `size_per_wire` elements. This function is responsible for slice `lw` in
+  // every direction and only touches `left_[lw]` / `right_[lw]` and the buffers
+  // that belong to wire `lw`, so several wires can run concurrently.
+  template <int MAX_DIR, typename T, typename ReduceOp>
+  void all_reduce_wire(
+      T* out_ptr,
+      int64_t size,
+      int64_t chunk_size,
+      int64_t size_per_wire,
+      int n_wires,
+      int lw,
+      ReduceOp reduce_op) {
+    constexpr int PIPELINE = 2;
+    constexpr int WC_NUM = PIPELINE * 2 * MAX_DIR;
     auto [sz, N] = buffer_size_from_message(size_per_wire * sizeof(T));
     N /= sizeof(T);
     int64_t n_steps = (size_per_wire + N - 1) / N;
+
+    // The element offset (within a chunk) of this wire's slice in each
+    // direction and the end of each direction's region. Wire slices are
+    // contiguous rather than interleaved. Direction `lr` owns the chunk region
+    // [lr * n_wires * size_per_wire, (lr + 1) * n_wires * size_per_wire) (the
+    // last region is clamped to chunk_size).
+    int64_t wire_offset[MAX_DIR];
+    int64_t region_end[MAX_DIR];
+    for (int lr = 0; lr < MAX_DIR; lr++) {
+      wire_offset[lr] = lr * n_wires * size_per_wire +
+          static_cast<int64_t>(lw) * size_per_wire;
+      region_end[lr] = std::min(chunk_size, (lr + 1) * n_wires * size_per_wire);
+    }
 
     // Counters to maintain the state of transfers
     int in_flight = 0;
@@ -73,26 +115,21 @@ class RingImpl {
     int64_t recv_offset[MAX_DIR];
     int64_t send_limits[MAX_DIR];
     int64_t recv_limits[MAX_DIR];
-    int send_count[MAX_DIR * RING_MAX_CONNS] = {0};
-    int recv_count[MAX_DIR * RING_MAX_CONNS] = {0};
+    int send_count[MAX_DIR] = {0};
+    int recv_count[MAX_DIR] = {0};
     send_offset[0] = rank_ * chunk_size;
     recv_offset[0] = ((rank_ + size_ - 1) % size_) * chunk_size;
+    send_limits[0] =
+        std::min(region_end[0], std::max<int64_t>(0, size - send_offset[0]));
+    recv_limits[0] =
+        std::min(region_end[0], std::max<int64_t>(0, size - recv_offset[0]));
     if constexpr (MAX_DIR == 2) {
       send_offset[1] = rank_ * chunk_size;
       recv_offset[1] = ((rank_ + 1) % size_) * chunk_size;
-      send_limits[0] = std::min(
-          n_wires * size_per_wire, std::max<int64_t>(0, size - send_offset[0]));
       send_limits[1] =
-          std::min(chunk_size, std::max<int64_t>(0, size - send_offset[1]));
-      recv_limits[0] = std::min(
-          n_wires * size_per_wire, std::max<int64_t>(0, size - recv_offset[0]));
+          std::min(region_end[1], std::max<int64_t>(0, size - send_offset[1]));
       recv_limits[1] =
-          std::min(chunk_size, std::max<int64_t>(0, size - recv_offset[1]));
-    } else {
-      send_limits[0] =
-          std::min(chunk_size, std::max<int64_t>(0, size - send_offset[0]));
-      recv_limits[0] =
-          std::min(chunk_size, std::max<int64_t>(0, size - recv_offset[0]));
+          std::min(region_end[1], std::max<int64_t>(0, size - recv_offset[1]));
     }
 
     // First reduce scatter
@@ -103,24 +140,22 @@ class RingImpl {
       // Prefill the pipeline
       int buff = 0;
       while (buff < n_steps && buff < PIPELINE) {
-        post_recv_all<MAX_DIR>(sz, buff, n_wires);
         for (int lr = 0; lr < MAX_DIR; lr++) {
-          for (int lw = 0; lw < n_wires; lw++) {
-            int64_t offset = lw * N +
-                send_count[lr * RING_MAX_CONNS + lw] * n_wires * N +
-                lr * n_wires * size_per_wire;
-            std::copy(
-                out_ptr + send_offset[lr] + offset,
-                out_ptr + send_offset[lr] +
-                    std::max(offset, std::min(offset + N, send_limits[lr])),
-                send_buffer(sz, buff, lr, lw).begin<T>());
-            send_count[lr * RING_MAX_CONNS + lw]++;
-          }
+          recv_from(sz, buff, lr, lw);
         }
-        post_send_all<MAX_DIR>(sz, buff, n_wires);
+        for (int lr = 0; lr < MAX_DIR; lr++) {
+          int64_t offset = wire_offset[lr] + send_count[lr] * N;
+          std::copy(
+              out_ptr + send_offset[lr] + offset,
+              out_ptr + send_offset[lr] +
+                  std::max(offset, std::min(offset + N, send_limits[lr])),
+              send_buffer(sz, buff, lr, lw).begin<T>());
+          send_count[lr]++;
+          send_to(sz, buff, lr, lw);
+        }
 
         buff++;
-        in_flight += 2 * MAX_DIR * n_wires;
+        in_flight += 2 * MAX_DIR;
       }
 
       // Main loop
@@ -128,19 +163,16 @@ class RingImpl {
       // Keep going until we have no longer data in flight.
       while (in_flight > 0) {
         ibv_wc wc[WC_NUM];
-        int n = poll(left_, right_, WC_NUM, wc);
+        int n = poll_wire(lw, WC_NUM, wc);
         for (int i = 0; i < n; i++) {
           int work_type = wc[i].wr_id >> 16;
           int buff = (wc[i].wr_id >> 8) & 0xff;
-          int wire = wc[i].wr_id & 0xff;
-          int lr = wire / RING_MAX_CONNS;
-          int lw = wire % RING_MAX_CONNS;
+          int lr = wc[i].wr_id & 0xff;
 
           in_flight--;
 
-          if (work_type == SEND_WR && send_count[wire] < n_steps) {
-            int64_t offset = lw * N + send_count[wire] * n_wires * N +
-                lr * n_wires * size_per_wire;
+          if (work_type == SEND_WR && send_count[lr] < n_steps) {
+            int64_t offset = wire_offset[lr] + send_count[lr] * N;
             std::copy(
                 out_ptr + send_offset[lr] + offset,
                 out_ptr + send_offset[lr] +
@@ -148,18 +180,17 @@ class RingImpl {
                 send_buffer(sz, buff, lr, lw).begin<T>());
             send_to(sz, buff, lr, lw);
             in_flight++;
-            send_count[wire]++;
+            send_count[lr]++;
           }
 
           else if (work_type == RECV_WR) {
-            int64_t offset = lw * N + recv_count[wire] * n_wires * N +
-                lr * n_wires * size_per_wire;
+            int64_t offset = wire_offset[lr] + recv_count[lr] * N;
             reduce_op(
                 recv_buffer(sz, buff, lr, lw).begin<T>(),
                 out_ptr + recv_offset[lr] + offset,
                 std::max<int64_t>(0, std::min(N, recv_limits[lr] - offset)));
-            recv_count[wire]++;
-            if (recv_count[wire] + (PIPELINE - 1) < n_steps) {
+            recv_count[lr]++;
+            if (recv_count[lr] + (PIPELINE - 1) < n_steps) {
               recv_from(sz, buff, lr, lw);
               in_flight++;
             }
@@ -171,27 +202,20 @@ class RingImpl {
           chunk_multiple_size;
       recv_offset[0] = (recv_offset[0] + chunk_multiple_size - chunk_size) %
           chunk_multiple_size;
+      send_limits[0] =
+          std::min(region_end[0], std::max<int64_t>(0, size - send_offset[0]));
+      recv_limits[0] =
+          std::min(region_end[0], std::max<int64_t>(0, size - recv_offset[0]));
       if constexpr (MAX_DIR == 2) {
         send_offset[1] = (send_offset[1] + chunk_size) % chunk_multiple_size;
         recv_offset[1] = (recv_offset[1] + chunk_size) % chunk_multiple_size;
-        send_limits[0] = std::min(
-            n_wires * size_per_wire,
-            std::max<int64_t>(0, size - send_offset[0]));
-        send_limits[1] =
-            std::min(chunk_size, std::max<int64_t>(0, size - send_offset[1]));
-        recv_limits[0] = std::min(
-            n_wires * size_per_wire,
-            std::max<int64_t>(0, size - recv_offset[0]));
-        recv_limits[1] =
-            std::min(chunk_size, std::max<int64_t>(0, size - recv_offset[1]));
-      } else {
-        send_limits[0] =
-            std::min(chunk_size, std::max<int64_t>(0, size - send_offset[0]));
-        recv_limits[0] =
-            std::min(chunk_size, std::max<int64_t>(0, size - recv_offset[0]));
+        send_limits[1] = std::min(
+            region_end[1], std::max<int64_t>(0, size - send_offset[1]));
+        recv_limits[1] = std::min(
+            region_end[1], std::max<int64_t>(0, size - recv_offset[1]));
       }
-      for (int i = 0; i < MAX_DIR * RING_MAX_CONNS; i++) {
-        send_count[i] = recv_count[i] = 0;
+      for (int lr = 0; lr < MAX_DIR; lr++) {
+        send_count[lr] = recv_count[lr] = 0;
       }
     }
 
@@ -202,24 +226,22 @@ class RingImpl {
       // Prefill the pipeline
       int buff = 0;
       while (buff < n_steps && buff < PIPELINE) {
-        post_recv_all<MAX_DIR>(sz, buff, n_wires);
         for (int lr = 0; lr < MAX_DIR; lr++) {
-          for (int lw = 0; lw < n_wires; lw++) {
-            int64_t offset = lw * N +
-                send_count[lr * RING_MAX_CONNS + lw] * n_wires * N +
-                lr * n_wires * size_per_wire;
-            std::copy(
-                out_ptr + send_offset[lr] + offset,
-                out_ptr + send_offset[lr] +
-                    std::max(offset, std::min(offset + N, send_limits[lr])),
-                send_buffer(sz, buff, lr, lw).begin<T>());
-            send_count[lr * RING_MAX_CONNS + lw]++;
-          }
+          recv_from(sz, buff, lr, lw);
         }
-        post_send_all<MAX_DIR>(sz, buff, n_wires);
+        for (int lr = 0; lr < MAX_DIR; lr++) {
+          int64_t offset = wire_offset[lr] + send_count[lr] * N;
+          std::copy(
+              out_ptr + send_offset[lr] + offset,
+              out_ptr + send_offset[lr] +
+                  std::max(offset, std::min(offset + N, send_limits[lr])),
+              send_buffer(sz, buff, lr, lw).begin<T>());
+          send_count[lr]++;
+          send_to(sz, buff, lr, lw);
+        }
 
         buff++;
-        in_flight += 2 * MAX_DIR * n_wires;
+        in_flight += 2 * MAX_DIR;
       }
 
       // Main loop
@@ -227,19 +249,16 @@ class RingImpl {
       // Keep going until we have no longer data in flight.
       while (in_flight > 0) {
         ibv_wc wc[WC_NUM];
-        int n = poll(left_, right_, WC_NUM, wc);
+        int n = poll_wire(lw, WC_NUM, wc);
         for (int i = 0; i < n; i++) {
           int work_type = wc[i].wr_id >> 16;
           int buff = (wc[i].wr_id >> 8) & 0xff;
-          int wire = wc[i].wr_id & 0xff;
-          int lr = wire / RING_MAX_CONNS;
-          int lw = wire % RING_MAX_CONNS;
+          int lr = wc[i].wr_id & 0xff;
 
           in_flight--;
 
-          if (work_type == SEND_WR && send_count[wire] < n_steps) {
-            int64_t offset = lw * N + send_count[wire] * n_wires * N +
-                lr * n_wires * size_per_wire;
+          if (work_type == SEND_WR && send_count[lr] < n_steps) {
+            int64_t offset = wire_offset[lr] + send_count[lr] * N;
             std::copy(
                 out_ptr + send_offset[lr] + offset,
                 out_ptr + send_offset[lr] +
@@ -247,19 +266,18 @@ class RingImpl {
                 send_buffer(sz, buff, lr, lw).begin<T>());
             send_to(sz, buff, lr, lw);
             in_flight++;
-            send_count[wire]++;
+            send_count[lr]++;
           }
 
           else if (work_type == RECV_WR) {
-            int64_t offset = lw * N + recv_count[wire] * n_wires * N +
-                lr * n_wires * size_per_wire;
+            int64_t offset = wire_offset[lr] + recv_count[lr] * N;
             std::copy(
                 recv_buffer(sz, buff, lr, lw).begin<T>(),
                 recv_buffer(sz, buff, lr, lw).begin<T>() +
                     std::max<int64_t>(0, std::min(N, recv_limits[lr] - offset)),
                 out_ptr + recv_offset[lr] + offset);
-            recv_count[wire]++;
-            if (recv_count[wire] + (PIPELINE - 1) < n_steps) {
+            recv_count[lr]++;
+            if (recv_count[lr] + (PIPELINE - 1) < n_steps) {
               recv_from(sz, buff, lr, lw);
               in_flight++;
             }
@@ -271,27 +289,20 @@ class RingImpl {
           chunk_multiple_size;
       recv_offset[0] = (recv_offset[0] + chunk_multiple_size - chunk_size) %
           chunk_multiple_size;
+      send_limits[0] =
+          std::min(region_end[0], std::max<int64_t>(0, size - send_offset[0]));
+      recv_limits[0] =
+          std::min(region_end[0], std::max<int64_t>(0, size - recv_offset[0]));
       if constexpr (MAX_DIR == 2) {
         send_offset[1] = (send_offset[1] + chunk_size) % chunk_multiple_size;
         recv_offset[1] = (recv_offset[1] + chunk_size) % chunk_multiple_size;
-        send_limits[0] = std::min(
-            n_wires * size_per_wire,
-            std::max<int64_t>(0, size - send_offset[0]));
-        send_limits[1] =
-            std::min(chunk_size, std::max<int64_t>(0, size - send_offset[1]));
-        recv_limits[0] = std::min(
-            n_wires * size_per_wire,
-            std::max<int64_t>(0, size - recv_offset[0]));
-        recv_limits[1] =
-            std::min(chunk_size, std::max<int64_t>(0, size - recv_offset[1]));
-      } else {
-        send_limits[0] =
-            std::min(chunk_size, std::max<int64_t>(0, size - send_offset[0]));
-        recv_limits[0] =
-            std::min(chunk_size, std::max<int64_t>(0, size - recv_offset[0]));
+        send_limits[1] = std::min(
+            region_end[1], std::max<int64_t>(0, size - send_offset[1]));
+        recv_limits[1] = std::min(
+            region_end[1], std::max<int64_t>(0, size - recv_offset[1]));
       }
-      for (int i = 0; i < MAX_DIR * RING_MAX_CONNS; i++) {
-        send_count[i] = recv_count[i] = 0;
+      for (int lr = 0; lr < MAX_DIR; lr++) {
+        send_count[lr] = recv_count[lr] = 0;
       }
     }
   }
@@ -301,25 +312,52 @@ class RingImpl {
     // Copy our data to the appropriate place
     std::memcpy(out_ptr + rank_ * n_bytes, in_ptr, n_bytes);
 
-    constexpr int PIPELINE = 2;
-    constexpr int WC_NUM = PIPELINE * RING_MAX_CONNS * 2 * 2;
+    // Split the all gather across the available wires. Each wire handles a
+    // contiguous slice of every rank's data in both directions.
+    //
+    // TODO: These calls are independent so they should be dispatched to a
+    // threadpool and run concurrently instead of sequentially.
     size_t n_bytes_per_wire = (n_bytes + (2 * n_wires) - 1) / (2 * n_wires);
+    for (int lw = 0; lw < n_wires; lw++) {
+      all_gather_wire(out_ptr, n_bytes, n_bytes_per_wire, lw);
+    }
+  }
+
+  // Perform the ring all gather for a single wire `lw`.
+  //
+  // The wire is responsible for the contiguous slice
+  //   [lw * n_bytes_per_wire, (lw + 1) * n_bytes_per_wire)
+  // of every rank's `n_bytes` region, sent in the left direction (lr == 0),
+  // and the mirrored slice sent in the right direction (lr == 1).
+  //
+  // This function only ever touches `left_[lw]` / `right_[lw]` and the buffers
+  // that belong to wire `lw` so several wires can run concurrently.
+  void all_gather_wire(
+      char* out_ptr,
+      int64_t n_bytes,
+      size_t n_bytes_per_wire,
+      int lw) {
+    constexpr int PIPELINE = 2;
+    constexpr int WC_NUM = PIPELINE * 2;
     size_t out_bytes = n_bytes * size_;
     auto [sz, N] = buffer_size_from_message(n_bytes_per_wire);
     int n_steps = (n_bytes_per_wire + N - 1) / N;
+
+    // The byte offset (within a rank's region) that this wire is responsible
+    // for. Wire slices are contiguous rather than interleaved.
+    int64_t wire_offset = static_cast<int64_t>(lw) * n_bytes_per_wire;
 
     // Counters to maintain the state of transfers
     int in_flight = 0;
     int64_t send_offset[2];
     int64_t recv_offset[2];
     int64_t limits[2];
-    int send_count[2 * RING_MAX_CONNS] = {0};
-    int recv_count[2 * RING_MAX_CONNS] = {0};
+    int send_count[2] = {0};
+    int recv_count[2] = {0};
     send_offset[0] = send_offset[1] = rank_ * n_bytes;
     recv_offset[0] = ((rank_ + size_ - 1) % size_) * n_bytes;
     recv_offset[1] = ((rank_ + 1) % size_) * n_bytes;
-    limits[0] = n_wires * n_bytes_per_wire;
-    limits[1] = n_bytes;
+    limits[0] = limits[1] = n_bytes;
 
     // Possible perf improvement by not syncing at every step but running ahead
     // as needed.
@@ -327,24 +365,22 @@ class RingImpl {
       // Prefill the pipeline
       int buff = 0;
       while (buff < n_steps && buff < PIPELINE) {
-        post_recv_all(sz, buff);
         for (int lr = 0; lr < 2; lr++) {
-          for (int lw = 0; lw < n_wires; lw++) {
-            int64_t offset = lw * N +
-                send_count[lr * RING_MAX_CONNS + lw] * n_wires * N +
-                lr * n_wires * n_bytes_per_wire;
-            std::copy(
-                out_ptr + send_offset[lr] + offset,
-                out_ptr + send_offset[lr] +
-                    std::max(offset, std::min(offset + N, limits[lr])),
-                send_buffer(sz, buff, lr, lw).begin<char>());
-            send_count[lr * RING_MAX_CONNS + lw]++;
-          }
+          recv_from(sz, buff, lr, lw);
         }
-        post_send_all(sz, buff);
+        for (int lr = 0; lr < 2; lr++) {
+          int64_t offset = wire_offset + send_count[lr] * N;
+          std::copy(
+              out_ptr + send_offset[lr] + offset,
+              out_ptr + send_offset[lr] +
+                  std::max(offset, std::min(offset + N, limits[lr])),
+              send_buffer(sz, buff, lr, lw).begin<char>());
+          send_count[lr]++;
+          send_to(sz, buff, lr, lw);
+        }
 
         buff++;
-        in_flight += 2 * 2 * n_wires;
+        in_flight += 2 * 2;
       }
 
       // Main loop
@@ -352,19 +388,16 @@ class RingImpl {
       // Keep going until we have no longer data in flight.
       while (in_flight > 0) {
         ibv_wc wc[WC_NUM];
-        int n = poll(left_, right_, WC_NUM, wc);
+        int n = poll_wire(lw, WC_NUM, wc);
         for (int i = 0; i < n; i++) {
           int work_type = wc[i].wr_id >> 16;
           int buff = (wc[i].wr_id >> 8) & 0xff;
-          int wire = wc[i].wr_id & 0xff;
-          int lr = wire / RING_MAX_CONNS;
-          int lw = wire % RING_MAX_CONNS;
+          int lr = wc[i].wr_id & 0xff;
 
           in_flight--;
 
-          if (work_type == SEND_WR && send_count[wire] < n_steps) {
-            int64_t offset = lw * N + send_count[wire] * n_wires * N +
-                lr * n_wires * n_bytes_per_wire;
+          if (work_type == SEND_WR && send_count[lr] < n_steps) {
+            int64_t offset = wire_offset + send_count[lr] * N;
             std::copy(
                 out_ptr + send_offset[lr] + offset,
                 out_ptr + send_offset[lr] +
@@ -372,19 +405,18 @@ class RingImpl {
                 send_buffer(sz, buff, lr, lw).begin<char>());
             send_to(sz, buff, lr, lw);
             in_flight++;
-            send_count[wire]++;
+            send_count[lr]++;
           }
 
           else if (work_type == RECV_WR) {
-            int64_t offset = lw * N + recv_count[wire] * n_wires * N +
-                lr * n_wires * n_bytes_per_wire;
+            int64_t offset = wire_offset + recv_count[lr] * N;
             std::copy(
                 recv_buffer(sz, buff, lr, lw).begin<char>(),
                 recv_buffer(sz, buff, lr, lw).begin<char>() +
                     std::max<int64_t>(0, std::min(N, limits[lr] - offset)),
                 out_ptr + recv_offset[lr] + offset);
-            recv_count[wire]++;
-            if (recv_count[wire] + (PIPELINE - 1) < n_steps) {
+            recv_count[lr]++;
+            if (recv_count[lr] + (PIPELINE - 1) < n_steps) {
               recv_from(sz, buff, lr, lw);
               in_flight++;
             }
@@ -396,9 +428,8 @@ class RingImpl {
       recv_offset[0] = (recv_offset[0] + out_bytes - n_bytes) % out_bytes;
       send_offset[1] = (send_offset[1] + n_bytes) % out_bytes;
       recv_offset[1] = (recv_offset[1] + n_bytes) % out_bytes;
-      for (int i = 0; i < 2 * RING_MAX_CONNS; i++) {
-        send_count[i] = recv_count[i] = 0;
-      }
+      send_count[0] = send_count[1] = 0;
+      recv_count[0] = recv_count[1] = 0;
     }
   }
 
@@ -408,37 +439,53 @@ class RingImpl {
     // In the case that size_ == 2 then left == right so we bias send towards
     // left and recv towards right so that the selections will be correct for
     // the 2 node case.
-    auto& conns = (dst == left) ? left_ : right_;
     int dir = dst == left;
 
-    constexpr int PIPELINE = 2;
-    constexpr int WC_NUM = PIPELINE * RING_MAX_CONNS;
-
     int64_t bytes_per_wire = (n_bytes + n_wires - 1) / n_wires;
+
+    // Split the send across the available wires. Each wire handles the
+    // contiguous slice [lw * bytes_per_wire, (lw + 1) * bytes_per_wire).
+    //
+    // TODO: These calls are independent so they should be dispatched to a
+    // threadpool and run concurrently instead of sequentially.
+    for (int lw = 0; lw < n_wires; lw++) {
+      send_wire(in_ptr, n_bytes, dir, bytes_per_wire, lw);
+    }
+  }
+
+  // Perform a point-to-point send for a single wire `lw`.
+  //
+  // Only touches the connection / buffers of wire `lw` so several wires can run
+  // concurrently.
+  void send_wire(
+      const char* in_ptr,
+      int64_t n_bytes,
+      int dir,
+      int64_t bytes_per_wire,
+      int lw) {
+    auto& conns = dir ? left_ : right_;
+
+    constexpr int PIPELINE = 2;
+    constexpr int WC_NUM = PIPELINE;
+
     auto [sz, N] = buffer_size_from_message(bytes_per_wire);
 
     int in_flight = 0;
-    int64_t read_offset[RING_MAX_CONNS];
-    int64_t limits[RING_MAX_CONNS];
-    for (int lw = 0; lw < n_wires; lw++) {
-      read_offset[lw] = std::min(lw * bytes_per_wire, n_bytes);
-      limits[lw] = std::min((lw + 1) * bytes_per_wire, n_bytes);
-    }
+    int64_t read_offset = std::min(lw * bytes_per_wire, n_bytes);
+    int64_t limit = std::min((lw + 1) * bytes_per_wire, n_bytes);
 
     // Prefill the pipeline
-    for (int lw = 0; lw < n_wires; lw++) {
-      int buff = 0;
-      while (read_offset[lw] < limits[lw] && buff < PIPELINE) {
-        std::copy(
-            in_ptr + read_offset[lw],
-            in_ptr + std::min(read_offset[lw] + N, limits[lw]),
-            send_buffer(sz, buff, dir, lw).begin<char>());
-        send_to(sz, buff, dir, lw);
+    int buff = 0;
+    while (read_offset < limit && buff < PIPELINE) {
+      std::copy(
+          in_ptr + read_offset,
+          in_ptr + std::min(read_offset + N, limit),
+          send_buffer(sz, buff, dir, lw).begin<char>());
+      send_to(sz, buff, dir, lw);
 
-        buff++;
-        read_offset[lw] += N;
-        in_flight++;
-      }
+      buff++;
+      read_offset += N;
+      in_flight++;
     }
 
     // Main loop
@@ -448,22 +495,20 @@ class RingImpl {
       // If a send was completed and we have more data to send then go ahead
       // and send them.
       ibv_wc wc[WC_NUM];
-      int n = poll(conns, WC_NUM, wc);
+      int n = conns[lw].poll(WC_NUM, wc);
       for (int i = 0; i < n; i++) {
         int buff = (wc[i].wr_id >> 8) & 0xff;
-        int wire = wc[i].wr_id & 0xff;
-        int lw = wire % RING_MAX_CONNS;
 
         in_flight--;
 
-        if (read_offset[lw] < limits[lw]) {
+        if (read_offset < limit) {
           std::copy(
-              in_ptr + read_offset[lw],
-              in_ptr + std::min(read_offset[lw] + N, limits[lw]),
+              in_ptr + read_offset,
+              in_ptr + std::min(read_offset + N, limit),
               send_buffer(sz, buff, dir, lw).begin<char>());
           send_to(sz, buff, dir, lw);
 
-          read_offset[lw] += N;
+          read_offset += N;
           in_flight++;
         }
       }
@@ -476,32 +521,48 @@ class RingImpl {
     // In the case that size_ == 2 then left == right so we bias send towards
     // left and recv towards right so that the selections will be correct for
     // the 2 node case.
-    auto& conns = (src == right) ? right_ : left_;
     int dir = src == right;
 
-    constexpr int PIPELINE = 2;
-    constexpr int WC_NUM = PIPELINE * RING_MAX_CONNS;
-
     int64_t bytes_per_wire = (n_bytes + n_wires - 1) / n_wires;
+
+    // Split the recv across the available wires. Each wire handles the
+    // contiguous slice [lw * bytes_per_wire, (lw + 1) * bytes_per_wire).
+    //
+    // TODO: These calls are independent so they should be dispatched to a
+    // threadpool and run concurrently instead of sequentially.
+    for (int lw = 0; lw < n_wires; lw++) {
+      recv_wire(out_ptr, n_bytes, dir, bytes_per_wire, lw);
+    }
+  }
+
+  // Perform a point-to-point recv for a single wire `lw`.
+  //
+  // Only touches the connection / buffers of wire `lw` so several wires can run
+  // concurrently.
+  void recv_wire(
+      char* out_ptr,
+      int64_t n_bytes,
+      int dir,
+      int64_t bytes_per_wire,
+      int lw) {
+    auto& conns = dir ? right_ : left_;
+
+    constexpr int PIPELINE = 2;
+    constexpr int WC_NUM = PIPELINE;
+
     auto [sz, N] = buffer_size_from_message(bytes_per_wire);
 
     int in_flight = 0;
-    int64_t write_offset[RING_MAX_CONNS];
-    int64_t limits[RING_MAX_CONNS];
-    for (int lw = 0; lw < n_wires; lw++) {
-      write_offset[lw] = std::min(lw * bytes_per_wire, n_bytes);
-      limits[lw] = std::min((lw + 1) * bytes_per_wire, n_bytes);
-    }
+    int64_t write_offset = std::min(lw * bytes_per_wire, n_bytes);
+    int64_t limit = std::min((lw + 1) * bytes_per_wire, n_bytes);
 
     // Prefill the pipeline
-    for (int lw = 0; lw < n_wires; lw++) {
-      int buff = 0;
-      while (N * buff < limits[lw] - write_offset[lw] && buff < PIPELINE) {
-        recv_from(sz, buff, dir, lw);
+    int buff = 0;
+    while (write_offset + N * buff < limit && buff < PIPELINE) {
+      recv_from(sz, buff, dir, lw);
 
-        buff++;
-        in_flight++;
-      }
+      buff++;
+      in_flight++;
     }
 
     // Main loop
@@ -511,11 +572,9 @@ class RingImpl {
       // If a recv was completed copy it to the output and if we have more
       // data to fetch post another recv.
       ibv_wc wc[WC_NUM];
-      int n = poll(conns, WC_NUM, wc);
+      int n = conns[lw].poll(WC_NUM, wc);
       for (int i = 0; i < n; i++) {
         int buff = (wc[i].wr_id >> 8) & 0xff;
-        int wire = wc[i].wr_id & 0xff;
-        int lw = wire % RING_MAX_CONNS;
 
         in_flight--;
 
@@ -523,11 +582,11 @@ class RingImpl {
             recv_buffer(sz, buff, dir, lw).begin<char>(),
             recv_buffer(sz, buff, dir, lw).begin<char>() +
                 std::max<int64_t>(
-                    0, std::min<int64_t>(limits[lw] - write_offset[lw], N)),
-            out_ptr + write_offset[lw]);
-        write_offset[lw] += N;
+                    0, std::min<int64_t>(limit - write_offset, N)),
+            out_ptr + write_offset);
+        write_offset += N;
 
-        if (write_offset[lw] + (PIPELINE - 1) * N < limits[lw]) {
+        if (write_offset + (PIPELINE - 1) * N < limit) {
           recv_from(sz, buff, dir, lw);
 
           in_flight++;
@@ -538,36 +597,17 @@ class RingImpl {
 
  private:
   void send_to(int sz, int buff, int left_right, int wire) {
-    if (left_right) {
-      left_[wire].post_send(
-          send_buffer_left(sz, buff, wire),
-          SEND_WR << 16 | buff << 8 | (RING_MAX_CONNS + wire));
-    } else {
-      right_[wire].post_send(
-          send_buffer_right(sz, buff, wire), SEND_WR << 16 | buff << 8 | wire);
-    }
+    auto& conns = left_right ? left_ : right_;
+    conns[wire].post_send(
+        send_buffer(sz, buff, left_right, wire),
+        SEND_WR << 16 | buff << 8 | left_right);
   }
 
   void recv_from(int sz, int buff, int left_right, int wire) {
-    if (left_right) {
-      right_[wire].post_recv(
-          recv_buffer_right(sz, buff, wire),
-          RECV_WR << 16 | buff << 8 | (RING_MAX_CONNS + wire));
-    } else {
-      left_[wire].post_recv(
-          recv_buffer_left(sz, buff, wire), RECV_WR << 16 | buff << 8 | wire);
-    }
-  }
-
-  SharedBuffer& send_buffer_right(int sz, int buff, int wire) {
-    return send_buffers_
-        [sz * NUM_BUFFERS * n_conns_ * 2 + buff * n_conns_ * 2 + wire];
-  }
-
-  SharedBuffer& send_buffer_left(int sz, int buff, int wire) {
-    return send_buffers_
-        [sz * NUM_BUFFERS * n_conns_ * 2 + buff * n_conns_ * 2 + n_conns_ +
-         wire];
+    auto& conns = left_right ? right_ : left_;
+    conns[wire].post_recv(
+        recv_buffer(sz, buff, left_right, wire),
+        RECV_WR << 16 | buff << 8 | left_right);
   }
 
   SharedBuffer& send_buffer(int sz, int buff, int left_right, int wire) {
@@ -576,47 +616,24 @@ class RingImpl {
          left_right * n_conns_ + wire];
   }
 
-  SharedBuffer& recv_buffer_left(int sz, int buff, int wire) {
-    return recv_buffers_
-        [sz * NUM_BUFFERS * n_conns_ * 2 + buff * n_conns_ * 2 + wire];
-  }
-
-  SharedBuffer& recv_buffer_right(int sz, int buff, int wire) {
-    return recv_buffers_
-        [sz * NUM_BUFFERS * n_conns_ * 2 + buff * n_conns_ * 2 + n_conns_ +
-         wire];
-  }
-
   SharedBuffer& recv_buffer(int sz, int buff, int left_right, int wire) {
     return recv_buffers_
         [sz * NUM_BUFFERS * n_conns_ * 2 + buff * n_conns_ * 2 +
          left_right * n_conns_ + wire];
   }
 
-  template <int MAX_DIR>
-  void post_recv_all(int sz, int buff, int n_wires) {
-    for (int lr = 0; lr < MAX_DIR; lr++) {
-      for (int lw = 0; lw < n_wires; lw++) {
-        recv_from(sz, buff, lr, lw);
-      }
-    }
-  }
-
-  void post_recv_all(int sz, int buff) {
-    post_recv_all<2>(sz, buff, n_conns_);
-  }
-
-  template <int MAX_DIR>
-  void post_send_all(int sz, int buff, int n_wires) {
-    for (int lr = 0; lr < MAX_DIR; lr++) {
-      for (int lw = 0; lw < n_wires; lw++) {
-        send_to(sz, buff, lr, lw);
-      }
-    }
-  }
-
-  void post_send_all(int sz, int buff) {
-    post_send_all<2>(sz, buff, n_conns_);
+  // Poll the completion queues that belong to a single wire.
+  //
+  // A wire always uses both its left and right connections (direction 0 sends
+  // right / receives left, direction 1 sends left / receives right) so both are
+  // polled here. Restricting polling to a single wire's connections is what
+  // allows several wires to run concurrently.
+  int poll_wire(int wire, int num_completions, ibv_wc* work_completions) {
+    return poll(
+        std::span<Connection>(&left_[wire], 1),
+        std::span<Connection>(&right_[wire], 1),
+        num_completions,
+        work_completions);
   }
 
   int rank_;

--- a/mlx/distributed/jaccl/lib/jaccl/threadpool.h
+++ b/mlx/distributed/jaccl/lib/jaccl/threadpool.h
@@ -1,0 +1,137 @@
+// This code was modified from https://github.com/progschj/ThreadPool
+// The original License is copied below:
+//
+// Copyright (c) 2012 Jakob Progsch, Václav Zeman
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+//    1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+//
+//    2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+//
+//    3. This notice may not be removed or altered from any source
+//    distribution.
+#pragma once
+
+#include <condition_variable>
+#include <functional>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <stdexcept>
+#include <thread>
+#include <vector>
+
+namespace jaccl {
+
+class ThreadPool {
+ public:
+  ThreadPool(size_t);
+  template <class F, class... Args>
+  auto enqueue(F&& f, Args&&... args)
+      -> std::future<typename std::invoke_result_t<F, Args...>>;
+  void resize(size_t);
+  ~ThreadPool();
+
+ private:
+  void stop_and_wait();
+  void start_threads(size_t);
+
+  std::vector<std::thread> workers;
+  std::queue<std::function<void()>> tasks;
+  std::mutex queue_mutex;
+  std::condition_variable condition;
+  bool stop;
+};
+
+inline ThreadPool::ThreadPool(size_t threads) : stop(false) {
+  start_threads(threads);
+}
+
+template <class F, class... Args>
+auto ThreadPool::enqueue(F&& f, Args&&... args)
+    -> std::future<typename std::invoke_result_t<F, Args...>> {
+  using return_type = typename std::invoke_result_t<F, Args...>;
+
+  auto task = std::make_shared<std::packaged_task<return_type()>>(
+      std::bind(std::forward<F>(f), std::forward<Args>(args)...));
+
+  std::future<return_type> res = task->get_future();
+  {
+    std::unique_lock<std::mutex> lock(queue_mutex);
+
+    if (stop) {
+      throw std::runtime_error(
+          "[ThreadPool::enqueue] Not allowed on stopped ThreadPool");
+    }
+
+    tasks.emplace([task]() { (*task)(); });
+  }
+  condition.notify_one();
+  return res;
+}
+
+inline void ThreadPool::resize(size_t threads) {
+  if (workers.size() == threads) {
+    return;
+  }
+
+  if (workers.size() > threads) {
+    stop_and_wait();
+  }
+  start_threads(threads - workers.size());
+}
+
+inline ThreadPool::~ThreadPool() {
+  stop_and_wait();
+}
+
+inline void ThreadPool::stop_and_wait() {
+  // Stop the current threads and wait until they finish
+  {
+    std::unique_lock<std::mutex> lock(queue_mutex);
+    stop = true;
+  }
+  condition.notify_all();
+  for (std::thread& worker : workers) {
+    worker.join();
+  }
+
+  // Reset the member variables so that the threadpool is reusable
+  stop = false;
+  workers.clear();
+}
+
+inline void ThreadPool::start_threads(size_t threads) {
+  for (size_t i = 0; i < threads; ++i) {
+    workers.emplace_back([this] {
+      for (;;) {
+        std::function<void()> task;
+
+        {
+          std::unique_lock<std::mutex> lock(this->queue_mutex);
+          this->condition.wait(
+              lock, [this] { return this->stop || !this->tasks.empty(); });
+          if (this->stop && this->tasks.empty())
+            return;
+          task = std::move(this->tasks.front());
+          this->tasks.pop();
+        }
+
+        task();
+      }
+    });
+  }
+}
+
+} // namespace jaccl


### PR DESCRIPTION
This is on top of the coordinator changes and I will rebase it when that is merged, for now focus on the changes in the reduction ops and more importantly the ring implementation.

The TL;DR is the following:
- Refactor the ring to extract the ring pass in a standalone function (with copy op or reduction)
- Refactor the reduction ops to support out of place reduction that allows us to avoid the initial copy
- Write a per-wire all reduce and all gather using the ring pass
- Copy the MLX threadpool and use it to dispatch the other wires to different threads

The performance on a single wire is maintained and there should be 0 overhead since that wire runs in the calling thread.

The following is a 2-node multi-wire all_sum before and after
<img width="1430" height="910" alt="ring-bandwidth" src="https://github.com/user-attachments/assets/36ece239-ce09-44bb-a7b0-3f2ce116fd0e" />

And a 4 node all_sum with 2 rings before and after
 
<img width="1820" height="780" alt="ring-4-bench" src="https://github.com/user-attachments/assets/8e6cf391-7065-473c-be5c-2996d23263df" />
