### PR TITLE
Fix sorted gather_mm activation row stride

### DIFF
--- a/mlx/backend/metal/matmul.cpp
+++ b/mlx/backend/metal/matmul.cpp
@@ -2114,7 +2114,7 @@ void gather_mm_rhs(
   int K = a.shape(-1);
   int M = a.size() / K;
   int N = b.shape(-1);
-  int lda = a.strides()[a.ndim() - 2]; // should be K
+  int lda = K;
 
   // Define the dispatch blocks
   int bm = 16, bn = 64, bk = 16;
@@ -2247,7 +2247,7 @@ void gather_mm_rhs_nax(
   int K = a.shape(-1);
   int M = a.size() / K;
   int N = b.shape(-1);
-  int lda = a.strides()[a.ndim() - 2]; // should be K
+  int lda = K;
   int E = b.shape(0);
 
   // Define the dispatch blocks


### PR DESCRIPTION
## Fix sorted `gather_mm` with singleton-dimension inputs

### Summary

Fix the activation row stride used by the specialized sorted RHS `gather_mm` implementations.

Both the Steel and NAX paths flatten the leading activation dimensions into `M`, so consecutive rows are `K` elements apart. However, they currently derive `lda` from the original second-to-last dimension, which can have stride `1` when it is a singleton dimension introduced by `expand_dims`.

### Reproduction

```python
import mlx.core as mx

mx.random.seed(42)

x = mx.random.normal((2, 64))
w = mx.random.normal((4, 64, 128))
indices = mx.array([3, 3], dtype=mx.int32)

a = mx.expand_dims(x, -2)  # [2, 1, 64]
expected = mx.matmul(a, w[indices])

sorted_output = mx.gather_mm(
    a,
    w,
    rhs_indices=indices,
    sorted_indices=True,
)
unsorted_output = mx.gather_mm(
    a,
    w,
    rhs_indices=indices,
    sorted_indices=False,
)

mx.eval(expected, sorted_output, unsorted_output)

print("sorted:", mx.max(mx.abs(sorted_output - expected)).item())
print("unsorted:", mx.max(mx.abs(unsorted_output - expected)).item())
```

Before this change, MLX 0.32 produces:

```text
sorted: 33.21953201293945
unsorted: 0.0
```

The first row is correct, while subsequent rows are read using the wrong offset.

### Root cause

The sorted RHS paths calculate:

```cpp
int K = a.shape(-1);
int M = a.size() / K;
int lda = a.strides()[a.ndim() - 2];
```

For the `[2, 1, 64]` view produced by `expand_dims`, the singleton dimension can have stride `1`. The kernel consequently reads the second row from `a.flatten()[1:65]` instead of `a.flatten()[64:128]`.

`mx.contiguous(a)` does not reliably avoid the issue because MLX can reuse the buffer and preserve its strides.

### Fix

The activation is row-contiguous before this calculation, and the leading dimensions are flattened into rows of length `K`. Therefore, both the Steel and NAX paths should use:

```cpp
int lda = K;
```

With this change, the sorted result agrees with the reference within floating-point tolerance.
