### PR TITLE
Fix Metal column reduction grid overflow

### DIFF
--- a/mlx/backend/common/reduce.h
+++ b/mlx/backend/common/reduce.h
@@ -46,6 +46,11 @@ struct ReductionPlan {
   ReductionPlan(ReductionOpType type_) : type(type_) {}
 };
 
+inline size_t col_reduce_grid_size(size_t reduction_stride, size_t block_size) {
+  return reduction_stride / block_size +
+      static_cast<size_t>(reduction_stride % block_size != 0);
+}
+
 ReductionPlan get_reduction_plan(const array& x, const std::vector<int>& axes);
 
 std::pair<Shape, Strides> shapes_without_reduction_axes(

--- a/mlx/backend/metal/reduce.cpp
+++ b/mlx/backend/metal/reduce.cpp
@@ -710,7 +710,7 @@ void strided_reduce_longcolumn(
   second_args.reduce_strides.push_back(out.size());
   second_args.reduce_ndim++;
   int BN = 32;
-  grid_dims = MTL::Size(256 * ((out.size() + BN - 1) / BN), 1, 1);
+  grid_dims = MTL::Size(col_reduce_grid_size(out.size(), BN), 1, 1);
   group_dims = MTL::Size(256, 1, 1);
 
   // Set the 2nd kernel
@@ -737,7 +737,7 @@ void strided_reduce_longcolumn(
   compute_encoder.set_input_array(intermediate, 0);
   compute_encoder.set_output_array(out, 1);
   second_args.encode(compute_encoder);
-  compute_encoder.dispatch_threads(grid_dims, group_dims);
+  compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
 }
 
 void strided_reduce_looped(
@@ -761,7 +761,7 @@ void strided_reduce_looped(
   int BM = 1024 / BN;
   int threadgroup_size = 8 * 32;
   MTL::Size grid_dims(
-      threadgroup_size * ((args.reduction_stride + BN - 1) / BN),
+      col_reduce_grid_size(args.reduction_stride, BN),
       out_grid_size.width,
       out_grid_size.height);
   MTL::Size group_dims(threadgroup_size, 1, 1);
@@ -802,7 +802,7 @@ void strided_reduce_looped(
   compute_encoder.set_input_array(in, 0);
   compute_encoder.set_output_array(out, 1);
   args.encode(compute_encoder);
-  compute_encoder.dispatch_threads(grid_dims, group_dims);
+  compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
 }
 
 void strided_reduce_2pass(
@@ -838,7 +838,7 @@ void strided_reduce_2pass(
   int BM = 1024 / BN;
   int threadgroup_size = 8 * 32;
   MTL::Size grid_dims(
-      threadgroup_size * ((args.reduction_stride + BN - 1) / BN),
+      col_reduce_grid_size(args.reduction_stride, BN),
       out_grid_size.width * outer_blocks,
       out_grid_size.height);
   MTL::Size group_dims(threadgroup_size, 1, 1);
@@ -880,14 +880,14 @@ void strided_reduce_2pass(
   compute_encoder.set_output_array(intermediate, 1);
   args.encode(compute_encoder);
   compute_encoder.set_bytes(out_size, 11);
-  compute_encoder.dispatch_threads(grid_dims, group_dims);
+  compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
 
   // Make the 2nd pass arguments and grid_dims
   ColReduceArgs second_args(intermediate);
   second_args.reduce_shape.push_back(outer_blocks);
   second_args.reduce_strides.push_back(out.size());
   second_args.reduce_ndim++;
-  grid_dims = MTL::Size(threadgroup_size * ((out.size() + BN - 1) / BN), 1, 1);
+  grid_dims = MTL::Size(col_reduce_grid_size(out.size(), BN), 1, 1);
 
   // Set the 2nd kernel
   func_name = "col_reduce_looped";
@@ -913,7 +913,7 @@ void strided_reduce_2pass(
   compute_encoder.set_input_array(intermediate, 0);
   compute_encoder.set_output_array(out, 1);
   second_args.encode(compute_encoder);
-  compute_encoder.dispatch_threads(grid_dims, group_dims);
+  compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
 }
 
 void strided_reduce_general_dispatch(

--- a/tests/utils_tests.cpp
+++ b/tests/utils_tests.cpp
@@ -1,10 +1,32 @@
 // Copyright © 2023 Apple Inc.
 
+#include <limits>
+
 #include "doctest/doctest.h"
 
+#include "mlx/backend/common/reduce.h"
 #include "mlx/mlx.h"
 
 using namespace mlx::core;
+
+TEST_CASE("test col reduce grid size") {
+  constexpr size_t block_size = 32;
+  CHECK_EQ(col_reduce_grid_size(0, block_size), 0);
+  CHECK_EQ(col_reduce_grid_size(1, block_size), 1);
+  CHECK_EQ(col_reduce_grid_size(31, block_size), 1);
+  CHECK_EQ(col_reduce_grid_size(32, block_size), 1);
+  CHECK_EQ(col_reduce_grid_size(33, block_size), 2);
+
+  constexpr size_t failing_reduction_stride = size_t{1} << 29;
+  constexpr size_t threadgroup_size = 256;
+  auto grid_size = col_reduce_grid_size(failing_reduction_stride, block_size);
+  CHECK_EQ(grid_size, size_t{1} << 24);
+  CHECK_EQ(grid_size * threadgroup_size, size_t{1} << 32);
+
+  CHECK_EQ(
+      col_reduce_grid_size(std::numeric_limits<size_t>::max(), block_size),
+      std::numeric_limits<size_t>::max() / block_size + 1);
+}
 
 TEST_CASE("test type promotion") {
   for (auto t : {bool_, uint32, int32, int64, float32}) {


### PR DESCRIPTION
## Proposed changes

Fixes #3784.

The affected Metal column-reduction launches express the x dimension as a
total thread count:

```text
256 * ceil(reduction_stride / 32)
```

For the reported reduction stride of `2^29`, that becomes `2^32` and overflows
the dispatch dimension. The kernels consume threadgroup coordinates, and the
thread count is always an exact multiple of the 256-thread group size.

This change expresses the four affected launches directly as threadgroup
counts. It preserves the kernel-visible grid for ordinary inputs while avoiding
the overflowing multiplication. The shared grid-size helper uses
quotient/remainder arithmetic so it remains valid at `SIZE_MAX`, and its test
covers the reported boundary without allocating the 32+ GiB reproducer.

Validation:

```text
focused grid-size test: 1 test case, 8 assertions passed
CPU C++ suite: 245 test cases, 3,246 assertions passed
host syntax check for metal/reduce.cpp: passed
pre-commit hooks on changed files: passed
```

The full Metal compiler is unavailable on this machine, and the original
large-memory runtime reproducer was not run. Repository CI and validation on
the reporter's large-memory Metal host remain the final runtime gates.

I used an AI coding assistant to help research and prepare this change; I
remain responsible for the submitted patch.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (not needed for this backend-only fix)
