### PR TITLE
added eye(0) support and tests

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -360,10 +360,15 @@ array ones_like(const array& a, StreamOrDevice s /* = {} */) {
 }
 
 array eye(int n, int m, int k, Dtype dtype, StreamOrDevice s /* = {} */) {
-  if (n <= 0 || m <= 0) {
+  if (n < 0 || m < 0) {
     throw std::invalid_argument("[eye] N and M must be positive integers.");
   }
   array result = zeros({n, m}, dtype, s);
+
+  if (n == 0 || m == 0) {
+    return result;
+  }
+
   if (k >= m || -k >= n) {
     return result;
   }

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -2513,8 +2513,12 @@ class TestOps(mlx_tests.MLXTestCase):
 
     def test_eye(self):
         self.assertCmpNumpy([3], mx.eye, np.eye)
+        # Test for zero rows and columns
+        self.assertCmpNumpy([0], mx.eye, np.eye)
         # Test for non-square matrix
         self.assertCmpNumpy([3, 4], mx.eye, np.eye)
+        # Test for zero rows
+        self.assertCmpNumpy([0, 4], mx.eye, np.eye)
         # Test with positive k parameter
         self.assertCmpNumpy([3, 4], mx.eye, np.eye, k=1)
         # Test with negative k parameter

--- a/tests/ops_tests.cpp
+++ b/tests/ops_tests.cpp
@@ -3140,6 +3140,11 @@ TEST_CASE("test eye") {
   CHECK_EQ(eye_3x2.shape(), Shape{3, 2});
   auto expected_eye_3x2 = array({1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f}, {3, 2});
   CHECK(array_equal(eye_3x2, expected_eye_3x2).item<bool>());
+
+  auto eye_0x0 = eye(0, 0);
+  CHECK_EQ(eye_0x0.shape(), Shape{0, 0});
+  CHECK_EQ(eye_0x0.size(), 0);
+  CHECK_EQ(eye_0x0.dtype(), float32);
 }
 
 TEST_CASE("test tri") {


### PR DESCRIPTION
## Proposed changes
This pull request improves the behavior of the `eye` function to correctly handle cases where the number of rows or columns is zero, and adds corresponding tests to ensure this behavior is correct.

**Bug fix and behavior improvement:**

* Updated the `eye` function in `mlx/ops.cpp` to return an empty array when either the number of rows or columns is zero, instead of throwing an error or producing invalid output.

**Testing enhancements:**

* Added new test cases to `python/tests/test_ops.py` for `mx.eye` to verify correct handling of zero rows and/or columns.
* Added C++ tests in `tests/ops_tests.cpp` to check that `eye(0, 0)` returns an empty array with the correct shape, size, and data type.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)

Hi, this was part of the https://github.com/data-apis/array-api-compat/issues/452 where we were trying to add support of MLX in `array-api-compat` where we found some of the issues when running tests.
