### PR TITLE
Accumulate low-precision float reductions in float32 on the CPU

### DIFF
--- a/mlx/backend/cpu/reduce.cpp
+++ b/mlx/backend/cpu/reduce.cpp
@@ -410,21 +410,49 @@ void reduce_dispatch_and_or(
   }
 }
 
+// Reduce into a float32 accumulator and narrow back to the low-precision output
+// dtype. A float16/bfloat16 accumulator saturates on a long reduction the same
+// way a scalar chain would (e.g. a float16 sum of 70000 ones overflows to inf
+// and a bfloat16 one stalls at 256), which also propagates into mean/var. This
+// keeps the reduction in float32 and only narrows once at the end.
+template <typename InT, typename Op>
+void reduce_float_in_fp32(
+    const array& in,
+    array& out,
+    Op,
+    const std::vector<int>& axes,
+    float init) {
+  array acc(out.shape(), float32, nullptr, {});
+  acc.set_data(allocator::malloc(acc.nbytes()));
+  reduction_op<InT, float, Op>(in, acc, axes, init);
+  auto acc_ptr = acc.data<float>();
+  auto out_ptr = out.data<InT>();
+  for (size_t i = 0; i < out.size(); i++) {
+    out_ptr[i] = static_cast<InT>(acc_ptr[i]);
+  }
+}
+
 template <typename InT>
 void reduce_dispatch_sum_prod(
     const array& in,
     array& out,
     Reduce::ReduceType rtype,
     const std::vector<int>& axes) {
+  constexpr bool is_low_precision_float =
+      std::is_same_v<InT, float16_t> || std::is_same_v<InT, bfloat16_t>;
   if (rtype == Reduce::Sum) {
     if constexpr (std::is_integral_v<InT> && sizeof(InT) <= 4) {
       reduction_op<InT, int32_t, SumReduce>(in, out, axes, 0);
+    } else if constexpr (is_low_precision_float) {
+      reduce_float_in_fp32<InT>(in, out, SumReduce{}, axes, 0.0f);
     } else {
       reduction_op<InT, InT, SumReduce>(in, out, axes, 0);
     }
   } else {
     if constexpr (std::is_integral_v<InT> && sizeof(InT) <= 4) {
       reduction_op<InT, int32_t, ProdReduce>(in, out, axes, 1);
+    } else if constexpr (is_low_precision_float) {
+      reduce_float_in_fp32<InT>(in, out, ProdReduce{}, axes, 1.0f);
     } else {
       reduction_op<InT, InT, ProdReduce>(in, out, axes, 1);
     }

--- a/python/tests/test_reduce.py
+++ b/python/tests/test_reduce.py
@@ -131,6 +131,37 @@ class TestReduce(mlx_tests.MLXTestCase):
         mxsum = y.sum().item()
         self.assertEqual(npsum, mxsum)
 
+    def test_low_precision_float_accumulation(self):
+        # Low-precision float reductions accumulate in float32 so a long sum
+        # does not saturate the accumulator. Pinned to the CPU stream (where the
+        # widening lives); on the unpatched backend a float16 sum of ones stalls
+        # (e.g. 20000 ones -> 16384) and a bfloat16 one saturates at 256, which
+        # then poisons mean/var.
+        with mx.stream(mx.cpu):
+            for t, rtol in [(mx.float16, 3e-3), (mx.bfloat16, 1e-2)]:
+                for n in [4096, 20000, 60000]:  # true sum stays within float16
+                    a = mx.ones((n,), t)
+                    self.assertTrue(
+                        mx.allclose(mx.sum(a), mx.array(n, t), rtol=rtol),
+                        msg=f"{t} sum of {n} ones = {mx.sum(a).item()}",
+                    )
+                    self.assertTrue(
+                        mx.allclose(mx.mean(a), mx.array(1.0, t), rtol=rtol)
+                    )
+                    self.assertTrue(mx.allclose(mx.var(a), mx.array(0.0, t), atol=1e-3))
+            # bfloat16 has the range to sum well past float16's max.
+            a = mx.ones((70000,), mx.bfloat16)
+            self.assertTrue(
+                mx.allclose(mx.sum(a), mx.array(70000, mx.bfloat16), rtol=1e-2)
+            )
+            # axis reduction (non-all-reduce) goes through the same path.
+            a = mx.ones((60000, 3), mx.float16)
+            self.assertTrue(
+                mx.allclose(
+                    mx.sum(a, axis=0), mx.full((3,), 60000, mx.float16), rtol=3e-3
+                )
+            )
+
     def test_many_reduction_axes(self):
 
         def check(x, axes):


### PR DESCRIPTION
### Problem

`Sum` / `Prod` reductions of `float16` / `bfloat16` accumulate in the input dtype (`reduction_op<InT, InT, ...>`), so a long reduction saturates the accumulator:

```python
with mx.stream(mx.cpu):
    mx.sum(mx.ones((20000,), mx.float16))    # 16384.0  (true 20000, numpy: 20000)
    mx.sum(mx.ones((70000,), mx.bfloat16))   #   256.0  (true 70000)
    mx.mean(mx.ones((70000,), mx.bfloat16))  #     0.0  (true 1.0)
```

The CPU result is both wrong and worse than numpy, which reduces in a wider type. Because `mean` and `var` are built on `sum`, they inherit the error (a large bfloat16 mean of ones returns 0). This is the reduce-path sibling of the scan issue in #3907.

### Fix

Integer reductions already widen to `int32`; do the same for low-precision floats. Reduce into a `float32` accumulator through the existing `reduction_op` machinery — which already supports an accumulator wider than the input (used for `int8`/`int16 -> int32`) — and narrow back to the output dtype once at the end. Every other dtype is untouched, so `float32` / int / complex results stay bit-identical.

```python
with mx.stream(mx.cpu):
    mx.sum(mx.ones((20000,), mx.float16))    # 20000.0
    mx.sum(mx.ones((70000,), mx.bfloat16))   # 70144.0  (nearest bfloat16)
    mx.mean(mx.ones((70000,), mx.bfloat16))  #     1.0
```

A `float16` sum still overflows to `inf` once the true value exceeds float16's ~65504 max — that is unavoidable for a `float16` output — but within range it now matches numpy, and `mean`/`var` are correct.

### Tests

Added `test_low_precision_float_accumulation` (float16/bfloat16 `sum`/`mean`/`var`, all-reduce and a strided axis reduction), pinned to the CPU stream. It fails on the current backend (stall/saturation) and passes with the fix. Full `test_reduce.py` + `test_ops.py` (157 tests / 5371 subtests) stay green; float32/int reductions remain bit-identical to numpy.

Verified with a CPU-only build (`MLX_BUILD_METAL=OFF`) on an M4.
