### PR TITLE
Add buffer-count probes: `get_active_buffer_count`, `get_cache_buffer_count`, `get_buffer_histogram`

### DIFF
--- a/docs/src/python/memory_management.rst
+++ b/docs/src/python/memory_management.rst
@@ -10,6 +10,9 @@ Memory Management
   get_peak_memory
   reset_peak_memory
   get_cache_memory
+  get_active_buffer_count
+  get_cache_buffer_count
+  get_buffer_histogram
   set_memory_limit
   set_cache_limit
   set_wired_limit

--- a/mlx/backend/common/buffer_cache.h
+++ b/mlx/backend/common/buffer_cache.h
@@ -102,6 +102,10 @@ class BufferCache {
     return pool_size_;
   }
 
+  size_t count() const {
+    return buffer_pool_.size();
+  }
+
   size_t page_size() const {
     return page_size_;
   }

--- a/mlx/backend/cuda/allocator.cpp
+++ b/mlx/backend/cuda/allocator.cpp
@@ -434,4 +434,15 @@ size_t set_wired_limit(size_t) {
   return 0;
 }
 
+// The CUDA resource limit is bytes, not handles; count probes return 0.
+size_t get_active_buffer_count() {
+  return 0;
+}
+size_t get_cache_buffer_count() {
+  return 0;
+}
+std::vector<std::pair<size_t, size_t>> get_buffer_histogram() {
+  return {};
+}
+
 } // namespace mlx::core

--- a/mlx/backend/metal/allocator.cpp
+++ b/mlx/backend/metal/allocator.cpp
@@ -52,6 +52,8 @@ MetalAllocator::MetalAllocator(Device& d)
             if (!buf->heap()) {
               residency_set_.erase(buf);
             }
+            // Called with mutex_ held by all paths that evict from the cache.
+            hist_sub(buf->length());
             auto pool = metal::new_scoped_memory_pool();
             buf->release();
           }) {
@@ -158,6 +160,7 @@ Buffer MetalAllocator::malloc(size_t size) {
     }
     lk.lock();
     num_resources_++;
+    hist_add(buf->length());
     if (!buf->heap()) {
       residency_set_.insert(buf);
     }
@@ -191,6 +194,7 @@ void MetalAllocator::free(Buffer buffer) {
     buffer_cache_.recycle_to_cache(buf);
   } else {
     num_resources_--;
+    hist_sub(buf->length());
     if (!buf->heap()) {
       residency_set_.erase(buf);
     }
@@ -198,6 +202,17 @@ void MetalAllocator::free(Buffer buffer) {
     auto pool = metal::new_scoped_memory_pool();
     buf->release();
   }
+}
+
+std::vector<std::pair<size_t, size_t>> MetalAllocator::get_buffer_histogram() {
+  std::unique_lock lk(mutex_);
+  std::vector<std::pair<size_t, size_t>> out;
+  for (size_t i = 0; i < live_by_class_.size(); ++i) {
+    if (live_by_class_[i] > 0) {
+      out.emplace_back(size_t(1) << i, live_by_class_[i]);
+    }
+  }
+  return out;
 }
 
 size_t MetalAllocator::size(Buffer buffer) const {
@@ -214,6 +229,7 @@ Buffer MetalAllocator::make_buffer(void* ptr, size_t size) {
   active_memory_ += buf->length();
   peak_memory_ = std::max(peak_memory_, active_memory_);
   num_resources_++;
+  hist_add(buf->length());
   return Buffer{static_cast<void*>(buf)};
 }
 
@@ -225,6 +241,7 @@ void MetalAllocator::release(Buffer buffer) {
   std::unique_lock lk(mutex_);
   active_memory_ -= buf->length();
   num_resources_--;
+  hist_sub(buf->length());
   residency_set_.erase(buf);
   lk.unlock();
   auto pool = metal::new_scoped_memory_pool();
@@ -271,6 +288,15 @@ void reset_peak_memory() {
 }
 size_t get_cache_memory() {
   return metal::allocator().get_cache_memory();
+}
+size_t get_active_buffer_count() {
+  return metal::allocator().get_active_buffer_count();
+}
+size_t get_cache_buffer_count() {
+  return metal::allocator().get_cache_buffer_count();
+}
+std::vector<std::pair<size_t, size_t>> get_buffer_histogram() {
+  return metal::allocator().get_buffer_histogram();
 }
 void clear_cache() {
   return metal::allocator().clear_cache();

--- a/mlx/backend/metal/allocator.h
+++ b/mlx/backend/metal/allocator.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <array>
 #include <map>
 #include <mutex>
 #include <vector>
@@ -36,6 +37,15 @@ class MetalAllocator : public allocator::Allocator {
   size_t get_cache_memory() {
     return buffer_cache_.cache_size();
   };
+  size_t get_active_buffer_count() {
+    std::unique_lock lk(mutex_);
+    return num_resources_;
+  };
+  size_t get_cache_buffer_count() {
+    std::unique_lock lk(mutex_);
+    return buffer_cache_.count();
+  };
+  std::vector<std::pair<size_t, size_t>> get_buffer_histogram();
   size_t set_cache_limit(size_t limit);
   size_t set_memory_limit(size_t limit);
   size_t get_memory_limit();
@@ -71,6 +81,31 @@ class MetalAllocator : public allocator::Allocator {
   size_t wired_limit_{0};
   size_t num_resources_{0};
   size_t resource_limit_{0};
+
+  // Histogram of live buffer objects by power-of-two size class,
+  // indexed by class exponent (class = 1 << i). A fixed array so the
+  // hot-path update cannot allocate or throw -- a map node allocation
+  // here could fail after newBuffer()/num_resources_++ and desync the
+  // histogram. Tracks the same population as num_resources_. Guarded
+  // by mutex_.
+  std::array<size_t, 64> live_by_class_{};
+
+  static int size_class(size_t size) {
+    int c = 0;
+    while (c < 63 && (size_t(1) << c) < size) {
+      c++;
+    }
+    return c;
+  }
+  void hist_add(size_t size) noexcept {
+    live_by_class_[size_class(size)]++;
+  }
+  void hist_sub(size_t size) noexcept {
+    auto& n = live_by_class_[size_class(size)];
+    if (n > 0) {
+      n--;
+    }
+  }
 
   std::mutex mutex_;
 };

--- a/mlx/backend/no_gpu/allocator.cpp
+++ b/mlx/backend/no_gpu/allocator.cpp
@@ -209,6 +209,15 @@ size_t set_cache_limit(size_t limit) {
 size_t set_wired_limit(size_t) {
   return 0;
 }
+size_t get_active_buffer_count() {
+  return 0;
+}
+size_t get_cache_buffer_count() {
+  return 0;
+}
+std::vector<std::pair<size_t, size_t>> get_buffer_histogram() {
+  return {};
+}
 void clear_cache() {
   allocator::common_allocator().clear_cache();
 }

--- a/mlx/memory.h
+++ b/mlx/memory.h
@@ -3,6 +3,8 @@
 #pragma once
 
 #include <cstdlib>
+#include <utility>
+#include <vector>
 
 #include "mlx/api.h"
 
@@ -32,6 +34,30 @@ MLX_API void reset_peak_memory();
  * to the system allocator.
  * */
 MLX_API size_t get_cache_memory();
+
+/* Get the number of live GPU buffer objects (active + cached).
+ *
+ * On Metal this counts the MTL::Buffer objects created through the allocator
+ * that have not yet been released. This count — not bytes — is what is
+ * checked against the per-process resource limit (~499k on Apple silicon)
+ * in the "[metal::malloc] Resource limit exceeded" error. Returns 0 on
+ * backends without a handle limit.
+ * */
+MLX_API size_t get_active_buffer_count();
+
+/* Get the number of buffer objects currently held by the buffer cache.
+ *
+ * These are included in get_active_buffer_count().
+ * */
+MLX_API size_t get_cache_buffer_count();
+
+/* Get a histogram of live GPU buffer objects bucketed by power-of-two
+ * size class.
+ *
+ * Returns (size_class_upper_bound_bytes, count) pairs sorted by size class.
+ * The counts sum to get_active_buffer_count().
+ * */
+MLX_API std::vector<std::pair<size_t, size_t>> get_buffer_histogram();
 
 /* Set the memory limit.
  * The memory limit is a guideline for the maximum amount of memory to use

--- a/python/src/memory.cpp
+++ b/python/src/memory.cpp
@@ -2,6 +2,8 @@
 
 #include "mlx/memory.h"
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/pair.h>
+#include <nanobind/stl/vector.h>
 
 namespace mx = mlx::core;
 namespace nb = nanobind;
@@ -40,6 +42,36 @@ void init_memory(nb::module_& m) {
 
       The cache includes memory not currently used that has not been returned
       to the system allocator.
+      )pbdoc");
+  m.def(
+      "get_active_buffer_count",
+      &mx::get_active_buffer_count,
+      R"pbdoc(
+      Get the number of live GPU buffer objects (active + cached).
+
+      On Metal this counts the ``MTL::Buffer`` objects created through the
+      allocator that have not yet been released. This count -- not bytes --
+      is what is checked against the per-process resource limit (~499k on
+      Apple silicon) in the ``[metal::malloc] Resource limit exceeded``
+      error. Returns 0 on backends without a handle limit.
+      )pbdoc");
+  m.def(
+      "get_cache_buffer_count",
+      &mx::get_cache_buffer_count,
+      R"pbdoc(
+      Get the number of buffer objects currently held by the buffer cache.
+
+      These are included in :func:`get_active_buffer_count`.
+      )pbdoc");
+  m.def(
+      "get_buffer_histogram",
+      &mx::get_buffer_histogram,
+      R"pbdoc(
+      Get a histogram of live GPU buffer objects by power-of-two size class.
+
+      Returns a list of ``(size_class_upper_bound_bytes, count)`` tuples
+      sorted by size class. The counts sum to
+      :func:`get_active_buffer_count`.
       )pbdoc");
   m.def(
       "set_memory_limit",

--- a/python/tests/test_memory.py
+++ b/python/tests/test_memory.py
@@ -58,6 +58,151 @@ class TestMemory(mlx_tests.MLXTestCase):
         with self.assertRaises(ValueError):
             mx.set_wired_limit(max_size + 10)
 
+    def test_buffer_counts(self):
+        def check_hist(hist, total):
+            # Documented structure: sorted power-of-two size-class upper
+            # bounds with positive counts, summing to the total count.
+            self.assertEqual(sum(n for _, n in hist), total)
+            keys = [k for k, _ in hist]
+            self.assertEqual(keys, sorted(keys))
+            for k, n in hist:
+                self.assertGreater(k, 0)
+                self.assertEqual(k & (k - 1), 0)
+                self.assertGreater(n, 0)
+
+        mx.synchronize()
+        count = mx.get_active_buffer_count()
+        cached = mx.get_cache_buffer_count()
+        self.assertTrue(count >= 0)
+        self.assertTrue(cached >= 0)
+        self.assertTrue(cached <= count)
+        check_hist(mx.get_buffer_histogram(), count)
+
+        if not mx.metal.is_available():
+            # Documented values on backends without a handle limit
+            self.assertEqual(count, 0)
+            self.assertEqual(cached, 0)
+            self.assertEqual(mx.get_buffer_histogram(), [])
+            return
+
+        if mx.default_device() != mx.gpu:
+            # The probes track the Metal allocator; in CPU mode nothing in
+            # this test would land there
+            return
+
+        # Warm up one-time allocations so the baseline below is stable
+        warm = mx.zeros((4096,))
+        mx.eval(warm)
+        del warm
+        mx.synchronize()
+        mx.clear_cache()
+
+        baseline = mx.get_active_buffer_count()
+        baseline_hist = mx.get_buffer_histogram()
+        self.assertEqual(mx.get_cache_buffer_count(), 0)
+
+        # A fresh 16 KB allocation raises the live count and lands in the
+        # 16384 size class
+        a = mx.zeros((4096,))  # 4096 x float32 = 16384 bytes
+        mx.eval(a)
+        mx.synchronize()
+        with_alloc = mx.get_active_buffer_count()
+        self.assertGreater(with_alloc, baseline)
+        hist = mx.get_buffer_histogram()
+        check_hist(hist, with_alloc)
+        self.assertGreaterEqual(
+            dict(hist).get(16384, 0), dict(baseline_hist).get(16384, 0) + 1
+        )
+
+        # With `a` live and the cache cleared, active and cached must
+        # disagree: live buffers are counted but are not cache entries
+        mx.clear_cache()
+        self.assertEqual(mx.get_cache_buffer_count(), 0)
+        self.assertGreater(mx.get_active_buffer_count(), 0)
+        post_clear = mx.get_active_buffer_count()
+
+        # Freeing recycles into the cache: still counted, now visible as
+        # cached
+        del a
+        mx.synchronize()
+        self.assertGreater(mx.get_cache_buffer_count(), 0)
+        self.assertEqual(mx.get_active_buffer_count(), post_clear)
+        check_hist(mx.get_buffer_histogram(), post_clear)
+
+        # Clearing the cache releases the buffers and restores the baseline
+        mx.clear_cache()
+        self.assertEqual(mx.get_cache_buffer_count(), 0)
+        self.assertEqual(mx.get_active_buffer_count(), baseline)
+        self.assertEqual(mx.get_buffer_histogram(), baseline_hist)
+
+        # malloc-from-cache: reallocating a freed size reuses the cached
+        # buffer instead of creating a new one
+        a = mx.zeros((4096,))
+        mx.eval(a)
+        mx.synchronize()
+        total = mx.get_active_buffer_count()
+        del a
+        mx.synchronize()
+        self.assertEqual(mx.get_active_buffer_count(), total)
+        a = mx.zeros((4096,))
+        mx.eval(a)
+        mx.synchronize()
+        self.assertLessEqual(mx.get_active_buffer_count(), total)
+        check_hist(mx.get_buffer_histogram(), mx.get_active_buffer_count())
+        del a
+        mx.synchronize()
+        mx.clear_cache()
+
+        # free-to-release: with the cache disabled, freeing decrements the
+        # count immediately
+        old_limit = mx.set_cache_limit(0)
+        try:
+            a = mx.zeros((4096,))
+            mx.eval(a)
+            mx.synchronize()
+            before_free = mx.get_active_buffer_count()
+            del a
+            mx.synchronize()
+            self.assertLess(mx.get_active_buffer_count(), before_free)
+            check_hist(mx.get_buffer_histogram(), mx.get_active_buffer_count())
+        finally:
+            mx.set_cache_limit(old_limit)
+
+        # cache eviction: buffers resting in the cache are released by a
+        # later malloc's cache trim (set_cache_limit does not trim; the
+        # 32-byte request cannot reuse the 16 KB entry), so the count
+        # and histogram cross the eviction-callback path. The zeros()
+        # eval may cache more than one buffer (e.g. its fill scalar), so
+        # count relative to the recorded cached population.
+        a = mx.zeros((4096,))
+        mx.eval(a)
+        mx.synchronize()
+        del a
+        mx.synchronize()
+        cached_before = mx.get_cache_buffer_count()
+        self.assertGreater(cached_before, 0)
+        with_cached = mx.get_active_buffer_count()
+        hist_cached = dict(mx.get_buffer_histogram())
+        old_limit = mx.set_cache_limit(0)
+        try:
+            b = mx.zeros((8,))
+            mx.eval(b)
+            mx.synchronize()
+            self.assertEqual(mx.get_cache_buffer_count(), 0)
+            after = mx.get_active_buffer_count()
+            # every previously cached buffer evicted, one output live
+            self.assertEqual(after, with_cached - cached_before + 1)
+            check_hist(mx.get_buffer_histogram(), after)
+            self.assertEqual(
+                dict(mx.get_buffer_histogram()).get(16384, 0),
+                hist_cached.get(16384, 0) - 1,
+            )
+            del b
+            mx.synchronize()
+        finally:
+            mx.set_cache_limit(old_limit)
+        mx.clear_cache()
+
     def test_active_memory_count(self):
         mx.synchronize()
         mx.clear_cache()

--- a/python/tests/test_zero_copy.py
+++ b/python/tests/test_zero_copy.py
@@ -46,6 +46,40 @@ class TestZeroCopy(mlx_tests.MLXTestCase):
         mx.eval(x)
         self.assertEqual(int(x[1]), 999)
 
+    def test_copy_false_buffer_counts(self):
+        """Adopted host buffers enter and leave the public live probes."""
+        if not mx.metal.is_available():
+            self.skipTest("copy=False requires Metal")
+        if mx.default_device() != mx.gpu:
+            self.skipTest("the probes track the Metal allocator")
+
+        nbytes = 4 * 1024 * 1024
+        raw = np.empty(nbytes + 16384, dtype=np.uint8)
+        offset = (-raw.ctypes.data) % 16384
+        aligned = raw[offset : offset + nbytes]
+        a = aligned.view(np.int32)
+        self.assertEqual(a.ctypes.data % 16384, 0)
+
+        gc.collect()
+        mx.synchronize()
+        baseline_count = mx.get_active_buffer_count()
+        baseline_hist = dict(mx.get_buffer_histogram())
+
+        x = mx.asarray(a, copy=False)
+        mx.synchronize()
+        self.assertEqual(mx.get_active_buffer_count(), baseline_count + 1)
+        histogram = dict(mx.get_buffer_histogram())
+        self.assertEqual(
+            histogram.get(nbytes, 0),
+            baseline_hist.get(nbytes, 0) + 1,
+        )
+
+        del x, a, aligned, raw
+        gc.collect()
+        mx.synchronize()
+        self.assertEqual(mx.get_active_buffer_count(), baseline_count)
+        self.assertEqual(dict(mx.get_buffer_histogram()), baseline_hist)
+
     def test_copy_false_dtype_conversion_raises(self):
         a = np.arange(16, dtype=np.float64)
         with self.assertRaises(Exception):


### PR DESCRIPTION
## What

Three read-only counters over existing allocator state, plus docs and focused memory/zero-copy tests:

- `mx.get_active_buffer_count()` — live buffer objects (active + cached); on Metal this is `num_resources_`, the exact quantity checked against the per-process resource limit in the `[metal::malloc] Resource limit (499000) exceeded` error.
- `mx.get_cache_buffer_count()` — buffer objects currently held by the buffer cache (a subset of the above).
- `mx.get_buffer_histogram()` — live objects bucketed by power-of-two size class, maintained under the allocator mutex. The store is a fixed 64-slot array indexed by class exponent, so the hot-path update is allocation-free and cannot throw (a map-node allocation could fail after `newBuffer()`/`num_resources_++` and desync the histogram).

Zero behavior change. CUDA and no-GPU backends return 0/empty (their limits are bytes, not handles), mirroring how `set_wired_limit` is stubbed. Docs entry added to `memory_management.rst`; backend-agnostic coverage lives in `python/tests/test_memory.py`, and the Metal zero-copy adoption path is pinned in `python/tests/test_zero_copy.py`.

Naming follows the #3464 review feedback: these count only the `MTL::Buffer` objects created through the allocator — not Events or other Metal resources — so they are buffer-count probes, not "resource" counts.

## Why (and why again, after #3464)

mlx-lm#1185 asked for exactly this probe, and #3464 proposed two of these counters but was closed with the feedback that `get_cache_memory` covers the diagnostic need and the APIs wouldn't help solve the root cause. Two new data points from a fully root-caused bug argue for reconsidering:

1. **Byte-side probes provably cannot see this bug class.** mlx-lm's qwen3_5/qwen3_next batch decode leaked one *4-byte* buffer object per unread SSM layer (#SSM − 1) per token (mlx-lm#1641): ~140 B/token. `get_active_memory`/`get_cache_memory` stayed flat all the way to the 499k-object crash. The only observable that moves is the object count — the resource the limit is actually enforced on.
2. **This time the probes come with the root cause, not instead of it.** They were used to measure the leak slope (+35.001 objects/token on Qwen3.5-122B, = #SSM layers − 1), predict the crash token within 0.5%, and validate the fix (mlx-lm PR https://github.com/ml-explore/mlx-lm/pull/1642). The histogram localized the leak to the 4-byte size class in a single run — something no existing API approximates.

## Test plan

- `python/tests/test_memory.py::test_buffer_counts`: structural invariants on every backend (probes non-negative, `cached <= active`; histogram keys are sorted powers of two with positive counts summing to the active count), with the documented `0 / 0 / []` asserted explicitly on CUDA/no-GPU. On Metal (guarded to GPU default device, so `DEVICE=cpu` runs on Metal hosts skip cleanly) it covers, against a cleared-cache baseline: fresh allocation (count rises, 16384 size class increments), live-vs-cached disagreement (buffer live + cache cleared ⇒ `active > 0`, `cached == 0` — a stub returning the wrong metric fails here), free-to-cache (total constant, cached rises), `clear_cache()` restoring count and histogram exactly to baseline, malloc-from-cache reuse (reallocation of a freed size does not grow the total), free-to-release with the cache limit at 0 (count drops immediately), and cache eviction (a buffer resting in the cache, released by a later malloc's cache trim while the limit is 0 — the count and histogram cross the eviction-callback path and stay consistent).
- `python/tests/test_zero_copy.py::test_copy_false_buffer_counts`: creates a guaranteed 16-KB-aligned 4-MiB NumPy view, adopts it through the public `mx.asarray(..., copy=False)` path (`make_buffer`), and asserts the active count and 4-MiB histogram class rise by exactly one. Deleting the MLX/source views and collecting them exercises `release`; count and the complete histogram return exactly to the pre-adoption baseline. This path is testable at Python level and does not require a C++-only fixture.
- Validation status at `cb83965c`: the build used for all measurements in mlx-lm#1641 (v0.32.0 base, Metal, macOS 26.5.2, M5 Max) carried this C++ modulo the API rename and a `std::map` histogram store, since replaced by the fixed-array store described above (review hardening; identical keys and counts). The current array-store C++ was built on arm64/Metal; all four memory tests and all seven zero-copy tests pass, and full MLX Python discovery is **790 passed / 45 skipped**. Histogram size-class boundaries and count conservation were additionally probe-checked. `clang-format` 21.1.8 / Black 25.1.0 are clean. The tests include the default-device guard plus malloc-from-cache, free-to-release, cache-eviction, and public zero-copy make-buffer/release paths.
