### PR TITLE
Validate freeze and unfreeze keys against the whole model when recursing

### DIFF
--- a/python/mlx/nn/layers/base.py
+++ b/python/mlx/nn/layers/base.py
@@ -461,6 +461,16 @@ class Module(dict):
                     raise KeyError(f"Module doesn't contain member {k}.")
         return keys
 
+    def _validate_keys_recursive(self, keys):
+        # A key such as "bias" is expected to be present somewhere in the model
+        # but not necessarily in every single submodule, so validate against the
+        # whole model rather than each module in isolation.
+        keys = keys if isinstance(keys, list) else [keys]
+        modules = self.modules()
+        for k in keys:
+            if not any(k in m for m in modules):
+                raise KeyError(f"Module doesn't contain member {k}.")
+
     def freeze(
         self,
         *,
@@ -511,6 +521,9 @@ class Module(dict):
             m._no_grad.update(local_keys)
 
         if recurse:
+            if strict and keys is not None:
+                self._validate_keys_recursive(keys)
+                strict = False
             self.apply_to_modules(_freeze_impl)
         else:
             _freeze_impl("", self)
@@ -561,6 +574,9 @@ class Module(dict):
                 m._no_grad.difference_update(local_keys)
 
         if recurse:
+            if strict and keys is not None:
+                self._validate_keys_recursive(keys)
+                strict = False
             self.apply_to_modules(_unfreeze_impl)
         else:
             _unfreeze_impl("", self)

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -199,6 +199,23 @@ class TestBase(mlx_tests.MLXTestCase):
         m.state["hello"] = "world"
         self.assertEqual(m.state["hello"], "world")
 
+    def test_freeze_strict_keys(self):
+        # "bias" is present in the model but not in every submodule, so a
+        # recursive freeze should accept it rather than raising on the first
+        # submodule that happens not to have one.
+        m = nn.Sequential(nn.Linear(2, 2, bias=False), nn.Linear(2, 2))
+        m.freeze(keys="bias", strict=True)
+        trainable = dict(tree_flatten(m.trainable_parameters()))
+        self.assertFalse(any(k.endswith("bias") for k in trainable))
+
+        m.unfreeze(keys="bias", strict=True)
+        trainable = dict(tree_flatten(m.trainable_parameters()))
+        self.assertTrue(any(k.endswith("bias") for k in trainable))
+
+        # A key that is nowhere in the model is still an error.
+        with self.assertRaises(KeyError):
+            m.freeze(keys="not_a_member", strict=True)
+
     def test_chaining(self):
         m = nn.Sequential(nn.Linear(2, 2), nn.ReLU(), nn.Linear(2, 1))
         pre_freeze_num_params = len(m.parameters())


### PR DESCRIPTION
## Proposed changes

`freeze` and `unfreeze` document `keys="bias"` as a whole model operation ("freeze all biases by calling `module.freeze(keys="bias")`", and `unfreeze`'s example is `nn.Transformer()` then `model.unfreeze(keys="bias")`). But with `strict=True` they validate the keys separately inside every visited submodule, so the first submodule without a bias aborts the whole call. That makes the two documented features unusable together on any model with mixed layers, including the bundled `Transformer`:

```python
import mlx.core as mx
import mlx.nn as nn
from mlx.utils import tree_flatten

m = nn.Transformer(dims=8, num_heads=2, num_encoder_layers=1, num_decoder_layers=0)
len([k for k, _ in tree_flatten(m.parameters()) if k.endswith("bias")])   # 6

m.freeze(keys="bias", strict=True)
# KeyError: "Module doesn't contain member bias."
```

It happens because `MultiHeadAttention`'s projections default to `bias=False` while the MLP `Linear` layers default to `bias=True`, so the traversal hits a module with no `bias` and raises even though six of them exist.

When recursing, this now checks the keys once against the whole model and only raises if a key is present nowhere. Behavior that stays the same:

- a key that really is absent everywhere still raises `KeyError`, including when it is one entry in a list
- `recurse=False` still validates against just that module
- `strict=False` and the no-keys case are untouched

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

(the new test fails on main with the `KeyError` and passes here; `test_nn.py` is green)

If you would rather read `strict` as per module and keep the current behavior, then the docstrings are what need changing instead, and I am glad to flip this into a docs only PR.

---

about me: freshman contributor, and i do use Claude Code while hunting for these, but i traced this one to the bias=False projections in MultiHeadAttention myself and checked the recurse and strict combinations by hand before writing it up. tell me if the whole model reading is not the one you intended.
