### PR TITLE
Add a tile-shape static_assert to tile_matmad_nax

### DIFF
--- a/mlx/backend/metal/kernels/steel/attn/nax.h
+++ b/mlx/backend/metal/kernels/steel/attn/nax.h
@@ -841,6 +841,15 @@ METAL_FUNC void tile_matmad_nax(
   constexpr short TK = transpose_b ? BTile::kTileCols : BTile::kTileRows;
   static_assert(TKa == TK, "MXU tile matmul: K dimensions do not match");
 
+  // The branches below cover TN % 2 == 0 and (TN == 1 && TM % 2 == 0) and
+  // nothing else. A tile shape outside both (e.g. TM == 1 && TN == 1) would
+  // discard every branch and compile to a no-op that leaves C untouched,
+  // returning zeros at full speed with no error.
+  static_assert(
+      (TN == 1 && TM % 2 == 0) || TN % 2 == 0,
+      "MXU tile matmul: no implementation for this tile shape; requires "
+      "TN % 2 == 0, or TN == 1 with TM % 2 == 0");
+
   constexpr auto ta = metal::bool_constant<transpose_a>{};
   constexpr auto tb = metal::bool_constant<transpose_b>{};
 

--- a/mlx/backend/metal/kernels/steel/gemm/nax.h
+++ b/mlx/backend/metal/kernels/steel/gemm/nax.h
@@ -841,6 +841,15 @@ METAL_FUNC void tile_matmad_nax(
   constexpr short TK = transpose_b ? BTile::kTileCols : BTile::kTileRows;
   static_assert(TKa == TK, "MXU tile matmul: K dimensions do not match");
 
+  // The branches below cover TN % 2 == 0 and (TN == 1 && TM % 2 == 0) and
+  // nothing else. A tile shape outside both (e.g. TM == 1 && TN == 1) would
+  // discard every branch and compile to a no-op that leaves C untouched,
+  // returning zeros at full speed with no error.
+  static_assert(
+      (TN == 1 && TM % 2 == 0) || TN % 2 == 0,
+      "MXU tile matmul: no implementation for this tile shape; requires "
+      "TN % 2 == 0, or TN == 1 with TM % 2 == 0");
+
   constexpr auto ta = metal::bool_constant<transpose_a>{};
   constexpr auto tb = metal::bool_constant<transpose_b>{};
 


### PR DESCRIPTION
### What

`tile_matmad_nax` dispatches its MMA loops through two `if constexpr` branches:

```cpp
if constexpr (TN == 1 && TM % 2 == 0) { ... }
else if constexpr (TN % 2 == 0) { ... }
```

A destination tile shape outside both — e.g. `TM == 1 && TN == 1` — matches neither branch, so the function body compiles away entirely. The kernel builds, runs at full speed, never touches `C`, and returns all zeros with no error at compile time or run time.

This adds a `static_assert` on the tile shape (in both copies of the helper, `steel/gemm/nax.h` and `steel/attn/nax.h`) so an unexpressible shape fails at compile with a message instead. Since the 16×32×16 NAX granule always consumes a fragment pair, single-fragment tiles are genuinely unexpressible here; the assert documents that constraint at the point where it bites.

### How this was found

While experimenting with block sizes for `affine_gather_qmm_rhs_nax` (short per-expert runs in MoE prefill), I instantiated a `BM=16, WM=1, WN=4` variant. That gives `SN = BN/WN = 16`, i.e. `TN = 1` with `TM = 1` — and every output row came back exactly zero. The "corruption" was silent: nothing asserted, nothing crashed, and the timing looked excellent.

### Verification (M5, macOS 26)

- Full build with the assert in place **passes** — every shipped instantiation satisfies the shape constraint, so this is a no-op for existing configurations.
- Re-adding the `TM=1/TN=1` instantiation now **fails at compile** with `MXU tile matmul: no implementation for this tile shape; requires TN % 2 == 0, or TN == 1 with TM % 2 == 0`, instead of building a kernel that silently returns zeros.
- `pre-commit` (clang-format) passes.

Separately, I have measurements on `gather_qmm_rhs_nax` block sizes for short expert runs (the `// TODO: Tune the block sizes`) — will open an issue with that data.
