### PR TITLE
Canonicalize the path returned by current_binary_dir()

### DIFF
--- a/mlx/backend/common/utils.cpp
+++ b/mlx/backend/common/utils.cpp
@@ -12,7 +12,10 @@ std::filesystem::path current_binary_dir() {
     if (!dladdr(reinterpret_cast<void*>(&current_binary_dir), &info)) {
       throw std::runtime_error("Unable to get current binary dir.");
     }
-    return std::filesystem::path(info.dli_fname).parent_path();
+    // dli_fname is the path the binary was loaded by, which may be relative,
+    // contain ".." or go through a symlink. Callers append relative paths to
+    // the result and check them for existence, so it has to be resolved.
+    return std::filesystem::weakly_canonical(info.dli_fname).parent_path();
   }();
   return binary_dir;
 }

--- a/tests/utils_tests.cpp
+++ b/tests/utils_tests.cpp
@@ -2,9 +2,16 @@
 
 #include "doctest/doctest.h"
 
+#include "mlx/backend/common/utils.h"
 #include "mlx/mlx.h"
 
 using namespace mlx::core;
+
+TEST_CASE("test current binary dir is resolved") {
+  auto dir = current_binary_dir();
+  CHECK(dir.is_absolute());
+  CHECK_EQ(dir, std::filesystem::weakly_canonical(dir));
+}
 
 TEST_CASE("test type promotion") {
   for (auto t : {bool_, uint32, int32, int64, float32}) {


### PR DESCRIPTION
## Proposed changes

`current_binary_dir()` returns `std::filesystem::path(info.dli_fname).parent_path()` without resolving it. On Linux, glibc reports `dli_fname` for the main executable as argv[0] verbatim, so the result can be a relative path, contain `..`, or point through a symlink.

Every caller appends a relative path to it and tests the result for existence — the CCCL and CUDA header search in `cuda/jit_module.cpp`, the compiler lookup in `cpu/jit_compiler.cpp`, `cuda/delayload.cpp`, and the metallib lookup in `metal/device.cpp` — so a non-canonical result makes those lookups depend on how the binary happened to be invoked, and for a relative argv[0] on the current working directory too.

Measured on Linux/glibc (aarch64) with the build-tree test binary:

| invoked as | `current_binary_dir()` before | after |
|---|---|---|
| `/build/tests/tests` | `/build/tests` | `/build/tests` |
| `/build/tests/../tests/tests` | `/build/tests/../tests` | `/build/tests` |
| `./tests` (cwd `/build/tests`) | `.` | `/build/tests` |

The last row is the damaging one: a bare `.` means the header search resolves against wherever the process is running rather than against the binary.

`std::filesystem::weakly_canonical` fixes all three, and also resolves the symlink case, where the old code returned a path that was syntactically canonical but pointed at the symlink's directory rather than the real binary's.

This is a no-op on macOS: dyld already reports a fully resolved `dli_fname` in all of those cases. I checked that directly before writing the patch.

## Verification

`tests/utils_tests.cpp` gains a case asserting the returned path is absolute and equal to its own `weakly_canonical`. It discriminates — on Linux, against unpatched `main`, the same test fails for rows 2 and 3 above:

```
/src/tests/utils_tests.cpp:13: ERROR: CHECK_EQ( dir, std::filesystem::weakly_canonical(dir) ) is NOT correct!
  values: CHECK_EQ( "/build/tests/../tests", "/build/tests" )

/src/tests/utils_tests.cpp:12: ERROR: CHECK( dir.is_absolute() ) is NOT correct!
  values: CHECK( false )
```

and passes for all three with the patch. Note it only fails when the binary is invoked non-canonically, so CI — which invokes it by absolute path — will show it green either way.

Full C++ suite run on both platforms, before and after:

* Linux (aarch64, CPU-only build): 11 failures, all in `compile_tests.cpp`, identical on unpatched `main`.
* macOS (arm64, Metal): 6 failures, all in `linalg_tests.cpp` (QR / lu / cholesky / eigh / inversion / pinv), byte-identical assertion counts on pristine `main` at the same commit.

Neither set touches this code path.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
