### PR TITLE
[Metal] Skip empty NAX GEMM output groups

### DIFF
--- a/mlx/backend/metal/kernels/steel/gemm/gemm_nax.h
+++ b/mlx/backend/metal/kernels/steel/gemm/gemm_nax.h
@@ -45,11 +45,17 @@ auto gemm_loop(
   NAXTile<AccumType, TM, TN> Dtile;
   Dtile.clear();
 
+  const bool has_output = sgp_sm > 0 && sgp_sn > 0;
+
   int gemm_k_iterations_ = gemm_k_iterations_aligned;
 
   STEEL_PRAGMA_NO_UNROLL
   for (int kk0 = 0; kk0 < gemm_k_iterations_; kk0++) {
     threadgroup_barrier(mem_flags::mem_none);
+    if constexpr (!kAlignedM || !kAlignedN) {
+      if (!has_output)
+        continue;
+    }
 
     STEEL_PRAGMA_NO_UNROLL
     for (int kk1 = 0; kk1 < BK; kk1 += SK) {
@@ -94,6 +100,10 @@ auto gemm_loop(
 
   if constexpr (!kAlignedK) {
     simdgroup_barrier(mem_flags::mem_none);
+    if constexpr (!kAlignedM || !kAlignedN) {
+      if (!has_output)
+        return Dtile;
+    }
 
     const short rem_bk = K - gemm_k_iterations_ * BK;
 

--- a/mlx/backend/metal/kernels/steel/gemm/kernels/steel_gemm_fused_nax.h
+++ b/mlx/backend/metal/kernels/steel/gemm/kernels/steel_gemm_fused_nax.h
@@ -200,14 +200,17 @@ template <
             params->gemm_k_iterations_aligned,
             sgp_sm,
             sgp_sn);
-        if (use_out_source) {
-          gemm_epilogue<kAlignedM.value, kAlignedN.value>(
-              Dtile, C, params, addmm_params, sgp_sm, sgp_sn);
-        }
-        if constexpr (kAlignedM && kAlignedN) {
-          Dtile.store(D, int(params->ldd));
-        } else {
-          Dtile.store_safe(D, int(params->ldd), short2(sgp_sn, sgp_sm));
+        if ((kAlignedM.value || sgp_sm > 0) &&
+            (kAlignedN.value || sgp_sn > 0)) {
+          if (use_out_source) {
+            gemm_epilogue<kAlignedM.value, kAlignedN.value>(
+                Dtile, C, params, addmm_params, sgp_sm, sgp_sn);
+          }
+          if constexpr (kAlignedM && kAlignedN) {
+            Dtile.store(D, int(params->ldd));
+          } else {
+            Dtile.store_safe(D, int(params->ldd), short2(sgp_sn, sgp_sm));
+          }
         }
       });
     });


### PR DESCRIPTION
## Proposed changes

NAX GEMM can dispatch SIMD groups whose output extent is zero for partial M or N tiles. These groups previously continued through the K loop, including tile loads and NAX matrix operations, even though they could not produce or store any output.

This change:

- Detects SIMD groups with no output rows or columns.
- Skips tile loads and matrix operations for empty groups.
- Skips the epilogue and output store when the output extent is empty.

## Performance

Measured on an iPhone 17 Pro Max running iOS 27.0 with Metal 4.1. The benchmarks use FP16, NN layout, batch size 1, 10 warmup iterations, and 20 timed iterations.

| M x N x K | Before | After | Speedup | Notes |
|---|---:|---:|---:|---|
| `129 x 2305 x 768` | 0.6692 ms | 0.4315 ms | 1.55x | Synthetic double-tail stress case. M and N are both one element past 128-aligned tile boundaries |
| `197 x 3072 x 768` | 0.7415 ms | 0.6290 ms | 1.18x | ViT-B/16 MLP expansion: 197 tokens projected from 768 to 3072. |

Each shape was measured for seven repeats with a three-second pause between repeats. The first result from each build was excluded, and the table reports the median GPU completion time of the remaining six results.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
