### PR TITLE
Fix incorrect examples and outputs in the usage docs

### DIFF
--- a/docs/src/usage/compile.rst
+++ b/docs/src/usage/compile.rst
@@ -207,9 +207,9 @@ You have two options to deal with this. The first option is to simply return
       state.append(z)
       return mx.exp(z), state
 
-    _, state = fun(mx.array(1.0), mx.array(2.0))
-    # Prints [array(3, dtype=float32)]
-    print(state)
+   _, state = fun(mx.array(1.0), mx.array(2.0))
+   # Prints [array(3, dtype=float32)]
+   print(state)
 
 In some cases returning updated state can be pretty inconvenient. Hence,
 :func:`compile` has a parameter to capture implicit outputs:
@@ -464,7 +464,7 @@ recompiled.
   x = mx.array(1.0)
   y = mx.array(-2.0)
 
-  # Firt call compiles the function
+  # First call compiles the function
   print(compiled_fun(x, y))
 
   # Second call with different shapes

--- a/docs/src/usage/indexing.rst
+++ b/docs/src/usage/indexing.rst
@@ -28,12 +28,11 @@ For multi-dimensional arrays, the ``...`` or :obj:`Ellipsis` syntax works as in 
 
   >>> arr = mx.arange(8).reshape(2, 2, 2)
   >>> arr[:, :, 0]
-  array(3, dtype=int32)
   array([[0, 2],
-         [4, 6]], dtype=int32
+         [4, 6]], dtype=int32)
   >>> arr[..., 0]
   array([[0, 2],
-         [4, 6]], dtype=int32
+         [4, 6]], dtype=int32)
 
 You can index with ``None`` to create a new axis:
 
@@ -41,9 +40,9 @@ You can index with ``None`` to create a new axis:
 
   >>> arr = mx.arange(8)
   >>> arr.shape
-  [8]
+  (8,)
   >>> arr[None].shape
-  [1, 8]
+  (1, 8)
 
 
 You can also use an :obj:`array` to index another :obj:`array`:
@@ -161,7 +160,7 @@ Other index types are routed through the standard scatter code.
    >>> updates = mx.array([5.0, 6.0])
    >>> a[mask] = updates
    >>> a
-   array([5.0, 2.0, 6.0], dtype=float32)
+   array([5, 2, 6], dtype=float32)
 
 Scalar assignments broadcast to every ``True`` entry in ``mask``. For non-scalar
 assignments, ``updates`` must provide at least as many elements as there are
@@ -174,8 +173,8 @@ assignments, ``updates`` must provide at least as many elements as there are
                         [False, False, True]])
    >>> a[mask] = 1.0
    >>> a
-   array([[1.0, 0.0, 1.0],
-          [0.0, 0.0, 1.0]], dtype=float32)
+   array([[1, 0, 1],
+          [0, 0, 1]], dtype=float32)
 
 Boolean masks follow NumPy semantics:
 

--- a/docs/src/usage/quick_start.rst
+++ b/docs/src/usage/quick_start.rst
@@ -14,7 +14,7 @@ Import ``mlx.core`` and make an :class:`array`:
   >> import mlx.core as mx
   >> a = mx.array([1, 2, 3, 4])
   >> a.shape
-  [4]
+  (4,)
   >> a.dtype
   int32
   >> b = mx.array([1.0, 2.0, 3.0, 4.0])


### PR DESCRIPTION
## Proposed changes

A few things in the usage docs do not match what the code actually does. I ran every example below on current main to check.

**`compile.rst`**

- The implicit-state example mixes 3 and 4 space indentation, so copying it into a file gives `IndentationError: unexpected indent`. Aligned the trailing lines with the rest of the block.
- Typo: "Firt call compiles the function".

**`indexing.rst`**

- The `arr[:, :, 0]` block had a stray `array(3, dtype=int32)` line that does not belong to either expression, and both outputs were missing their closing paren. Actual result for both is `array([[0, 2], [4, 6]], dtype=int32)`.
- `arr.shape` was shown as `[8]` and `arr[None].shape` as `[1, 8]`. `shape` is a tuple, so these print as `(8,)` and `(1, 8)`.
- The two boolean-mask assignment examples showed `array([5.0, 2.0, 6.0], ...)` and `array([[1.0, 0.0, 1.0], ...])`, but MLX drops the trailing `.0` for whole valued floats, so they print as `array([5, 2, 6], dtype=float32)` and `array([[1, 0, 1], [0, 0, 1]], dtype=float32)`.

**`quick_start.rst`**

- Same shape issue: `a.shape` shown as `[4]`, actually `(4,)`.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

(docs only; every example above was executed against current main and the new outputs are copied from the actual results)

---

small note on how i work: i'm a freshman contributor and i use Claude Code to help me spot this kind of drift, but for this one i pulled each code block out into a scratch file, ran it, and pasted back what it really printed. if any of these outputs look different on your machine i would like to know, since that would be more interesting than the typo.
