### PR TITLE
Fix Transformer ignoring a custom encoder or decoder with no parameters

### DIFF
--- a/python/mlx/nn/layers/transformer.py
+++ b/python/mlx/nn/layers/transformer.py
@@ -327,27 +327,33 @@ class Transformer(Module):
     ):
         super().__init__()
 
-        self.encoder = custom_encoder or TransformerEncoder(
-            num_encoder_layers,
-            dims,
-            num_heads,
-            mlp_dims,
-            dropout,
-            activation,
-            norm_first,
-            checkpoint,
-        )
+        if custom_encoder is not None:
+            self.encoder = custom_encoder
+        else:
+            self.encoder = TransformerEncoder(
+                num_encoder_layers,
+                dims,
+                num_heads,
+                mlp_dims,
+                dropout,
+                activation,
+                norm_first,
+                checkpoint,
+            )
 
-        self.decoder = custom_decoder or TransformerDecoder(
-            num_decoder_layers,
-            dims,
-            num_heads,
-            mlp_dims,
-            dropout,
-            activation,
-            norm_first,
-            checkpoint,
-        )
+        if custom_decoder is not None:
+            self.decoder = custom_decoder
+        else:
+            self.decoder = TransformerDecoder(
+                num_decoder_layers,
+                dims,
+                num_heads,
+                mlp_dims,
+                dropout,
+                activation,
+                norm_first,
+                checkpoint,
+            )
 
     def __call__(self, src, tgt, src_mask, tgt_mask, memory_mask):
         memory = self.encoder(src, src_mask)

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -2258,6 +2258,20 @@ class TestLayers(mlx_tests.MLXTestCase):
         out = model(src, tgt, src_mask=None, tgt_mask=None, memory_mask=None)
         self.assertEqual(out.shape, tgt.shape)
 
+    def test_transformer_custom_modules(self):
+        # A custom encoder or decoder without any parameters is still a
+        # module and should not be replaced by the default one.
+        model = nn.Transformer(
+            dims=32,
+            num_heads=4,
+            num_encoder_layers=2,
+            num_decoder_layers=2,
+            custom_encoder=nn.Identity(),
+            custom_decoder=nn.Identity(),
+        )
+        self.assertTrue(isinstance(model.encoder, nn.Identity))
+        self.assertTrue(isinstance(model.decoder, nn.Identity))
+
 
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner()


### PR DESCRIPTION
## Proposed changes

`Transformer` picks its submodules with `custom_encoder or TransformerEncoder(...)`. Since `Module` subclasses `dict`, a module that holds no arrays is an empty dict and therefore falsy, so a parameterless custom encoder or decoder gets silently thrown away and the default one is built instead:

```python
import mlx.core as mx
import mlx.nn as nn

bool(nn.Identity())   # False

t = nn.Transformer(dims=8, num_heads=2, num_encoder_layers=3, num_decoder_layers=1,
                   custom_encoder=nn.Identity())
type(t.encoder)       # TransformerEncoder, not Identity
```

Same for `custom_decoder`. It only shows up when the custom module has no parameters of its own, so a custom encoder that happens to hold a weight works fine and this looks inconsistent rather than broken. Switched both to an explicit `is not None` check.

Added a small test for it. It fails on main with the current truthiness check and passes with this change.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

(`test_nn.py` passes; happy to drop the test if you would rather keep this to the one line change)

---

context on me: freshman contributor, and i lean on Claude Code when hunting for things like this, but i confirmed the empty-module-is-falsy behaviour myself and checked that a custom module holding a parameter behaves differently, which is what made it click. if you would rather express the fix as a conditional expression than an if/else, say the word.
