### PR TITLE
Add special functions (erf, erfc, i0, gammaln, digamma) as mlx.special

### DIFF
--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -71,6 +71,7 @@ are the CPU and GPU.
    python/fast
    python/fft
    python/linalg
+   python/special
    python/metal
    python/cuda
    python/memory_management

--- a/docs/src/python/special.rst
+++ b/docs/src/python/special.rst
@@ -1,0 +1,20 @@
+.. _special:
+
+Special Functions
+=================
+
+The :mod:`mlx.special` module provides MLX-native implementations of common
+special functions, mirroring a subset of :mod:`scipy.special`. Each function is
+implemented with pure ``mlx.core`` operations, so results are lazy,
+differentiable, and run on the same device as their inputs.
+
+.. currentmodule:: mlx.special
+
+.. autosummary::
+  :toctree: _autosummary
+
+   erf
+   erfc
+   i0
+   gammaln
+   digamma

--- a/python/mlx/special.py
+++ b/python/mlx/special.py
@@ -1,0 +1,281 @@
+# Copyright © 2024 Apple Inc.
+
+"""Special mathematical functions implemented purely with ``mlx.core`` ops.
+
+This module provides MLX-native equivalents of a subset of
+:mod:`scipy.special`. Every function is written using only element-wise
+``mlx.core`` operations, so the results are lazy, differentiable, and run on
+whatever device (CPU / GPU) the input array lives on — no custom Metal or C++
+kernels required.
+
+The implementations use classic closed-form approximations whose error bounds
+are well characterised:
+
+* ``erf`` / ``erfc`` — Abramowitz & Stegun 7.1.26 (rational approximation,
+  ``|error| <= 1.5e-7``).
+* ``i0`` — Abramowitz & Stegun 9.8.1 / 9.8.2 (polynomial approximations,
+  ``|error| <= 1.9e-7``).
+* ``gammaln`` — Lanczos approximation (``g = 7``, 9 coefficients), with the
+  reflection formula for arguments ``< 1/2``.
+* ``digamma`` — upward recurrence to the asymptotic (Stirling) regime, with the
+  reflection formula for non-positive arguments.
+
+References:
+    M. Abramowitz and I. A. Stegun, *Handbook of Mathematical Functions*,
+    National Bureau of Standards, 1964.
+    C. Lanczos, "A Precision Approximation of the Gamma Function",
+    *J. SIAM Numer. Anal.* 1 (1964) 86-96.
+"""
+
+import math
+
+import mlx.core as mx
+
+__all__ = ["erf", "erfc", "i0", "gammaln", "digamma"]
+
+# Abramowitz & Stegun 7.1.26 coefficients (error function).
+_ERF_P = 0.3275911
+_ERF_A = (0.254829592, -0.284496736, 1.421413741, -1.453152027, 1.061405429)
+
+# Abramowitz & Stegun 9.8.1 coefficients (I0, |x| <= 3.75, argument t = (x/3.75)**2).
+_I0_SMALL = (
+    1.0,
+    3.5156229,
+    3.0899424,
+    1.2067492,
+    0.2659732,
+    0.0360768,
+    0.0045813,
+)
+# Abramowitz & Stegun 9.8.2 coefficients (I0, |x| >= 3.75, argument t = 3.75/x).
+_I0_LARGE = (
+    0.39894228,
+    0.01328592,
+    0.00225319,
+    -0.00157565,
+    0.00916281,
+    -0.02057706,
+    0.02635537,
+    -0.01647633,
+    0.00392377,
+)
+
+# Lanczos coefficients for g = 7 (log-gamma).
+_LANCZOS_G = 7.0
+_LANCZOS_C = (
+    0.99999999999980993,
+    676.5203681218851,
+    -1259.1392167224028,
+    771.32342877765313,
+    -176.61502916214059,
+    12.507343278686905,
+    -0.13857109526572012,
+    9.9843695780195716e-6,
+    1.5056327351493116e-7,
+)
+_HALF_LOG_2PI = 0.5 * math.log(2.0 * math.pi)
+
+
+def _as_float(x: mx.array) -> mx.array:
+    """Return ``x`` as a floating-point array, promoting integer inputs."""
+    x = mx.array(x)
+    if x.dtype in (mx.float16, mx.bfloat16, mx.float32, mx.float64):
+        return x
+    return x.astype(mx.float32)
+
+
+def _horner(t: mx.array, coeffs) -> mx.array:
+    """Evaluate a polynomial ``sum(coeffs[i] * t**i)`` via Horner's method."""
+    result = mx.full(t.shape, coeffs[-1], dtype=t.dtype)
+    for c in reversed(coeffs[:-1]):
+        result = result * t + c
+    return result
+
+
+def erf(x: mx.array) -> mx.array:
+    r"""Error function.
+
+    Computes
+
+    .. math::
+
+        \operatorname{erf}(x) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2}\, dt
+
+    using the rational approximation of Abramowitz & Stegun 7.1.26 applied to
+    ``|x|`` (with ``erf(-x) = -erf(x)``), whose absolute error is bounded by
+    ``1.5e-7``.
+
+    Args:
+        x (array): Input array.
+
+    Returns:
+        array: ``erf(x)`` with the same shape and floating dtype as ``x``.
+    """
+    x = _as_float(x)
+    sign = mx.sign(x)
+    ax = mx.abs(x)
+    t = 1.0 / (1.0 + _ERF_P * ax)
+    # A&S 7.1.26: erf(ax) = 1 - (a1 t + ... + a5 t^5) exp(-ax^2).
+    poly = t * _horner(t, _ERF_A)
+    return sign * (1.0 - poly * mx.exp(-ax * ax))
+
+
+def erfc(x: mx.array) -> mx.array:
+    r"""Complementary error function, ``erfc(x) = 1 - erf(x)``.
+
+    Rather than forming ``1 - erf(x)`` (which loses precision for large ``x``
+    where ``erf(x) -> 1``), the tail term of Abramowitz & Stegun 7.1.26 is
+    evaluated directly:
+
+    .. math::
+
+        \operatorname{erfc}(x) = (a_1 t + \dots + a_5 t^5)\, e^{-x^2},
+        \quad t = \frac{1}{1 + p\,x}, \quad x \ge 0,
+
+    and the reflection ``erfc(-x) = 2 - erfc(x)`` is used for negative inputs.
+    This keeps the small positive values returned for large ``x`` accurate.
+
+    Args:
+        x (array): Input array.
+
+    Returns:
+        array: ``erfc(x)`` with the same shape and floating dtype as ``x``.
+    """
+    x = _as_float(x)
+    ax = mx.abs(x)
+    t = 1.0 / (1.0 + _ERF_P * ax)
+    tail = t * _horner(t, _ERF_A) * mx.exp(-ax * ax)  # == erfc(|x|)
+    return mx.where(x >= 0, tail, 2.0 - tail)
+
+
+def i0(x: mx.array) -> mx.array:
+    r"""Modified Bessel function of the first kind, order zero.
+
+    Computes
+
+    .. math::
+
+        I_0(x) = \sum_{k=0}^{\infty} \frac{(x^2/4)^k}{(k!)^2}
+
+    with the piecewise polynomial approximations of Abramowitz & Stegun 9.8.1
+    (``|x| <= 3.75``) and 9.8.2 (``|x| >= 3.75``). ``I_0`` is even, so ``|x|``
+    is used throughout. The absolute error of the approximation is bounded by
+    ``1.9e-7``.
+
+    Args:
+        x (array): Input array.
+
+    Returns:
+        array: ``i0(x)`` with the same shape and floating dtype as ``x``.
+    """
+    x = _as_float(x)
+    ax = mx.abs(x)
+
+    # Small-argument branch (A&S 9.8.1), t = (x / 3.75)^2.
+    t_small = (ax / 3.75) ** 2
+    small = _horner(t_small, _I0_SMALL)
+
+    # Large-argument branch (A&S 9.8.2), t = 3.75 / x. Clamp the denominator so
+    # the (discarded) values in the small region stay finite.
+    ax_large = mx.maximum(ax, 3.75)
+    t_large = 3.75 / ax_large
+    large = mx.exp(ax_large) / mx.sqrt(ax_large) * _horner(t_large, _I0_LARGE)
+
+    result = mx.where(ax < 3.75, small, large)
+    # I0(±inf) = +inf; the large-argument branch evaluates to inf/inf = nan there.
+    return mx.where(mx.isinf(ax), mx.full(x.shape, float("inf"), dtype=x.dtype), result)
+
+
+def _lanczos_lgamma(w: mx.array) -> mx.array:
+    """Log-gamma via the Lanczos series; assumes ``w >= 0.5`` element-wise."""
+    w1 = w - 1.0
+    series = mx.full(w.shape, _LANCZOS_C[0], dtype=w.dtype)
+    for i in range(1, len(_LANCZOS_C)):
+        series = series + _LANCZOS_C[i] / (w1 + i)
+    t = w1 + _LANCZOS_G + 0.5
+    return _HALF_LOG_2PI + (w1 + 0.5) * mx.log(t) - t + mx.log(series)
+
+
+def gammaln(x: mx.array) -> mx.array:
+    r"""Natural logarithm of the absolute value of the gamma function.
+
+    Returns :math:`\log |\Gamma(x)|`, matching :func:`scipy.special.gammaln`.
+    The Lanczos approximation (``g = 7``, 9 coefficients) is evaluated on
+    ``max(x, 1 - x)`` so its argument is always ``>= 1/2``; for ``x < 1/2`` the
+    reflection formula
+
+    .. math::
+
+        \log|\Gamma(x)| = \log \pi - \log|\sin(\pi x)| - \log|\Gamma(1 - x)|
+
+    is then applied. The relative error is on the order of machine precision for
+    ``float64`` inputs; poles at non-positive integers return ``+inf``.
+
+    Args:
+        x (array): Input array.
+
+    Returns:
+        array: ``gammaln(x)`` with the same shape and floating dtype as ``x``.
+    """
+    x = _as_float(x)
+    reflect = x < 0.5
+    # Argument fed to the Lanczos series is always >= 0.5.
+    w = mx.where(reflect, 1.0 - x, x)
+    lanczos = _lanczos_lgamma(w)
+    reflected = math.log(math.pi) - mx.log(mx.abs(mx.sin(math.pi * x))) - lanczos
+    result = mx.where(reflect, reflected, lanczos)
+    # gammaln(+inf) = +inf; the Lanczos series evaluates to inf - inf = nan there.
+    pos_inf = mx.logical_and(mx.isinf(x), x > 0)
+    return mx.where(pos_inf, mx.full(x.shape, float("inf"), dtype=x.dtype), result)
+
+
+def digamma(x: mx.array) -> mx.array:
+    r"""Digamma function, the logarithmic derivative of the gamma function.
+
+    Computes :math:`\psi(x) = \frac{d}{dx} \log \Gamma(x)`. Non-positive
+    arguments are handled with the reflection formula
+
+    .. math::
+
+        \psi(x) = \psi(1 - x) - \pi \cot(\pi x),
+
+    after which the recurrence :math:`\psi(x) = \psi(x + 1) - 1/x` shifts the
+    argument into the region ``x >= 6``, where the asymptotic expansion
+
+    .. math::
+
+        \psi(x) \sim \ln x - \frac{1}{2x}
+        - \frac{1}{12x^2} + \frac{1}{120x^4}
+        - \frac{1}{252x^6} + \frac{1}{240x^8}
+
+    is accurate to better than ``1e-9``.
+
+    Args:
+        x (array): Input array.
+
+    Returns:
+        array: ``digamma(x)`` with the same shape and floating dtype as ``x``.
+    """
+    x = _as_float(x)
+    reflect = x <= 0
+    # Fold non-positive arguments to the positive half-line via reflection.
+    arg = mx.where(reflect, 1.0 - x, x)
+
+    # Upward recurrence: psi(arg) = psi(arg + 1) - 1/arg until arg >= 6.
+    threshold = 6.0
+    correction = mx.zeros(arg.shape, dtype=arg.dtype)
+    work = arg
+    # From any positive start the loop reaches `threshold` in at most 6 steps.
+    while float(mx.min(work).item()) < threshold:
+        below = work < threshold
+        correction = correction - mx.where(below, 1.0 / work, 0.0)
+        work = work + mx.where(below, 1.0, 0.0)
+
+    inv = 1.0 / work
+    inv2 = inv * inv
+    # Horner form of the Bernoulli-number asymptotic series.
+    series = inv2 * (1.0 / 12 - inv2 * (1.0 / 120 - inv2 * (1.0 / 252 - inv2 / 240)))
+    psi_pos = correction + mx.log(work) - 0.5 * inv - series
+
+    reflected = psi_pos - math.pi / mx.tan(math.pi * x)
+    return mx.where(reflect, reflected, psi_pos)

--- a/python/tests/test_special.py
+++ b/python/tests/test_special.py
@@ -1,0 +1,153 @@
+# Copyright © 2024 Apple Inc.
+
+"""Tests for :mod:`mlx.special`, checked against :mod:`scipy.special`."""
+
+import math
+
+import mlx.core as mx
+import numpy as np
+import pytest
+from mlx import special
+from scipy import special as sp
+
+TOL = 1e-5
+N = 50
+
+
+def _np(x):
+    """Convert an mlx array to a NumPy array."""
+    return np.array(x)
+
+
+def _max_abs_err(got, ref):
+    return float(np.max(np.abs(np.asarray(got, dtype=np.float64) - ref)))
+
+
+def _rng():
+    return np.random.default_rng(0)
+
+
+def _nonint_negatives(rng, n, low, high, margin=0.25):
+    """Sample ``n`` negative reals in ``(low, high)`` bounded away from integers.
+
+    Both ``gammaln`` and ``digamma`` have poles at the non-positive integers; in
+    float32 the reflection terms (``log|sin(pi x)|`` and ``pi / tan(pi x)``) lose
+    precision very close to those poles, so samples are kept a small margin away.
+    """
+    out = []
+    while len(out) < n:
+        v = rng.uniform(low, high)
+        if abs(v - round(v)) > margin:
+            out.append(v)
+    return np.array(out, dtype=np.float32)
+
+
+# --------------------------------------------------------------------------- #
+# Numerical accuracy vs. scipy on random inputs across the valid domain.
+# --------------------------------------------------------------------------- #
+class TestAccuracy:
+    def test_erf(self):
+        xs = _rng().uniform(-4.0, 4.0, N).astype(np.float32)
+        got = _np(special.erf(mx.array(xs)))
+        assert _max_abs_err(got, sp.erf(xs.astype(np.float64))) < TOL
+
+    def test_erfc(self):
+        xs = _rng().uniform(-4.0, 4.0, N).astype(np.float32)
+        got = _np(special.erfc(mx.array(xs)))
+        assert _max_abs_err(got, sp.erfc(xs.astype(np.float64))) < TOL
+
+    def test_i0(self):
+        xs = _rng().uniform(-6.0, 6.0, N).astype(np.float32)
+        got = _np(special.i0(mx.array(xs)))
+        assert _max_abs_err(got, sp.i0(xs.astype(np.float64))) < TOL
+
+    def test_gammaln_positive(self):
+        xs = _rng().uniform(0.1, 15.0, N).astype(np.float32)
+        got = _np(special.gammaln(mx.array(xs)))
+        assert _max_abs_err(got, sp.gammaln(xs.astype(np.float64))) < TOL
+
+    def test_gammaln_negative(self):
+        xs = _nonint_negatives(_rng(), N, -4.5, -0.25)
+        got = _np(special.gammaln(mx.array(xs)))
+        assert _max_abs_err(got, sp.gammaln(xs.astype(np.float64))) < TOL
+
+    def test_digamma_positive(self):
+        xs = _rng().uniform(0.1, 15.0, N).astype(np.float32)
+        got = _np(special.digamma(mx.array(xs)))
+        assert _max_abs_err(got, sp.digamma(xs.astype(np.float64))) < TOL
+
+    def test_digamma_negative(self):
+        xs = _nonint_negatives(_rng(), N, -4.5, -0.25)
+        got = _np(special.digamma(mx.array(xs)))
+        assert _max_abs_err(got, sp.digamma(xs.astype(np.float64))) < TOL
+
+
+# --------------------------------------------------------------------------- #
+# Shape preservation across scalar, 1D and 2D inputs.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "fn", [special.erf, special.erfc, special.i0, special.gammaln, special.digamma]
+)
+@pytest.mark.parametrize("shape", [(), (7,), (3, 4)])
+class TestShapePreservation:
+    def test_shape(self, fn, shape):
+        rng = _rng()
+        # Positive domain keeps every function (incl. gammaln/digamma) well defined.
+        xs = rng.uniform(0.5, 3.0, size=shape).astype(np.float32)
+        out = fn(mx.array(xs))
+        assert out.shape == xs.shape
+
+        ref_fn = {
+            special.erf: sp.erf,
+            special.erfc: sp.erfc,
+            special.i0: sp.i0,
+            special.gammaln: sp.gammaln,
+            special.digamma: sp.digamma,
+        }[fn]
+        assert _max_abs_err(_np(out), ref_fn(xs.astype(np.float64))) < TOL
+
+
+# --------------------------------------------------------------------------- #
+# Edge cases: 0, +inf, -inf where applicable.
+# --------------------------------------------------------------------------- #
+class TestEdgeCases:
+    def test_erf_limits(self):
+        out = _np(special.erf(mx.array([0.0, math.inf, -math.inf], dtype=mx.float32)))
+        assert out[0] == pytest.approx(0.0, abs=TOL)
+        assert out[1] == pytest.approx(1.0, abs=TOL)
+        assert out[2] == pytest.approx(-1.0, abs=TOL)
+
+    def test_erfc_limits(self):
+        out = _np(special.erfc(mx.array([0.0, math.inf, -math.inf], dtype=mx.float32)))
+        assert out[0] == pytest.approx(1.0, abs=TOL)
+        assert out[1] == pytest.approx(0.0, abs=TOL)
+        assert out[2] == pytest.approx(2.0, abs=TOL)
+
+    def test_i0_limits(self):
+        out = _np(special.i0(mx.array([0.0, math.inf], dtype=mx.float32)))
+        assert out[0] == pytest.approx(1.0, abs=TOL)
+        assert np.isposinf(out[1])
+
+    def test_gammaln_known_values(self):
+        # Gamma(1) = Gamma(2) = 1  ->  gammaln = 0; Gamma(5) = 24.
+        out = _np(special.gammaln(mx.array([1.0, 2.0, 5.0], dtype=mx.float32)))
+        assert out[0] == pytest.approx(0.0, abs=TOL)
+        assert out[1] == pytest.approx(0.0, abs=TOL)
+        assert out[2] == pytest.approx(math.log(24.0), abs=TOL)
+
+    def test_gammaln_inf(self):
+        out = _np(special.gammaln(mx.array([math.inf], dtype=mx.float32)))
+        assert np.isposinf(out[0])
+
+    def test_digamma_known_value(self):
+        # psi(1) = -gamma (Euler-Mascheroni).
+        out = _np(special.digamma(mx.array([1.0], dtype=mx.float32)))
+        assert out[0] == pytest.approx(-0.5772156649, abs=TOL)
+
+    def test_digamma_inf(self):
+        out = _np(special.digamma(mx.array([math.inf], dtype=mx.float32)))
+        assert np.isposinf(out[0])
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Proposed changes

Addresses #3330.

This PR adds `mlx.special`, a small module of pure-`mlx.core` implementations of common `scipy.special` functions. Everything is written with existing element-wise ops, so the results are lazy, differentiable, and run on whatever device the input array lives on — no Metal/C++ kernels required.

**Added** (5 functions):

| Function | Method | Reference |
| --- | --- | --- |
| `erf(x)` | rational approximation (odd symmetry for negatives) | A&S 7.1.26 |
| `erfc(x)` | tail term evaluated directly (stable for large `x`) + reflection | A&S 7.1.26 |
| `i0(x)` | piecewise polynomial (even symmetry) | A&S 9.8.1 / 9.8.2 |
| `gammaln(x)` | Lanczos (`g=7`, 9 coeffs) + reflection for `x < 1/2` | Lanczos 1964 |
| `digamma(x)` | negative-arg reflection → upward recurrence → asymptotic series | — |

Files:
- `python/mlx/special.py` — implementations, type hints, and docstrings citing the formula for each function.
- `python/tests/test_special.py` — tests validating against `scipy.special`.
- `docs/src/python/special.rst` (+ `docs/src/index.rst`) — API reference page for the new module.

**Test results:** `29 passed`. Each function is compared against `scipy.special` on 50 random inputs across its valid domain with **max absolute error < 1e-5**, plus tests for shape preservation (scalar, 1D, 2D) and edge cases (`0`, `±inf`).

A couple of test-domain notes (both are float32 precision limits, not implementation issues): `i0` is checked on `|x| <= 6`, and the negative-argument `gammaln`/`digamma` samples are kept a small margin away from the non-positive-integer poles where the float32 reflection terms lose precision.

A short note: open to relocating these into whatever namespace maintainers prefer, and to adding float64 paths if wanted.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
