### PR TITLE
Fix step activation docstring to match >= threshold behavior

### DIFF
--- a/python/mlx/nn/layers/activations.py
+++ b/python/mlx/nn/layers/activations.py
@@ -225,7 +225,8 @@ def step(x: mx.array, threshold: float = 0.0):
     r"""Applies the Step Activation Function.
 
     This function implements a binary step activation, where the output is set
-    to 1 if the input is greater than a specified threshold, and 0 otherwise.
+    to 1 if the input is greater than or equal to a specified threshold, and 0
+    otherwise.
 
     .. math::
         \text{step}(x) = \begin{cases}
@@ -234,7 +235,7 @@ def step(x: mx.array, threshold: float = 0.0):
         \end{cases}
 
     Args:
-        threshold: The value to threshold at.
+        threshold: The value to threshold at. Default: ``0.0``.
     """
 
     return mx.where(x >= threshold, 1, 0)
@@ -606,7 +607,8 @@ class Step(Module):
     r"""Applies the Step Activation Function.
 
     This function implements a binary step activation, where the output is set
-    to 1 if the input is greater than a specified threshold, and 0 otherwise.
+    to 1 if the input is greater than or equal to a specified threshold, and 0
+    otherwise.
 
     .. math::
         \text{step}(x) = \begin{cases}
@@ -615,7 +617,7 @@ class Step(Module):
         \end{cases}
 
     Args:
-        threshold: The value to threshold at.
+        threshold: The value to threshold at. Default: ``0.0``.
     """
 
     def __init__(self, threshold: float = 0.0):


### PR DESCRIPTION
## Proposed changes

The `step` function and `Step` module docstrings say the output is "1 if the input is greater than a specified threshold", but the implementation is `mx.where(x >= threshold, 1, 0)` and the math block right below the prose already uses `x >= threshold`. So the prose was the only part that disagreed. Quick check on main:

```python
import mlx.core as mx
import mlx.nn as nn

nn.Step(0.0)(mx.array([-1.0, 0.0, 1.0])).tolist()  # [0, 1, 1]  -> 0 maps to 1, i.e. >=
```

Updated the prose to "greater than or equal to" in both places, and documented the `threshold` default (`0.0`) while I was there.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

(docstring-only, test_nn.py still passes 69/69)

---

quick note: i'm a freshman still learning, and i lean on Claude Code to surface these doc/code mismatches, but i ran the snippet above myself to confirm the boundary value maps to 1 before writing this. happy to adjust if you'd word it differently.
