### PR TITLE
Fix filter_and_map docstring argument order for filter_fn and is_leaf_fn

### DIFF
--- a/python/mlx/nn/layers/base.py
+++ b/python/mlx/nn/layers/base.py
@@ -255,13 +255,13 @@ class Module(dict):
         but it can also be used to extract any subset of the module's parameters.
 
         Args:
-            filter_fn (Callable): Given a value, the key in which it is found
-                and the containing module, decide whether to keep the value or
+            filter_fn (Callable): Given the containing module, the key in which
+                it is found and the value, decide whether to keep the value or
                 drop it.
             map_fn (Callable, optional): Optionally transform the value before
                 returning it.
-            is_leaf_fn (Callable, optional): Given a value, the key in which it
-                is found and the containing module decide if it is a leaf.
+            is_leaf_fn (Callable, optional): Given the containing module, the
+                key in which it is found and the value decide if it is a leaf.
 
         Returns:
             A dictionary containing the contents of the module recursively filtered


### PR DESCRIPTION
## Proposed changes

`Module.filter_and_map` describes the `filter_fn` and `is_leaf_fn` callbacks as taking "a value, the key in which it is found and the containing module", but they are actually called as `filter_fn(self, k, v)`, i.e. `(module, key, value)`. That also matches the type hints (`Callable[[Module, str, Any], bool]`) and the built-in filters like `valid_parameter_filter(module, key, value)`. The prose just listed the three arguments in reverse order.

Reordered the description to `(module, key, value)` for both callbacks. Doc only, no behavior change.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

(docstring-only, test_nn.py passes)

---

honest note: freshman contributor here, i use Claude Code to help spot these doc/signature mismatches but i traced the actual call site (`filter_fn(self, k, v)`) and the parameter filters myself to confirm the order before opening this. let me know if i missed something.
