### PR TITLE
Optimize large NVFP4 QMV on M5 Max

### DIFF
--- a/mlx/backend/metal/kernels/fp_quantized.h
+++ b/mlx/backend/metal/kernels/fp_quantized.h
@@ -1,4 +1,4 @@
-// Copyright © 2025 Apple Inc.
+// Copyright © 2025-2026 Apple Inc.
 
 #include <metal_simdgroup>
 #include <metal_stdlib>
@@ -321,7 +321,12 @@ METAL_FUNC void fp_qmv_quad_impl(
   }
 }
 
-template <typename T, int group_size, int bits, bool has_global_scale = false>
+template <
+    typename T,
+    int group_size,
+    int bits,
+    bool has_global_scale = false,
+    int results_per_simdgroup = 4>
 METAL_FUNC void fp_qmv_fast_impl(
     const device uint32_t* w,
     const device uint8_t* scales,
@@ -335,7 +340,6 @@ METAL_FUNC void fp_qmv_fast_impl(
     uint simd_lid [[thread_index_in_simdgroup]]) {
   constexpr int packs_per_thread = 2;
   constexpr int num_simdgroups = 2;
-  constexpr int results_per_simdgroup = 4;
   constexpr int pack_factor = get_pack_factor<32, bits>();
   constexpr int bytes_per_pack = get_bytes_per_pack<32>();
   constexpr int values_per_thread = pack_factor * packs_per_thread;
@@ -1167,7 +1171,8 @@ template <
     int group_size,
     int bits,
     bool batched,
-    bool has_global_scale = false>
+    bool has_global_scale = false,
+    int results_per_simdgroup = 4>
 [[kernel]] void fp_qmv_fast(
     const device uint32_t* w,
     const device uint8_t* scales,
@@ -1203,7 +1208,12 @@ template <
         s_strides,
         tid);
   }
-  fp_qmv_fast_impl<T, group_size, bits, has_global_scale>(
+  fp_qmv_fast_impl<
+      T,
+      group_size,
+      bits,
+      has_global_scale,
+      results_per_simdgroup>(
       w,
       scales,
       global_scale,

--- a/mlx/backend/metal/kernels/fp_quantized.metal
+++ b/mlx/backend/metal/kernels/fp_quantized.metal
@@ -1,4 +1,4 @@
-// Copyright © 2025 Apple Inc.
+// Copyright © 2025-2026 Apple Inc.
 
 // clang-format off
 #include "mlx/backend/metal/kernels/utils.h"
@@ -56,6 +56,30 @@
       bits,       \
       aligned, \
       batched)
+
+#define instantiate_quantized_qmv_fast(mode, type, results, batched, group_size, bits) \
+  instantiate_kernel( \
+      #mode "_qmv_fast_" #type "_gs_" #group_size "_b_" #bits "_r_" #results "_batch_" #batched, \
+      fp_qmv_fast, \
+      type, \
+      group_size, \
+      bits, \
+      batched, \
+      false, \
+      results) \
+  instantiate_kernel( \
+      #mode "_qmv_fast_" #type "_gs_" #group_size "_b_" #bits "_r_" #results "_batch_" #batched "_hgs", \
+      fp_qmv_fast, \
+      type, \
+      group_size, \
+      bits, \
+      batched, \
+      true, \
+      results)
+
+#define instantiate_quantized_qmv_fast_r2(mode, type, group_size, bits) \
+  instantiate_quantized_qmv_fast(mode, type, 2, 1, group_size, bits) \
+  instantiate_quantized_qmv_fast(mode, type, 2, 0, group_size, bits)
 
 #define instantiate_quantized_quad(mode, name, type, D, batched, group_size, bits) \
   instantiate_kernel( \
@@ -185,13 +209,14 @@
   instantiate_quantized_all_rhs(type, mode, group_size, bits)
 
 #define instantiate_quantized_types(type) \
-  instantiate_quantized_modes(type, nvfp4, 16, 4) \
-  instantiate_quantized_modes(type, mxfp8, 32, 8) \
-  instantiate_quantized_modes(type, mxfp4, 32, 4) \
-  instantiate_quantize_dequantize(type, nvfp4, 16, 4, false) \
-  instantiate_quantize_dequantize(type, nvfp4, 16, 4, true)  \
-  instantiate_quantize_dequantize(type, mxfp8, 32, 8, false) \
-  instantiate_quantize_dequantize(type, mxfp4, 32, 4, false) \
+ instantiate_quantized_modes(type, nvfp4, 16, 4) \
+ instantiate_quantized_modes(type, mxfp8, 32, 8) \
+ instantiate_quantized_modes(type, mxfp4, 32, 4) \
+ instantiate_quantize_dequantize(type, nvfp4, 16, 4, false) \
+ instantiate_quantize_dequantize(type, nvfp4, 16, 4, true)  \
+ instantiate_quantize_dequantize(type, mxfp8, 32, 8, false) \
+ instantiate_quantize_dequantize(type, mxfp4, 32, 4, false) \
+ instantiate_quantized_qmv_fast_r2(nvfp4, type, 16, 4)
 
 instantiate_quantized_types(float)
 instantiate_quantized_types(bfloat16_t)

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -502,27 +502,17 @@ void qmv(
       use_narrow_qmv ? "_r_2" : "",
       B > 1 ? "_batch_1" : "_batch_0",
       global_scale ? "_hgs" : "");
-  auto kernel = use_narrow_qmv ? get_quantized_kernel_wrapped(
-                                     d,
-                                     kname,
-                                     "qmv_fast",
-                                     mode,
-                                     type_string,
-                                     group_size,
-                                     bits,
-                                     B > 1,
-                                     global_scale.has_value(),
-                                     results_per_simdgroup)
-                               : get_quantized_kernel_wrapped(
-                                     d,
-                                     kname,
-                                     (fast ? "qmv_fast" : "qmv"),
-                                     mode,
-                                     type_string,
-                                     group_size,
-                                     bits,
-                                     B > 1,
-                                     global_scale.has_value());
+  auto kernel = get_quantized_kernel_wrapped(
+      d,
+      kname,
+      (fast ? "qmv_fast" : "qmv"),
+      mode,
+      type_string,
+      group_size,
+      bits,
+      B > 1,
+      global_scale.has_value(),
+      results_per_simdgroup);
 
   auto& compute_encoder = metal::get_command_encoder(s);
   compute_encoder.set_compute_pipeline_state(kernel);

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023-2024 Apple Inc.
+// Copyright © 2023-2026 Apple Inc.
 
 #include "mlx/backend/common/quantized.h"
 #include "mlx/backend/common/broadcasting.h"
@@ -477,13 +477,19 @@ void qmv(
 
   int bn = 8;
   int bk = 32;
-  MTL::Size group_dims(bk, 2, 1);
-  MTL::Size grid_dims(M, (N + bn - 1) / bn, B);
 
   std::string kname;
   kname.reserve(64);
   std::string type_string = get_type_string(x.dtype());
   bool fast = N % bn == 0 && K % qmv_fast_k_alignment(bits) == 0;
+  // A narrower output tile reduces register pressure for large
+  // floating-point quantized matrix-vector products on M5 Max GPUs.
+  bool use_narrow_qmv = fast && N >= 4096 && d.get_architecture_gen() == 17 &&
+      d.get_architecture().back() == 's' && mode == "nvfp4";
+  int results_per_simdgroup = use_narrow_qmv ? 2 : 4;
+  bn = 2 * results_per_simdgroup;
+  MTL::Size group_dims(bk, 2, 1);
+  MTL::Size grid_dims(M, (N + bn - 1) / bn, B);
 
   concatenate(
       kname,
@@ -493,18 +499,30 @@ void qmv(
       group_size,
       "_b_",
       bits,
+      use_narrow_qmv ? "_r_2" : "",
       B > 1 ? "_batch_1" : "_batch_0",
       global_scale ? "_hgs" : "");
-  auto kernel = get_quantized_kernel_wrapped(
-      d,
-      kname,
-      (fast ? "qmv_fast" : "qmv"),
-      mode,
-      type_string,
-      group_size,
-      bits,
-      B > 1,
-      global_scale.has_value());
+  auto kernel = use_narrow_qmv ? get_quantized_kernel_wrapped(
+                                     d,
+                                     kname,
+                                     "qmv_fast",
+                                     mode,
+                                     type_string,
+                                     group_size,
+                                     bits,
+                                     B > 1,
+                                     global_scale.has_value(),
+                                     results_per_simdgroup)
+                               : get_quantized_kernel_wrapped(
+                                     d,
+                                     kname,
+                                     (fast ? "qmv_fast" : "qmv"),
+                                     mode,
+                                     type_string,
+                                     group_size,
+                                     bits,
+                                     B > 1,
+                                     global_scale.has_value());
 
   auto& compute_encoder = metal::get_command_encoder(s);
   compute_encoder.set_compute_pipeline_state(kernel);

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -1,4 +1,4 @@
-# Copyright © 2023 Apple Inc.
+# Copyright © 2023-2026 Apple Inc.
 
 import platform
 import subprocess
@@ -515,6 +515,40 @@ class TestQuantized(mlx_tests.MLXTestCase):
             y_hat = x @ mx.swapaxes(w_hat, -1, -2)
             self.assertEqual(y_q.shape, y_hat.shape)
             self.assertLess((y_q - y_hat).abs().max(), 1e-3)
+
+    def test_fp_qmv_large_output(self):
+        key = mx.random.key(0)
+        k1, k2 = mx.random.split(key)
+        K = 512
+        N = 4096
+
+        for B in [1, 2]:
+            with self.subTest(B=B, N=N, K=K):
+                x_shape = (1, K) if B == 1 else (B, 1, K)
+                w_shape = (N, K) if B == 1 else (B, N, K)
+                x = mx.random.normal(shape=x_shape, key=k1) / K**0.5
+                w = mx.random.normal(shape=w_shape, key=k2)
+                w_q, scales = mx.quantize(w, mode="nvfp4")
+
+                dtypes = (
+                    [mx.float16, mx.bfloat16, mx.float32]
+                    if mx.default_device() == mx.gpu
+                    else [mx.float32]
+                )
+                for dtype in dtypes:
+                    with self.subTest(dtype=dtype):
+                        x_t = x.astype(dtype)
+                        w_hat = mx.dequantize(w_q, scales, mode="nvfp4", dtype=dtype)
+                        y_q = mx.quantized_matmul(
+                            x_t,
+                            w_q,
+                            scales,
+                            transpose=True,
+                            mode="nvfp4",
+                        )
+                        y_hat = x_t @ mx.swapaxes(w_hat, -1, -2)
+                        self.assertEqual(y_q.shape, y_hat.shape)
+                        self.assertTrue(mx.allclose(y_q, y_hat, rtol=1e-3, atol=1e-3))
 
     def test_qmv_wide(self):
         # M in [2, vector_limit) routes to qmv_wide -- except K in {64, 128}

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -548,7 +548,8 @@ class TestQuantized(mlx_tests.MLXTestCase):
                         )
                         y_hat = x_t @ mx.swapaxes(w_hat, -1, -2)
                         self.assertEqual(y_q.shape, y_hat.shape)
-                        self.assertTrue(mx.allclose(y_q, y_hat, rtol=1e-3, atol=1e-3))
+                        tol = 1e-2 if dtype == mx.bfloat16 else 1e-3
+                        self.assertTrue(mx.allclose(y_q, y_hat, rtol=tol, atol=tol))
 
     def test_qmv_wide(self):
         # M in [2, vector_limit) routes to qmv_wide -- except K in {64, 128}


### PR DESCRIPTION
## Proposed changes

Use a narrower output tile for large NVFP4 matrix-vector products on M5 Max GPUs. Reducing the results per SIMD-group from four to two lowers register pressure for output dimensions of 4096 or greater.

Keep the existing kernel configuration for other architectures, quantization modes, and smaller output dimensions.

Add coverage for batched and unbatched large-output QMV across the supported floating-point types.

## Performance

Apple M5 Max, 40-core GPU, 128 GB, macOS 26.5.2.

The optimized path is intentionally limited to M5 Max (`applegpu_g17s`), which is the only M5 configuration I was able to test. The narrower tile may also benefit other M5 GPUs, but I do not have the hardware to validate that tradeoff without risking regressions.

```shell
python -m mlx_lm.benchmark \
  --model mlx-community/Qwen3.5-4B-nvfp4 \
  -p 2048 -g 128 -n 9
```

After a warmup, baseline and candidate were run in B/A/A/B order. Results are the midpoint of the paired nine-trial medians.

| Model | Prompt tok/s | Generation tok/s |
|---|---:|---:|
| Qwen3.5 4B NVFP4 | 5394.5 → 5416.0 (+0.4%) | 128.0 → 131.5 (**+2.7%**) |

Ollama MLX generation improved by 2.8% on Qwen3.5 4B NVFP4 and 3.9% on Qwen3.5 9B NVFP4; prompt throughput was effectively unchanged.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
