### PR TITLE
Accumulate low-precision float scans in float32 on the CPU

### DIFF
--- a/mlx/backend/cpu/scan.cpp
+++ b/mlx/backend/cpu/scan.cpp
@@ -1,6 +1,7 @@
 // Copyright © 2023 Apple Inc.
 
 #include <cassert>
+#include <vector>
 
 #include "mlx/backend/common/utils.h"
 #include "mlx/backend/cpu/binary_ops.h"
@@ -13,7 +14,7 @@ namespace mlx::core {
 
 namespace {
 
-template <typename T, typename U, typename Op>
+template <typename T, typename U, typename AccT, typename Op>
 void contiguous_scan(
     const T* input,
     U* output,
@@ -22,24 +23,33 @@ void contiguous_scan(
     bool reverse,
     bool inclusive,
     const Op& op,
-    U init) {
+    AccT init) {
+  // The running value is kept in AccT (which is wider than U for low-precision
+  // floats) and only narrowed to U on store, so that a long scan does not
+  // accumulate in a type whose ULP eventually swamps the increment (e.g. a
+  // float16 cumsum stalling at 2048). For every dtype where AccT == U this is
+  // bit-identical to a plain in-place accumulation.
   if (!reverse) {
     if (inclusive) {
       for (int i = 0; i < count; i++) {
-        *output = *input;
+        AccT acc = static_cast<AccT>(*input);
+        *output = static_cast<U>(acc);
         for (int j = 1; j < stride; j++) {
           input++;
           output++;
-          *output = op(*(output - 1), *input);
+          acc = op(acc, *input);
+          *output = static_cast<U>(acc);
         }
         output++;
         input++;
       }
     } else {
       for (int i = 0; i < count; i++) {
-        *output = init;
+        AccT acc = init;
+        *output = static_cast<U>(acc);
         for (int j = 1; j < stride; j++) {
-          *(output + 1) = op(*output, *input);
+          acc = op(acc, *input);
+          *(output + 1) = static_cast<U>(acc);
           input++;
           output++;
         }
@@ -52,11 +62,13 @@ void contiguous_scan(
       for (int i = 0; i < count; i++) {
         output += stride - 1;
         input += stride - 1;
-        *output = *input;
+        AccT acc = static_cast<AccT>(*input);
+        *output = static_cast<U>(acc);
         for (int j = 1; j < stride; j++) {
           input--;
           output--;
-          *output = op(*(output + 1), *input);
+          acc = op(acc, *input);
+          *output = static_cast<U>(acc);
         }
         output += stride;
         input += stride;
@@ -65,9 +77,11 @@ void contiguous_scan(
       for (int i = 0; i < count; i++) {
         output += stride - 1;
         input += stride - 1;
-        *output = init;
+        AccT acc = init;
+        *output = static_cast<U>(acc);
         for (int j = 1; j < stride; j++) {
-          *(output - 1) = op(*output, *input);
+          acc = op(acc, *input);
+          *(output - 1) = static_cast<U>(acc);
           input--;
           output--;
         }
@@ -78,7 +92,7 @@ void contiguous_scan(
   }
 };
 
-template <typename T, typename U, typename Op>
+template <typename T, typename U, typename AccT, typename Op>
 void strided_scan(
     const T* input,
     U* output,
@@ -88,17 +102,24 @@ void strided_scan(
     bool reverse,
     bool inclusive,
     const Op& op,
-    U init) {
+    AccT init) {
   // TODO: Vectorize the following naive implementation
+  // One running accumulator per lane, kept in AccT and narrowed to U on store
+  // (see the note in contiguous_scan); bit-identical when AccT == U.
+  std::vector<AccT> acc(stride);
   if (!reverse) {
     if (inclusive) {
       for (int i = 0; i < count; i++) {
-        std::copy(input, input + stride, output);
+        for (int k = 0; k < stride; k++) {
+          acc[k] = static_cast<AccT>(input[k]);
+          output[k] = static_cast<U>(acc[k]);
+        }
         output += stride;
         input += stride;
         for (int j = 1; j < size; j++) {
           for (int k = 0; k < stride; k++) {
-            *output = op(*(output - stride), *input);
+            acc[k] = op(acc[k], *input);
+            *output = static_cast<U>(acc[k]);
             output++;
             input++;
           }
@@ -106,12 +127,16 @@ void strided_scan(
       }
     } else {
       for (int i = 0; i < count; i++) {
-        std::fill(output, output + stride, init);
+        for (int k = 0; k < stride; k++) {
+          acc[k] = init;
+          output[k] = static_cast<U>(acc[k]);
+        }
         output += stride;
         input += stride;
         for (int j = 1; j < size; j++) {
           for (int k = 0; k < stride; k++) {
-            *output = op(*(output - stride), *(input - stride));
+            acc[k] = op(acc[k], *(input - stride));
+            *output = static_cast<U>(acc[k]);
             output++;
             input++;
           }
@@ -123,12 +148,16 @@ void strided_scan(
       for (int i = 0; i < count; i++) {
         output += (size - 1) * stride;
         input += (size - 1) * stride;
-        std::copy(input, input + stride, output);
+        for (int k = 0; k < stride; k++) {
+          acc[k] = static_cast<AccT>(input[k]);
+          output[k] = static_cast<U>(acc[k]);
+        }
         for (int j = 1; j < size; j++) {
-          for (int k = 0; k < stride; k++) {
+          for (int k = stride - 1; k >= 0; k--) {
             output--;
             input--;
-            *output = op(*(output + stride), *input);
+            acc[k] = op(acc[k], *input);
+            *output = static_cast<U>(acc[k]);
           }
         }
         output += size * stride;
@@ -138,12 +167,16 @@ void strided_scan(
       for (int i = 0; i < count; i++) {
         output += (size - 1) * stride;
         input += (size - 1) * stride;
-        std::fill(output, output + stride, init);
+        for (int k = 0; k < stride; k++) {
+          acc[k] = init;
+          output[k] = static_cast<U>(acc[k]);
+        }
         for (int j = 1; j < size; j++) {
-          for (int k = 0; k < stride; k++) {
+          for (int k = stride - 1; k >= 0; k--) {
             output--;
             input--;
-            *output = op(*(output + stride), *(input + stride));
+            acc[k] = op(acc[k], *(input + stride));
+            *output = static_cast<U>(acc[k]);
           }
         }
         output += size * stride;
@@ -153,7 +186,7 @@ void strided_scan(
   }
 };
 
-template <typename T, typename U, typename Op>
+template <typename T, typename U, typename AccT, typename Op>
 void scan_op(
     const array& in,
     array& out,
@@ -161,7 +194,7 @@ void scan_op(
     bool reverse,
     bool inclusive,
     const Op& op,
-    U init) {
+    AccT init) {
   if (in.flags().row_contiguous) {
     if (in.strides()[axis] == 1) {
       contiguous_scan(
@@ -190,7 +223,7 @@ void scan_op(
   }
 }
 
-template <typename T, typename U>
+template <typename T, typename U, typename AccT = U>
 void scan_dispatch(
     Scan::ReduceType rtype,
     const array& in,
@@ -200,41 +233,47 @@ void scan_dispatch(
     bool inclusive) {
   switch (rtype) {
     case Scan::Sum: {
-      auto op = [](U y, T x) { return y + x; };
-      auto init = static_cast<U>(0);
-      scan_op<T, U>(in, out, axis, reverse, inclusive, op, init);
+      auto op = [](AccT y, T x) { return y + static_cast<AccT>(x); };
+      auto init = static_cast<AccT>(0);
+      scan_op<T, U, AccT>(in, out, axis, reverse, inclusive, op, init);
       break;
     }
     case Scan::Prod: {
-      auto op = [](U y, T x) { return y * x; };
-      auto init = static_cast<U>(1);
-      scan_op<T, U>(in, out, axis, reverse, inclusive, op, init);
+      auto op = [](AccT y, T x) { return y * static_cast<AccT>(x); };
+      auto init = static_cast<AccT>(1);
+      scan_op<T, U, AccT>(in, out, axis, reverse, inclusive, op, init);
       break;
     }
     case Scan::Min: {
-      auto op = [](U y, T x) { return x < y ? x : y; };
+      auto op = [](AccT y, T x) {
+        auto xa = static_cast<AccT>(x);
+        return xa < y ? xa : y;
+      };
       auto init = (issubdtype(in.dtype(), floating))
-          ? static_cast<U>(std::numeric_limits<float>::infinity())
-          : std::numeric_limits<U>::max();
-      scan_op<T, U>(in, out, axis, reverse, inclusive, op, init);
+          ? static_cast<AccT>(std::numeric_limits<float>::infinity())
+          : std::numeric_limits<AccT>::max();
+      scan_op<T, U, AccT>(in, out, axis, reverse, inclusive, op, init);
       break;
     }
     case Scan::Max: {
-      auto op = [](U y, T x) { return x < y ? y : x; };
+      auto op = [](AccT y, T x) {
+        auto xa = static_cast<AccT>(x);
+        return xa < y ? y : xa;
+      };
       auto init = (issubdtype(in.dtype(), floating))
-          ? static_cast<U>(-std::numeric_limits<float>::infinity())
-          : std::numeric_limits<U>::min();
-      scan_op<T, U>(in, out, axis, reverse, inclusive, op, init);
+          ? static_cast<AccT>(-std::numeric_limits<float>::infinity())
+          : std::numeric_limits<AccT>::min();
+      scan_op<T, U, AccT>(in, out, axis, reverse, inclusive, op, init);
       break;
     }
     case Scan::LogAddExp: {
-      auto op = [](U a, T b) {
-        return detail::LogAddExp{}(a, static_cast<U>(b));
+      auto op = [](AccT a, T b) {
+        return detail::LogAddExp{}(a, static_cast<AccT>(b));
       };
       auto init = (issubdtype(in.dtype(), floating))
-          ? static_cast<U>(-std::numeric_limits<float>::infinity())
-          : std::numeric_limits<U>::min();
-      scan_op<T, U>(in, out, axis, reverse, inclusive, op, init);
+          ? static_cast<AccT>(-std::numeric_limits<float>::infinity())
+          : std::numeric_limits<AccT>::min();
+      scan_op<T, U, AccT>(in, out, axis, reverse, inclusive, op, init);
       break;
     }
   }
@@ -312,7 +351,11 @@ void Scan::eval_cpu(const std::vector<array>& inputs, array& out) {
             reduce_type_, in, out, axis_, reverse_, inclusive_);
         break;
       case float16:
-        scan_dispatch<float16_t, float16_t>(
+        // Accumulate low-precision floats in float32 so a long scan does not
+        // stall once the running value's ULP exceeds the increment (a float16
+        // cumsum of ones otherwise saturates at 2048, disagreeing with the
+        // GPU).
+        scan_dispatch<float16_t, float16_t, float>(
             reduce_type_, in, out, axis_, reverse_, inclusive_);
         break;
       case float32:
@@ -324,7 +367,7 @@ void Scan::eval_cpu(const std::vector<array>& inputs, array& out) {
             reduce_type_, in, out, axis_, reverse_, inclusive_);
         break;
       case bfloat16:
-        scan_dispatch<bfloat16_t, bfloat16_t>(
+        scan_dispatch<bfloat16_t, bfloat16_t, float>(
             reduce_type_, in, out, axis_, reverse_, inclusive_);
         break;
       case complex64:

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -2290,6 +2290,22 @@ class TestOps(mlx_tests.MLXTestCase):
             expected = mx.repeat(expected[:, None], 2, axis=1)
             self.assertTrue(mx.array_equal(expected, out))
 
+        # Low-precision float scans must accumulate in higher precision so a long
+        # scan does not stall once the running value's ULP exceeds the increment.
+        # Pinned to the CPU stream (the accumulator widening lives there); on the
+        # unpatched CPU backend a float16 cumsum of ones saturates at 2048 and a
+        # bfloat16 one at 256.
+        for t, rtol in [(mx.float16, 3e-3), (mx.bfloat16, 1e-2)]:
+            for s in [4096, 5000, 20000]:
+                out = mx.cumsum(mx.ones((s,), t), stream=mx.cpu)
+                self.assertTrue(
+                    mx.allclose(out[-1], mx.array(s, t), rtol=rtol),
+                    msg=f"{t} cumsum of {s} ones stalled at {out[-1].item()}",
+                )
+                # non-contiguous (strided) scan over a non-last axis
+                out = mx.cumsum(mx.ones((s, 3), t), axis=0, stream=mx.cpu)
+                self.assertTrue(mx.allclose(out[-1], mx.full((3,), s, t), rtol=rtol))
+
         # Test donation
         def fn(its):
             x = mx.ones((32,))


### PR DESCRIPTION
### Problem

The CPU scan keeps its running value in the output dtype and reads it back from the output buffer each step (`op(*(output - 1), *input)`). For `float16` / `bfloat16` a long cumulative sum stops growing once the running value's ULP exceeds the increment:

```python
mx.cumsum(mx.ones((5000,), mx.float16))[-1]   # CPU: 2048.0,  GPU: 5000.0
mx.cumsum(mx.ones((5000,), mx.bfloat16))[-1]  # CPU:  256.0,  GPU: 4992.0
```

The float16 sum saturates at 2048 and bfloat16 at 256, regardless of length. The GPU's blocked scan stays accurate, so the **same call returns different results on the two backends**. (numpy has the same saturation summing in-dtype, but the CPU/GPU divergence within MLX is the real issue.)

The file already anticipated this:

```cpp
// TODO: If we add the option to accumulate floats in higher precision
//       floats perhaps we should add the full all-to-all dispatch.
```

### Fix

Carry the scan accumulator in a separate `AccT` type and narrow to the output dtype only on store, mirroring the existing `bool -> int32` accumulation. `AccT` is `float32` for `float16`/`bfloat16` and the output type for every other dtype, so all non-low-precision dtypes are bit-identical and only the float16/bfloat16 paths change. The contiguous and strided scans both carry the accumulator (the strided path uses one accumulator per lane).

After the fix the CPU matches the GPU and the true value:

```python
mx.cumsum(mx.ones((5000,), mx.float16))[-1]   # 5000.0
mx.cumsum(mx.ones((5000,), mx.bfloat16))[-1]  # 4992.0  (nearest bfloat16, == GPU)
```

### Tests

Extended `test_scans` with a float16/bfloat16 `cumsum`-of-ones check past the stall point (sizes 4096/5000/20000, contiguous and strided), pinned to the CPU stream. It fails on the current CPU backend (stalls at 2048) and passes with the fix. Full `test_ops.py` (146 tests / 309 subtests) and the autograd cumprod-grad test stay green; `cumsum`/`cumprod` for int and float32 remain bit-identical to numpy.

Verified with a CPU-only build (`MLX_BUILD_METAL=OFF`) on an M4.
