### PR TITLE
Fix cholesky_inv documented argument name to match the binding

### DIFF
--- a/python/src/linalg.cpp
+++ b/python/src/linalg.cpp
@@ -326,7 +326,7 @@ void init_linalg(nb::module_& parent_module) {
       nb::kw_only(),
       "stream"_a = nb::none(),
       nb::sig(
-          "def cholesky_inv(L: array, upper: bool = False, *, stream: Union[None, Stream, Device] = None) -> array"),
+          "def cholesky_inv(a: array, upper: bool = False, *, stream: Union[None, Stream, Device] = None) -> array"),
       R"pbdoc(
         Compute the inverse of a real symmetric positive semi-definite matrix using it's Cholesky decomposition.
 
@@ -347,7 +347,8 @@ void init_linalg(nb::module_& parent_module) {
         If the input matrix is not a triangular matrix behaviour is undefined.
 
         Args:
-            L (array): Input array.
+            a (array): Input array. This is the Cholesky factor
+              :math:`\mathbf{L}`, not :math:`\mathbf{A}` itself.
             upper (bool, optional): If ``True``, return the upper triangular Cholesky factor.
               If ``False``, return the lower triangular Cholesky factor. Default: ``False``.
             stream (Stream, optional): Stream or device. Defaults to ``None``


### PR DESCRIPTION
## Proposed changes

`cholesky_inv` advertises its first argument as `L` in both `nb::sig` and the docstring, but the bound keyword is `a`, so the documented call fails:

```python
L = mx.linalg.cholesky(a, stream=mx.cpu)
mx.linalg.cholesky_inv(L=L, stream=mx.cpu)   # TypeError: incompatible function arguments
mx.linalg.cholesky_inv(a=L, stream=mx.cpu)   # works, but is not what the docs say
```

I fixed the signature and docstring to say `a` rather than renaming the bound argument, for two reasons: every other binding in `linalg.cpp` uses `"a"_a`, and renaming would break anyone already calling `a=`. Since the surrounding math uses `L` for the Cholesky factor and `A` for the original matrix, I also spelled out in the arg description that the input is the factor, so the rename does not read as "pass A here".

If you would rather go the other way and rename the bound argument to `L`, that is a one word change and I am happy to switch it.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

(docs only, no behavior change; rebuilt CPU-only and checked the rendered signature, `test_linalg.py` passes)

---

usual disclosure: i'm a freshman and Claude Code helps me catch this sort of drift, but i ran both calls above myself, checked the other linalg bindings to see which name was the odd one out, and rebuilt to confirm the signature renders correctly. glad to be told if you prefer the other direction.
