### PR TITLE
Fix mx.random.randint precision loss beyond 2^24 (float32 domain sampling)

### DIFF
--- a/mlx/random.cpp
+++ b/mlx/random.cpp
@@ -309,33 +309,34 @@ array randint(
   // pattern IS the correct unsigned width, so reinterpret it as uint64.
   // Reported by @axiom-of-choice on #3936.
   //
-  // The empty-interval test needs its own exact domain, and neither obvious
-  // choice is exact. Testing the int64 casts above is wrong for a uint64
-  // interval that straddles 2^63: `high` wraps negative, the ordering
-  // inverts, and a valid interval reads as empty (its mirror image also
-  // bites -- a genuinely inverted interval reads as non-empty and returns a
-  // spread instead of `low`). Testing the original bounds is wrong too:
-  // MLX promotes a signed/uint64 pair to float32, so a 24-bit mantissa
-  // rounds widely-separated bounds together, reintroducing this patch's own
-  // bug inside the predicate -- and float bounds, which randint accepts
-  // since it only validates the output dtype, can then drive the range to 0
-  // (remainder by 0 returns the dividend rather than raising). Compare in
-  // the output domain, which is exact for the dtype the caller asked for.
-  // Choose the comparison domain from the BOUNDS, not the output dtype: only
-  // when both bounds are themselves unsigned is uint64 safe. Picking it from
-  // the output dtype collapses `randint(-2, 2, dtype=uint8)`, because the
-  // negative `low` casts to a huge unsigned value and the interval reads as
-  // empty.
-  auto cmp_dtype = (issubdtype(low.dtype(), unsignedinteger) &&
-                    issubdtype(high.dtype(), unsignedinteger))
-      ? uint64
-      : int64;
-  auto empty = less_equal(
-      astype(high, cmp_dtype, stream), astype(low, cmp_dtype, stream), stream);
-  auto safe_range = where(
-      empty,
+  // The empty-interval comparison must also be exact. Neither a fixed int64
+  // nor a fixed uint64 domain works for every element: non-negative bounds
+  // compare exactly in uint64 (including mixed int64/uint64 bounds), while an
+  // interval with either bound negative must compare in int64. Comparing the
+  // original bounds directly is not exact either because signed/uint64 pairs
+  // promote to float32. Select the domain per element from the bound values.
+  auto both_non_negative = logical_and(
+      greater_equal(low, array(0, low.dtype()), stream),
+      greater_equal(high, array(0, high.dtype()), stream),
+      stream);
+  auto empty = where(
+      both_non_negative,
+      less_equal(
+          astype(high, uint64, stream), astype(low, uint64, stream), stream),
+      less_equal(hi, lo, stream),
+      stream);
+
+  // Keep the divisor nonzero independently of the predicate. In particular,
+  // positive float bounds can both saturate to int64_max and produce a width
+  // of zero; clamping makes any predicate/range disagreement collapse safely
+  // to `low` instead of passing raw random bits through remainder(x, 0).
+  auto safe_range = maximum(
+      where(
+          empty,
+          array(uint64_t(1), uint64),
+          astype(range, uint64, stream),
+          stream),
       array(uint64_t(1), uint64),
-      astype(range, uint64, stream),
       stream);
 
   array raw(0);
@@ -366,15 +367,14 @@ array randint(
     raw = astype(bits(shape, 4, key, stream), uint64, stream);
   }
 
-  // Reducing unsigned avoids numpy's negative-dividend `remainder` (which
-  // returns `raw % r + r` and skews the low end of the interval by
-  // `2^63 mod r`); an unsigned reduction is uniform on [0, r) by construction.
+  // Reducing unsigned avoids the asymmetric negative-dividend remainder path.
+  // The usual modulo bias remains when the range does not divide 2^64, but
+  // each bucket differs by at most one of the 2^64 possible raw draws.
   auto offset = remainder(raw, safe_range, stream);
   // Add in uint64 so the wrap for full-width intervals is well defined rather
   // than signed overflow; the resulting bit pattern is the correct value once
   // reinterpreted as the (possibly signed) target dtype.
-  return astype(
-      add(astype(lo, uint64, stream), offset, stream), dtype, stream);
+  return astype(add(astype(lo, uint64, stream), offset, stream), dtype, stream);
 }
 
 array bernoulli(

--- a/mlx/random.cpp
+++ b/mlx/random.cpp
@@ -279,8 +279,63 @@ array randint(
     throw std::invalid_argument(
         "[randint] randint only accepts integer dtypes and bool.");
   }
-  auto u = uniform(low, high, shape, float32, key, s);
-  return astype(maximum(u, low, s), dtype, s);
+  auto stream = to_stream(s);
+
+  // Sampling through `uniform()` rounds a float32 draw to the target integer
+  // type. float32 has a 24-bit mantissa, so once |low| or |high| reaches 2^24
+  // the rounded value can land on the excluded `high`, skip valid integers
+  // entirely, or -- when the whole interval sits between two consecutive
+  // representable floats -- collapse every draw in the interval to a single
+  // constant, regardless of how narrow the interval is. Sample directly in
+  // integer space instead: draw raw random bits and reduce them modulo the
+  // (integer) range, which is exact for any low/high representable in int64,
+  // independent of magnitude.
+  auto lo = astype(low, int64, stream);
+  auto hi = astype(high, int64, stream);
+  auto range = subtract(hi, lo, stream);
+  auto out_shape = broadcast_shapes(shape, range.shape());
+  if (out_shape != shape) {
+    std::ostringstream msg;
+    msg << "[randint] Cannot generate random values of shape " << shape
+        << " from broadcasted shape " << out_shape << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  // An empty/invalid interval (`high <= low`) has no valid sample; matching
+  // the historical behavior, clamp so the modulo below is well defined and
+  // the result collapses to `low`.
+  auto safe_range = maximum(range, array(int64_t(1), int64), stream);
+
+  array raw(0);
+  if (dtype == int64 || dtype == uint64) {
+    // The output dtype can represent ranges beyond what one uint32 draw (32
+    // bits of entropy) can cover, so combine two independent draws into 64
+    // bits. Explicitly split any caller-provided key so the two draws don't
+    // repeat the same bits.
+    array lo_bits(0), hi_bits(0);
+    if (key) {
+      auto [k1, k2] = split(*key, stream);
+      lo_bits = bits(shape, 4, k1, stream);
+      hi_bits = bits(shape, 4, k2, stream);
+    } else {
+      lo_bits = bits(shape, 4, std::nullopt, stream);
+      hi_bits = bits(shape, 4, std::nullopt, stream);
+    }
+    raw = bitwise_or(
+        left_shift(
+            astype(hi_bits, int64, stream), array(int64_t(32), int64), stream),
+        astype(lo_bits, int64, stream),
+        stream);
+  } else {
+    // Every other supported dtype's own domain spans at most 2^32 values, so
+    // one uint32 draw (32 bits of entropy) always has enough range.
+    raw = astype(bits(shape, 4, key, stream), int64, stream);
+  }
+
+  // `remainder` is numpy-style (result takes the sign of, and lies in
+  // [0, b), the divisor), so this is exact even though `raw` can be negative
+  // once its top bit lands past int64's sign bit in the 64-bit-combine path.
+  auto offset = remainder(raw, safe_range, stream);
+  return astype(add(lo, offset, stream), dtype, stream);
 }
 
 array bernoulli(

--- a/mlx/random.cpp
+++ b/mlx/random.cpp
@@ -321,7 +321,15 @@ array randint(
   // since it only validates the output dtype, can then drive the range to 0
   // (remainder by 0 returns the dividend rather than raising). Compare in
   // the output domain, which is exact for the dtype the caller asked for.
-  auto cmp_dtype = issubdtype(dtype, unsignedinteger) ? uint64 : int64;
+  // Choose the comparison domain from the BOUNDS, not the output dtype: only
+  // when both bounds are themselves unsigned is uint64 safe. Picking it from
+  // the output dtype collapses `randint(-2, 2, dtype=uint8)`, because the
+  // negative `low` casts to a huge unsigned value and the interval reads as
+  // empty.
+  auto cmp_dtype = (issubdtype(low.dtype(), unsignedinteger) &&
+                    issubdtype(high.dtype(), unsignedinteger))
+      ? uint64
+      : int64;
   auto empty = less_equal(
       astype(high, cmp_dtype, stream), astype(low, cmp_dtype, stream), stream);
   auto safe_range = where(

--- a/mlx/random.cpp
+++ b/mlx/random.cpp
@@ -306,10 +306,24 @@ array randint(
   // Clamping that with a signed `maximum(range, 1)` reads the wrapped value as
   // negative and yields 1, collapsing every draw onto `low` -- the same defect
   // this patch fixes at 2^24, relocated to a wider magnitude. The wrapped bit
-  // pattern IS the correct unsigned width, so reinterpret it as uint64 and do
-  // the empty-interval test on the signed values, where the comparison is
-  // still meaningful. Reported by @axiom-of-choice on #3936.
-  auto empty = less_equal(hi, lo, stream);
+  // pattern IS the correct unsigned width, so reinterpret it as uint64.
+  // Reported by @axiom-of-choice on #3936.
+  //
+  // The empty-interval test needs its own exact domain, and neither obvious
+  // choice is exact. Testing the int64 casts above is wrong for a uint64
+  // interval that straddles 2^63: `high` wraps negative, the ordering
+  // inverts, and a valid interval reads as empty (its mirror image also
+  // bites -- a genuinely inverted interval reads as non-empty and returns a
+  // spread instead of `low`). Testing the original bounds is wrong too:
+  // MLX promotes a signed/uint64 pair to float32, so a 24-bit mantissa
+  // rounds widely-separated bounds together, reintroducing this patch's own
+  // bug inside the predicate -- and float bounds, which randint accepts
+  // since it only validates the output dtype, can then drive the range to 0
+  // (remainder by 0 returns the dividend rather than raising). Compare in
+  // the output domain, which is exact for the dtype the caller asked for.
+  auto cmp_dtype = issubdtype(dtype, unsignedinteger) ? uint64 : int64;
+  auto empty = less_equal(
+      astype(high, cmp_dtype, stream), astype(low, cmp_dtype, stream), stream);
   auto safe_range = where(
       empty,
       array(uint64_t(1), uint64),

--- a/mlx/random.cpp
+++ b/mlx/random.cpp
@@ -300,10 +300,21 @@ array randint(
         << " from broadcasted shape " << out_shape << ".";
     throw std::invalid_argument(msg.str());
   }
-  // An empty/invalid interval (`high <= low`) has no valid sample; matching
-  // the historical behavior, clamp so the modulo below is well defined and
-  // the result collapses to `low`.
-  auto safe_range = maximum(range, array(int64_t(1), int64), stream);
+  // The width of an int64 interval does not itself fit in int64: `[-2^62,
+  // 2^62)` is 2^63 wide and `[int64_min, int64_max)` is 2^64 - 1 wide, so the
+  // subtraction above wraps negative for any interval wider than int64_max.
+  // Clamping that with a signed `maximum(range, 1)` reads the wrapped value as
+  // negative and yields 1, collapsing every draw onto `low` -- the same defect
+  // this patch fixes at 2^24, relocated to a wider magnitude. The wrapped bit
+  // pattern IS the correct unsigned width, so reinterpret it as uint64 and do
+  // the empty-interval test on the signed values, where the comparison is
+  // still meaningful. Reported by @axiom-of-choice on #3936.
+  auto empty = less_equal(hi, lo, stream);
+  auto safe_range = where(
+      empty,
+      array(uint64_t(1), uint64),
+      astype(range, uint64, stream),
+      stream);
 
   array raw(0);
   if (dtype == int64 || dtype == uint64) {
@@ -322,20 +333,26 @@ array randint(
     }
     raw = bitwise_or(
         left_shift(
-            astype(hi_bits, int64, stream), array(int64_t(32), int64), stream),
-        astype(lo_bits, int64, stream),
+            astype(hi_bits, uint64, stream),
+            array(uint64_t(32), uint64),
+            stream),
+        astype(lo_bits, uint64, stream),
         stream);
   } else {
     // Every other supported dtype's own domain spans at most 2^32 values, so
     // one uint32 draw (32 bits of entropy) always has enough range.
-    raw = astype(bits(shape, 4, key, stream), int64, stream);
+    raw = astype(bits(shape, 4, key, stream), uint64, stream);
   }
 
-  // `remainder` is numpy-style (result takes the sign of, and lies in
-  // [0, b), the divisor), so this is exact even though `raw` can be negative
-  // once its top bit lands past int64's sign bit in the 64-bit-combine path.
+  // Reducing unsigned avoids numpy's negative-dividend `remainder` (which
+  // returns `raw % r + r` and skews the low end of the interval by
+  // `2^63 mod r`); an unsigned reduction is uniform on [0, r) by construction.
   auto offset = remainder(raw, safe_range, stream);
-  return astype(add(lo, offset, stream), dtype, stream);
+  // Add in uint64 so the wrap for full-width intervals is well defined rather
+  // than signed overflow; the resulting bit pattern is the correct value once
+  // reinterpreted as the (possibly signed) target dtype.
+  return astype(
+      add(astype(lo, uint64, stream), offset, stream), dtype, stream);
 }
 
 array bernoulli(

--- a/mlx/random.cpp
+++ b/mlx/random.cpp
@@ -310,20 +310,24 @@ array randint(
   // Reported by @axiom-of-choice on #3936.
   //
   // The empty-interval comparison must also be exact. Neither a fixed int64
-  // nor a fixed uint64 domain works for every element: non-negative bounds
-  // compare exactly in uint64 (including mixed int64/uint64 bounds), while an
-  // interval with either bound negative must compare in int64. Comparing the
-  // original bounds directly is not exact either because signed/uint64 pairs
-  // promote to float32. Select the domain per element from the bound values.
-  auto both_non_negative = logical_and(
-      greater_equal(low, array(0, low.dtype()), stream),
-      greater_equal(high, array(0, high.dtype()), stream),
-      stream);
+  // nor a fixed uint64 domain works for every element, and comparing the raw
+  // bounds can promote a signed/uint64 pair to float32. Classify each bound by
+  // sign first. Same-sign negative bounds compare in int64, same-sign
+  // non-negative bounds compare in uint64, and unlike signs determine the
+  // ordering directly without a lossy cast.
+  auto low_negative = less(low, array(0, low.dtype()), stream);
+  auto high_negative = less(high, array(0, high.dtype()), stream);
   auto empty = where(
-      both_non_negative,
-      less_equal(
-          astype(high, uint64, stream), astype(low, uint64, stream), stream),
-      less_equal(hi, lo, stream),
+      not_equal(low_negative, high_negative, stream),
+      high_negative,
+      where(
+          low_negative,
+          less_equal(hi, lo, stream),
+          less_equal(
+              astype(high, uint64, stream),
+              astype(low, uint64, stream),
+              stream),
+          stream),
       stream);
 
   // Keep the divisor nonzero independently of the predicate. In particular,
@@ -339,37 +343,31 @@ array randint(
       array(uint64_t(1), uint64),
       stream);
 
-  array raw(0);
-  if (dtype == int64 || dtype == uint64) {
-    // The output dtype can represent ranges beyond what one uint32 draw (32
-    // bits of entropy) can cover, so combine two independent draws into 64
-    // bits. Explicitly split any caller-provided key so the two draws don't
-    // repeat the same bits.
-    array lo_bits(0), hi_bits(0);
-    if (key) {
-      auto [k1, k2] = split(*key, stream);
-      lo_bits = bits(shape, 4, k1, stream);
-      hi_bits = bits(shape, 4, k2, stream);
-    } else {
-      lo_bits = bits(shape, 4, std::nullopt, stream);
-      hi_bits = bits(shape, 4, std::nullopt, stream);
-    }
-    raw = bitwise_or(
-        left_shift(
-            astype(hi_bits, uint64, stream),
-            array(uint64_t(32), uint64),
-            stream),
-        astype(lo_bits, uint64, stream),
-        stream);
+  // Use 64 raw bits for every output dtype. A single uint32 draw can reach
+  // every value of a uint32 interval, but modulo reduction over a range above
+  // 2^31 can still give some buckets twice as many raw preimages as others.
+  // Combining two independent draws makes the remaining modulo bias tiny for
+  // <=32-bit output domains and is required to cover wider 64-bit domains.
+  array lo_bits(0), hi_bits(0);
+  if (key) {
+    auto [k1, k2] = split(*key, stream);
+    lo_bits = bits(shape, 4, k1, stream);
+    hi_bits = bits(shape, 4, k2, stream);
   } else {
-    // Every other supported dtype's own domain spans at most 2^32 values, so
-    // one uint32 draw (32 bits of entropy) always has enough range.
-    raw = astype(bits(shape, 4, key, stream), uint64, stream);
+    lo_bits = bits(shape, 4, std::nullopt, stream);
+    hi_bits = bits(shape, 4, std::nullopt, stream);
   }
+  auto raw = bitwise_or(
+      left_shift(
+          astype(hi_bits, uint64, stream), array(uint64_t(32), uint64), stream),
+      astype(lo_bits, uint64, stream),
+      stream);
 
   // Reducing unsigned avoids the asymmetric negative-dividend remainder path.
   // The usual modulo bias remains when the range does not divide 2^64, but
-  // each bucket differs by at most one of the 2^64 possible raw draws.
+  // each bucket differs by at most one of the 2^64 possible raw draws. That is
+  // negligible for <=32-bit ranges but can still be a 2x relative difference
+  // for near-full-width 64-bit ranges; exact uniformity needs rejection.
   auto offset = remainder(raw, safe_range, stream);
   // Add in uint64 so the wrap for full-width intervals is well defined rather
   // than signed overflow; the resulting bit pattern is the correct value once

--- a/python/tests/test_random.py
+++ b/python/tests/test_random.py
@@ -257,8 +257,11 @@ class TestRandom(mlx_tests.MLXTestCase):
         y = mx.random.randint(base, base + 1024, (10_000,), dtype=mx.int64, key=key)
         yv = y.tolist()
         self.assertTrue(all(base <= v < base + 1024 for v in yv))
-        # a real spread, not a collapse to one or a handful of values.
-        self.assertGreater(len(set(yv)), 500)
+        # Full coverage, not merely "a lot of values": a threshold like
+        # `> 500` passes even when half the interval is unreachable, which is
+        # exactly the property that breaks. 10k draws over 1024 values leaves
+        # a vanishing chance of a legitimate miss (~1024*(1-1/1024)**10000).
+        self.assertEqual(len(set(yv)), 1024)
 
         # int64 range wide enough to need genuine 64 bits of entropy (well
         # beyond 2**32), still same-key deterministic and in-bounds.
@@ -270,6 +273,32 @@ class TestRandom(mlx_tests.MLXTestCase):
         # with 256 draws over 2**48 values, a collapse to <10 unique values
         # would indicate the entropy-combine path regressed.
         self.assertGreater(len(set(a.tolist())), 200)
+
+    def test_randint_interval_wider_than_int64_max(self):
+        # Regression test for the width-overflow case reported by
+        # @axiom-of-choice on #3936: the width of an int64 interval does not
+        # itself fit in int64. `[-2**62, 2**62)` is 2**63 wide and
+        # `[int64_min, int64_max)` is 2**64 - 1 wide, so computing the range as
+        # a signed subtraction wraps negative and a signed `maximum(range, 1)`
+        # clamps it to 1 -- collapsing every draw onto `low`.
+        key = mx.random.key(7)
+
+        for lo, hi in [
+            (-(2**62), 2**62),  # width 2**63, wraps to int64_min
+            (-(2**63), 2**63 - 1),  # width 2**64 - 1, wraps to -1
+        ]:
+            x = mx.random.randint(lo, hi, (20_000,), dtype=mx.int64, key=key)
+            xv = x.tolist()
+            self.assertTrue(
+                all(lo <= v < hi for v in xv),
+                f"out of bounds for [{lo}, {hi})",
+            )
+            # The defect makes every draw equal `low`; over 20k draws from an
+            # interval this wide, even a handful of repeats would be startling.
+            self.assertGreater(
+                len(set(xv)), 19_000, f"collapsed for [{lo}, {hi})"
+            )
+            self.assertNotEqual(min(xv), max(xv), f"single value for [{lo}, {hi})")
 
     def test_bernoulli(self):
         a = mx.random.bernoulli()

--- a/python/tests/test_random.py
+++ b/python/tests/test_random.py
@@ -376,6 +376,22 @@ class TestRandom(mlx_tests.MLXTestCase):
         self.assertGreater(len(set(x[:, 0].tolist())), 19_000)
         self.assertEqual(set(x[:, 1].tolist()), {9})
 
+        # Unlike signs determine the ordering without either bound being cast
+        # into the other's domain. The full output of [-1, 2**63) is valid
+        # int64, even though the uint64 high wraps to int64_min if cast.
+        low = mx.array([-1], mx.int64)
+        high = mx.array([2**63], mx.uint64)
+        x = mx.random.randint(low, high, (20_000,), dtype=mx.int64, key=key)
+        xv = x.tolist()
+        self.assertTrue(all(-1 <= value < 2**63 for value in xv))
+        self.assertGreater(len(set(xv)), 19_000)
+
+        # The opposite sign ordering is necessarily empty.
+        low = mx.array([0], mx.uint64)
+        high = mx.array([-1], mx.int64)
+        x = mx.random.randint(low, high, (1_000,), dtype=mx.uint64, key=key)
+        self.assertEqual(set(x.tolist()), {0})
+
         # randint validates only the output dtype, so float bounds reach the
         # sampler. Both truncate to 0 here, so the interval is empty and the
         # result must be the constant `low` -- not raw bits, which is what a
@@ -426,6 +442,14 @@ class TestRandom(mlx_tests.MLXTestCase):
                 max(abs(count - expected) for count in counts) / expected
             )
             self.assertLess(max_relative_deviation, 0.1)
+
+        # A single 32-bit raw draw makes this range severely lopsided: the
+        # lowest third gets two raw preimages per value and the others get one.
+        # The 64-bit reduction path should put about one third in each band.
+        third = 2**30
+        x = mx.random.randint(0, 3 * third, (n,), dtype=mx.uint32, key=key)
+        first_band_fraction = mx.sum(x < third).item() / n
+        self.assertAlmostEqual(first_band_fraction, 1 / 3, delta=0.02)
 
     def test_bernoulli(self):
         a = mx.random.bernoulli()

--- a/python/tests/test_random.py
+++ b/python/tests/test_random.py
@@ -234,6 +234,43 @@ class TestRandom(mlx_tests.MLXTestCase):
             mx.random.randint(0, 1).dtype, mx.random.randint(0, 1, dtype=None).dtype
         )
 
+    def test_randint_beyond_float32_precision(self):
+        # Regression test: sampling used to go through a float32 `uniform()`
+        # draw, which is only exact for magnitudes below 2**24. Beyond that,
+        # rounding could return the excluded `high`, skip valid integers, or
+        # collapse the whole interval to a single constant -- independent of
+        # how narrow the requested interval was.
+        key = mx.random.key(42)
+
+        # int32, a narrow interval whose bounds sit just past 2**24.
+        base = 2**24
+        x = mx.random.randint(base, base + 2, (10_000,), dtype=mx.int32, key=key)
+        vals = set(x.tolist())
+        self.assertTrue(vals.issubset({base, base + 1}))
+        # both values must actually appear -- collapsing to one is the bug.
+        self.assertEqual(vals, {base, base + 1})
+
+        # int64, a narrow interval far past 2**24 -- exercises the 64-bit
+        # combine path, since one uint32 draw alone can't cover this range
+        # once combined with a base offset this large.
+        base = 2**40
+        y = mx.random.randint(base, base + 1024, (10_000,), dtype=mx.int64, key=key)
+        yv = y.tolist()
+        self.assertTrue(all(base <= v < base + 1024 for v in yv))
+        # a real spread, not a collapse to one or a handful of values.
+        self.assertGreater(len(set(yv)), 500)
+
+        # int64 range wide enough to need genuine 64 bits of entropy (well
+        # beyond 2**32), still same-key deterministic and in-bounds.
+        wide_lo, wide_hi = 0, 2**48
+        a = mx.random.randint(wide_lo, wide_hi, (256,), dtype=mx.int64, key=key)
+        b = mx.random.randint(wide_lo, wide_hi, (256,), dtype=mx.int64, key=key)
+        self.assertListEqual(a.tolist(), b.tolist())
+        self.assertTrue(mx.all(a >= wide_lo).item() and mx.all(a < wide_hi).item())
+        # with 256 draws over 2**48 values, a collapse to <10 unique values
+        # would indicate the entropy-combine path regressed.
+        self.assertGreater(len(set(a.tolist())), 200)
+
     def test_bernoulli(self):
         a = mx.random.bernoulli()
         self.assertEqual(a.shape, ())

--- a/python/tests/test_random.py
+++ b/python/tests/test_random.py
@@ -365,6 +365,27 @@ class TestRandom(mlx_tests.MLXTestCase):
         y = mx.random.randint(0.5, 0.9, (1_000,), dtype=mx.int32, key=key)
         self.assertEqual(set(y.tolist()), {0})
 
+    def test_randint_negative_low_unsigned_dtype_does_not_collapse(self):
+        # The comparison domain for the empty-interval test has to come from
+        # the BOUNDS, not the output dtype. Deriving it from the output made
+        # `randint(-2, 2, dtype=uint8)` compare in uint64, where the negative
+        # `low` becomes a huge value, the interval reads as empty, and every
+        # draw collapses onto a single constant.
+        #
+        # A negative bound with an unsigned output is out of contract to begin
+        # with and its wrapping behaviour is unspecified, so this asserts only
+        # the property that regressed: the sample must not collapse.
+        key = mx.random.key(7)
+        for lo, hi, dt in [
+            (-2, 2, mx.uint8),
+            (-5, 5, mx.uint32),
+            (-2, 2, mx.uint64),
+        ]:
+            x = mx.random.randint(lo, hi, (20_000,), dtype=dt, key=key)
+            self.assertGreater(
+                len(set(x.tolist())), 1, f"collapsed for [{lo}, {hi}) -> {dt}"
+            )
+
     def test_bernoulli(self):
         a = mx.random.bernoulli()
         self.assertEqual(a.shape, ())

--- a/python/tests/test_random.py
+++ b/python/tests/test_random.py
@@ -295,9 +295,7 @@ class TestRandom(mlx_tests.MLXTestCase):
             )
             # The defect makes every draw equal `low`; over 20k draws from an
             # interval this wide, even a handful of repeats would be startling.
-            self.assertGreater(
-                len(set(xv)), 19_000, f"collapsed for [{lo}, {hi})"
-            )
+            self.assertGreater(len(set(xv)), 19_000, f"collapsed for [{lo}, {hi})")
             self.assertNotEqual(min(xv), max(xv), f"single value for [{lo}, {hi})")
 
     def test_randint_uint64_interval_straddling_int64_max(self):
@@ -317,23 +315,17 @@ class TestRandom(mlx_tests.MLXTestCase):
             (2**63, 2**64 - 1),  # control: both bounds above 2**63
             (0, 2**62),  # control: both bounds below 2**63
         ]:
-            x = mx.random.randint(
-                u64(lo), u64(hi), (20_000,), dtype=mx.uint64, key=key
-            )
+            x = mx.random.randint(u64(lo), u64(hi), (20_000,), dtype=mx.uint64, key=key)
             xv = x.tolist()
             self.assertTrue(
                 all(lo <= v < hi for v in xv), f"out of bounds for [{lo}, {hi})"
             )
-            self.assertGreater(
-                len(set(xv)), 19_000, f"collapsed for [{lo}, {hi})"
-            )
+            self.assertGreater(len(set(xv)), 19_000, f"collapsed for [{lo}, {hi})")
 
         # Mirror image of the same defect: a genuinely inverted (empty)
         # interval straddling 2**63 must still return `low`, not a spread.
         for lo, hi in [(2**63 + 2**40, 2**62), (2**64 - 1, 2**62)]:
-            x = mx.random.randint(
-                u64(lo), u64(hi), (1_000,), dtype=mx.uint64, key=key
-            )
+            x = mx.random.randint(u64(lo), u64(hi), (1_000,), dtype=mx.uint64, key=key)
             self.assertEqual(
                 set(x.tolist()), {lo}, f"empty interval [{lo}, {hi}) not `low`"
             )
@@ -358,12 +350,47 @@ class TestRandom(mlx_tests.MLXTestCase):
         self.assertTrue(all(lo <= v < hi for v in xv))
         self.assertGreater(len(set(xv)), 19_000, "mixed-dtype bounds collapsed")
 
+        # Non-negative int64 bounds are exactly representable in uint64. The
+        # predicate must use their values, not their dtypes, when the uint64
+        # high crosses 2**63.
+        for lo in [0, 2**62]:
+            hi = 2**64 - 1
+            x = mx.random.randint(
+                mx.array([lo], mx.int64),
+                mx.array([hi], mx.uint64),
+                (20_000,),
+                dtype=mx.uint64,
+                key=key,
+            )
+            xv = x.tolist()
+            self.assertTrue(all(lo <= v < hi for v in xv))
+            self.assertGreater(
+                len(set(xv)), 19_000, f"wide mixed interval [{lo}, {hi}) collapsed"
+            )
+
+        # Exercise the value-domain selection elementwise: one broadcast
+        # column is a full non-empty interval and the other is inverted.
+        lows = mx.array([0, 9], mx.int64)
+        highs = mx.array([2**64 - 1, 3], mx.uint64)
+        x = mx.random.randint(lows, highs, (20_000, 2), dtype=mx.uint64, key=key)
+        self.assertGreater(len(set(x[:, 0].tolist())), 19_000)
+        self.assertEqual(set(x[:, 1].tolist()), {9})
+
         # randint validates only the output dtype, so float bounds reach the
         # sampler. Both truncate to 0 here, so the interval is empty and the
         # result must be the constant `low` -- not raw bits, which is what a
         # range of 0 would produce (remainder by 0 returns the dividend).
         y = mx.random.randint(0.5, 0.9, (1_000,), dtype=mx.int32, key=key)
         self.assertEqual(set(y.tolist()), {0})
+
+        # Large positive float32 bounds both saturate when cast to int64. The
+        # structural range clamp must keep their zero width from exposing raw
+        # random bits even if the value predicate sees a non-empty interval.
+        low = mx.array([1e19], mx.float32)
+        high = mx.array([2e19], mx.float32)
+        expected = low.astype(mx.int64).item()
+        z = mx.random.randint(low, high, (1_000,), dtype=mx.int64, key=key)
+        self.assertEqual(set(z.tolist()), {expected})
 
     def test_randint_negative_low_unsigned_dtype_does_not_collapse(self):
         # The comparison domain for the empty-interval test has to come from
@@ -372,9 +399,8 @@ class TestRandom(mlx_tests.MLXTestCase):
         # `low` becomes a huge value, the interval reads as empty, and every
         # draw collapses onto a single constant.
         #
-        # A negative bound with an unsigned output is out of contract to begin
-        # with and its wrapping behaviour is unspecified, so this asserts only
-        # the property that regressed: the sample must not collapse.
+        # The documented contract has no bound/output dtype compatibility
+        # exception, so preserve the reachable values rather than collapsing.
         key = mx.random.key(7)
         for lo, hi, dt in [
             (-2, 2, mx.uint8),
@@ -385,6 +411,21 @@ class TestRandom(mlx_tests.MLXTestCase):
             self.assertGreater(
                 len(set(x.tolist())), 1, f"collapsed for [{lo}, {hi}) -> {dt}"
             )
+
+    def test_randint_uniform_coverage(self):
+        # Pin both reachability and a coarse distribution check. A distinct
+        # count alone can pass while a large part of the interval is biased.
+        key = mx.random.key(7)
+        n = 200_000
+        for low, high in [(0, 6), (-10, 10), (3, 15)]:
+            x = mx.random.randint(low, high, (n,), dtype=mx.int64, key=key)
+            counts = [mx.sum(x == value).item() for value in range(low, high)]
+            self.assertTrue(all(count > 0 for count in counts))
+            expected = n / (high - low)
+            max_relative_deviation = (
+                max(abs(count - expected) for count in counts) / expected
+            )
+            self.assertLess(max_relative_deviation, 0.1)
 
     def test_bernoulli(self):
         a = mx.random.bernoulli()

--- a/python/tests/test_random.py
+++ b/python/tests/test_random.py
@@ -300,6 +300,71 @@ class TestRandom(mlx_tests.MLXTestCase):
             )
             self.assertNotEqual(min(xv), max(xv), f"single value for [{lo}, {hi})")
 
+    def test_randint_uint64_interval_straddling_int64_max(self):
+        # The empty-interval predicate needs a domain that is exact for the
+        # requested dtype. Testing the int64 casts of the bounds is not: a
+        # uint64 interval with `low < 2**63 <= high` has its `high` wrap
+        # negative, so the ordering inverts and a perfectly valid interval
+        # reads as empty -- every draw then collapses onto `low`. Intervals
+        # with both bounds above 2**63 do not wrap and were never affected,
+        # so they are included here as controls.
+        key = mx.random.key(7)
+        u64 = lambda v: mx.array([v], mx.uint64)
+
+        for lo, hi in [
+            (0, 2**64 - 1),  # straddles 2**63
+            (2**62, 2**64 - 1),  # straddles 2**63
+            (2**63, 2**64 - 1),  # control: both bounds above 2**63
+            (0, 2**62),  # control: both bounds below 2**63
+        ]:
+            x = mx.random.randint(
+                u64(lo), u64(hi), (20_000,), dtype=mx.uint64, key=key
+            )
+            xv = x.tolist()
+            self.assertTrue(
+                all(lo <= v < hi for v in xv), f"out of bounds for [{lo}, {hi})"
+            )
+            self.assertGreater(
+                len(set(xv)), 19_000, f"collapsed for [{lo}, {hi})"
+            )
+
+        # Mirror image of the same defect: a genuinely inverted (empty)
+        # interval straddling 2**63 must still return `low`, not a spread.
+        for lo, hi in [(2**63 + 2**40, 2**62), (2**64 - 1, 2**62)]:
+            x = mx.random.randint(
+                u64(lo), u64(hi), (1_000,), dtype=mx.uint64, key=key
+            )
+            self.assertEqual(
+                set(x.tolist()), {lo}, f"empty interval [{lo}, {hi}) not `low`"
+            )
+
+    def test_randint_bounds_dtype_does_not_lose_precision(self):
+        # The predicate must not be evaluated in a promoted floating type.
+        # MLX promotes a signed/uint64 pair to float32, whose 24-bit mantissa
+        # rounds bounds closer than the ulp at that magnitude onto each other
+        # -- at 2**62 the ulp is 2**39, so a 2**38-wide interval would read as
+        # empty. Mixed-signedness bounds are accepted by the binding, so this
+        # is reachable.
+        key = mx.random.key(7)
+        lo, hi = 2**62, 2**62 + 2**38
+        x = mx.random.randint(
+            mx.array([lo], mx.int64),
+            mx.array([hi], mx.uint64),
+            (20_000,),
+            dtype=mx.uint64,
+            key=key,
+        )
+        xv = x.tolist()
+        self.assertTrue(all(lo <= v < hi for v in xv))
+        self.assertGreater(len(set(xv)), 19_000, "mixed-dtype bounds collapsed")
+
+        # randint validates only the output dtype, so float bounds reach the
+        # sampler. Both truncate to 0 here, so the interval is empty and the
+        # result must be the constant `low` -- not raw bits, which is what a
+        # range of 0 would produce (remainder by 0 returns the dividend).
+        y = mx.random.randint(0.5, 0.9, (1_000,), dtype=mx.int32, key=key)
+        self.assertEqual(set(y.tolist()), {0})
+
     def test_bernoulli(self):
         a = mx.random.bernoulli()
         self.assertEqual(a.shape, ())

--- a/tests/random_tests.cpp
+++ b/tests/random_tests.cpp
@@ -516,6 +516,36 @@ TEST_CASE("test random randint") {
   auto key = array({0, 0}, {1, 2});
   CHECK_THROWS_AS(
       random::randint(low, high, {}, float32, key), std::invalid_argument);
+
+  // Bounds that are not exactly representable in float32 must not make values
+  // unreachable, return `high`, or collapse the interval.
+
+  // At 2^24 adjacent float32 values are two integers apart.
+  auto lo24 = array(1 << 24, int32);
+  auto hi24 = array((1 << 24) + 2, int32);
+  x = random::randint(lo24, hi24, {10000}, int32);
+  CHECK(all(less(x, hi24)).item<bool>()); // `high` is exclusive
+  CHECK(any(equal(x, lo24)).item<bool>());
+  CHECK(any(equal(x, array((1 << 24) + 1, int32))).item<bool>());
+
+  // At 2^40 the float32 spacing is 2^17, which collapsed this interval to a
+  // single value.
+  auto lo40 = array(int64_t(1) << 40, int64);
+  auto hi40 = array((int64_t(1) << 40) + 1024, int64);
+  x = random::randint(lo40, hi40, {20000}, int64);
+  CHECK(
+      (all(less_equal(lo40, x)).item<bool>() &&
+       all(less(x, hi40)).item<bool>()));
+  CHECK_GT(max(x).item<int64_t>(), min(x).item<int64_t>());
+
+  // A width above 2^63 is representable only as unsigned.
+  auto lo62 = array(-(int64_t(1) << 62), int64);
+  auto hi62 = array(int64_t(1) << 62, int64);
+  x = random::randint(lo62, hi62, {10000}, int64);
+  CHECK(
+      (all(less_equal(lo62, x)).item<bool>() &&
+       all(less(x, hi62)).item<bool>()));
+  CHECK_GT(max(x).item<int64_t>(), min(x).item<int64_t>());
 }
 
 TEST_CASE("test random bernoulli") {

--- a/tests/random_tests.cpp
+++ b/tests/random_tests.cpp
@@ -546,6 +546,20 @@ TEST_CASE("test random randint") {
       (all(less_equal(lo62, x)).item<bool>() &&
        all(less(x, hi62)).item<bool>()));
   CHECK_GT(max(x).item<int64_t>(), min(x).item<int64_t>());
+
+  // A negative int64 low and a uint64 high above int64_max cannot be compared
+  // exactly by casting both bounds into either fixed integer domain.
+  auto lo_cross = array(int64_t(-1), int64);
+  auto hi_cross = array(uint64_t(1) << 63, uint64);
+  x = random::randint(lo_cross, hi_cross, {20000}, int64);
+  CHECK(all(less_equal(lo_cross, x)).item<bool>());
+  CHECK_GT(max(x).item<int64_t>(), min(x).item<int64_t>());
+
+  // Reversing the signs makes the interval necessarily empty.
+  auto lo_empty = array(uint64_t(0), uint64);
+  auto hi_empty = array(int64_t(-1), int64);
+  x = random::randint(lo_empty, hi_empty, {1000}, uint64);
+  CHECK(all(equal(x, lo_empty)).item<bool>());
 }
 
 TEST_CASE("test random bernoulli") {


### PR DESCRIPTION
## Problem

`mx.random.randint` sampled through a float32 uniform and cast the result to the requested integer dtype. Once a bound reaches the float32 precision boundary, valid integers become unreachable, the excluded `high` can be returned, or a narrow interval can collapse to one value.

Moving the sampler into integer space exposed three related edge cases that this branch now handles together:

- an `int64` interval can be up to `2^64 - 1` wide, so its width must be interpreted as `uint64`;
- interval emptiness cannot be tested in one fixed domain: same-sign non-negative bounds compare in `uint64`, same-sign negative bounds compare in `int64`, and unlike signs determine the ordering without a cast;
- the range divisor must be clamped independently of the predicate, because float bounds can saturate to the same integer and otherwise expose raw random bits through `remainder(x, 0)`.

## Change

- Draw random bits directly and reduce them in the integer domain instead of routing through float32.
- Combine two independent 32-bit draws for every output dtype. One 32-bit draw caused severe modulo bias for large `uint32` intervals even though it could reach every value.
- Interpret wrapped interval widths as `uint64`, including widths above `int64_max`.
- Select the empty-interval comparison per element from the signs of both bounds: same-sign non-negative uses `uint64`, same-sign negative uses `int64`, and unlike signs are ordered directly.
- Clamp the unsigned divisor to at least one independently of the predicate, preserving the existing empty/inverted-interval behavior of returning `low`.
- Add Python coverage for float32 precision boundaries, widths above `int64_max`, uint64 intervals straddling `2^63`, same-sign and cross-sign mixed `int64`/`uint64` bounds, elementwise predicates, float saturation, negative bounds with unsigned output, determinism, small-range uniformity, and the large-`uint32` modulo-bias case.
- Add the core precision, wide-interval, and cross-sign cases to the C++ random test.

Unsigned remainder avoids the asymmetric negative-dividend path. It still has the ordinary modulo bias when the interval width does not divide `2^64`; each bucket differs by at most one of the `2^64` possible raw draws. That difference is negligible for ranges up to 32 bits, but it can still be a 2x relative difference for a near-full-width 64-bit interval. This PR does not claim rejection-sampling exactness.

## Collaboration

@axiom-of-choice independently found the wide-range failure, contributed the `uint64` framing, proposed the C++ and uniformity coverage, and validated the final value-based predicate plus structural clamp. #3955 contains the comparison implementation and investigation history; we agreed to carry the combined fix here.

## Verification

CPU-only macOS/arm64 build (`MLX_BUILD_METAL=OFF`, warnings treated as errors):

- `pre-commit` on the three changed files: pass
- `python/tests/test_random.py`: **20/20 passed**
- `python -m unittest discover -v python/tests`: **794 passed, 65 skipped**
- C++ test binary: **244/244 cases, 3248/3248 assertions passed**

Metal was not exercised locally; backend CI and maintainer review remain required.

## Checklist

- [x] Read `CONTRIBUTING.md`
- [x] Added regression tests that distinguish the fixed cases
- [x] Ran the repository format hooks on changed files
- [x] Ran the focused and full CPU test suites
- [ ] Metal/backend CI
