### PR TITLE
Sample randint directly instead of through a float32 uniform

### DIFF
--- a/mlx/random.cpp
+++ b/mlx/random.cpp
@@ -279,8 +279,49 @@ array randint(
     throw std::invalid_argument(
         "[randint] randint only accepts integer dtypes and bool.");
   }
-  auto u = uniform(low, high, shape, float32, key, s);
-  return astype(maximum(u, low, s), dtype, s);
+  auto stream = to_stream(s);
+
+  // Sample the integers directly rather than by casting a float32 uniform.
+  // Routing through float32 loses the integer interval whenever the bounds are
+  // not exactly representable: at 2^24 consecutive float32 values are already
+  // two apart, so values become unreachable, `high` itself can be returned,
+  // and a wide int64 interval can collapse to a single value.
+  auto lo = astype(low, int64, stream);
+  auto hi = astype(high, int64, stream);
+
+  // Width of the half-open interval, as uint64: an int64 interval can be up to
+  // 2^64 - 1 wide, which only uint64 holds. The subtraction is done in int64
+  // and reinterpreted, which is correct even when the difference overflows
+  // int64 — the wrapped bit pattern is the intended unsigned width. Note the
+  // clamp below therefore has to act on the *unsigned* value: clamping the
+  // signed difference would read a genuine width above 2^63 as negative and
+  // collapse the whole interval onto `low`.
+  //
+  // An empty interval (high <= low) is documented to return `low`, and a
+  // remainder by zero is undefined, so those entries get a divisor of 1, which
+  // yields an offset of 0.
+  auto empty = less_equal(hi, lo, stream);
+  auto range = where(
+      empty,
+      array(1, uint64),
+      astype(subtract(hi, lo, stream), uint64, stream),
+      stream);
+
+  // 64 uniform bits per sample, assembled from two 32-bit draws.
+  auto wide_shape = shape;
+  wide_shape.push_back(2);
+  auto words = astype(bits(wide_shape, 4, key, stream), uint64, stream);
+  auto halves = split(words, 2, -1, stream);
+  auto u = bitwise_or(
+      left_shift(squeeze(halves[0], -1, stream), array(32, uint64), stream),
+      squeeze(halves[1], -1, stream),
+      stream);
+
+  // Reduce onto [0, range). The residual modulo bias is bounded by
+  // range / 2^64: below 1e-9 for any range under 2^32, and exactly zero
+  // whenever range is a power of two.
+  auto offset = astype(remainder(u, range, stream), int64, stream);
+  return astype(add(lo, offset, stream), dtype, stream);
 }
 
 array bernoulli(

--- a/python/tests/test_random.py
+++ b/python/tests/test_random.py
@@ -234,6 +234,41 @@ class TestRandom(mlx_tests.MLXTestCase):
             mx.random.randint(0, 1).dtype, mx.random.randint(0, 1, dtype=None).dtype
         )
 
+    def test_randint_exact_integer_range(self):
+        # Bounds that are not exactly representable in float32 must not make
+        # values unreachable, return `high`, or collapse the interval.
+        key = mx.random.key(42)
+
+        # At 2**24 adjacent float32 values are two integers apart.
+        a = mx.random.randint(2**24, 2**24 + 2, (10_000,), dtype=mx.int32, key=key)
+        values = set(a.tolist())
+        self.assertNotIn(2**24 + 2, values)  # `high` is exclusive
+        self.assertEqual(values, {2**24, 2**24 + 1})  # both are reachable
+
+        # At 2**40 the float32 spacing is 2**17, which collapsed this interval
+        # to a single value.
+        b = mx.random.randint(2**40, 2**40 + 1024, (20_000,), dtype=mx.int64, key=key)
+        self.assertTrue(mx.all(b >= 2**40).item())
+        self.assertTrue(mx.all(b < 2**40 + 1024).item())
+        self.assertEqual(len(set(b.tolist())), 1024)
+
+        # A width above 2**63 is representable only as unsigned.
+        c = mx.random.randint(-(2**62), 2**62, (10_000,), dtype=mx.int64, key=key)
+        self.assertTrue(mx.all(c >= -(2**62)).item())
+        self.assertTrue(mx.all(c < 2**62).item())
+        self.assertGreater(len(set(c.tolist())), 1)
+
+    def test_randint_uniform_coverage(self):
+        # Every value in a small interval should be reachable, with roughly
+        # equal probability.
+        n = 200_000
+        for low, high in [(0, 6), (-10, 10), (3, 15)]:
+            a = mx.random.randint(low, high, (n,), dtype=mx.int64)
+            counts = [mx.sum(a == v).item() for v in range(low, high)]
+            self.assertTrue(all(c > 0 for c in counts))
+            expected = n / (high - low)
+            self.assertLess(max(abs(c - expected) for c in counts) / expected, 0.1)
+
     def test_bernoulli(self):
         a = mx.random.bernoulli()
         self.assertEqual(a.shape, ())

--- a/tests/random_tests.cpp
+++ b/tests/random_tests.cpp
@@ -516,6 +516,36 @@ TEST_CASE("test random randint") {
   auto key = array({0, 0}, {1, 2});
   CHECK_THROWS_AS(
       random::randint(low, high, {}, float32, key), std::invalid_argument);
+
+  // Bounds that are not exactly representable in float32 must not make values
+  // unreachable, return `high`, or collapse the interval.
+
+  // At 2^24 adjacent float32 values are two integers apart.
+  auto lo24 = array(1 << 24, int32);
+  auto hi24 = array((1 << 24) + 2, int32);
+  x = random::randint(lo24, hi24, {10000}, int32);
+  CHECK(all(less(x, hi24)).item<bool>()); // `high` is exclusive
+  CHECK(any(equal(x, lo24)).item<bool>());
+  CHECK(any(equal(x, array((1 << 24) + 1, int32))).item<bool>());
+
+  // At 2^40 the float32 spacing is 2^17, which collapsed this interval to a
+  // single value.
+  auto lo40 = array(int64_t(1) << 40, int64);
+  auto hi40 = array((int64_t(1) << 40) + 1024, int64);
+  x = random::randint(lo40, hi40, {20000}, int64);
+  CHECK(
+      (all(less_equal(lo40, x)).item<bool>() &&
+       all(less(x, hi40)).item<bool>()));
+  CHECK_GT(max(x).item<int64_t>(), min(x).item<int64_t>());
+
+  // A width above 2^63 is representable only as unsigned.
+  auto lo62 = array(-(int64_t(1) << 62), int64);
+  auto hi62 = array(int64_t(1) << 62, int64);
+  x = random::randint(lo62, hi62, {10000}, int64);
+  CHECK(
+      (all(less_equal(lo62, x)).item<bool>() &&
+       all(less(x, hi62)).item<bool>()));
+  CHECK_GT(max(x).item<int64_t>(), min(x).item<int64_t>());
 }
 
 TEST_CASE("test random bernoulli") {


### PR DESCRIPTION
## Proposed changes

Fixes #3926.

## Problem

`randint` sampled through a float32 uniform and cast the result:

```cpp
auto u = uniform(low, high, shape, float32, key, s);
return astype(maximum(u, low, s), dtype, s);
```

float32 has a 24-bit mantissa, so once the bounds reach 2^24 the integer interval is gone before the cast. Three distinct symptoms, all on `main`:

```python
>>> key = mx.random.key(42)
>>> x = mx.random.randint(2**24, 2**24 + 2, (10_000,), dtype=mx.int32, key=key)
>>> sorted(set(x.tolist()))
[16777216, 16777218]      # returns `high` (excluded); never returns 2**24 + 1

>>> y = mx.random.randint(2**40, 2**40 + 1024, (10_000,), dtype=mx.int64, key=key)
>>> len(set(y.tolist()))
1                         # a 1024-wide interval collapses to one value
```

At 2^24 adjacent float32 values are two integers apart; at 2^40 the spacing is 2^17, so the whole interval sits between two representable floats.

## Change

Sample the integers directly. The interval width is computed in int64 and reinterpreted as **uint64**, then 64 uniform bits (two `bits()` draws) are reduced onto it with a remainder.

The residual modulo bias is bounded by `range / 2^64`, below 1e-9 for any range under 2^32, and exactly zero when the width is a power of two. That is against the current behaviour of making values unreachable outright.

Empty intervals (`high <= low`) keep returning `low`, as before.

## Relationship to #3936

#3936 proposes the same integer-domain approach, and I want to be clear that the idea is not mine alone; I reached it independently and [said so there](https://github.com/ml-explore/mlx/pull/3936#issuecomment-5144707879), offering the fix below as a patch to that branch rather than a competing PR. Opening this now so there is a reviewable version that closes the remaining case; happy for it to be closed in favour of #3936 if that branch picks the fix up.

The gap is that #3936 clamps the **signed** difference:

```cpp
auto range = subtract(hi, lo, stream);                                   // int64
auto safe_range = maximum(range, array(int64_t(1), int64), stream);      // signed compare
```

For an interval wider than 2^63 the true width overflows int64 and wraps negative, so `maximum(range, 1)` reads it as negative and clamps to `1`. Every draw then lands on `low`.

I built that branch (`6de5378`, CPU-only, macOS/arm64) and measured 20,000 draws per interval against this one:

| interval | #3936 | this PR |
|---|---|---|
| `[2^24, 2^24+2)` | 2 distinct ✅ | 2 distinct ✅ |
| `[2^40, 2^40+1024)` | 1024 ✅ | 1024 ✅ |
| `[0, 2^63-1)` | 20000 ✅ | 20000 ✅ |
| `[-2^62, 2^62)` | **1** ❌ | 20000 ✅ |
| `[-2^63, 2^63-1)` | **1** ❌ | 20000 ✅ |

```python
# on #3936
>>> x = mx.random.randint(-(2**62), 2**62, (20_000,), dtype=mx.int64)
>>> min(x.tolist()), max(x.tolist()), len(set(x.tolist()))
(-4611686018427387904, -4611686018427387904, 1)   # every draw == low
```

So `randint(-2^62, 2^62)` returns a constant, the same failure this work sets out to fix, relocated to a wider magnitude. An int64 interval can be up to 2^64 - 1 wide, and uint64 is the only type that holds every width `randint` can legitimately be asked for, which is why the clamp has to happen after the reinterpretation:

```cpp
auto empty = less_equal(hi, lo, stream);      // signed, where the compare is meaningful
auto range = where(
    empty,
    array(1, uint64),
    astype(subtract(hi, lo, stream), uint64, stream),
    stream);
```

One smaller point: #3936's comment argues numpy `remainder` semantics keep the 64-bit path exact when the combined draw goes negative. The *sign* of the result is right, but `remainder(raw, r)` for negative `raw` is `raw % r + r`, which skews the distribution toward the low end of the interval by roughly `2^63 mod r`. Reducing in uint64 removes the need for that argument.

## Verification

Reported cases, and the overflow edges:

```
[2^24, 2^24+2)          in_bounds=True  distinct=2
[2^40, 2^40+1024)       in_bounds=True  distinct=1024
[-2^62, 2^62)           in_bounds=True  distinct=20000
[-2^63, 2^63-1)         in_bounds=True  distinct=20000
[0, 2^63-1)             in_bounds=True  distinct=20000
```

Uniformity over 600,000 draws. Every value reachable, worst-case deviation from uniform ~1%:

```
[0, 6)                  coverage=6/6      max_rel_dev=0.0036
[2^24, 2^24+2)          coverage=2/2      max_rel_dev=0.0003
[-10, 10)               coverage=20/20    max_rel_dev=0.0147
```

Existing behaviour preserved: `randint(10, -10, ...)` still returns `low`, same-key draws still reproduce, broadcasting of array bounds unchanged, and `bool` / `uint8` dtypes unchanged.

Suites, CPU-only build on macOS/arm64:

- `python/tests/test_random.py`: 16 passed
- `python/tests/`: 727 passed, 66 skipped, 9718 subtests passed
- `./build-tests/tests/tests`: 244 cases, 3245 assertions, all passed

I could not exercise the Metal path (no full Xcode locally, so no `metal` compiler). The change is in `mlx/random.cpp` above any backend dispatch and the issue reproduces identically on `mx.cpu` and `mx.gpu`, but the GPU path is the part worth a second look.

## Tests added

- `python/tests/test_random.py::test_randint_exact_integer_range`: the 2^24 and 2^40 cases plus a width above 2^63.
- `python/tests/test_random.py::test_randint_uniform_coverage`: every value in a small interval is reachable at roughly equal frequency.
- `tests/random_tests.cpp`: the same three intervals in the existing `test random randint` case.

Both Python tests fail on `main` and pass with the change.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit` (on the changed files: clang-format, black, isort all pass) prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed). The documented contract ("integers in `[low, high)` with equal probability") is unchanged; this makes the implementation match it
