### PR TITLE
metal: reduce NVFP4 scales per 16-lane group

### DIFF
--- a/mlx/backend/metal/kernels/fp_quantized.h
+++ b/mlx/backend/metal/kernels/fp_quantized.h
@@ -2002,7 +2002,8 @@ template <typename T, const int group_size, const int bits>
     device uint8_t* out [[buffer(1)]],
     device uint8_t* scales [[buffer(2)]],
     uint2 tidx [[thread_position_in_grid]],
-    uint2 grid_dim [[threads_per_grid]]) {
+    uint2 grid_dim [[threads_per_grid]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
   constexpr bool use_mx_scale = group_size == 32;
   size_t index = tidx.x + grid_dim.x * size_t(tidx.y);
 
@@ -2011,9 +2012,9 @@ template <typename T, const int group_size, const int bits>
   if (use_mx_scale) {
     scale = simd_max(abs(w_thread));
   } else {
-    float w_max_l = simd_max(tidx.x < 16 ? abs(w_thread) : 0.0);
-    float w_max_r = simd_max(tidx.x >= 16 ? abs(w_thread) : 0.0);
-    scale = tidx.x < 16 ? w_max_l : w_max_r;
+    float w_max_l = simd_max(simd_lid < 16 ? abs(w_thread) : 0.0);
+    float w_max_r = simd_max(simd_lid >= 16 ? abs(w_thread) : 0.0);
+    scale = simd_lid < 16 ? w_max_l : w_max_r;
   }
   scale /= bits == 4 ? 6.0f : 448.0f;
 
@@ -2075,7 +2076,8 @@ template <typename T, const int group_size, const int bits>
     const device T* w [[buffer(0)]],
     device T* out [[buffer(1)]],
     uint2 tidx [[thread_position_in_grid]],
-    uint2 grid_dim [[threads_per_grid]]) {
+    uint2 grid_dim [[threads_per_grid]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
   constexpr bool use_mx_scale = group_size == 32;
   size_t index = tidx.x + grid_dim.x * size_t(tidx.y);
 
@@ -2084,9 +2086,9 @@ template <typename T, const int group_size, const int bits>
   if (use_mx_scale) {
     scale = simd_max(abs(w_thread));
   } else {
-    float w_max_l = simd_max(tidx.x < 16 ? abs(w_thread) : 0.0);
-    float w_max_r = simd_max(tidx.x >= 16 ? abs(w_thread) : 0.0);
-    scale = tidx.x < 16 ? w_max_l : w_max_r;
+    float w_max_l = simd_max(simd_lid < 16 ? abs(w_thread) : 0.0);
+    float w_max_r = simd_max(simd_lid >= 16 ? abs(w_thread) : 0.0);
+    scale = simd_lid < 16 ? w_max_l : w_max_r;
   }
   scale /= bits == 4 ? 6.0f : 448.0f;
 

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -154,6 +154,15 @@ class TestQuantized(mlx_tests.MLXTestCase):
         w_hat = mx.dequantize(w_q, scales, mode="nvfp4")
         self.assertTrue(mx.allclose(w, w_hat, rtol=1e-5, atol=1e-5))
 
+        # A scale shared across a 32-value SIMD group instead of computed
+        # per 16-value group cannot represent the low-magnitude groups.
+        alternating = mx.zeros((64, 16), dtype=mx.bfloat16)
+        alternating[::2] = 6 * 2**-9
+        alternating[1::2] = 6.0
+        w_q, scales = mx.quantize(alternating, mode="nvfp4")
+        w_hat = mx.dequantize(w_q, scales, mode="nvfp4", dtype=mx.bfloat16)
+        self.assertTrue(mx.allclose(alternating, w_hat, rtol=1e-5, atol=1e-6))
+
         # test quantize/dequantize 0s
         a = mx.zeros((256, 512))
         w_q, scales = mx.quantize(a, mode="nvfp4")


### PR DESCRIPTION
Use the SIMD lane rather than the global grid index when splitting each SIMD group. This prevents every SIMD group after the first from sharing one 32-value maximum across two independently scaled NVFP4 groups.

Wikitext-2 test perplexity, Qwen3.6-35B-A3B quantized to NVFP4 with mlx-lm (297k tokens, Apple M5): 6.848 -> 6.778, bf16 baseline 6.432.