### PR TITLE
Fuse the causal mask into the SDPA fallback softmax

### DIFF
--- a/mlx/backend/metal/kernels/defines.h
+++ b/mlx/backend/metal/kernels/defines.h
@@ -12,6 +12,7 @@ static MTL_CONST constexpr int MAX_REDUCE_SPECIALIZED_DIMS = 4;
 static MTL_CONST constexpr int REDUCE_N_READS = 4;
 static MTL_CONST constexpr int REDUCE_N_WRITES = 4;
 static MTL_CONST constexpr int SOFTMAX_N_READS = 4;
+static MTL_CONST constexpr int SOFTMAX_LOOPED_LIMIT = 4096;
 static MTL_CONST constexpr int RMS_N_READS = 4;
 static MTL_CONST constexpr int RMS_LOOPED_LIMIT = 4096;
 

--- a/mlx/backend/metal/softmax.cpp
+++ b/mlx/backend/metal/softmax.cpp
@@ -10,8 +10,6 @@
 
 namespace mlx::core {
 
-constexpr int SOFTMAX_LOOPED_LIMIT = 4096;
-
 void Softmax::eval_gpu(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 1);
   if (!issubdtype(out.dtype(), floating)) {

--- a/mlx/fast.cpp
+++ b/mlx/fast.cpp
@@ -1,7 +1,10 @@
 // Copyright © 2023-2024 Apple Inc.
 #include <cassert>
+#include <limits>
 #include <numeric>
 
+#include "mlx/backend/metal/kernels/defines.h"
+#include "mlx/backend/metal/metal.h"
 #include "mlx/fast.h"
 #include "mlx/fast_primitives.h"
 #include "mlx/ops.h"
@@ -9,6 +12,141 @@
 #include "mlx/transforms_impl.h"
 
 namespace mlx::core::fast {
+
+namespace {
+
+// Threadgroup size of the stock softmax_looped dispatch (the pipeline's
+// maxTotalThreadsPerThreadgroup on current Apple GPUs). Bit-identity with
+// the stock chain requires matching it exactly: the f32 accumulation order
+// depends on lsize.
+constexpr int FUSED_SOFTMAX_THREADGROUP = 1024;
+
+// Fused causal-mask + softmax for the SDPA ops fallback: the body of
+// softmax_looped (precise, N_READS = 4) from backend/metal/kernels/softmax.h
+// with the causal select applied at both load sites, replacing the
+// greater_equal -> where(finfo.min) -> softmax(precise) chain. The body must
+// stay bit-identical to that chain, which holds because the masked value is
+// the exact bf16 finfo.min as f32 and exp(min - max) underflows to exactly 0
+// in f32, so masked lanes never reach the output arithmetic (every row has a
+// valid element since offset = kL - qL >= 0).
+const char* fused_causal_softmax_header = R"MLX(
+constant constexpr float BF16_MINF = -0x1.FEp+127f;
+template <typename T>
+inline T softmax_exp(T x) {
+  return fast::exp(x);
+}
+)MLX";
+
+const char* fused_causal_softmax_source = R"MLX(
+const int axis_size = params[0];
+const int cofs = params[1];
+const int qL = params[2];
+
+uint gid = threadgroup_position_in_grid.x;
+uint lid = thread_position_in_threadgroup.x;
+uint lsize = threads_per_threadgroup.x;
+uint simd_lane_id = thread_index_in_simdgroup;
+uint simd_group_id = simdgroup_index_in_threadgroup;
+
+const device bfloat16_t* in = scores;
+device bfloat16_t* out = y;
+in += gid * size_t(axis_size);
+const int rowlim = cofs + int(gid) % qL;
+
+constexpr int SIMD_SIZE = 32;
+constexpr int N_READS = 4;
+
+threadgroup float local_max[SIMD_SIZE];
+threadgroup float local_normalizer[SIMD_SIZE];
+
+float prevmax;
+float maxval = Limits<float>::finite_min;
+float normalizer = 0;
+for (int r = 0; r < static_cast<int>(ceildiv(axis_size, N_READS * lsize));
+     r++) {
+  int offset = r * lsize * N_READS + lid * N_READS;
+  float vals[N_READS];
+  if (offset + N_READS <= axis_size) {
+    for (int i = 0; i < N_READS; i++) {
+      vals[i] =
+          (offset + i <= rowlim) ? float(in[offset + i]) : BF16_MINF;
+    }
+  } else {
+    for (int i = 0; i < N_READS; i++) {
+      vals[i] =
+          (offset + i < axis_size)
+          ? ((offset + i <= rowlim) ? float(in[offset + i]) : BF16_MINF)
+          : Limits<float>::min;
+    }
+  }
+  prevmax = maxval;
+  for (int i = 0; i < N_READS; i++) {
+    maxval = (maxval < vals[i]) ? vals[i] : maxval;
+  }
+  normalizer *= softmax_exp(prevmax - maxval);
+  for (int i = 0; i < N_READS; i++) {
+    normalizer += softmax_exp(vals[i] - maxval);
+  }
+}
+prevmax = maxval;
+maxval = simd_max(maxval);
+normalizer *= softmax_exp(prevmax - maxval);
+normalizer = simd_sum(normalizer);
+
+prevmax = maxval;
+if (simd_lane_id == 0) {
+  local_max[simd_group_id] = maxval;
+}
+threadgroup_barrier(mem_flags::mem_threadgroup);
+maxval = simd_max(local_max[simd_lane_id]);
+normalizer *= softmax_exp(prevmax - maxval);
+if (simd_lane_id == 0) {
+  local_normalizer[simd_group_id] = normalizer;
+}
+threadgroup_barrier(mem_flags::mem_threadgroup);
+normalizer = simd_sum(local_normalizer[simd_lane_id]);
+normalizer = 1 / normalizer;
+
+out += gid * size_t(axis_size);
+for (int r = 0; r < static_cast<int>(ceildiv(axis_size, N_READS * lsize));
+     r++) {
+  int offset = r * lsize * N_READS + lid * N_READS;
+  if (offset + N_READS <= axis_size) {
+    for (int i = 0; i < N_READS; i++) {
+      out[offset + i] = bfloat16_t(
+          softmax_exp(
+              ((offset + i <= rowlim) ? float(in[offset + i]) : BF16_MINF) -
+              maxval) *
+          normalizer);
+    }
+  } else {
+    for (int i = 0; i < N_READS; i++) {
+      if (offset + i < axis_size) {
+        out[offset + i] = bfloat16_t(
+            softmax_exp(
+                ((offset + i <= rowlim) ? float(in[offset + i]) : BF16_MINF) -
+                maxval) *
+            normalizer);
+      }
+    }
+  }
+}
+)MLX";
+
+const CustomKernelFunction& fused_causal_softmax() {
+  // The output must be named "y": the frozen kernel body aliases it
+  // (`device bfloat16_t* out = y;`), so renaming it here stops the
+  // generated source from compiling.
+  static auto fn = metal_kernel(
+      "sdpa_causal_softmax",
+      {"scores", "params"},
+      {"y"},
+      fused_causal_softmax_source,
+      fused_causal_softmax_header);
+  return fn;
+}
+
+} // namespace
 
 std::vector<array> Custom::vjp(
     const std::vector<array>& primals,
@@ -714,79 +852,109 @@ array scaled_dot_product_attention(
   auto k = astype(keys, final_type, s);
   auto v = astype(values, final_type, s);
 
-  auto fallback = [scale,
-                   n_q_heads,
-                   n_kv_heads,
-                   do_causal,
-                   has_sinks,
-                   has_arr_mask,
-                   s](const std::vector<array>& inputs) {
-    auto q = multiply(array(scale, inputs[0].dtype()), inputs[0], s);
-    int n_repeats = n_q_heads / n_kv_heads;
-    auto k = inputs[1];
-    auto v = inputs[2];
-    if (n_repeats > 1) {
-      q = unflatten(q, 1, {n_kv_heads, n_repeats}, s);
-      k = expand_dims(k, 2, s);
-      v = expand_dims(v, 2, s);
-    }
-    auto scores = matmul(q, swapaxes(k, -1, -2, s), s);
-    if (has_arr_mask || do_causal) {
-      // Mask must be broadcast-compatible with [B, n_q_heads, L_q, L_kv]
-      auto make_or_fetch_mask = [&]() {
-        if (do_causal) {
-          int kL = k.shape(-2);
-          int qL = q.shape(-2);
-          int offset = kL - qL;
-          auto q_idx = arange(offset, qL + offset, s);
-          auto k_idx = arange(0, kL, s);
-          q_idx = expand_dims(q_idx, 1, s);
-          k_idx = expand_dims(k_idx, 0, s);
-          return greater_equal(q_idx, k_idx, s);
+  auto fallback =
+      [scale, n_q_heads, n_kv_heads, do_causal, has_sinks, has_arr_mask, s](
+          const std::vector<array>& inputs) {
+        auto q = multiply(array(scale, inputs[0].dtype()), inputs[0], s);
+        int n_repeats = n_q_heads / n_kv_heads;
+        auto k = inputs[1];
+        auto v = inputs[2];
+        if (n_repeats > 1) {
+          q = unflatten(q, 1, {n_kv_heads, n_repeats}, s);
+          k = expand_dims(k, 2, s);
+          v = expand_dims(v, 2, s);
         }
-        return inputs[3];
-      };
-      auto mask = make_or_fetch_mask();
-
-      if (n_repeats > 1 && mask.ndim() >= 3) {
-        if (mask.shape(-3) == 1) {
-          mask = expand_dims(mask, -3, s);
+        auto scores = matmul(q, swapaxes(k, -1, -2, s), s);
+        // Bf16 causal bool-mask chains above the looped-softmax limit take the
+        // fused kernel, which skips the mask materialization and the
+        // masked-scores round trip. Traces (grad, vmap, compile) keep the stock
+        // chain: it differentiates, and a captured graph must not bake in the
+        // shape-dependent params built below.
+        const int kL = scores.shape(-1);
+        const size_t n_rows = scores.size() / kL;
+        const bool use_fused_causal_softmax = do_causal && !has_arr_mask &&
+            !has_sinks && scores.dtype() == bfloat16 &&
+            kL > SOFTMAX_LOOPED_LIMIT && metal::is_available() &&
+            to_stream(s).device == Device::gpu && !detail::in_tracing() &&
+            n_rows <= static_cast<size_t>(
+                          std::numeric_limits<int>::max() /
+                          FUSED_SOFTMAX_THREADGROUP);
+        if (use_fused_causal_softmax) {
+          const int qL = q.shape(-2);
+          array params({kL, kL - qL, qL}, int32);
+          scores = fused_causal_softmax()(
+              {scores, params},
+              {scores.shape()},
+              {scores.dtype()},
+              std::make_tuple(
+                  static_cast<int>(n_rows) * FUSED_SOFTMAX_THREADGROUP, 1, 1),
+              std::make_tuple(FUSED_SOFTMAX_THREADGROUP, 1, 1),
+              {},
+              std::nullopt,
+              false,
+              s)[0];
         } else {
-          mask = unflatten(mask, -3, {n_kv_heads, n_repeats}, s);
+          if (has_arr_mask || do_causal) {
+            // Mask must be broadcast-compatible with [B, n_q_heads, L_q, L_kv]
+            auto make_or_fetch_mask = [&]() {
+              if (do_causal) {
+                int kL = k.shape(-2);
+                int qL = q.shape(-2);
+                int offset = kL - qL;
+                auto q_idx = arange(offset, qL + offset, s);
+                auto k_idx = arange(0, kL, s);
+                q_idx = expand_dims(q_idx, 1, s);
+                k_idx = expand_dims(k_idx, 0, s);
+                return greater_equal(q_idx, k_idx, s);
+              }
+              return inputs[3];
+            };
+            auto mask = make_or_fetch_mask();
+
+            if (n_repeats > 1 && mask.ndim() >= 3) {
+              if (mask.shape(-3) == 1) {
+                mask = expand_dims(mask, -3, s);
+              } else {
+                mask = unflatten(mask, -3, {n_kv_heads, n_repeats}, s);
+              }
+            }
+            if (mask.dtype() == bool_) {
+              scores = where(
+                  mask,
+                  scores,
+                  array(finfo(scores.dtype()).min, scores.dtype()),
+                  s);
+            } else {
+              scores = add(scores, mask, s);
+            }
+          }
+          if (has_sinks) {
+            auto sinks = inputs.back();
+            // scores has shape B N_q N_k L_q L_k
+            sinks = expand_dims(sinks, {0, 2, 3}, s);
+            if (scores.ndim() == 5) {
+              sinks = unflatten(sinks, 1, {n_kv_heads, n_repeats}, s);
+            }
+            auto bsx_shape = scores.shape();
+            bsx_shape.back() = 1;
+            scores =
+                concatenate({broadcast_to(sinks, bsx_shape, s), scores}, -1, s);
+          }
+          scores = softmax(scores, std::vector<int>{-1}, true, s);
+          if (has_sinks) {
+            // Slice off scores
+            auto start = Shape(scores.ndim(), 0);
+            start.back() = 1;
+            auto stop = scores.shape();
+            scores = slice(scores, std::move(start), std::move(stop), s);
+          }
         }
-      }
-      if (mask.dtype() == bool_) {
-        scores = where(
-            mask, scores, array(finfo(scores.dtype()).min, scores.dtype()), s);
-      } else {
-        scores = add(scores, mask, s);
-      }
-    }
-    if (has_sinks) {
-      auto sinks = inputs.back();
-      // scores has shape B N_q N_k L_q L_k
-      sinks = expand_dims(sinks, {0, 2, 3}, s);
-      if (scores.ndim() == 5) {
-        sinks = unflatten(sinks, 1, {n_kv_heads, n_repeats}, s);
-      }
-      auto bsx_shape = scores.shape();
-      bsx_shape.back() = 1;
-      scores = concatenate({broadcast_to(sinks, bsx_shape, s), scores}, -1, s);
-    }
-    scores = softmax(scores, std::vector<int>{-1}, true, s);
-    if (has_sinks) {
-      // Slice off scores
-      auto start = Shape(scores.ndim(), 0);
-      start.back() = 1;
-      auto stop = scores.shape();
-      scores = slice(scores, std::move(start), std::move(stop), s);
-    }
-    auto out = matmul(scores, v, s);
-    if (n_repeats > 1) {
-      out = flatten(out, 1, 2, s);
-    }
-    return std::vector<array>{out};
-  };
+        auto out = matmul(scores, v, s);
+        if (n_repeats > 1) {
+          out = flatten(out, 1, 2, s);
+        }
+        return std::vector<array>{out};
+      };
 
   auto stream = to_stream(s);
   std::vector<array> inputs = {q, k, v};

--- a/python/tests/test_fast_sdpa.py
+++ b/python/tests/test_fast_sdpa.py
@@ -500,6 +500,26 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
                 diff = mx.abs(out - ref) - atol * mx.abs(ref)
                 self.assertLessEqual(mx.max(diff).item(), atol)
 
+    def test_sdpa_ops_fallback_fused_causal_softmax(self):
+        # A bf16 causal mask above the looped-softmax limit, with a head dim
+        # the fast kernels don't cover, takes the fused causal softmax in the
+        # ops fallback. It must be bit-identical to the unfused chain.
+        D = 72
+        for qL, kL in [(4352, 4352), (128, 4480)]:
+            with self.subTest(qL=qL, kL=kL):
+                mx.random.seed(0)
+                q = mx.random.normal(shape=(1, 2, qL, D)).astype(mx.bfloat16)
+                k = mx.random.normal(shape=(1, 2, kL, D)).astype(mx.bfloat16)
+                v = mx.random.normal(shape=(1, 2, kL, D)).astype(mx.bfloat16)
+                scale = 1.0 / math.sqrt(D)
+
+                out = mx.fast.scaled_dot_product_attention(
+                    q, k, v, scale=scale, mask="causal"
+                )
+                ref = mlx_ref_attn(q, k, v, scale=scale, mask="causal")
+
+                self.assertTrue(mx.array_equal(out, ref))
+
     def test_sdpa_broadcast_mask(self):
         mask = mx.array(True)
         D = 64


### PR DESCRIPTION
Long-context prefill takes the SDPA ops fallback for shapes the fast kernels don't cover. With a causal mask, that chain is greater_equal -> where(finfo.min) -> softmax(precise): at 32K it materializes 512 MB of masked scores plus a 32 MB bool mask per layer chunk, all to feed a softmax that immediately reduces over the same data. The chain costs about 6.5 ms per chunk, of which the mask build and the where are about 3 ms.

This folds the causal condition into the looped softmax kernel: the same precise reduction tree with N_READS=4, with the causal select applied at the load sites. Scores get read once and probabilities written once, and the two mask passes plus the giant intermediate disappear.

The result is bit-identical to the chain it replaces, not approximately. The masked value is exactly bf16 finfo.min upcast to f32, and exp(min - max) underflows to exact zero, so per-element arithmetic is unchanged. Verified bitwise on 14 of 14 configurations (3 seeds, sequence lengths 8192 and 32768, several mask offsets), and token-identical over 48 of 48 interleaved end-to-end A/B pairs on a 35B model. A test in test_fast_sdpa.py forces the fallback and asserts exact equality against the reference chain, so the bit-identity claim is enforced in CI rather than taken on faith.

The gate is deliberately conservative: causal only, no array mask, no sinks, bf16, softmax axis > 4096, GPU stream with Metal available, and never inside a function transform, so grad, vmap, and compile keep the differentiable stock chain. Anything outside the gate takes the stock chain exactly as before.

Measured: the mask+softmax stage drops 45% at 32K and 61% at 8K, which lands on the softmax's memory-traffic floor. End to end that is +2.8% prefill at 32K on Qwen3.6-35B-A3B (M3 Max), plus the memory-pressure relief from never allocating the masked-scores tensor.

The kernel body is deliberately a frozen copy of softmax_looped's body with the select applied at the load sites, since that is what the bitwise verification covered. If you would rather see this as a causal template parameter on softmax_looped itself (or a proper primitive with per-backend gating), happy to rework it that way as a follow-up and re-verify.
