### PR TITLE
Raise a clear error for an invalid quantization mode in nn layers

### DIFF
--- a/python/mlx/nn/layers/quantized.py
+++ b/python/mlx/nn/layers/quantized.py
@@ -15,6 +15,11 @@ def _defaults_for_mode(mode, group_size, bits):
         "nvfp4": (16, 4),
         "mxfp8": (32, 8),
     }
+    if mode not in mode_defaults:
+        raise ValueError(
+            f"Invalid quantization mode '{mode}'. "
+            f"Valid modes are: {', '.join(mode_defaults)}."
+        )
     default_group_size, default_bits = mode_defaults[mode]
     return group_size or default_group_size, bits or default_bits
 


### PR DESCRIPTION
## Proposed changes

`mx.quantize` validates its `mode` argument and gives a clear message, but the `nn` quantized layers hit a bare dict lookup first, so a typo'd mode surfaces as a raw `KeyError` with no hint about what is wrong or which modes exist:

```python
import mlx.core as mx
import mlx.nn as nn

mx.quantize(mx.random.uniform(shape=(8, 8)), 64, 4, mode="bogus")
# ValueError: [quantize] Invalid quantization mode 'bogus'.

nn.QuantizedLinear(8, 8, mode="bogus")
# KeyError: 'bogus'
```

Same `KeyError` for `QuantizedEmbedding`, `QQLinear`, `from_linear`, `from_embedding`, and `nn.quantize(model, mode=...)`, since all of them call `_defaults_for_mode` before anything reaches `mx.quantize`.

This adds the missing check in `_defaults_for_mode` so those paths raise a `ValueError` that names the valid modes instead. Added the cases to `test_quantize`; they fail on main with `KeyError: 'xyz'` and pass with the change.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)

(test_nn.py 69/69 and test_quantized.py 32/32 pass locally on CPU)

---

heads up on process: i'm a freshman contributor and i use Claude Code to help me hunt for things like this, but i reproduced every one of those `KeyError` paths myself, checked that the valid modes list matches `mode_defaults`, and confirmed the new test actually fails on main before opening this. if you'd rather word the error differently or put the check somewhere else, happy to change it.
