### PR TITLE
Fix InstanceNorm Shape docstring to require at least 3 dimensions

### DIFF
--- a/python/mlx/nn/layers/normalization.py
+++ b/python/mlx/nn/layers/normalization.py
@@ -25,7 +25,8 @@ class InstanceNorm(Module):
         affine (bool): Default: ``False``.
 
     Shape:
-      - Input: :math:`(..., C)` where :math:`C` is equal to :attr:`dims`.
+      - Input: :math:`(N, ..., C)` where :math:`C` is equal to :attr:`dims`.
+        The input must have at least 3 dimensions.
       - Output: Same shape as the input.
 
     Examples:


### PR DESCRIPTION
## Proposed changes

The `InstanceNorm` docstring Shape section says the input is `(..., C)`, which reads like a 2D `(N, C)` input is allowed, but `__call__` raises for anything with fewer than 3 dimensions:

```python
import mlx.core as mx
import mlx.nn as nn

nn.InstanceNorm(4)(mx.zeros((2, 4)))
# ValueError: InstanceNorm expects inputs with at least 3 dimensions (N, ..., C) ...
```

Updated the Shape line to `(N, ..., C)` and noted the at-least-3-dimensions requirement, matching the error message and the reduction over the spatial axes. Same spirit as the earlier BatchNorm shape doc fix (#3782).

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

(docstring-only, test_nn.py passes 69/69)

---

being honest: freshman here, Claude Code helps me find these mismatches but i reproduced the 3-dimension error above myself and read the reduction axes to make sure the constraint is real before opening this. corrections welcome :)
