### PR TITLE
docs: remove references to removed --no-verify-script launch flag

### DIFF
--- a/docs/src/usage/launching_distributed.rst
+++ b/docs/src/usage/launching_distributed.rst
@@ -160,11 +160,6 @@ host and on the same path. A good checklist to debug errors is the following:
   ``mlx.launch --print-python`` to see what that path is.
 * the script you want to run is available on all hosts at the same path
 
-If you are launching from a node with a completely different setup than the
-nodes that the program will run on, you can specify ``--no-verify-script`` so
-that ``mlx.launch`` does not attempt to verify that the executable and script
-exist locally before launching the distributed job.
-
 .. _ring_specifics:
 
 Ring Specifics
@@ -207,7 +202,7 @@ multi-gpu jobs. For instance
 
 .. code-block::
 
-   mlx.launch --backend nccl --hosts linux-1,linux-2 -n 8 --no-verify-script -- ./my-job.sh
+   mlx.launch --backend nccl --hosts linux-1,linux-2 -n 8 -- ./my-job.sh
 
 will attempt to launch 16 processes, 8 on each node that will all run
 ``my-job.sh``.


### PR DESCRIPTION
The distributed-launch guide documents a `--no-verify-script` flag for `mlx.launch`, but that flag was removed from the launcher.

`python/mlx/_distributed_utils/launch.py` (the `mlx.launch` entry point) defines no `--no-verify-script` option and contains no script-verification logic — grep for `verify` there returns nothing. The flag and its logic were removed in the launcher cleanup (PR #3513); this doc page was last edited before that and went stale.

Because `launch.py` uses `parse_known_args()`, the documented command does not error cleanly — `--no-verify-script` falls into the leftover args, and since it is not `--`, the launcher treats `--no-verify-script` as the program to run instead of `./my-job.sh`, so the job does not run as documented.

This removes the flag from the example command and deletes the paragraph describing the no-longer-existent feature. Docs-only, no functional change.
