### PR TITLE
Fix fp quantized matmul corruption when the quantized dim is not a multiple of 32

### DIFF
--- a/mlx/backend/metal/kernels/fp_quantized.h
+++ b/mlx/backend/metal/kernels/fp_quantized.h
@@ -163,9 +163,18 @@ struct QuantizedBlockLoader {
   MLX_MTL_CONST short group_steps = group_size < BCOLS ? 1 : group_size / BCOLS;
   MLX_MTL_CONST short scale_step = group_size < BCOLS ? BCOLS / group_size : 1;
 
+  // BCOLS tiles the quantized dim, which is always a multiple of group_size,
+  // so a partial column extent is only possible when BCOLS does not divide
+  // group_size. That is nvfp4 (16 against a 32-wide block) alone; for every
+  // other mode the column bound below is dropped at compile time.
+  MLX_MTL_CONST bool partial_cols = group_size % BCOLS != 0;
+
   static_assert(
       (n_reads * pack_factor) <= group_size,
       "The number of reads per thread must be less than the group size.");
+  static_assert(
+      group_size % (n_reads * pack_factor) == 0,
+      "The group size must be a multiple of the columns read per thread.");
 
   const int src_ld;
   const int tile_stride;
@@ -220,18 +229,28 @@ struct QuantizedBlockLoader {
       return;
     }
 
-    if (reduction_dim == 1 && bi >= src_tile_dim.x) {
+    // src_tile_dim is (valid columns, valid rows), the convention the steel
+    // BlockLoader uses. bi is a row index, so it bounds against .y for every
+    // reduction_dim; the previous compare against .x could never fire for
+    // reduction_dim == 1, which let a partial row tile read past the source.
+    if (bi >= src_tile_dim.y) {
       for (int i = 0; i < n_reads * pack_factor; i++) {
         dst[i] = T(0);
       }
       return;
     }
 
-    if (reduction_dim == 0 && bi >= src_tile_dim.y) {
-      for (int i = 0; i < n_reads * pack_factor; i++) {
-        dst[i] = T(0);
+    // Each thread owns n_reads * pack_factor contiguous columns of one row,
+    // and a partial column extent is a whole number of quantization groups,
+    // hence a multiple of that span per the static_assert above, so a thread
+    // is either fully inside or fully outside the tile.
+    if constexpr (partial_cols) {
+      if (bj * pack_factor >= src_tile_dim.x) {
+        for (int i = 0; i < n_reads * pack_factor; i++) {
+          dst[i] = T(0);
+        }
+        return;
       }
-      return;
     }
 
     T scale = dequantize_scale<T, group_size>(*scales);
@@ -848,9 +867,16 @@ METAL_FUNC void fp_qmm_t_impl(
   loader_w_t loader_w(wl, scales, K, Ws, simd_gid, simd_lid);
   mma_t mma_op(simd_gid, simd_lid);
 
+  // K is a multiple of group_size, so it can only end in a partial tile when
+  // group_size does not divide BK. That is nvfp4 (group_size 16) alone; the
+  // other fp modes have group_size == BK, so the remainder tile below is
+  // discarded at compile time for them.
+  constexpr bool partial_k = group_size % BK != 0;
+  const int k_blocks = K_eff / BK;
+  const short num_k = partial_k ? short(K_eff - k_blocks * BK) : short(0);
   if (num_els < BM) {
     if (!aligned_N && num_outs < BN) {
-      for (int k = 0; k < K_eff; k += BK) {
+      for (int k = 0; k < k_blocks; k++) {
         threadgroup_barrier(mem_flags::mem_threadgroup);
         loader_x.load_safe(short2(BK, num_els));
         loader_w.load_safe(short2(BK, num_outs));
@@ -860,7 +886,7 @@ METAL_FUNC void fp_qmm_t_impl(
         loader_w.next();
       }
     } else {
-      for (int k = 0; k < K_eff; k += BK) {
+      for (int k = 0; k < k_blocks; k++) {
         threadgroup_barrier(mem_flags::mem_threadgroup);
         loader_x.load_safe(short2(BK, num_els));
         loader_w.load_unsafe();
@@ -870,9 +896,18 @@ METAL_FUNC void fp_qmm_t_impl(
         loader_w.next();
       }
     }
+    if constexpr (partial_k) {
+      if (num_k > 0) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_safe(short2(num_k, num_els));
+        loader_w.load_safe(short2(num_k, num_outs));
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(Xs, Ws);
+      }
+    }
   } else {
     if (!aligned_N && num_outs < BN) {
-      for (int k = 0; k < K_eff; k += BK) {
+      for (int k = 0; k < k_blocks; k++) {
         threadgroup_barrier(mem_flags::mem_threadgroup);
         loader_x.load_unsafe();
         loader_w.load_safe(short2(BK, num_outs));
@@ -882,7 +917,7 @@ METAL_FUNC void fp_qmm_t_impl(
         loader_w.next();
       }
     } else {
-      for (int k = 0; k < K_eff; k += BK) {
+      for (int k = 0; k < k_blocks; k++) {
         threadgroup_barrier(mem_flags::mem_threadgroup);
         loader_x.load_unsafe();
         loader_w.load_unsafe();
@@ -891,6 +926,15 @@ METAL_FUNC void fp_qmm_t_impl(
         mma_op.mma(Xs, Ws);
         loader_x.next();
         loader_w.next();
+      }
+    }
+    if constexpr (partial_k) {
+      if (num_k > 0) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_safe(short2(num_k, BM));
+        loader_w.load_safe(short2(num_k, num_outs));
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(Xs, Ws);
       }
     }
   }
@@ -969,13 +1013,24 @@ METAL_FUNC void fp_qmm_n_impl(
   loader_w_t loader_w(wl, scales, N, Ws, simd_gid, simd_lid);
   mma_t mma_op(simd_gid, simd_lid);
 
+  // N is a multiple of group_size, so it can only end in a partial tile when
+  // group_size does not divide BN. That is nvfp4 (group_size 16) alone; for
+  // the other fp modes num_outs is always BN and the bounded loads below are
+  // discarded at compile time.
+  constexpr bool partial_n = group_size % BN != 0;
+  const short num_outs = partial_n ? short(min(BN, N - y_col)) : short(BN);
+
   if (num_els < BM) {
     if ((K % BK) != 0) {
       const int k_blocks = K / BK;
       for (int k = 0; k < k_blocks; k++) {
         threadgroup_barrier(mem_flags::mem_threadgroup);
         loader_x.load_safe(short2(BK, num_els));
-        loader_w.load_unsafe();
+        if constexpr (partial_n) {
+          loader_w.load_safe(short2(num_outs, BK));
+        } else {
+          loader_w.load_unsafe();
+        }
         threadgroup_barrier(mem_flags::mem_threadgroup);
         mma_op.mma(Xs, Ws);
         loader_x.next();
@@ -984,9 +1039,19 @@ METAL_FUNC void fp_qmm_n_impl(
       const short num_k = K - k_blocks * BK;
       threadgroup_barrier(mem_flags::mem_threadgroup);
       loader_x.load_safe(short2(num_k, num_els));
-      loader_w.load_safe(short2(BN, num_k));
+      loader_w.load_safe(short2(num_outs, num_k));
       threadgroup_barrier(mem_flags::mem_threadgroup);
       mma_op.mma(Xs, Ws);
+    } else if (num_outs < BN) {
+      for (int k = 0; k < K; k += BK) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_safe(short2(BK, num_els));
+        loader_w.load_safe(short2(num_outs, BK));
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(Xs, Ws);
+        loader_x.next();
+        loader_w.next();
+      }
     } else {
       for (int k = 0; k < K; k += BK) {
         threadgroup_barrier(mem_flags::mem_threadgroup);
@@ -1004,7 +1069,11 @@ METAL_FUNC void fp_qmm_n_impl(
       for (int k = 0; k < k_blocks; k++) {
         threadgroup_barrier(mem_flags::mem_threadgroup);
         loader_x.load_unsafe();
-        loader_w.load_unsafe();
+        if constexpr (partial_n) {
+          loader_w.load_safe(short2(num_outs, BK));
+        } else {
+          loader_w.load_unsafe();
+        }
         threadgroup_barrier(mem_flags::mem_threadgroup);
         mma_op.mma(Xs, Ws);
         loader_x.next();
@@ -1013,9 +1082,19 @@ METAL_FUNC void fp_qmm_n_impl(
       const short num_k = K - k_blocks * BK;
       threadgroup_barrier(mem_flags::mem_threadgroup);
       loader_x.load_safe(short2(num_k, BM));
-      loader_w.load_safe(short2(BN, num_k));
+      loader_w.load_safe(short2(num_outs, num_k));
       threadgroup_barrier(mem_flags::mem_threadgroup);
       mma_op.mma(Xs, Ws);
+    } else if (num_outs < BN) {
+      for (int k = 0; k < K; k += BK) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_unsafe();
+        loader_w.load_safe(short2(num_outs, BK));
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(Xs, Ws);
+        loader_x.next();
+        loader_w.next();
+      }
     } else {
       for (int k = 0; k < K; k += BK) {
         threadgroup_barrier(mem_flags::mem_threadgroup);
@@ -1031,8 +1110,8 @@ METAL_FUNC void fp_qmm_n_impl(
 
   // Store results to device memory
   threadgroup_barrier(mem_flags::mem_threadgroup);
-  if (num_els < BM) {
-    mma_op.store_result_safe(y, N, short2(BN, num_els));
+  if (num_els < BM || num_outs < BN) {
+    mma_op.store_result_safe(y, N, short2(num_outs, num_els));
   } else {
     mma_op.store_result(y, N);
   }

--- a/mlx/backend/metal/kernels/fp_quantized.h
+++ b/mlx/backend/metal/kernels/fp_quantized.h
@@ -163,10 +163,6 @@ struct QuantizedBlockLoader {
   MLX_MTL_CONST short group_steps = group_size < BCOLS ? 1 : group_size / BCOLS;
   MLX_MTL_CONST short scale_step = group_size < BCOLS ? BCOLS / group_size : 1;
 
-  // BCOLS tiles the quantized dim, which is always a multiple of group_size,
-  // so a partial column extent is only possible when BCOLS does not divide
-  // group_size. That is nvfp4 (16 against a 32-wide block) alone; for every
-  // other mode the column bound below is dropped at compile time.
   MLX_MTL_CONST bool partial_cols = group_size % BCOLS != 0;
 
   static_assert(
@@ -855,10 +851,6 @@ METAL_FUNC void fp_qmm_t_impl(
   loader_w_t loader_w(wl, scales, K, Ws, simd_gid, simd_lid);
   mma_t mma_op(simd_gid, simd_lid);
 
-  // K is a multiple of group_size, so it can only end in a partial tile when
-  // group_size does not divide BK. That is nvfp4 (group_size 16) alone; the
-  // other fp modes have group_size == BK, so the remainder tile below is
-  // discarded at compile time for them.
   constexpr bool partial_k = group_size % BK != 0;
   const int k_blocks = K_eff / BK;
   const short num_k = partial_k ? short(K_eff - k_blocks * BK) : short(0);
@@ -1001,10 +993,6 @@ METAL_FUNC void fp_qmm_n_impl(
   loader_w_t loader_w(wl, scales, N, Ws, simd_gid, simd_lid);
   mma_t mma_op(simd_gid, simd_lid);
 
-  // N is a multiple of group_size, so it can only end in a partial tile when
-  // group_size does not divide BN. That is nvfp4 (group_size 16) alone; for
-  // the other fp modes num_outs is always BN and the bounded loads below are
-  // discarded at compile time.
   constexpr bool partial_n = group_size % BN != 0;
   const short num_outs = partial_n ? short(min(BN, N - y_col)) : short(BN);
 

--- a/mlx/backend/metal/kernels/fp_quantized.h
+++ b/mlx/backend/metal/kernels/fp_quantized.h
@@ -240,18 +240,6 @@ struct QuantizedBlockLoader {
       return;
     }
 
-    // Each thread owns n_reads * pack_factor contiguous columns of one row,
-    // and a partial column extent is a whole number of quantization groups,
-    // hence a multiple of that span per the static_assert above, so a thread
-    // is either fully inside or fully outside the tile.
-    if constexpr (partial_cols) {
-      if (bj * pack_factor >= src_tile_dim.x) {
-        for (int i = 0; i < n_reads * pack_factor; i++) {
-          dst[i] = T(0);
-        }
-        return;
-      }
-    }
 
     T scale = dequantize_scale<T, group_size>(*scales);
     for (int i = 0; i < n_reads; i++) {

--- a/mlx/backend/metal/kernels/fp_quantized.h
+++ b/mlx/backend/metal/kernels/fp_quantized.h
@@ -232,7 +232,6 @@ struct QuantizedBlockLoader {
       return;
     }
 
-
     T scale = dequantize_scale<T, group_size>(*scales);
     for (int i = 0; i < n_reads; i++) {
       dequantize<T, bits>(

--- a/mlx/backend/metal/kernels/fp_quantized.h
+++ b/mlx/backend/metal/kernels/fp_quantized.h
@@ -225,10 +225,6 @@ struct QuantizedBlockLoader {
       return;
     }
 
-    // src_tile_dim is (valid columns, valid rows), the convention the steel
-    // BlockLoader uses. bi is a row index, so it bounds against .y for every
-    // reduction_dim; the previous compare against .x could never fire for
-    // reduction_dim == 1, which let a partial row tile read past the source.
     if (bi >= src_tile_dim.y) {
       for (int i = 0; i < n_reads * pack_factor; i++) {
         dst[i] = T(0);

--- a/mlx/backend/metal/kernels/quantized.h
+++ b/mlx/backend/metal/kernels/quantized.h
@@ -589,6 +589,16 @@ struct QuantizedBlockLoader {
       (BCOLS_PACKED * BROWS < tgp_size) ? 1 : (BCOLS_PACKED * BROWS) / tgp_size;
   MLX_MTL_CONST short group_steps = group_size / BCOLS;
 
+  // BCOLS tiles the quantized dim, which is always a multiple of group_size,
+  // so a partial column extent is only possible when BCOLS does not divide
+  // group_size. Every affine group size is a multiple of the block, so the
+  // column bound below is dropped at compile time for all of them.
+  MLX_MTL_CONST bool partial_cols = group_size % BCOLS != 0;
+
+  static_assert(
+      group_size % (n_reads * pack_factor) == 0,
+      "The group size must be a multiple of the columns read per thread.");
+
   const int src_ld;
   const int tile_stride;
   short group_step_cnt;
@@ -644,18 +654,28 @@ struct QuantizedBlockLoader {
       return;
     }
 
-    if (reduction_dim == 1 && bi >= src_tile_dim.x) {
+    // src_tile_dim is (valid columns, valid rows), the convention the steel
+    // BlockLoader uses. bi is a row index, so it bounds against .y for every
+    // reduction_dim; the previous compare against .x could never fire for
+    // reduction_dim == 1, which let a partial row tile read past the source.
+    if (bi >= src_tile_dim.y) {
       for (int i = 0; i < n_reads * pack_factor; i++) {
         dst[i] = T(0);
       }
       return;
     }
 
-    if (reduction_dim == 0 && bi >= src_tile_dim.y) {
-      for (int i = 0; i < n_reads * pack_factor; i++) {
-        dst[i] = T(0);
+    // Each thread owns n_reads * pack_factor contiguous columns of one row,
+    // and a partial column extent is a whole number of quantization groups,
+    // hence a multiple of that span per the static_assert above, so a thread
+    // is either fully inside or fully outside the tile.
+    if constexpr (partial_cols) {
+      if (bj * pack_factor >= src_tile_dim.x) {
+        for (int i = 0; i < n_reads * pack_factor; i++) {
+          dst[i] = T(0);
+        }
+        return;
       }
-      return;
     }
 
     T scale = *scales;

--- a/mlx/backend/metal/kernels/quantized.h
+++ b/mlx/backend/metal/kernels/quantized.h
@@ -665,19 +665,6 @@ struct QuantizedBlockLoader {
       return;
     }
 
-    // Each thread owns n_reads * pack_factor contiguous columns of one row,
-    // and a partial column extent is a whole number of quantization groups,
-    // hence a multiple of that span per the static_assert above, so a thread
-    // is either fully inside or fully outside the tile.
-    if constexpr (partial_cols) {
-      if (bj * pack_factor >= src_tile_dim.x) {
-        for (int i = 0; i < n_reads * pack_factor; i++) {
-          dst[i] = T(0);
-        }
-        return;
-      }
-    }
-
     T scale = *scales;
     T bias = *biases;
     for (int i = 0; i < n_reads; i++) {

--- a/mlx/backend/metal/kernels/quantized.h
+++ b/mlx/backend/metal/kernels/quantized.h
@@ -589,10 +589,6 @@ struct QuantizedBlockLoader {
       (BCOLS_PACKED * BROWS < tgp_size) ? 1 : (BCOLS_PACKED * BROWS) / tgp_size;
   MLX_MTL_CONST short group_steps = group_size / BCOLS;
 
-  // BCOLS tiles the quantized dim, which is always a multiple of group_size,
-  // so a partial column extent is only possible when BCOLS does not divide
-  // group_size. Every affine group size is a multiple of the block, so the
-  // column bound below is dropped at compile time for all of them.
   MLX_MTL_CONST bool partial_cols = group_size % BCOLS != 0;
 
   static_assert(
@@ -654,10 +650,6 @@ struct QuantizedBlockLoader {
       return;
     }
 
-    // src_tile_dim is (valid columns, valid rows), the convention the steel
-    // BlockLoader uses. bi is a row index, so it bounds against .y for every
-    // reduction_dim; the previous compare against .x could never fire for
-    // reduction_dim == 1, which let a partial row tile read past the source.
     if (bi >= src_tile_dim.y) {
       for (int i = 0; i < n_reads * pack_factor; i++) {
         dst[i] = T(0);

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -715,6 +715,197 @@ class TestQuantized(mlx_tests.MLXTestCase):
                     self.assertEqual(y_q.shape, y_hat.shape)
                     self.assertLess((y_q - y_hat).abs().max(), 2e-3)
 
+    def test_fp_qmm_non_multiple_of_32(self):
+        # nvfp4's group_size of 16 lets the quantized dim be a multiple of 16
+        # but not of 32; the qmm kernels tile that dim by 32 and must bound
+        # the 16-wide tail tile. mxfp4 and mxfp8 have group_size 32 and can
+        # never produce that tail, so they run here as a control.
+        key = mx.random.key(0)
+        k1, k2 = mx.random.split(key)
+        # The half types only run on the GPU: on the CPU the reference
+        # matmul is evaluated in the same low precision, and its own
+        # accumulation error over K swamps the comparison.
+        dtypes = [mx.float32]
+        if mx.default_device() == mx.gpu:
+            dtypes += [mx.float16, mx.bfloat16]
+        tols = {mx.float32: 1e-3, mx.float16: 5e-3, mx.bfloat16: 4e-2}
+
+        # transpose=True: K % 32 == 16. M >= 33 keeps the shape on the tiled
+        # kernel for every chip (the qmv batch limit caps at 32).
+        for dtype in dtypes:
+            for M, K, N in [(50, 1040, 128), (33, 528, 64)]:
+                with self.subTest(M=M, K=K, N=N, transpose=True, dtype=dtype):
+                    x = (mx.random.normal(shape=(M, K), key=k1) / K**0.5).astype(dtype)
+                    w = mx.random.normal(shape=(N, K), key=k2).astype(dtype)
+                    w_q, scales = mx.quantize(w, mode="nvfp4")
+                    w_hat = mx.dequantize(w_q, scales, mode="nvfp4")
+                    y_q = mx.quantized_matmul(
+                        x, w_q, scales, transpose=True, mode="nvfp4"
+                    )
+                    y_hat = x @ mx.swapaxes(w_hat, -1, -2)
+                    self.assertEqual(y_q.shape, y_hat.shape)
+                    self.assertLess((y_q - y_hat).abs().max(), tols[dtype])
+
+        # transpose=False: N % 32 == 16. An unbounded store of the tail tile
+        # spills onto the next output row and races the threadgroup that owns
+        # it, so also check that two identical runs agree bit for bit.
+        for dtype in dtypes:
+            M, K, N = 50, 512, 1040
+            with self.subTest(M=M, K=K, N=N, transpose=False, dtype=dtype):
+                x = (mx.random.normal(shape=(M, K), key=k1) / K**0.5).astype(dtype)
+                w = mx.random.normal(shape=(K, N), key=k2).astype(dtype)
+                w_q, scales = mx.quantize(w, mode="nvfp4")
+                w_hat = mx.dequantize(w_q, scales, mode="nvfp4")
+                y_q = mx.quantized_matmul(x, w_q, scales, transpose=False, mode="nvfp4")
+                y_q2 = mx.quantized_matmul(
+                    x, w_q, scales, transpose=False, mode="nvfp4"
+                )
+                y_hat = x @ w_hat
+                self.assertEqual(y_q.shape, y_hat.shape)
+                self.assertLess((y_q - y_hat).abs().max(), tols[dtype])
+                self.assertTrue(mx.array_equal(y_q, y_q2))
+
+        # Control: the group_size 32 modes at the same block-unaligned shapes.
+        for mode in ["mxfp4", "mxfp8"]:
+            for M, K, N in [(50, 1056, 128), (50, 512, 1056)]:
+                transpose = N == 128
+                with self.subTest(M=M, K=K, N=N, mode=mode):
+                    x = mx.random.normal(shape=(M, K), key=k1)
+                    w_shape = (N, K) if transpose else (K, N)
+                    w = mx.random.normal(shape=w_shape, key=k2)
+                    w_q, scales = mx.quantize(w, mode=mode)
+                    w_hat = mx.dequantize(w_q, scales, mode=mode)
+                    y_q = mx.quantized_matmul(
+                        x, w_q, scales, transpose=transpose, mode=mode
+                    )
+                    y_hat = x @ mx.swapaxes(w_hat, -1, -2) if transpose else x @ w_hat
+                    self.assertEqual(y_q.shape, y_hat.shape)
+                    self.assertLess((y_q - y_hat).abs().max(), 1e-3)
+
+    def test_fp_qmm_non_multiple_of_32_vjp(self):
+        # The backward of quantized_matmul runs the same kernels with the
+        # transpose flipped, so cover both directions at a tail shape.
+        key = mx.random.key(0)
+        k1, k2, k3 = mx.random.split(key, 3)
+        M, K, N = 50, 1040, 128
+
+        for transpose in [True, False]:
+            with self.subTest(transpose=transpose):
+                w_shape = (N, K) if transpose else (K, N)
+                x = mx.random.normal(shape=(M, K), key=k1)
+                w = mx.random.normal(shape=w_shape, key=k2)
+                w_q, scales = mx.quantize(w, mode="nvfp4")
+                w_hat = mx.dequantize(w_q, scales, mode="nvfp4")
+                cot = mx.random.normal(shape=(M, N), key=k3)
+
+                def f(x):
+                    return mx.quantized_matmul(
+                        x, w_q, scales, transpose=transpose, mode="nvfp4"
+                    )
+
+                _, (grad,) = mx.vjp(f, (x,), (cot,))
+                expected = cot @ (w_hat if transpose else mx.swapaxes(w_hat, -1, -2))
+                self.assertEqual(grad.shape, expected.shape)
+                self.assertLess((grad - expected).abs().max(), 1e-3)
+
+    def test_fp_gather_qmm_non_multiple_of_32(self):
+        # K % 32 == 16 through both gather_qmm kernels: the sorted-indices
+        # (MoE prefill) kernel and the tiled gather kernel.
+        key = mx.random.key(0)
+        k1, k2, k3 = mx.random.split(key, 3)
+        mode = "nvfp4"
+        T, E, K, N = 64, 4, 1040, 128
+        # The half types only run on the GPU: on the CPU the reference
+        # matmul is evaluated in the same low precision, and its own
+        # accumulation error over K swamps the comparison.
+        dtypes = [mx.float32]
+        if mx.default_device() == mx.gpu:
+            dtypes += [mx.float16, mx.bfloat16]
+        tols = {mx.float32: 1e-3, mx.float16: 5e-3, mx.bfloat16: 4e-2}
+
+        for dtype in dtypes:
+            w = mx.random.normal(shape=(E, N, K), key=k2).astype(dtype)
+            w_q, scales = mx.quantize(w, mode=mode)
+            w_hat = mx.dequantize(w_q, scales, mode=mode)
+
+            with self.subTest(sorted_indices=True, dtype=dtype):
+                x = (mx.random.normal(shape=(T, 1, K), key=k1) / K**0.5).astype(dtype)
+                rhs = mx.sort(
+                    (mx.random.uniform(shape=(T,), key=k3) * E).astype(mx.uint32)
+                )
+                y_q = mx.gather_qmm(
+                    x,
+                    w_q,
+                    scales,
+                    rhs_indices=rhs,
+                    transpose=True,
+                    mode=mode,
+                    sorted_indices=True,
+                )
+                w_sel = mx.take(w_hat, rhs, axis=0)
+                y_hat = x @ mx.swapaxes(w_sel, -1, -2)
+                self.assertEqual(y_q.shape, y_hat.shape)
+                self.assertLess((y_q - y_hat).abs().max(), tols[dtype])
+
+            with self.subTest(sorted_indices=False, dtype=dtype):
+                B, M = 8, 50
+                x = (mx.random.normal(shape=(B, M, K), key=k1) / K**0.5).astype(dtype)
+                lhs = mx.arange(B, dtype=mx.uint32)
+                rhs = (mx.random.uniform(shape=(B,), key=k3) * E).astype(mx.uint32)
+                y_q = mx.gather_qmm(
+                    x,
+                    w_q,
+                    scales,
+                    lhs_indices=lhs,
+                    rhs_indices=rhs,
+                    transpose=True,
+                    mode=mode,
+                )
+                w_sel = mx.take(w_hat, rhs, axis=0)
+                y_hat = x @ mx.swapaxes(w_sel, -1, -2)
+                self.assertEqual(y_q.shape, y_hat.shape)
+                self.assertLess((y_q - y_hat).abs().max(), tols[dtype])
+
+        # The other quantized dim: transpose=False puts the 16-wide tail on N.
+        Kn, Nn = 512, 1040
+        w = mx.random.normal(shape=(E, Kn, Nn), key=k2)
+        w_q, scales = mx.quantize(w, mode=mode)
+        w_hat = mx.dequantize(w_q, scales, mode=mode)
+
+        with self.subTest(transpose=False, sorted_indices=True):
+            x = mx.random.normal(shape=(T, 1, Kn), key=k1)
+            rhs = mx.sort((mx.random.uniform(shape=(T,), key=k3) * E).astype(mx.uint32))
+            y_q = mx.gather_qmm(
+                x,
+                w_q,
+                scales,
+                rhs_indices=rhs,
+                transpose=False,
+                mode=mode,
+                sorted_indices=True,
+            )
+            y_hat = x @ mx.take(w_hat, rhs, axis=0)
+            self.assertEqual(y_q.shape, y_hat.shape)
+            self.assertLess((y_q - y_hat).abs().max(), 1e-3)
+
+        with self.subTest(transpose=False, sorted_indices=False):
+            B, M = 8, 50
+            x = mx.random.normal(shape=(B, M, Kn), key=k1)
+            lhs = mx.arange(B, dtype=mx.uint32)
+            rhs = (mx.random.uniform(shape=(B,), key=k3) * E).astype(mx.uint32)
+            y_q = mx.gather_qmm(
+                x,
+                w_q,
+                scales,
+                lhs_indices=lhs,
+                rhs_indices=rhs,
+                transpose=False,
+                mode=mode,
+            )
+            y_hat = x @ mx.take(w_hat, rhs, axis=0)
+            self.assertEqual(y_q.shape, y_hat.shape)
+            self.assertLess((y_q - y_hat).abs().max(), 1e-3)
+
     def test_mode_error_cases(self):
         w = mx.random.normal(shape=(256, 256))
         x = mx.random.normal(shape=(1, 256))

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -715,72 +715,64 @@ class TestQuantized(mlx_tests.MLXTestCase):
                     self.assertEqual(y_q.shape, y_hat.shape)
                     self.assertLess((y_q - y_hat).abs().max(), 2e-3)
 
+
+    FP_TAIL_TOLS = {mx.float32: 1e-3, mx.float16: 5e-3, mx.bfloat16: 4e-2}
+
+    def _fp_tail_dtypes(self):
+        # The half types only run on the GPU
+        if mx.default_device() == mx.gpu:
+            return [mx.float32, mx.float16, mx.bfloat16]
+        return [mx.float32]
+
     def test_fp_qmm_non_multiple_of_32(self):
-        # nvfp4's group_size of 16 lets the quantized dim be a multiple of 16
-        # but not of 32; the qmm kernels tile that dim by 32 and must bound
-        # the 16-wide tail tile. mxfp4 and mxfp8 have group_size 32 and can
-        # never produce that tail, so they run here as a control.
         key = mx.random.key(0)
         k1, k2 = mx.random.split(key)
-        # The half types only run on the GPU: on the CPU the reference
-        # matmul is evaluated in the same low precision, and its own
-        # accumulation error over K swamps the comparison.
-        dtypes = [mx.float32]
-        if mx.default_device() == mx.gpu:
-            dtypes += [mx.float16, mx.bfloat16]
-        tols = {mx.float32: 1e-3, mx.float16: 5e-3, mx.bfloat16: 4e-2}
 
-        # transpose=True: K % 32 == 16. M >= 33 keeps the shape on the tiled
-        # kernel for every chip (the qmv batch limit caps at 32).
-        for dtype in dtypes:
-            for M, K, N in [(50, 1040, 128), (33, 528, 64)]:
-                with self.subTest(M=M, K=K, N=N, transpose=True, dtype=dtype):
-                    x = (mx.random.normal(shape=(M, K), key=k1) / K**0.5).astype(dtype)
-                    w = mx.random.normal(shape=(N, K), key=k2).astype(dtype)
-                    w_q, scales = mx.quantize(w, mode="nvfp4")
-                    w_hat = mx.dequantize(w_q, scales, mode="nvfp4")
-                    y_q = mx.quantized_matmul(
-                        x, w_q, scales, transpose=True, mode="nvfp4"
-                    )
-                    y_hat = x @ mx.swapaxes(w_hat, -1, -2)
-                    self.assertEqual(y_q.shape, y_hat.shape)
-                    self.assertLess((y_q - y_hat).abs().max(), tols[dtype])
-
-        # transpose=False: N % 32 == 16. An unbounded store of the tail tile
-        # spills onto the next output row and races the threadgroup that owns
-        # it, so also check that two identical runs agree bit for bit.
-        for dtype in dtypes:
-            M, K, N = 50, 512, 1040
-            with self.subTest(M=M, K=K, N=N, transpose=False, dtype=dtype):
+        def check(M, K, N, transpose, mode, dtype):
+            with self.subTest(
+                M=M, K=K, N=N, transpose=transpose, mode=mode, dtype=dtype
+            ):
+                w_shape = (N, K) if transpose else (K, N)
                 x = (mx.random.normal(shape=(M, K), key=k1) / K**0.5).astype(dtype)
-                w = mx.random.normal(shape=(K, N), key=k2).astype(dtype)
-                w_q, scales = mx.quantize(w, mode="nvfp4")
-                w_hat = mx.dequantize(w_q, scales, mode="nvfp4")
-                y_q = mx.quantized_matmul(x, w_q, scales, transpose=False, mode="nvfp4")
-                y_q2 = mx.quantized_matmul(
-                    x, w_q, scales, transpose=False, mode="nvfp4"
-                )
-                y_hat = x @ w_hat
-                self.assertEqual(y_q.shape, y_hat.shape)
-                self.assertLess((y_q - y_hat).abs().max(), tols[dtype])
-                self.assertTrue(mx.array_equal(y_q, y_q2))
+                w = mx.random.normal(shape=w_shape, key=k2).astype(dtype)
+                w_q, scales = mx.quantize(w, mode=mode)
+                w_hat = mx.dequantize(w_q, scales, mode=mode)
 
-        # Control: the group_size 32 modes at the same block-unaligned shapes.
-        for mode in ["mxfp4", "mxfp8"]:
-            for M, K, N in [(50, 1056, 128), (50, 512, 1056)]:
-                transpose = N == 128
-                with self.subTest(M=M, K=K, N=N, mode=mode):
-                    x = mx.random.normal(shape=(M, K), key=k1)
-                    w_shape = (N, K) if transpose else (K, N)
-                    w = mx.random.normal(shape=w_shape, key=k2)
-                    w_q, scales = mx.quantize(w, mode=mode)
-                    w_hat = mx.dequantize(w_q, scales, mode=mode)
-                    y_q = mx.quantized_matmul(
-                        x, w_q, scales, transpose=transpose, mode=mode
-                    )
-                    y_hat = x @ mx.swapaxes(w_hat, -1, -2) if transpose else x @ w_hat
-                    self.assertEqual(y_q.shape, y_hat.shape)
-                    self.assertLess((y_q - y_hat).abs().max(), 1e-3)
+                y_q = mx.quantized_matmul(
+                    x, w_q, scales, transpose=transpose, mode=mode
+                )
+                # An unbounded store of the N tail spills onto the next output
+                # row and races the threadgroup that owns it, so two identical
+                # runs must agree bit for bit.
+                y_q2 = mx.quantized_matmul(
+                    x, w_q, scales, transpose=transpose, mode=mode
+                )
+                y_hat = x @ (mx.swapaxes(w_hat, -1, -2) if transpose else w_hat)
+
+                self.assertEqual(y_q.shape, y_hat.shape)
+                self.assertTrue(mx.array_equal(y_q, y_q2))
+                self.assertLess((y_q - y_hat).abs().max(), self.FP_TAIL_TOLS[dtype])
+
+        # (M, K, N, transpose). M is kept clear of the qmv batch limit
+        # (get_qmv_batch_limit caps at 32) so these route to the tiled kernel.
+        nvfp4_shapes = [
+            (50, 1040, 128, True),  # K % 32 == 16
+            (33, 528, 64, True),  # K % 32 == 16, M just over one BM tile
+            (50, 512, 1040, False),  # N % 32 == 16
+            (50, 1040, 1040, False),  # both dims carry a tail
+            (50, 16, 128, True),  # K is a single partial tile
+        ]
+        control_shapes = [
+            (50, 1056, 128, True),  # K % 32 == 0
+            (50, 512, 1056, False),  # N % 32 == 0
+        ]
+
+        for dtype in self._fp_tail_dtypes():
+            for M, K, N, transpose in nvfp4_shapes:
+                check(M, K, N, transpose, "nvfp4", dtype)
+            for mode in ["mxfp4", "mxfp8"]:
+                for M, K, N, transpose in control_shapes:
+                    check(M, K, N, transpose, mode, dtype)
 
     def test_fp_qmm_non_multiple_of_32_vjp(self):
         # The backward of quantized_matmul runs the same kernels with the
@@ -789,122 +781,101 @@ class TestQuantized(mlx_tests.MLXTestCase):
         k1, k2, k3 = mx.random.split(key, 3)
         M, K, N = 50, 1040, 128
 
-        for transpose in [True, False]:
-            with self.subTest(transpose=transpose):
-                w_shape = (N, K) if transpose else (K, N)
-                x = mx.random.normal(shape=(M, K), key=k1)
-                w = mx.random.normal(shape=w_shape, key=k2)
-                w_q, scales = mx.quantize(w, mode="nvfp4")
-                w_hat = mx.dequantize(w_q, scales, mode="nvfp4")
-                cot = mx.random.normal(shape=(M, N), key=k3)
-
-                def f(x):
-                    return mx.quantized_matmul(
-                        x, w_q, scales, transpose=transpose, mode="nvfp4"
+        for dtype in self._fp_tail_dtypes():
+            for transpose in [True, False]:
+                with self.subTest(transpose=transpose, dtype=dtype):
+                    w_shape = (N, K) if transpose else (K, N)
+                    x = (mx.random.normal(shape=(M, K), key=k1) / K**0.5).astype(dtype)
+                    w = mx.random.normal(shape=w_shape, key=k2).astype(dtype)
+                    w_q, scales = mx.quantize(w, mode="nvfp4")
+                    w_hat = mx.dequantize(w_q, scales, mode="nvfp4")
+                    cot = (mx.random.normal(shape=(M, N), key=k3) / N**0.5).astype(
+                        dtype
                     )
 
-                _, (grad,) = mx.vjp(f, (x,), (cot,))
-                expected = cot @ (w_hat if transpose else mx.swapaxes(w_hat, -1, -2))
-                self.assertEqual(grad.shape, expected.shape)
-                self.assertLess((grad - expected).abs().max(), 1e-3)
+                    def f(x):
+                        return mx.quantized_matmul(
+                            x, w_q, scales, transpose=transpose, mode="nvfp4"
+                        )
+
+                    (out,), (grad,) = mx.vjp(f, (x,), (cot,))
+                    tol = self.FP_TAIL_TOLS[dtype]
+
+                    # The forward runs the tail kernel for this transpose; the
+                    # backward runs it for the other one, we might as well check both.
+                    out_hat = x @ (mx.swapaxes(w_hat, -1, -2) if transpose else w_hat)
+                    self.assertEqual(out.shape, out_hat.shape)
+                    self.assertLess((out - out_hat).abs().max(), tol)
+
+                    grad_hat = cot @ (
+                        w_hat if transpose else mx.swapaxes(w_hat, -1, -2)
+                    )
+                    self.assertEqual(grad.shape, grad_hat.shape)
+                    self.assertLess((grad - grad_hat).abs().max(), tol)
 
     def test_fp_gather_qmm_non_multiple_of_32(self):
-        # K % 32 == 16 through both gather_qmm kernels: the sorted-indices
-        # (MoE prefill) kernel and the tiled gather kernel.
+        # Both gather_qmm kernels: the sorted-indices (MoE prefill) kernel and
+        # the tiled gather kernel.
         key = mx.random.key(0)
         k1, k2, k3 = mx.random.split(key, 3)
         mode = "nvfp4"
-        T, E, K, N = 64, 4, 1040, 128
-        # The half types only run on the GPU: on the CPU the reference
-        # matmul is evaluated in the same low precision, and its own
-        # accumulation error over K swamps the comparison.
-        dtypes = [mx.float32]
-        if mx.default_device() == mx.gpu:
-            dtypes += [mx.float16, mx.bfloat16]
-        tols = {mx.float32: 1e-3, mx.float16: 5e-3, mx.bfloat16: 4e-2}
+        E = 4
 
-        for dtype in dtypes:
-            w = mx.random.normal(shape=(E, N, K), key=k2).astype(dtype)
-            w_q, scales = mx.quantize(w, mode=mode)
-            w_hat = mx.dequantize(w_q, scales, mode=mode)
+        def check(K, N, transpose, sorted_indices, dtype):
+            with self.subTest(
+                K=K,
+                N=N,
+                transpose=transpose,
+                sorted_indices=sorted_indices,
+                dtype=dtype,
+            ):
+                w_shape = (E, N, K) if transpose else (E, K, N)
+                w = mx.random.normal(shape=w_shape, key=k2).astype(dtype)
+                w_q, scales = mx.quantize(w, mode=mode)
+                w_hat = mx.dequantize(w_q, scales, mode=mode)
 
-            with self.subTest(sorted_indices=True, dtype=dtype):
-                x = (mx.random.normal(shape=(T, 1, K), key=k1) / K**0.5).astype(dtype)
-                rhs = mx.sort(
-                    (mx.random.uniform(shape=(T,), key=k3) * E).astype(mx.uint32)
-                )
-                y_q = mx.gather_qmm(
-                    x,
-                    w_q,
-                    scales,
-                    rhs_indices=rhs,
-                    transpose=True,
-                    mode=mode,
-                    sorted_indices=True,
-                )
-                w_sel = mx.take(w_hat, rhs, axis=0)
-                y_hat = x @ mx.swapaxes(w_sel, -1, -2)
-                self.assertEqual(y_q.shape, y_hat.shape)
-                self.assertLess((y_q - y_hat).abs().max(), tols[dtype])
+                if sorted_indices:
+                    T = 64
+                    x = (mx.random.normal(shape=(T, 1, K), key=k1) / K**0.5).astype(
+                        dtype
+                    )
+                    rhs = mx.sort(mx.random.randint(0, E, shape=(T,), key=k3)).astype(
+                        mx.uint32
+                    )
+                    lhs = None
+                else:
+                    B, M = 8, 50
+                    x = (mx.random.normal(shape=(B, M, K), key=k1) / K**0.5).astype(
+                        dtype
+                    )
+                    rhs = mx.random.randint(0, E, shape=(B,), key=k3).astype(mx.uint32)
+                    lhs = mx.arange(B, dtype=mx.uint32)
 
-            with self.subTest(sorted_indices=False, dtype=dtype):
-                B, M = 8, 50
-                x = (mx.random.normal(shape=(B, M, K), key=k1) / K**0.5).astype(dtype)
-                lhs = mx.arange(B, dtype=mx.uint32)
-                rhs = (mx.random.uniform(shape=(B,), key=k3) * E).astype(mx.uint32)
                 y_q = mx.gather_qmm(
                     x,
                     w_q,
                     scales,
                     lhs_indices=lhs,
                     rhs_indices=rhs,
-                    transpose=True,
+                    transpose=transpose,
                     mode=mode,
+                    sorted_indices=sorted_indices,
                 )
                 w_sel = mx.take(w_hat, rhs, axis=0)
-                y_hat = x @ mx.swapaxes(w_sel, -1, -2)
+                y_hat = x @ (mx.swapaxes(w_sel, -1, -2) if transpose else w_sel)
+
                 self.assertEqual(y_q.shape, y_hat.shape)
-                self.assertLess((y_q - y_hat).abs().max(), tols[dtype])
+                self.assertLess((y_q - y_hat).abs().max(), self.FP_TAIL_TOLS[dtype])
 
-        # The other quantized dim: transpose=False puts the 16-wide tail on N.
-        Kn, Nn = 512, 1040
-        w = mx.random.normal(shape=(E, Kn, Nn), key=k2)
-        w_q, scales = mx.quantize(w, mode=mode)
-        w_hat = mx.dequantize(w_q, scales, mode=mode)
-
-        with self.subTest(transpose=False, sorted_indices=True):
-            x = mx.random.normal(shape=(T, 1, Kn), key=k1)
-            rhs = mx.sort((mx.random.uniform(shape=(T,), key=k3) * E).astype(mx.uint32))
-            y_q = mx.gather_qmm(
-                x,
-                w_q,
-                scales,
-                rhs_indices=rhs,
-                transpose=False,
-                mode=mode,
-                sorted_indices=True,
-            )
-            y_hat = x @ mx.take(w_hat, rhs, axis=0)
-            self.assertEqual(y_q.shape, y_hat.shape)
-            self.assertLess((y_q - y_hat).abs().max(), 1e-3)
-
-        with self.subTest(transpose=False, sorted_indices=False):
-            B, M = 8, 50
-            x = mx.random.normal(shape=(B, M, Kn), key=k1)
-            lhs = mx.arange(B, dtype=mx.uint32)
-            rhs = (mx.random.uniform(shape=(B,), key=k3) * E).astype(mx.uint32)
-            y_q = mx.gather_qmm(
-                x,
-                w_q,
-                scales,
-                lhs_indices=lhs,
-                rhs_indices=rhs,
-                transpose=False,
-                mode=mode,
-            )
-            y_hat = x @ mx.take(w_hat, rhs, axis=0)
-            self.assertEqual(y_q.shape, y_hat.shape)
-            self.assertLess((y_q - y_hat).abs().max(), 1e-3)
+        # (K, N, transpose): transpose puts the tail on K, else on N.
+        shapes = [
+            (1040, 128, True),  # K % 32 == 16
+            (512, 1040, False),  # N % 32 == 16
+        ]
+        for dtype in self._fp_tail_dtypes():
+            for K, N, transpose in shapes:
+                for sorted_indices in [True, False]:
+                    check(K, N, transpose, sorted_indices, dtype)
 
     def test_mode_error_cases(self):
         w = mx.random.normal(shape=(256, 256))

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -715,7 +715,6 @@ class TestQuantized(mlx_tests.MLXTestCase):
                     self.assertEqual(y_q.shape, y_hat.shape)
                     self.assertLess((y_q - y_hat).abs().max(), 2e-3)
 
-
     FP_TAIL_TOLS = {mx.float32: 1e-3, mx.float16: 5e-3, mx.bfloat16: 4e-2}
 
     def _fp_tail_dtypes(self):


### PR DESCRIPTION
## Problem

nvfp4 is the only quantization mode whose group size (16) lets the quantized
dimension of a matmul legally be a multiple of 16 but not of 32.
`mx.quantize(w, mode="nvfp4")` accepts `K = 1040`, and the fp quantized Metal
kernels tile that dimension by 32 without bounding the 16-wide tail. Whenever it
happens, every matrix-sized `quantized_matmul` / `gather_qmm` on the GPU
silently returns corrupted results. The CPU backend and the vector (decode)
kernels handle the same shapes correctly, so a model can decode perfectly and
corrupt during prefill, which is about as quiet as corruption gets.

Minimal reproducer (M3 Pro, macOS 25.5, main @ 39d9a8ac2):

```python
import mlx.core as mx

M, K, N = 50, 1040, 128  # K % 32 == 16; M large enough for the tiled kernel
x = mx.random.normal((M, K)).astype(mx.float16)
w = mx.random.normal((N, K)).astype(mx.float16)
wq, s = mx.quantize(w, mode="nvfp4")

out = mx.quantized_matmul(x, wq, s, transpose=True, mode="nvfp4")
ref = x @ mx.dequantize(wq, s, mode="nvfp4").T
print((out - ref).abs().max())   # ~40; 72% of outputs wrong
```

`stream=mx.cpu`: 1.2e-3. `M=1` (vector kernel): 1.1e-3. Aligned `K=1024`: 3e-3.
Only the GPU matrix path with `K % 32 == 16` is wrong.

## The three defects

All in `mlx/backend/metal/kernels/fp_quantized.h`, introduced with the Metal
nvfp4 support in #2946.

1. **`fp_qmm_t_impl` ran its K loop past `K_eff`** (`for (int k = 0; k < K_eff;
   k += BK)` with full-BK loads), so the final iteration read 16 columns of the
   next output row's packed weights and scales (past the buffer for the last
   row) into the accumulator. Metal shader validation on the unpatched kernel:
   `Invalid device load at offset 2129920 … "nvfp4_qmm_t_float16_t_gs_16_b_4_alN_true_batch_0"`
   (the weight buffer is exactly 2129920 bytes). Also backs the tiled
   `gather_qmm`, so the unsorted MoE path fails identically.

2. **`fp_qmm_n_impl` stored full 32-column tiles for a 16-column tail.** The
   store clipped rows only (`store_result_safe(y, N, short2(BN, num_els))`), so
   with `N % 32 == 16` the last column tile stored 32 columns into rows only N
   long: the 16 spilled columns land on the next row's first 16 outputs (racing
   the neighbouring threadgroup) and past the end of the output buffer for the
   last row. Unpatched: 200 identical runs give **61 distinct results**,
   corruption sits exactly at columns 0 to 15, and shader validation flags
   `Invalid device store at offset 1064976 … "nvfp4_qmm_n_float16_t_gs_16_b_4_batch_0"`.

3. **`QuantizedBlockLoader::load_safe` masked the wrong axis** (`if
   (reduction_dim == 1 && bi >= src_tile_dim.x)`): `bi` is the thread's row,
   `src_tile_dim.x` the column-direction bound. In the K-remainder step of the
   sorted-MoE kernel `fp_gather_qmm_rhs` (`tile_w = short2(k_remain=16,
   tgp_bn)`), this zeroed the threads owning output columns 16 to 31 of each tile
   and silently dropped their last 16 K-elements. Positive ID: on the unpatched
   kernel the wrong columns are exactly those ≡ 16..31 (mod 32), and their
   values equal `ref - x[:, K-16:] @ w[e][:, K-16:].T` to within 0.05 (fp16
   rounding): the dot product minus exactly its tail. In the `fp_qmm_t` call
   sites the same compare is `bi >= 32`, dead code, so their intended column
   masking never ran.

## Fix

- **`fp_qmm_t_impl`**: iterate `K_eff / BK` full tiles, then one bounded
  remainder tile, mirroring `fp_qmm_n_impl`'s existing K handling. The split-K
  kernel `fp_qmm_t_splitk` passes `K_eff = k_partition_size`, which #3854 keeps
  a multiple of 32, so `num_k == 0` and split-K is unchanged.
- **`fp_qmm_n_impl`**: take `num_outs = min(BN, N - y_col)`, clip the w loads to
  it, and store with `store_result_safe(y, N, short2(num_outs, num_els))`.
  Removes the race and the out-of-bounds store.
- **`QuantizedBlockLoader::load_safe`** (`fp_quantized.h` and the affine twin in
  `quantized.h`): mask rows against `.y` and the thread's columns against `.x`.
  A thread owns `n_reads * pack_factor` contiguous columns and every legal
  partial extent is a whole number of quantization groups, so a thread is never
  straddled; the new `static_assert(group_size % (n_reads * pack_factor) == 0)`
  in both loaders pins that invariant.

A quantized dim is always a multiple of `group_size`, so it can only end in a
partial tile when `group_size` does not divide the block. Only nvfp4 does;
mxfp4 and mxfp8 have `group_size == 32 == BK == BN`, and every affine group
size is a multiple of the block. The remainder tile and the column bound are
therefore selected with `if constexpr` on `group_size % BK != 0`,
`group_size % BN != 0` and `group_size % BCOLS != 0`, so they are discarded at
compile time for those modes.

### This also removes an out-of-bounds read that affine and mxfp hit today

The row half of the mask is not nvfp4-only. In `qmm_t_impl` the w loader is
instantiated with `BROWS = BN` and `reduction_dim = 1`, and the call is
`load_safe(short2(BK, num_outs))`. The old compare was `bi >= src_tile_dim.x`,
that is `bi >= BK == 32`, while `bi` ranges over `[0, BROWS) == [0, 32)`, so it
never fired: whenever `N % BN != 0` the last tile read weight and scale rows
past `N`. The store already clipped those columns, so results were correct;
this is a read past the end of the buffer, not corruption. It reproduces on
affine, which is the most used mode:

```python
import mlx.core as mx

M, K, N = 64, 32768, 100  # N % 32 != 0, M >= 33 for the tiled kernel
x = mx.random.normal((M, K)).astype(mx.float16)
w = mx.random.normal((N, K)).astype(mx.float16)
wq, s, b = mx.quantize(w, group_size=32, bits=4)
mx.eval(x, wq, s, b)
mx.eval(mx.quantized_matmul(x, wq, s, b, transpose=True, group_size=32, bits=4))
```

`K = 32768` makes the packed weight buffer an exact multiple of the page size,
so the over-read crosses the allocation. Under Metal shader validation on
39d9a8ac2:

```
Invalid device load at offset 213056, executing kernel function:
"affine_qmm_t_splitk_float16_t_gs_32_b_4_alN_false"
```

With this change the same run is clean, as are the two nvfp4 shapes below. The
same applies to mxfp4 and mxfp8 with `N % BN != 0`.

On the loader mask: `bi` is a row index and `bj` a packed column index, and
every call site passes `src_tile_dim` as (valid columns, valid rows), swapping
which physical dim that is to match the layout. `fp_qmm_t_impl` passes
`short2(BK, num_outs)` with `BROWS = BN`, `fp_qmm_n_impl` passes
`short2(num_outs, BK)` with `BROWS = BK`, and `fp_gather_qmm_rhs` picks
`short2(k_remain, tgp_bn)` or `short2(tgp_bn, k_remain)` on `transpose`. That is
the convention steel's `BlockLoader::load_safe` already uses
(`src_tile_dim - short2(bj, bi)`), so the row index tests against `.y` in every
case and the mask does not depend on `reduction_dim`.

## Validation

M3 Pro (applegpu_g15s), macOS 25.5, against main @ 39d9a8ac2. "ref" is fp64 on
the MLX-dequantized weights (bit-identical CPU vs GPU dequantize, asserted).

| check | unpatched | patched |
| --- | --- | --- |
| t=1, M=50, K=1040/4112 (3 seeds) | rel err 0.33 to 0.69, 46 to 72% of outputs >5% off | 1.2e-3 |
| t=0, M=50, K=512, N=1040 | rel err 5.2 at cols 0 to 15 | 1.7e-3 |
| t=0 determinism, 200 identical runs | 61 distinct | 1 (also 1/200 across 4 families × 3 seeds) |
| sorted gather, T=64, K=1040 | cols ≡16..31(32) = ref minus K-tail (±0.05) | 1.2e-3 |
| unsorted gather, M=50, K=1040 | rel err 0.82 | 2.0e-3 |
| split-K (`fp_qmm_t_splitk`), K∈{2048,4096,8192} | (unaffected; K_eff a mult of 32) | 2.6 to 3.9e-3 |
| vjp of quantized_matmul + gather_qmm, both transposes | n/a | 1.5e-6 to 8.1e-6 |
| shader validation, nvfp4 t=1 read / t=0 store | invalid load @2129920 / invalid store @1064976 | 0 faults |
| shader validation, affine `N % BN != 0` | invalid load @213056 | 0 faults |
| added regression tests | 17/19 subtests fail | pass |
| python/tests/test_quantized.py | n/a | 36/36 |
| full python test suite | n/a | 804 OK, 3 skipped |
| deterministic misalignment sweep (all 4 kernels, fp32, 1e-3 gate) | n/a | 289/289 |
| randomized differential campaign (affine 2 to 8 bits gs 32/64/128 / mxfp4 / mxfp8 / nvfp4 × fp16/bf16/fp32 × both transposes × contiguous+strided × plain/gather/sorted-MoE, GPU vs fp64) | n/a | 4515 cases, 0 GPU failures |

The campaign's CPU cross-check uses a looser gate for fp16 and bf16, since the
CPU backend accumulates those differently over a large K; that is not code this
PR touches.

The added tests use M ≥ 33; `get_qmv_batch_limit` caps the vector/matrix
threshold at 32, so the tiled kernels are exercised on every Apple GPU family
(M1 to M4, including Max/Ultra). 17 of the 19 subtests fail on 39d9a8ac2 and all
pass with the fix. The two that pass on both are controls: the vjp with
`transpose=False` has an aligned quantized dim, and the sorted gather with
`transpose=False` runs the loader with `reduction_dim == 0`, where the old row
compare was already correct.

To confirm the `if constexpr` guards cost the other modes nothing, I compiled
`fp_quantized.metal` against the base headers and against this branch and
compared every emitted kernel body after normalizing metadata ids. Of the 306
`gs_32` kernels, 253 are byte-identical and **none gained a single
instruction**; 53 shrank, for a net of −141 instructions, while the +12950
instructions added by the fix land entirely on the nvfp4 kernels. The 53 that
shrank are exactly the `reduction_dim == 1` families (`qmm_t`, `qmm_t_splitk`,
`gather_qmm_t`, `gather_qmm_rhs_nt`), where the row mask now short-circuits the
rows it used to read out of bounds.

## Perf (aligned fast path, min-of-medians, ms, before -> after)

```
                              aligned         unaligned gather
nvfp4  qmm_t  512x4096x4096   4.247 -> 4.191
nvfp4  qmm_n  512x4096x4096   4.175 -> 4.151
mxfp4  qmm_t  512x4096x4096   4.274 -> 4.215
mxfp4  qmm_n  512x4096x4096   4.208 -> 4.157
mxfp8  qmm_t  512x4096x4096   4.340 -> 4.305
mxfp8  qmm_n  512x4096x4096   4.262 -> 4.209
affine qmm_t  512x4096x4096   4.217 -> 4.230
affine qmm_n  512x4096x4096   4.203 -> 4.146
nvfp4  gather_rhs 512/8/2048  1.514 -> 1.454
mxfp4  gather_rhs 512/8/2048  1.514 -> 1.453
mxfp4  gather_rhs nt T=500 K=2080 N=2080   1.619 -> 1.556
mxfp8  gather_rhs nt T=500 K=2080 N=2080   1.700 -> 1.637
mxfp4  gather_rhs nn T=500 K=2080 N=2080   1.636 -> 1.578
mxfp8  gather_rhs nn T=500 K=2080 N=2080   1.695 -> 1.627
```

Nothing regresses. The mxfp4, mxfp8 and affine rows are the ones that matter
for the `if constexpr` guards above, and the unaligned gather rows are the
kernels where the row mask now short-circuits work the base build was doing on
rows it read out of bounds.

## Why fix the kernel rather than reject the dimension

`group_size = 16` advertises that quantized dimensions which are multiples of 16
are supported; silently corrupting a legal, documented input is an API-contract
violation the kernel should honor rather than an input to reject at the op layer.
The inconsistency already shows: `mx.quantize(w, mode="nvfp4", stream=mx.cpu)`
*throws* a reshape error when `w.size % 32 != 0` while the GPU path accepts the
same tensor and later corrupts. One backend rejects what the other silently
mishandles. Making the kernels correct for every legal group_size=16 dimension
resolves both.

## Provenance

Introduced with the Metal nvfp4 kernels in #2946. #3854 narrowed only the
split-K route: for `K ≡ 16 (mod 32)` no split_k makes `K % (split_k * 32) == 0`,
so those shapes always take its `split_k = 1` fallback straight into plain
`qmm()` -> `fp_qmm_t_impl`, the unbounded loop fixed here. The reproducer above
(M=50, K=1040, B=1, transpose=True) is exactly that path, so the shapes #3854
meant to protect were still corrupted.

Related but distinct: #3856 reports affine `gather_qmm` corruption at large unaligned
row counts (`n > 32768`, `n % 64 != 0`) on M5, a row-count (M) bug. This is a
quantized-dimension (K/N) bug specific to nvfp4; #3856's own repro does not reproduce
against this branch, and this fix leaves its `K % 64 == 0` shapes on the same NAX
kernel, so the two do not overlap.

## Tests

`test_fp_qmm_non_multiple_of_32` covers K=1040/528 (transpose=True) and N=1040
(transpose=False, run twice and compared bit for bit to catch the store race),
each in fp32, fp16 and bf16, plus mxfp4 and mxfp8 at the same block-unaligned
shapes as a control that the `if constexpr` guards did not change them.
`test_fp_gather_qmm_non_multiple_of_32` covers sorted and unsorted `gather_qmm`
in the same three dtypes, with the tail on K (transpose=True) and on N
(transpose=False). `test_fp_qmm_non_multiple_of_32_vjp` covers the backward of
both transposes. Inputs are scaled by `1 / sqrt(K)` so the dot products are
O(1); at magnitude 32 a single fp16 ulp is 0.03 and would swamp the tolerance.

