### PR TITLE
Fix docstring mismatches in the Python bindings

### DIFF
--- a/python/src/export.cpp
+++ b/python/src/export.cpp
@@ -249,7 +249,7 @@ void init_export(nb::module_& m) {
        A context managing class for exporting multiple traces of the same
        function to a file.
 
-       Make an instance of this class by calling fun:`mx.exporter`.
+       Make an instance of this class by calling :func:`mx.exporter`.
       )pbdoc")
       .def("close", &PyFunctionExporter::close)
       .def("__enter__", [](PyFunctionExporter& exporter) { return &exporter; })

--- a/python/src/fft.cpp
+++ b/python/src/fft.cpp
@@ -494,6 +494,7 @@ void init_fft(nb::module_& parent_module) {
 
         Returns:
             array: The real DFT of the input along the given axes. The output
+            data type will be complex.
       )pbdoc");
   m.def(
       "irfftn",

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -3479,7 +3479,7 @@ void init_ops(nb::module_& m) {
             mode: Padding mode. One of the following strings:
               "constant" (default): Pads with a constant value.
               "edge": Pads with the edge values of array.
-            constant_value (array or scalar, optional): Optional constant value
+            constant_values (array or scalar, optional): Optional constant value
               to pad the edges of the array with.
 
         Returns:
@@ -4724,13 +4724,13 @@ void init_ops(nb::module_& m) {
           bits (int, optional): The number of bits occupied by each element of
             ``w`` in the quantized array. See supported values and defaults in the
             :ref:`table of quantization modes <quantize-modes>`. Default: ``None``.
+          mode (str, optional): The quantization mode. Default: ``"affine"``.
           global_scale (array, optional): The per-input float32 scale used for
             ``"nvfp4"`` quantization if provided. Default: ``None``.
           dtype (Dtype, optional): The data type of the dequantized output. If
             ``None`` the return type is inferred from the scales and biases
             when possible and otherwise defaults to ``bfloat16``.
             Default: ``None``.
-          mode (str, optional): The quantization mode. Default: ``"affine"``.
 
         Returns:
           array: The dequantized version of ``w``


### PR DESCRIPTION
## Proposed changes

Four docstring fixes in `python/src`, all cases where the doc text disagrees with the binding it is attached to. Checked each against the compiled module after rebuilding.

1. `dequantize` (ops.cpp): the `Args:` block listed `mode` last, after `global_scale` and `dtype`, but the signature has it before them. Anyone following the doc order positionally gets a `TypeError`:

```python
wq, s, b = mx.quantize(mx.random.normal((64, 64)), 32, 4)
mx.dequantize(wq, s, b, 32, 4, "affine", None, None)   # signature order, fine
mx.dequantize(wq, s, b, 32, 4, None, None, "affine")   # doc order, TypeError
```

2. `pad` (ops.cpp): documented as `constant_value`, but the keyword is `constant_values`, so the documented spelling raises `TypeError: incompatible function arguments`.

3. `rfftn` (fft.cpp): the `Returns:` sentence was cut off at "The output" mid-thought. Completed it to match `rfft` and `rfft2` ("The output data type will be complex."), which is also what it returns (`complex64`).

4. `FunctionExporter` (export.cpp): `fun:\`mx.exporter\`` was missing the leading colon on the role, so it rendered as literal text instead of a link to `:func:\`mx.exporter\``.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

(docstring text only, no tests; rebuilt CPU-only locally and confirmed the rendered docstrings)

Happy to split this into separate PRs if you would rather review them apart.

---

for transparency: freshman contributor here, and Claude Code helps me scan for this kind of doc/signature drift, but i ran the two `TypeError` cases above myself, diffed each docstring against its own `nb::sig` line, and rebuilt to check the strings render before opening this. tell me if any of the rewording should read differently.
