### PR TITLE
Support head dimension 96 in Metal full attention

### DIFF
--- a/benchmarks/python/sdpa_bench.py
+++ b/benchmarks/python/sdpa_bench.py
@@ -189,6 +189,15 @@ if __name__ == "__main__":
           (  1,  2048,  32121,      80,   32,     8),
     )
 
+    shapes_96 = (
+        # (  B,   qsl,   ksl, head_dim, n_qh, n_kvh)
+          (  1,  1024,  1024,       96,   32,     8),
+          (  1,  2048,  2048,       96,   32,     8),
+          (  1,  4096,  4096,       96,   32,     8),
+          (  1,  4096,  5000,       96,   32,     8),
+          (  1,  2048,  32121,      96,   32,     8),
+    )
+
     shapes_128 = (
         # (  B,   qsl,   ksl, head_dim, n_qh, n_kvh)
           (  1,  1024,  1024,      128,   32,     8),
@@ -199,7 +208,7 @@ if __name__ == "__main__":
     )
     # fmt: on
 
-    shapes = shapes_64 + shapes_80 + shapes_128
+    shapes = shapes_64 + shapes_80 + shapes_96 + shapes_128
 
     masks = [None, "bool", "causal"]
 

--- a/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention.metal
+++ b/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention.metal
@@ -13,6 +13,7 @@
 
 #define instantiate_attn_shapes_helper(iname, itype, mname, mtype)  \
     instantiate_attn(iname, itype, 32, 16, 128, 4, 1, mname, mtype) \
+    instantiate_attn(iname, itype, 32, 32,  96, 4, 1, mname, mtype) \
     instantiate_attn(iname, itype, 32, 32,  80, 4, 1, mname, mtype) \
     instantiate_attn(iname, itype, 32, 32,  64, 4, 1, mname, mtype)
 

--- a/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention_nax.metal
+++ b/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention_nax.metal
@@ -13,6 +13,7 @@
 
 #define instantiate_attn_shapes_helper(iname, itype, mname, mtype)  \
     instantiate_attn(iname, itype, 64, 32, 128, 4, 1, mname, mtype) \
+    instantiate_attn(iname, itype, 64, 32,  96, 4, 1, mname, mtype) \
     instantiate_attn(iname, itype, 64, 32,  64, 4, 1, mname, mtype) \
     instantiate_attn(iname, itype, 64, 64, 128, 4, 1, mname, mtype) \
     instantiate_attn(iname, itype, 64, 64,  64, 4, 1, mname, mtype)

--- a/mlx/backend/metal/scaled_dot_product_attention.cpp
+++ b/mlx/backend/metal/scaled_dot_product_attention.cpp
@@ -626,7 +626,8 @@ bool ScaledDotProductAttention::use_fallback(
         query_head_dim == 256)) ||
       (query_head_dim == 192 && value_head_dim == 128);
   const bool sdpa_full_supported_head_dim = query_head_dim == value_head_dim &&
-      (query_head_dim == 64 || query_head_dim == 80 || query_head_dim == 128);
+      (query_head_dim == 64 || query_head_dim == 80 || query_head_dim == 96 ||
+       query_head_dim == 128);
 
   const bool sdpa_full_supported_mask = !has_mask || has_arr_mask ||
       (query_sequence_length <= key_sequence_length && do_causal);

--- a/python/tests/test_fast_sdpa.py
+++ b/python/tests/test_fast_sdpa.py
@@ -117,6 +117,33 @@ def mlx_primitives_sdpa(q, k, v, scale, mask=None):
 
 
 class TestFastSDPA(mlx_tests.MLXTestCase):
+    @unittest.skipIf(not mx.is_available(mx.gpu), "GPU kernel path only")
+    def test_sdpa_head_dim_96(self):
+        B, D, qH, kH = (1, 96, 8, 2)
+        for qL, kL, dtype, mask_str in product(
+            (64, 65),
+            (128, 127),
+            (mx.float16, mx.bfloat16, mx.float32),
+            (None, "additive", "bool", "causal"),
+        ):
+            with self.subTest(qL=qL, kL=kL, dtype=dtype, mask=mask_str):
+                q, k, v, scale, mask = prepare_inputs(
+                    B, qL, kL, D, qH, kH, mask_str, False, dtype
+                )
+                ref = mlx_ref_attn(q, k, v, scale, mask)
+                out = mx.fast.scaled_dot_product_attention(
+                    q, k, v, scale=scale, mask=mask
+                )
+
+                if dtype == mx.float32:
+                    atol = 1e-5
+                elif dtype == mx.bfloat16:
+                    atol = 5e-3
+                else:
+                    atol = 3e-4
+                diff = mx.abs(out - ref) - atol * mx.abs(ref)
+                self.assertLessEqual(mx.max(diff).item(), atol)
+
     def test_sdpa_vector_kv_transposed_head_seq(self):
         D = 64
         Nq = 4


### PR DESCRIPTION
## Proposed changes

Instantiate head dimension 96 variants of the standard Steel and NAX full-attention kernels and allow scaled dot product attention to select them. This avoids the unfused fallback for full-attention workloads with that head dimension.

Add aligned and unaligned correctness coverage across float16, bfloat16, and float32, including unmasked, additive, boolean, and causal masks. Add head dimension 96 cases to the existing SDPA benchmark.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
