### PR TITLE
[CUDA] Define MLX_CCCL_DIR for every build tree, not only tests

### DIFF
--- a/mlx/backend/cuda/CMakeLists.txt
+++ b/mlx/backend/cuda/CMakeLists.txt
@@ -236,12 +236,10 @@ install(DIRECTORY ${cccl_SOURCE_DIR}/include/cuda
 install(DIRECTORY ${cccl_SOURCE_DIR}/include/nv
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cccl)
 
-# The binary of C++ tests will not be installed so it can not find the CCCL
-# headers, and we have to hard-code the path.
-if(MLX_BUILD_TESTS)
-  target_compile_definitions(mlx_dirs
-                             PRIVATE MLX_CCCL_DIR="${cccl_SOURCE_DIR}/include")
-endif()
+# Binaries in the build tree are not installed, so they can not find the CCCL
+# headers next to them and have to fall back to this hard-coded path.
+target_compile_definitions(mlx_dirs
+                           PRIVATE MLX_CCCL_DIR="${cccl_SOURCE_DIR}/include")
 
 # Use fixed version of NVTX.
 FetchContent_Declare(


### PR DESCRIPTION
## Proposed changes

`cccl_dir()` backs the fallback branch of `include_path_args()` in `jit_module.cpp`: when the installed `include/cccl` directory is not next to the binary, the JIT falls back to the CCCL tree that `FetchContent` downloaded at build time. That is exactly the situation for any binary running out of a build tree.

But the `MLX_CCCL_DIR` define that `cccl_dir()` reads is applied only under `if(MLX_BUILD_TESTS)`. In any other CUDA build tree `cccl_dir()` returns `nullptr`, the CCCL `--include-path` is dropped silently — the branch is guarded by `std::filesystem::exists`, so nothing throws — and NVRTC then fails to find `cuda/std/*` for every JIT'd kernel that includes it.

The comment above the guard already states the rationale: *"The binary of C++ tests will not be installed so it can not find the CCCL headers, and we have to hard-code the path."* That is true of every binary in the build tree, not only the test binary. This PR widens the define to match, and rewords the comment.

Dropping the guard is cheap:

* CCCL is fetched unconditionally ~10 lines above, so `cccl_SOURCE_DIR` is always populated by the time this runs.
* The define is already `PRIVATE` to `mlx_dirs`, the small object library that exists to hold these path defines, so nothing else recompiles.

## Verification

Configured with `-DMLX_BUILD_CUDA=ON -DMLX_BUILD_TESTS=OFF` (CUDA 13.0.88, aarch64 Linux, `MLX_CUDA_ARCHITECTURES=80`), built the `mlx_dirs` target, and linked `dirs.cpp.o` against a small driver that prints `cccl_dir()`:

|  | `dirs.cpp` compile line | `cccl_dir()` returns |
|---|---|---|
| before | no `-DMLX_CCCL_DIR` | `(nullptr)` |
| after | `-DMLX_CCCL_DIR="<build>/_deps/cccl-src/include"` | `<build>/_deps/cccl-src/include` |

and that directory does hold the fetched `cuda/std/` headers.

Adjacent but not overlapping: #3930 (for #3859) fixes the CUDA *runtime* header lookup for the pip wheel layouts. This is the CCCL branch of the same function, and the two changes touch different code.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)

On tests: the define is missing precisely when `MLX_BUILD_TESTS=OFF`, i.e. when the test binary is not built, so no in-tree test can observe the defect — which is also why CI does not catch it. The before/after above is the closest equivalent I could run. Happy to add something if you have a preferred way to cover build-configuration behaviour.
