### PR TITLE
Add new_thread_unsafe_stream to the devices and streams docs

### DIFF
--- a/docs/src/python/devices_and_streams.rst
+++ b/docs/src/python/devices_and_streams.rst
@@ -15,6 +15,7 @@ Devices and Streams
    default_stream
    new_stream
    new_thread_local_stream
+   new_thread_unsafe_stream
    set_default_stream
    stream
    synchronize


### PR DESCRIPTION
## Proposed changes

`new_thread_unsafe_stream` is public and works, and it has a full docstring that cross references :func:`new_stream`, but it never made it into the API reference. Its two siblings `new_stream` and `new_thread_local_stream` are both listed in `devices_and_streams.rst`, so right now the only way to find this one is to already know it exists.

```python
import mlx.core as mx
s = mx.new_thread_unsafe_stream(mx.cpu)
mx.add(mx.array(1), mx.array(2), stream=s)   # array(3, dtype=int32)
```

Looks like it was just missed when the API was added in #3578. This adds the one autosummary entry, next to the other two stream constructors.

While I was checking, I also compared every public callable in `mlx.core` against the whole of `docs/src` and this was the only properly bound function absent from the docs. The remaining unlisted names (`pow`, `matrix_norm`, `cumulative_sum`, `acos` and friends) are plain aliases whose docstrings render under the aliased name, so listing those would show a signature like `power(...)` on a page called `pow`. I left them alone since that looks deliberate, but happy to revisit if you would rather they were documented too.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

(docs only, one line)

---

for transparency: freshman contributor, i use Claude Code to help me sweep for gaps like this, but i verified the function actually runs, read its docstring, and diffed the full public API against the docs myself before opening. the alias question above is a genuine one, not rhetorical, so tell me if you want those listed as well.
