### PR TITLE
Fix Upsample align_corners=False for fractional scale factors

### DIFF
--- a/python/mlx/nn/layers/upsample.py
+++ b/python/mlx/nn/layers/upsample.py
@@ -14,8 +14,13 @@ def _scaled_indices(N, scale, align_corners, dim, ndims):
     if align_corners:
         indices = mx.arange(M, dtype=mx.float32) * ((N - 1) / max(M - 1, 1))
     else:
+        # Half-pixel convention: src = (i + 0.5) * step - 0.5, i.e. a constant
+        # offset of (1 - step) / 2. The previous ((M - 1) * step - N + 1) / 2
+        # only equals this when M == scale * N exactly; for a fractional scale
+        # M = int(scale * N) is floored, which re-centers the grid to the
+        # corner-aligned behavior and makes align_corners=False a no-op.
         step = 1 / scale
-        start = ((M - 1) * step - N + 1) / 2
+        start = (1 - step) / 2
         indices = mx.arange(M, dtype=mx.float32) * step - start
 
     shape = [1] * ndims

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -1524,6 +1524,28 @@ class TestLayers(mlx_tests.MLXTestCase):
         self.assertEqual(out.shape, (1, 1, 1))
         self.assertTrue(np.allclose(out, x_1d[:, :1, :]))
 
+    def test_upsample_align_corners_false_fractional_scale(self):
+        # For a fractional scale factor, M = int(scale * N) is floored, and the
+        # align_corners=False grid used to be mis-centered onto the
+        # corner-aligned (align_corners=True) grid, making the flag a no-op.
+        # With the half-pixel convention the two must differ, and the
+        # align_corners=False sampling positions are (i + 0.5) / scale - 0.5.
+        x = mx.arange(5).reshape((1, 5, 1)).astype(mx.float32)
+        out_false = nn.Upsample(scale_factor=1.5, mode="linear", align_corners=False)(
+            x
+        ).reshape(-1)
+        out_true = nn.Upsample(scale_factor=1.5, mode="linear", align_corners=True)(
+            x
+        ).reshape(-1)
+
+        # x holds identity values, so a linear sample equals its clamped source
+        # coordinate: src_i = clip((i + 0.5) / 1.5 - 0.5, 0, 4).
+        expected = mx.array(
+            [0.0, 0.5, 7 / 6, 11 / 6, 2.5, 19 / 6, 23 / 6], dtype=mx.float32
+        )
+        self.assertTrue(np.allclose(out_false, expected))
+        self.assertFalse(np.allclose(out_false, out_true))
+
     def test_pooling(self):
         # Test 1d pooling
         x = mx.array(


### PR DESCRIPTION
### Problem

`_scaled_indices` computes the `align_corners=False` start offset as

```python
start = ((M - 1) * step - N + 1) / 2   # M = int(scale * N), step = 1 / scale
```

This equals the half-pixel offset `(1 - step) / 2` only when `M == scale * N` exactly. For a **fractional** scale factor `M = int(scale * N)` is floored, so the grid is re-centered to the corner-aligned (`align_corners=True`) grid. The result: `align_corners=False` output becomes bit-identical to `align_corners=True`, i.e. the flag is silently ignored.

```python
x = mx.arange(5).reshape(1, 5, 1).astype(mx.float32)
f = nn.Upsample(scale_factor=1.5, mode="linear", align_corners=False)(x)
t = nn.Upsample(scale_factor=1.5, mode="linear", align_corners=True)(x)
# f == t == [0, 0.667, 1.333, 2.0, 2.667, 3.333, 4.0]
# correct half-pixel: [0, 0.5, 1.167, 1.833, 2.5, 3.167, 3.833]
```

This affects `linear` and `cubic` modes (both route through `_scaled_indices`) at any fractional scale (1.5, 1.25, ...). All existing upsample tests use integer scale factors, where the two expressions coincide, so the regime was untested.

### Fix

Use the constant half-pixel offset `start = (1 - step) / 2`, so the sampling positions are `(i + 0.5) / scale - 0.5` for every scale. Integer scale factors are unchanged.

### Test

Added `test_upsample_align_corners_false_fractional_scale` pinning the half-pixel positions at `scale=1.5` and asserting `align_corners=False` now differs from `True`. It fails on the old code and passes with the fix; the existing upsample tests stay green.
