### PR TITLE
Pad 2D conv input channels to reach the specialized Metal kernel

### DIFF
--- a/mlx/backend/metal/conv.cpp
+++ b/mlx/backend/metal/conv.cpp
@@ -977,6 +977,36 @@ void depthwise_conv_2D_gpu(
   compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
 }
 
+void pad_in_channels_conv_2D_gpu(
+    const Stream& s,
+    metal::Device& d,
+    const array& in_pre,
+    const array& wt_pre,
+    array& out,
+    const MLXConvParams<2>& conv_params) {
+  // Only the input channels are padded, so the kernel writes straight into out
+  // and the output stays contiguous. Assumes conv_params.groups == 1.
+  int extra_c = ((conv_params.C + 15) / 16) * 16 - conv_params.C;
+
+  // Pad function
+  auto pad_array = [&](const array& x) {
+    auto xshape = x.shape();
+    xshape.back() += extra_c;
+    array x_copy(xshape, x.dtype(), nullptr, {});
+    array zero(0, x.dtype());
+    pad_gpu(x, zero, x_copy, {-1}, {0}, s);
+    metal::get_command_encoder(s).add_temporary(x_copy);
+
+    return x_copy;
+  };
+
+  array in = pad_array(in_pre);
+  array wt = pad_array(wt_pre);
+  auto new_params =
+      MLXConvParams<2>::with_padded_channels(conv_params, 0, extra_c);
+  implicit_gemm_conv_2D_gpu(s, d, in, wt, out, new_params);
+}
+
 void dispatch_conv_2D_gpu(
     const Stream& s,
     metal::Device& d,
@@ -1026,9 +1056,23 @@ void dispatch_conv_2D_gpu(
     return winograd_conv_2D_gpu(s, d, in, wt, out, conv_params, copies);
   }
 
+  // Whether the specialized implicit gemm kernel can take the channels as-is.
+  bool specialized_channels = (conv_params.C <= 4 || conv_params.C % 16 == 0) &&
+      (conv_params.O <= 16 || conv_params.O % 16 == 0);
+
+  // Pad the input channels up to a multiple of 16 to use the faster specialized
+  // kernel instead of the general one. Only worth the padded work for stride-1
+  // convs with a large enough output and kernel, and only when the output
+  // channels are already aligned so the kernel writes contiguously into out
+  // (padding those too needs a copy that can cost more than the kernel saves).
+  bool out_channels_aligned = conv_params.O <= 16 || conv_params.O % 16 == 0;
+  if (is_idil_one && is_stride_one && out_large && !specialized_channels &&
+      out_channels_aligned && (conv_params.wS[0] * conv_params.wS[1]) >= 9) {
+    return pad_in_channels_conv_2D_gpu(s, d, in, wt, out, conv_params);
+  }
+
   // Direct to implicit gemm conv
-  if (is_idil_one && (conv_params.C <= 4 || conv_params.C % 16 == 0) &&
-      (conv_params.O <= 16 || conv_params.O % 16 == 0)) {
+  if (is_idil_one && specialized_channels) {
     return implicit_gemm_conv_2D_gpu(s, d, in, wt, out, conv_params);
   }
 

--- a/python/tests/test_conv.py
+++ b/python/tests/test_conv.py
@@ -1202,6 +1202,18 @@ class TestConv(mlx_tests.MLXTestCase):
         y_hat = mx.conv2d(x, w)
         self.assertTrue(mx.allclose(y, y_hat))
 
+        x = mx.random.uniform(shape=(2, 16, 16, 24))
+        w = mx.random.uniform(shape=(32, 5, 5, 24))
+        y = mx.conv2d(x, w, padding=2, stream=mx.cpu)
+        y_hat = mx.conv2d(x, w, padding=2)
+        self.assertTrue(mx.allclose(y, y_hat))
+
+        x = mx.random.uniform(shape=(2, 16, 16, 24))
+        w = mx.random.uniform(shape=(32, 3, 3, 24))
+        y = mx.conv_transpose2d(x, w, stream=mx.cpu)
+        y_hat = mx.conv_transpose2d(x, w)
+        self.assertTrue(mx.allclose(y, y_hat))
+
     def test_conv2d_large_filter_small_channels(self):
         x = mx.random.normal(shape=(1, 181, 181, 1))
         w = mx.random.normal(shape=(1, 182, 182, 1))


### PR DESCRIPTION
## Proposed changes

A conv whose input channels are not a multiple of 16 misses the specialized implicit gemm kernel and falls to the general one that #2258 added for these shapes. Making that path faster was left open there.

Zero padding the input channels up to a multiple of 16 and running the specialized kernel beats the general kernel on the original shape, even after paying for the padded work.

The gate is narrow. It needs a stride of 1, an output large enough for implicit gemm, a kernel area of at least 9, and output channels that are already aligned. `conv_transpose2d` maps its stride onto an input dilation, so only the stride-1 transpose qualifies.

Leaving the output channels alone lets the kernel write straight into `out`, so nothing is sliced or copied back and the result stays row contiguous.

Weights get the same zero padding, so the added channels contribute nothing to the sum. Output is bit identical to before in `fp32`, `fp16` and `bf16`.

Peak memory during the conv grows by the padded copies of the input and the weights, both released with the command buffer. Over 220 shapes that hit the gate it ran a median of 1.8x and at most 2.4x, worst where the channel count sits just above a multiple of 16 and the kernel is large.

Added two shapes to `test_conv2d_unaligned_channels`.

### Benchmarks

M5 Pro, macOS 27.0, fp32. One shape per process, best of 150 iterations, the two builds measured turn by turn, min of 7 rounds.

| input x weight | before | after | |
|---|---:|---:|---:|
| `(4, 32, 32, 21) x (128, 3, 3, 21)` | 0.194 ms | 0.175 ms | 1.11x |
| `(4, 32, 32, 370) x (128, 7, 7, 370)` | 3.532 ms | 2.281 ms | 1.55x |
| `(16, 56, 56, 40) x (64, 3, 3, 40)` | 0.854 ms | 0.616 ms | 1.39x |
| `(8, 56, 56, 24) x (32, 5, 5, 24)` | 0.511 ms | 0.344 ms | 1.49x |
| `(16, 28, 28, 200) x (256, 3, 3, 200)` | 2.237 ms | 1.925 ms | 1.16x |
| `(16, 224, 224, 40) x (128, 3, 3, 40)` | 22.570 ms | 13.945 ms | 1.62x |
| `(8, 128, 128, 40) x (128, 7, 7, 40)` | 19.232 ms | 10.857 ms | 1.77x |

The first two rows are shapes 1 and 4 from `benchmarks/python/conv_unaligned_bench.py`, and the last two are larger, where the padded work amortizes and the gain grows. Shapes that miss the gate run the same code as before and measured 0.96x to 1.05x, the noise floor of the measurement.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
