### PR TITLE
add runnable data parallel example

### DIFF
--- a/examples/python/data_parallel.py
+++ b/examples/python/data_parallel.py
@@ -1,0 +1,59 @@
+# Copyright © 2026 Apple Inc.
+
+"""train linear regression with data parallel workers.
+
+run locally with:
+
+    mlx.launch -n 2 python examples/python/data_parallel.py
+"""
+
+import time
+
+import mlx.core as mx
+import mlx.nn as nn
+
+num_features = 100
+num_examples = 1_000
+num_iters = 100
+lr = 0.1
+
+world = mx.distributed.init()
+
+# every rank learns the same parameters from a different synthetic data shard.
+w_star = mx.random.normal((num_features,), key=mx.random.key(0))
+X = mx.random.normal(
+    (num_examples, num_features), key=mx.random.key(world.rank() + 1)
+)
+eps = 1e-2 * mx.random.normal(
+    (num_examples,), key=mx.random.key(world.rank() + 1_000)
+)
+y = X @ w_star + eps
+
+# parameters must start with the same values on every rank.
+w = 1e-2 * mx.random.normal((num_features,), key=mx.random.key(2_000))
+
+
+def loss_fn(w):
+    return 0.5 * mx.mean(mx.square(X @ w - y))
+
+
+grad_fn = mx.grad(loss_fn)
+
+tic = time.perf_counter()
+for _ in range(num_iters):
+    grad = grad_fn(w)
+    grad = nn.average_gradients(grad, group=world)
+    w = w - lr * grad
+    mx.eval(w)
+toc = time.perf_counter()
+
+loss = mx.distributed.all_sum(loss_fn(w), group=world) / world.size()
+loss_value = loss.item()
+error_norm = mx.sum(mx.square(w - w_star)).item() ** 0.5
+throughput = num_iters / (toc - tic)
+
+if world.rank() == 0:
+    print(
+        f"Loss {loss_value:.5f}, L2 distance: |w-w*| = {error_norm:.5f}, "
+        f"Throughput {throughput:.5f} (it/s), Ranks {world.size()}"
+    )


### PR DESCRIPTION
## proposed changes

#2930 asks for standalone distributed examples. #2973 added the explanation, but `examples/python` still has no data parallel script users can run end to end.

this adds a linear regression example where each rank creates its own synthetic data shard, starts from the same parameters, and averages gradients with `nn.average_gradients`. the final loss is evaluated on every rank before rank zero prints. without that step, lazy evaluation can leave one process waiting on a collective after its peer exits.

run it with:

```sh
mlx.launch -n 2 python examples/python/data_parallel.py
```

on my m4 mac, the one rank run finished with an l2 distance of `0.00971`. the two rank run finished at `0.00464`.

## checks

- `pre-commit run --all-files`
- `python examples/python/data_parallel.py`
- `mlx.launch -n 2 python examples/python/data_parallel.py`

## checklist

- [x] i have read the contributing document
- [x] i have run `pre-commit run --all-files`
- [ ] i have added automated tests. this pr adds a runnable example and the checks above exercise both paths
- [ ] i have updated the necessary documentation. no api or existing docs changed
