### PR TITLE
Fix CUDA batched GEMV grid overflow

### DIFF
--- a/mlx/backend/cuda/gemms/gemv.cu
+++ b/mlx/backend/cuda/gemms/gemv.cu
@@ -13,6 +13,14 @@ namespace cg = cooperative_groups;
 
 static constexpr int rows_per_block = 8;
 
+// Split batches across grid.y/z because both dimensions are capped at 65,535.
+static dim3 get_gemv_grid_dims(uint32_t num_blocks_x, uint32_t batch_size) {
+  constexpr uint32_t max_grid_yz_dim = 65535;
+  uint32_t num_blocks_z = cuda::ceil_div(batch_size, max_grid_yz_dim);
+  uint32_t num_blocks_y = cuda::ceil_div(batch_size, num_blocks_z);
+  return {num_blocks_x, num_blocks_y, num_blocks_z};
+}
+
 // Accumulator type selection per input element type T.
 template <typename T>
 struct GemvAccType {
@@ -88,12 +96,17 @@ __global__ void gemv_batched(
     T* out,
     int rows,
     int cols,
+    uint32_t batch_size,
     const __grid_constant__ Shape batch_shape,
     const __grid_constant__ Strides mat_batch_strides,
     const __grid_constant__ Strides vec_batch_strides,
     int batch_ndim) {
-  auto block = cg::this_thread_block();
-  auto batch_idx = block.group_index().y;
+  auto grid = cg::this_grid();
+  auto batch_idx =
+      grid.block_index().z * grid.dim_blocks().y + grid.block_index().y;
+  if (batch_idx >= batch_size) {
+    return;
+  }
   auto [vec_offset, mat_offset] = elem_to_loc(
       batch_idx,
       batch_shape.data(),
@@ -113,6 +126,7 @@ __global__ void gemv_gather(
     uint32_t* vec_indices,
     int rows,
     int cols,
+    uint32_t batch_size,
     const __grid_constant__ Shape mat_batch_shape,
     const __grid_constant__ Strides mat_batch_strides,
     int mat_batch_ndim,
@@ -123,8 +137,12 @@ __global__ void gemv_gather(
     const __grid_constant__ Strides mat_index_strides,
     const __grid_constant__ Strides vec_index_strides,
     int index_batch_ndim) {
-  auto block = cg::this_thread_block();
-  auto indices_idx = block.group_index().y;
+  auto grid = cg::this_grid();
+  auto indices_idx =
+      grid.block_index().z * grid.dim_blocks().y + grid.block_index().y;
+  if (indices_idx >= batch_size) {
+    return;
+  }
   uint32_t index_mat, index_vec;
   if (index_batch_ndim > 1) {
     auto [mat_idx_offset, vec_idx_offset] = elem_to_loc(
@@ -245,13 +263,14 @@ void gemv(
         auto kernel = gemv_batched<DataType, rows_per_block, n_per_thread()>;
         encoder.add_kernel_node(
             kernel,
-            dim3{num_blocks_x, batch_count},
+            get_gemv_grid_dims(num_blocks_x, batch_count),
             block_dims,
             mat,
             vec,
             gpu_ptr<DataType>(out),
             rows,
             cols,
+            batch_count,
             const_param(batch_shape),
             mat_strides,
             vec_strides,
@@ -298,7 +317,7 @@ void gather_mv(
       auto kernel = gemv_gather<DataType, rows_per_block, n_per_thread()>;
       encoder.add_kernel_node(
           kernel,
-          dim3{num_blocks_x, batch_size},
+          get_gemv_grid_dims(num_blocks_x, batch_size),
           block_dims,
           mat,
           vec,
@@ -307,6 +326,7 @@ void gather_mv(
           gpu_ptr<uint32_t>(vec_indices),
           rows,
           cols,
+          batch_size,
           const_param(mat_.shape()),
           const_param(mat_.strides()),
           mat_.ndim() - 2,

--- a/mlx/backend/cuda/gemms/gemv.cu
+++ b/mlx/backend/cuda/gemms/gemv.cu
@@ -14,7 +14,7 @@ namespace cg = cooperative_groups;
 static constexpr int rows_per_block = 8;
 
 // Split batches across grid.y/z because both dimensions are capped at 65,535.
-static dim3 get_gemv_grid_dims(uint32_t num_blocks_x, uint32_t batch_size) {
+inline dim3 get_gemv_grid_dims(uint32_t num_blocks_x, uint32_t batch_size) {
   constexpr uint32_t max_grid_yz_dim = 65535;
   uint32_t num_blocks_z = cuda::ceil_div(batch_size, max_grid_yz_dim);
   uint32_t num_blocks_y = cuda::ceil_div(batch_size, num_blocks_z);

--- a/mlx/backend/cuda/matmul.cpp
+++ b/mlx/backend/cuda/matmul.cpp
@@ -374,8 +374,8 @@ void GatherMM::eval_gpu(const std::vector<array>& inputs, array& out) {
   auto& a_pre = inputs[0];
   auto& b_pre = inputs[1];
 
-  // Return 0s if either input is empty.
-  if (a_pre.size() == 0 || b_pre.size() == 0) {
+  // Return 0s if the output or either input is empty.
+  if (out.size() == 0 || a_pre.size() == 0 || b_pre.size() == 0) {
     array zero(0, a_pre.dtype());
     encoder.add_temporary(zero);
     fill_gpu(zero, out, s);

--- a/python/tests/test_blas.py
+++ b/python/tests/test_blas.py
@@ -376,32 +376,6 @@ class TestBlas(mlx_tests.MLXTestCase):
                         shape_mat, shape_vec, mat_first=False, np_dtype=np_dtype
                     )
 
-    def test_cuda_matrix_vector_large_batch(self):
-        if not mx.cuda.is_available():
-            self.skipTest("requires CUDA")
-
-        with mx.stream(mx.gpu):
-            for batch_size in (65535, 65536, 65537):
-                with self.subTest(batch_size=batch_size):
-                    idx = mx.arange(batch_size, dtype=mx.float32)
-                    mat = mx.stack(
-                        (idx + 1, 2 * idx + 1, 3 * idx + 1, 4 * idx + 1),
-                        axis=-1,
-                    ).reshape(batch_size, 2, 2)
-                    vec_0 = idx % 7 + 1
-                    vec_1 = idx % 5 + 1
-                    vec = mx.stack((vec_0, vec_1), axis=-1)[..., None]
-
-                    out = mx.matmul(mat, vec)[..., 0]
-                    expected = mx.stack(
-                        (
-                            (idx + 1) * vec_0 + (2 * idx + 1) * vec_1,
-                            (3 * idx + 1) * vec_0 + (4 * idx + 1) * vec_1,
-                        ),
-                        axis=-1,
-                    )
-                    self.assertTrue(mx.array_equal(out, expected).item())
-
     def test_matrix_vector_broadcast(self):
         for dtype in self.dtypes:
             with self.subTest(dtype=dtype):
@@ -1361,50 +1335,6 @@ class TestBlas(mlx_tests.MLXTestCase):
         out_mx = mx.gather_mm(a_mx, b_mx_t, lhs_indices_mx, rhs_indices_mx)
 
         self.assertTrue(np.allclose(out_np, out_mx, atol=1e-5))
-
-    def test_cuda_gather_matrix_vector_large_batch(self):
-        if not mx.cuda.is_available():
-            self.skipTest("requires CUDA")
-
-        with mx.stream(mx.gpu):
-            mat = mx.array(
-                (
-                    ((1.0, 0.0), (0.0, 2.0)),
-                    ((2.0, 0.0), (0.0, 3.0)),
-                    ((3.0, 0.0), (0.0, 4.0)),
-                )
-            )
-            vec = mx.array(
-                (
-                    ((1.0,), (1.0,)),
-                    ((2.0,), (3.0,)),
-                    ((3.0,), (5.0,)),
-                    ((4.0,), (7.0,)),
-                    ((5.0,), (9.0,)),
-                )
-            )
-            empty = mx.array([], dtype=mx.uint32)
-            out = mx.gather_mm(mat, vec, empty, empty)
-            mx.eval(out)
-            self.assertEqual(out.shape, (0, 2, 1))
-
-            for batch_size in (65535, 65536, 65537):
-                with self.subTest(batch_size=batch_size):
-                    idx = mx.arange(batch_size, dtype=mx.uint32)
-                    lhs_indices = idx % 3
-                    rhs_indices = idx % 5
-                    out = mx.gather_mm(mat, vec, lhs_indices, rhs_indices)[..., 0]
-
-                    lhs = lhs_indices.astype(mx.float32)
-                    rhs = rhs_indices.astype(mx.float32)
-                    expected = mx.stack(
-                        (
-                            (lhs + 1) * (rhs + 1),
-                            (lhs + 2) * (2 * rhs + 1),
-                        ),
-                        axis=-1,
-                    )
-                    self.assertTrue(mx.array_equal(out, expected).item())
 
     def test_gather_mm_blocks(self):
         if mx.default_device() == mx.cpu:

--- a/python/tests/test_blas.py
+++ b/python/tests/test_blas.py
@@ -376,6 +376,32 @@ class TestBlas(mlx_tests.MLXTestCase):
                         shape_mat, shape_vec, mat_first=False, np_dtype=np_dtype
                     )
 
+    def test_cuda_matrix_vector_large_batch(self):
+        if not mx.cuda.is_available():
+            self.skipTest("requires CUDA")
+
+        with mx.stream(mx.gpu):
+            for batch_size in (65535, 65536, 65537):
+                with self.subTest(batch_size=batch_size):
+                    idx = mx.arange(batch_size, dtype=mx.float32)
+                    mat = mx.stack(
+                        (idx + 1, 2 * idx + 1, 3 * idx + 1, 4 * idx + 1),
+                        axis=-1,
+                    ).reshape(batch_size, 2, 2)
+                    vec_0 = idx % 7 + 1
+                    vec_1 = idx % 5 + 1
+                    vec = mx.stack((vec_0, vec_1), axis=-1)[..., None]
+
+                    out = mx.matmul(mat, vec)[..., 0]
+                    expected = mx.stack(
+                        (
+                            (idx + 1) * vec_0 + (2 * idx + 1) * vec_1,
+                            (3 * idx + 1) * vec_0 + (4 * idx + 1) * vec_1,
+                        ),
+                        axis=-1,
+                    )
+                    self.assertTrue(mx.array_equal(out, expected).item())
+
     def test_matrix_vector_broadcast(self):
         for dtype in self.dtypes:
             with self.subTest(dtype=dtype):
@@ -1335,6 +1361,50 @@ class TestBlas(mlx_tests.MLXTestCase):
         out_mx = mx.gather_mm(a_mx, b_mx_t, lhs_indices_mx, rhs_indices_mx)
 
         self.assertTrue(np.allclose(out_np, out_mx, atol=1e-5))
+
+    def test_cuda_gather_matrix_vector_large_batch(self):
+        if not mx.cuda.is_available():
+            self.skipTest("requires CUDA")
+
+        with mx.stream(mx.gpu):
+            mat = mx.array(
+                (
+                    ((1.0, 0.0), (0.0, 2.0)),
+                    ((2.0, 0.0), (0.0, 3.0)),
+                    ((3.0, 0.0), (0.0, 4.0)),
+                )
+            )
+            vec = mx.array(
+                (
+                    ((1.0,), (1.0,)),
+                    ((2.0,), (3.0,)),
+                    ((3.0,), (5.0,)),
+                    ((4.0,), (7.0,)),
+                    ((5.0,), (9.0,)),
+                )
+            )
+            empty = mx.array([], dtype=mx.uint32)
+            out = mx.gather_mm(mat, vec, empty, empty)
+            mx.eval(out)
+            self.assertEqual(out.shape, (0, 2, 1))
+
+            for batch_size in (65535, 65536, 65537):
+                with self.subTest(batch_size=batch_size):
+                    idx = mx.arange(batch_size, dtype=mx.uint32)
+                    lhs_indices = idx % 3
+                    rhs_indices = idx % 5
+                    out = mx.gather_mm(mat, vec, lhs_indices, rhs_indices)[..., 0]
+
+                    lhs = lhs_indices.astype(mx.float32)
+                    rhs = rhs_indices.astype(mx.float32)
+                    expected = mx.stack(
+                        (
+                            (lhs + 1) * (rhs + 1),
+                            (lhs + 2) * (2 * rhs + 1),
+                        ),
+                        axis=-1,
+                    )
+                    self.assertTrue(mx.array_equal(out, expected).item())
 
     def test_gather_mm_blocks(self):
         if mx.default_device() == mx.cpu:


### PR DESCRIPTION
## Proposed changes

Fixes #3858.

CUDA batched GEMV used `grid.y` as a linear batch index, so valid batches above
65,535 exceeded the CUDA grid-dimension limit before kernel execution.
`gemv_gather` used the same launch geometry.

This change splits the batch dimension over `grid.y` and `grid.z`, reconstructs
the logical batch index in both kernels, and ignores the one padded slot when
the rectangular grid is not exact. It also keeps empty gathered outputs from
reaching a zero-sized launch.

The regression tests cover ordinary and gathered GEMV at batch sizes 65,535,
65,536, and 65,537 using small analytical inputs, plus an empty gather.

Validation:

```text
pre-commit hooks on changed files: passed
Python test syntax: passed
independent grid-mapping and value-oracle checks: passed
CPU C++ suite: 229 test cases, 3,070 assertions passed
```

This machine does not have a CUDA toolkit or NVIDIA GPU, so CUDA compilation
and execution are left to the repository CI matrix.

I used an AI coding assistant to help research and prepare this change; I
remain responsible for the submitted patch.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (not needed for this backend-only fix)
