### PR TITLE
Template Metal C2C FFT scalar lanes

### DIFF
--- a/mlx/backend/metal/kernels/fft.h
+++ b/mlx/backend/metal/kernels/fft.h
@@ -16,7 +16,7 @@ using namespace metal;
 
 #define MAX_RADIX 13
 // Reached when elems_per_thread_ = 6, max_radix = 13
-// and some threads have to do 3 radix 6s requiring 18 float2s.
+// and some threads have to do 3 radix 6s requiring 18 complex values.
 #define MAX_OUTPUT_SIZE 18
 
 // Specialize for a particular value of N at runtime
@@ -46,17 +46,18 @@ STEEL_CONST int rader_4_steps_ [[function_constant(19)]];
 STEEL_CONST int rader_3_steps_ [[function_constant(20)]];
 STEEL_CONST int rader_2_steps_ [[function_constant(21)]];
 
-// See "radix.h" for radix codelets
-typedef void (*RadixFunc)(thread float2*, thread float2*);
+// See "radix.h" for radix codelets.
+template <typename T>
+using RadixFunc = void (*)(thread vec<T, 2>*, thread vec<T, 2>*);
 
 // Perform a single radix n butterfly with appropriate twiddles
-template <int radix, RadixFunc radix_func>
+template <typename T, int radix, RadixFunc<T> radix_func>
 METAL_FUNC void radix_butterfly(
     int i,
     int p,
-    thread float2* x,
+    thread vec<T, 2>* x,
     thread short* indices,
-    thread float2* y) {
+    thread vec<T, 2>* y) {
   // i: the index in the overall DFT that we're processing.
   // p: the size of the DFTs we're merging at this step.
   // m: how many threads are working on this DFT.
@@ -75,14 +76,14 @@ METAL_FUNC void radix_butterfly(
 
   // Apply twiddles
   if (p > 1) {
-    float2 twiddle_1 = get_twiddle(k, radix * p);
-    float2 twiddle = twiddle_1;
-    x[1] = complex_mul(x[1], twiddle);
+    vec<T, 2> twiddle_1 = get_twiddle<T>(k, radix * p);
+    vec<T, 2> twiddle = twiddle_1;
+    x[1] = complex_mul<T>(x[1], twiddle);
 
     STEEL_PRAGMA_UNROLL
     for (int t = 2; t < radix; t++) {
-      twiddle = complex_mul(twiddle, twiddle_1);
-      x[t] = complex_mul(x[t], twiddle);
+      twiddle = complex_mul<T>(twiddle, twiddle_1);
+      x[t] = complex_mul<T>(x[t], twiddle);
     }
   }
 
@@ -96,17 +97,17 @@ METAL_FUNC void radix_butterfly(
 
 // Perform all the radix steps required for a
 // particular radix size n.
-template <int radix, RadixFunc radix_func>
+template <typename T, int radix, RadixFunc<T> radix_func>
 METAL_FUNC void radix_n_steps(
     int i,
     thread int* p,
     int m,
     int n,
     int num_steps,
-    thread float2* inputs,
+    thread vec<T, 2>* inputs,
     thread short* indices,
-    thread float2* values,
-    threadgroup float2* buf) {
+    thread vec<T, 2>* values,
+    threadgroup vec<T, 2>* buf) {
   int m_r = n / radix;
   // When combining different sized radices, we have to do
   // multiple butterflies in a single thread.
@@ -126,7 +127,7 @@ METAL_FUNC void radix_n_steps(
         for (int r = 0; r < radix; r++) {
           inputs[r] = buf[index + r * m_r];
         }
-        radix_butterfly<radix, radix_func>(
+        radix_butterfly<T, radix, radix_func>(
             index, *p, inputs, indices + t * radix, values + t * radix);
       }
     }
@@ -151,15 +152,19 @@ METAL_FUNC void radix_n_steps(
 }
 
 #define RADIX_STEP(radix, radix_func, num_steps) \
-  radix_n_steps<radix, radix_func>(              \
+  radix_n_steps<T, radix, radix_func<T>>(        \
       fft_idx, p, m, n, num_steps, inputs, indices, values, buf);
 
-template <bool rader = false>
-METAL_FUNC void
-perform_fft(int fft_idx, thread int* p, int m, int n, threadgroup float2* buf) {
-  float2 inputs[MAX_RADIX];
+template <typename T, bool rader = false>
+METAL_FUNC void perform_fft(
+    int fft_idx,
+    thread int* p,
+    int m,
+    int n,
+    threadgroup vec<T, 2>* buf) {
+  vec<T, 2> inputs[MAX_RADIX];
   short indices[MAX_OUTPUT_SIZE];
-  float2 values[MAX_OUTPUT_SIZE];
+  vec<T, 2> values[MAX_OUTPUT_SIZE];
 
   RADIX_STEP(2, radix2, rader ? rader_2_steps_ : radix_2_steps_);
   RADIX_STEP(3, radix3, rader ? rader_3_steps_ : radix_3_steps_);
@@ -184,7 +189,8 @@ template <int tg_mem_size, typename in_T, typename out_T>
     constant const int& batch_size,
     uint3 elem [[thread_position_in_grid]],
     uint3 grid [[threads_per_grid]]) {
-  threadgroup float2 shared_in[tg_mem_size];
+  using scalar_T = typename FFTIOTypeTraits<in_T, out_T>::scalar_T;
+  threadgroup vec<scalar_T, 2> shared_in[tg_mem_size];
 
   thread ReadWriter<in_T, out_T> read_writer = ReadWriter<in_T, out_T>(
       in,
@@ -208,9 +214,9 @@ template <int tg_mem_size, typename in_T, typename out_T>
   int fft_idx = elem.z; // Thread index in DFT
   int m = grid.z; // Threads per DFT
   int tg_idx = elem.y * n; // Index of this DFT in threadgroup
-  threadgroup float2* buf = &shared_in[tg_idx];
+  threadgroup vec<scalar_T, 2>* buf = &shared_in[tg_idx];
 
-  perform_fft(fft_idx, &p, m, n, buf);
+  perform_fft<scalar_T>(fft_idx, &p, m, n, buf);
 
   read_writer.write();
 }
@@ -219,7 +225,8 @@ template <int tg_mem_size, typename in_T, typename out_T>
 [[kernel]] void rader_fft(
     const device in_T* in [[buffer(0)]],
     device out_T* out [[buffer(1)]],
-    const device float2* raders_b_q [[buffer(2)]],
+    const device vec<typename FFTIOTypeTraits<in_T, out_T>::scalar_T, 2>*
+        raders_b_q [[buffer(2)]],
     const device short* raders_g_q [[buffer(3)]],
     const device short* raders_g_minus_q [[buffer(4)]],
     constant const int& n,
@@ -227,6 +234,7 @@ template <int tg_mem_size, typename in_T, typename out_T>
     constant const int& rader_n,
     uint3 elem [[thread_position_in_grid]],
     uint3 grid [[threads_per_grid]]) {
+  using scalar_T = typename FFTIOTypeTraits<in_T, out_T>::scalar_T;
   // Use Rader's algorithm to compute fast FFTs
   // when a prime factor `p` of `n` is greater than 13 but
   // has `p - 1` Stockham decomposable into prime factors <= 13.
@@ -250,7 +258,7 @@ template <int tg_mem_size, typename in_T, typename out_T>
   //
   // Rader's uses fewer operations than Bluestein's and so
   // is more accurate. It's also faster in most cases.
-  threadgroup float2 shared_in[tg_mem_size];
+  threadgroup vec<scalar_T, 2> shared_in[tg_mem_size];
 
   thread ReadWriter<in_T, out_T> read_writer = ReadWriter<in_T, out_T>(
       in,
@@ -275,7 +283,7 @@ template <int tg_mem_size, typename in_T, typename out_T>
 
   int fft_idx = elem.z;
   int tg_idx = elem.y * n;
-  threadgroup float2* buf = &shared_in[tg_idx];
+  threadgroup vec<scalar_T, 2>* buf = &shared_in[tg_idx];
 
   // rader_m = n / rader_n;
   int rader_m = rader_m_;
@@ -287,10 +295,10 @@ template <int tg_mem_size, typename in_T, typename out_T>
   // 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
   short x_0_index =
       metal::min(fft_idx * elems_per_thread_ / (rader_n - 1), rader_m - 1);
-  float2 x_0[2] = {buf[x_0_index], buf[x_0_index + 1]};
+  vec<scalar_T, 2> x_0[2] = {buf[x_0_index], buf[x_0_index + 1]};
 
   // Do the Rader permutation in shared memory
-  float2 temp[MAX_RADIX];
+  vec<scalar_T, 2> temp[MAX_RADIX];
   int max_index = n - rader_m - 1;
   for (int e = 0; e < elems_per_thread_; e++) {
     short index = metal::min(fft_idx * elems_per_thread_ + e, max_index);
@@ -309,19 +317,20 @@ template <int tg_mem_size, typename in_T, typename out_T>
 
   // Rader FFT on x[rader_m:]
   int p = 1;
-  perform_fft</*rader=*/true>(fft_idx, &p, m, n - rader_m, buf + rader_m);
+  perform_fft<scalar_T, /*rader=*/true>(
+      fft_idx, &p, m, n - rader_m, buf + rader_m);
 
   // x_1 + ... + x_n is computed for us in the first FFT step so
   // we save it in the first rader_m indices of the array for later.
   int x_sum_index = metal::min(fft_idx, rader_m - 1);
   buf[x_sum_index] = buf[rader_m + x_sum_index * (rader_n - 1)];
 
-  float2 inv = {1.0f, -1.0f};
+  vec<scalar_T, 2> inv = {1.0f, -1.0f};
   for (int e = 0; e < elems_per_thread_; e++) {
     short index = metal::min(fft_idx * elems_per_thread_ + e, max_index);
     short interleaved_index =
         index / rader_m + (index % rader_m) * (rader_n - 1);
-    temp[e] = complex_mul(
+    temp[e] = complex_mul<scalar_T>(
         buf[rader_m + interleaved_index],
         raders_b_q[interleaved_index % (rader_n - 1)]);
   }
@@ -337,9 +346,11 @@ template <int tg_mem_size, typename in_T, typename out_T>
 
   // Rader IFFT on x[rader_m:]
   p = 1;
-  perform_fft</*rader=*/true>(fft_idx, &p, m, n - rader_m, buf + rader_m);
+  perform_fft<scalar_T, /*rader=*/true>(
+      fft_idx, &p, m, n - rader_m, buf + rader_m);
 
-  float2 rader_inv_factor = {1.0f / (rader_n - 1), -1.0f / (rader_n - 1)};
+  scalar_T rader_inv_r = static_cast<scalar_T>(1.0f / (rader_n - 1));
+  vec<scalar_T, 2> rader_inv_factor = {rader_inv_r, -rader_inv_r};
 
   for (int e = 0; e < elems_per_thread_; e++) {
     short index = metal::min(fft_idx * elems_per_thread_ + e, n - rader_m - 1);
@@ -348,7 +359,7 @@ template <int tg_mem_size, typename in_T, typename out_T>
   }
 
   // Use the sum of elements that was computed in the first FFT
-  float2 x_sum = buf[x_0_index] + x_0[0];
+  vec<scalar_T, 2> x_sum = buf[x_0_index] + x_0[0];
 
   threadgroup_barrier(mem_flags::mem_threadgroup);
 
@@ -365,7 +376,7 @@ template <int tg_mem_size, typename in_T, typename out_T>
   threadgroup_barrier(mem_flags::mem_threadgroup);
 
   p = rader_n;
-  perform_fft(fft_idx, &p, m, n, buf);
+  perform_fft<scalar_T>(fft_idx, &p, m, n, buf);
 
   read_writer.write();
 }
@@ -374,13 +385,16 @@ template <int tg_mem_size, typename in_T, typename out_T>
 [[kernel]] void bluestein_fft(
     const device in_T* in [[buffer(0)]],
     device out_T* out [[buffer(1)]],
-    const device float2* w_q [[buffer(2)]],
-    const device float2* w_k [[buffer(3)]],
+    const device vec<typename FFTIOTypeTraits<in_T, out_T>::scalar_T, 2>* w_q
+    [[buffer(2)]],
+    const device vec<typename FFTIOTypeTraits<in_T, out_T>::scalar_T, 2>* w_k
+    [[buffer(3)]],
     constant const int& length,
     constant const int& n,
     constant const int& batch_size,
     uint3 elem [[thread_position_in_grid]],
     uint3 grid [[threads_per_grid]]) {
+  using scalar_T = typename FFTIOTypeTraits<in_T, out_T>::scalar_T;
   // Computes arbitrary length FFTs with Bluestein's algorithm
   //
   // In numpy:
@@ -390,7 +404,7 @@ template <int tg_mem_size, typename in_T, typename out_T>
   // Where w_k and w_q are precomputed on CPU in high precision as:
   //   w_k = np.exp(-1j * np.pi / n * (np.arange(-n + 1, n) ** 2))
   //   w_q = np.fft.fft(1/w_k[-n:])
-  threadgroup float2 shared_in[tg_mem_size];
+  threadgroup vec<scalar_T, 2> shared_in[tg_mem_size];
 
   thread ReadWriter<in_T, out_T> read_writer = ReadWriter<in_T, out_T>(
       in,
@@ -414,22 +428,22 @@ template <int tg_mem_size, typename in_T, typename out_T>
   int fft_idx = elem.z; // Thread index in DFT
   int m = grid.z; // Threads per DFT
   int tg_idx = elem.y * n; // Index of this DFT in threadgroup
-  threadgroup float2* buf = &shared_in[tg_idx];
+  threadgroup vec<scalar_T, 2>* buf = &shared_in[tg_idx];
 
   // fft
-  perform_fft(fft_idx, &p, m, n, buf);
+  perform_fft<scalar_T>(fft_idx, &p, m, n, buf);
 
-  float2 inv = float2(1.0f, -1.0f);
+  vec<scalar_T, 2> inv = {1.0f, -1.0f};
   for (int t = 0; t < elems_per_thread_; t++) {
     int index = fft_idx + t * m;
-    buf[index] = complex_mul(buf[index], w_q[index]) * inv;
+    buf[index] = complex_mul<scalar_T>(buf[index], w_q[index]) * inv;
   }
 
   threadgroup_barrier(mem_flags::mem_threadgroup);
 
   // ifft
   p = 1;
-  perform_fft(fft_idx, &p, m, n, buf);
+  perform_fft<scalar_T>(fft_idx, &p, m, n, buf);
 
   read_writer.write_padded(length, w_k);
 }
@@ -448,6 +462,7 @@ template <
     constant const int& batch_size,
     uint3 elem [[thread_position_in_grid]],
     uint3 grid [[threads_per_grid]]) {
+  using scalar_T = typename FFTIOTypeTraits<in_T, out_T>::scalar_T;
   // Fast four step FFT implementation for powers of 2.
   int overall_n = n1 * n2;
   int n = step == 0 ? n1 : n2;
@@ -457,8 +472,8 @@ template <
   int m = grid.z;
   int fft_idx = elem.z;
 
-  threadgroup float2 shared_in[tg_mem_size];
-  threadgroup float2* buf = &shared_in[elem.y * n];
+  threadgroup vec<scalar_T, 2> shared_in[tg_mem_size];
+  threadgroup vec<scalar_T, 2>* buf = &shared_in[elem.y * n];
 
   using read_writer_t = ReadWriter<in_T, out_T, step, real>;
   read_writer_t read_writer = read_writer_t(
@@ -480,7 +495,7 @@ template <
   threadgroup_barrier(mem_flags::mem_threadgroup);
 
   int p = 1;
-  perform_fft(fft_idx, &p, m, n, buf);
+  perform_fft<scalar_T>(fft_idx, &p, m, n, buf);
 
   read_writer.write_strided(stride, overall_n);
 }

--- a/mlx/backend/metal/kernels/fft.h
+++ b/mlx/backend/metal/kernels/fft.h
@@ -16,7 +16,7 @@ using namespace metal;
 
 #define MAX_RADIX 13
 // Reached when elems_per_thread_ = 6, max_radix = 13
-// and some threads have to do 3 radix 6s requiring 18 float2s.
+// and some threads have to do 3 radix 6s requiring 18 complex values.
 #define MAX_OUTPUT_SIZE 18
 
 // Specialize for a particular value of N at runtime
@@ -46,17 +46,18 @@ STEEL_CONST int rader_4_steps_ [[function_constant(19)]];
 STEEL_CONST int rader_3_steps_ [[function_constant(20)]];
 STEEL_CONST int rader_2_steps_ [[function_constant(21)]];
 
-// See "radix.h" for radix codelets
-typedef void (*RadixFunc)(thread float2*, thread float2*);
+// See "radix.h" for radix codelets.
+template <typename T>
+using RadixFunc = void (*)(thread fft_complex_t<T>*, thread fft_complex_t<T>*);
 
 // Perform a single radix n butterfly with appropriate twiddles
-template <int radix, RadixFunc radix_func>
+template <typename T, int radix, RadixFunc<T> radix_func>
 METAL_FUNC void radix_butterfly(
     int i,
     int p,
-    thread float2* x,
+    thread fft_complex_t<T>* x,
     thread short* indices,
-    thread float2* y) {
+    thread fft_complex_t<T>* y) {
   // i: the index in the overall DFT that we're processing.
   // p: the size of the DFTs we're merging at this step.
   // m: how many threads are working on this DFT.
@@ -75,14 +76,14 @@ METAL_FUNC void radix_butterfly(
 
   // Apply twiddles
   if (p > 1) {
-    float2 twiddle_1 = get_twiddle(k, radix * p);
-    float2 twiddle = twiddle_1;
-    x[1] = complex_mul(x[1], twiddle);
+    fft_complex_t<T> twiddle_1 = get_twiddle<T>(k, radix * p);
+    fft_complex_t<T> twiddle = twiddle_1;
+    x[1] = complex_mul<T>(x[1], twiddle);
 
     STEEL_PRAGMA_UNROLL
     for (int t = 2; t < radix; t++) {
-      twiddle = complex_mul(twiddle, twiddle_1);
-      x[t] = complex_mul(x[t], twiddle);
+      twiddle = complex_mul<T>(twiddle, twiddle_1);
+      x[t] = complex_mul<T>(x[t], twiddle);
     }
   }
 
@@ -96,17 +97,17 @@ METAL_FUNC void radix_butterfly(
 
 // Perform all the radix steps required for a
 // particular radix size n.
-template <int radix, RadixFunc radix_func>
+template <typename T, int radix, RadixFunc<T> radix_func>
 METAL_FUNC void radix_n_steps(
     int i,
     thread int* p,
     int m,
     int n,
     int num_steps,
-    thread float2* inputs,
+    thread fft_complex_t<T>* inputs,
     thread short* indices,
-    thread float2* values,
-    threadgroup float2* buf) {
+    thread fft_complex_t<T>* values,
+    threadgroup fft_complex_t<T>* buf) {
   int m_r = n / radix;
   // When combining different sized radices, we have to do
   // multiple butterflies in a single thread.
@@ -126,7 +127,7 @@ METAL_FUNC void radix_n_steps(
         for (int r = 0; r < radix; r++) {
           inputs[r] = buf[index + r * m_r];
         }
-        radix_butterfly<radix, radix_func>(
+        radix_butterfly<T, radix, radix_func>(
             index, *p, inputs, indices + t * radix, values + t * radix);
       }
     }
@@ -151,15 +152,19 @@ METAL_FUNC void radix_n_steps(
 }
 
 #define RADIX_STEP(radix, radix_func, num_steps) \
-  radix_n_steps<radix, radix_func>(              \
+  radix_n_steps<T, radix, radix_func<T>>(        \
       fft_idx, p, m, n, num_steps, inputs, indices, values, buf);
 
-template <bool rader = false>
-METAL_FUNC void
-perform_fft(int fft_idx, thread int* p, int m, int n, threadgroup float2* buf) {
-  float2 inputs[MAX_RADIX];
+template <typename T, bool rader = false>
+METAL_FUNC void perform_fft(
+    int fft_idx,
+    thread int* p,
+    int m,
+    int n,
+    threadgroup fft_complex_t<T>* buf) {
+  fft_complex_t<T> inputs[MAX_RADIX];
   short indices[MAX_OUTPUT_SIZE];
-  float2 values[MAX_OUTPUT_SIZE];
+  fft_complex_t<T> values[MAX_OUTPUT_SIZE];
 
   RADIX_STEP(2, radix2, rader ? rader_2_steps_ : radix_2_steps_);
   RADIX_STEP(3, radix3, rader ? rader_3_steps_ : radix_3_steps_);
@@ -184,7 +189,8 @@ template <int tg_mem_size, typename in_T, typename out_T>
     constant const int& batch_size,
     uint3 elem [[thread_position_in_grid]],
     uint3 grid [[threads_per_grid]]) {
-  threadgroup float2 shared_in[tg_mem_size];
+  using scalar_T = typename FFTIOTypeTraits<in_T, out_T>::scalar_T;
+  threadgroup fft_complex_t<scalar_T> shared_in[tg_mem_size];
 
   thread ReadWriter<in_T, out_T> read_writer = ReadWriter<in_T, out_T>(
       in,
@@ -208,9 +214,9 @@ template <int tg_mem_size, typename in_T, typename out_T>
   int fft_idx = elem.z; // Thread index in DFT
   int m = grid.z; // Threads per DFT
   int tg_idx = elem.y * n; // Index of this DFT in threadgroup
-  threadgroup float2* buf = &shared_in[tg_idx];
+  threadgroup fft_complex_t<scalar_T>* buf = &shared_in[tg_idx];
 
-  perform_fft(fft_idx, &p, m, n, buf);
+  perform_fft<scalar_T>(fft_idx, &p, m, n, buf);
 
   read_writer.write();
 }
@@ -219,7 +225,8 @@ template <int tg_mem_size, typename in_T, typename out_T>
 [[kernel]] void rader_fft(
     const device in_T* in [[buffer(0)]],
     device out_T* out [[buffer(1)]],
-    const device float2* raders_b_q [[buffer(2)]],
+    const device fft_complex_t<typename FFTIOTypeTraits<in_T, out_T>::scalar_T>*
+        raders_b_q [[buffer(2)]],
     const device short* raders_g_q [[buffer(3)]],
     const device short* raders_g_minus_q [[buffer(4)]],
     constant const int& n,
@@ -227,6 +234,7 @@ template <int tg_mem_size, typename in_T, typename out_T>
     constant const int& rader_n,
     uint3 elem [[thread_position_in_grid]],
     uint3 grid [[threads_per_grid]]) {
+  using scalar_T = typename FFTIOTypeTraits<in_T, out_T>::scalar_T;
   // Use Rader's algorithm to compute fast FFTs
   // when a prime factor `p` of `n` is greater than 13 but
   // has `p - 1` Stockham decomposable into prime factors <= 13.
@@ -250,7 +258,7 @@ template <int tg_mem_size, typename in_T, typename out_T>
   //
   // Rader's uses fewer operations than Bluestein's and so
   // is more accurate. It's also faster in most cases.
-  threadgroup float2 shared_in[tg_mem_size];
+  threadgroup fft_complex_t<scalar_T> shared_in[tg_mem_size];
 
   thread ReadWriter<in_T, out_T> read_writer = ReadWriter<in_T, out_T>(
       in,
@@ -275,7 +283,7 @@ template <int tg_mem_size, typename in_T, typename out_T>
 
   int fft_idx = elem.z;
   int tg_idx = elem.y * n;
-  threadgroup float2* buf = &shared_in[tg_idx];
+  threadgroup fft_complex_t<scalar_T>* buf = &shared_in[tg_idx];
 
   // rader_m = n / rader_n;
   int rader_m = rader_m_;
@@ -287,10 +295,10 @@ template <int tg_mem_size, typename in_T, typename out_T>
   // 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
   short x_0_index =
       metal::min(fft_idx * elems_per_thread_ / (rader_n - 1), rader_m - 1);
-  float2 x_0[2] = {buf[x_0_index], buf[x_0_index + 1]};
+  fft_complex_t<scalar_T> x_0[2] = {buf[x_0_index], buf[x_0_index + 1]};
 
   // Do the Rader permutation in shared memory
-  float2 temp[MAX_RADIX];
+  fft_complex_t<scalar_T> temp[MAX_RADIX];
   int max_index = n - rader_m - 1;
   for (int e = 0; e < elems_per_thread_; e++) {
     short index = metal::min(fft_idx * elems_per_thread_ + e, max_index);
@@ -309,19 +317,20 @@ template <int tg_mem_size, typename in_T, typename out_T>
 
   // Rader FFT on x[rader_m:]
   int p = 1;
-  perform_fft</*rader=*/true>(fft_idx, &p, m, n - rader_m, buf + rader_m);
+  perform_fft<scalar_T, /*rader=*/true>(
+      fft_idx, &p, m, n - rader_m, buf + rader_m);
 
   // x_1 + ... + x_n is computed for us in the first FFT step so
   // we save it in the first rader_m indices of the array for later.
   int x_sum_index = metal::min(fft_idx, rader_m - 1);
   buf[x_sum_index] = buf[rader_m + x_sum_index * (rader_n - 1)];
 
-  float2 inv = {1.0f, -1.0f};
+  auto inv = fft_make_complex<scalar_T>(1.0f, -1.0f);
   for (int e = 0; e < elems_per_thread_; e++) {
     short index = metal::min(fft_idx * elems_per_thread_ + e, max_index);
     short interleaved_index =
         index / rader_m + (index % rader_m) * (rader_n - 1);
-    temp[e] = complex_mul(
+    temp[e] = complex_mul<scalar_T>(
         buf[rader_m + interleaved_index],
         raders_b_q[interleaved_index % (rader_n - 1)]);
   }
@@ -337,9 +346,10 @@ template <int tg_mem_size, typename in_T, typename out_T>
 
   // Rader IFFT on x[rader_m:]
   p = 1;
-  perform_fft</*rader=*/true>(fft_idx, &p, m, n - rader_m, buf + rader_m);
+  perform_fft<scalar_T, /*rader=*/true>(
+      fft_idx, &p, m, n - rader_m, buf + rader_m);
 
-  float2 rader_inv_factor = {1.0f / (rader_n - 1), -1.0f / (rader_n - 1)};
+  auto rader_inv_factor = fft_inverse_factor<scalar_T>(rader_n - 1);
 
   for (int e = 0; e < elems_per_thread_; e++) {
     short index = metal::min(fft_idx * elems_per_thread_ + e, n - rader_m - 1);
@@ -348,7 +358,7 @@ template <int tg_mem_size, typename in_T, typename out_T>
   }
 
   // Use the sum of elements that was computed in the first FFT
-  float2 x_sum = buf[x_0_index] + x_0[0];
+  fft_complex_t<scalar_T> x_sum = buf[x_0_index] + x_0[0];
 
   threadgroup_barrier(mem_flags::mem_threadgroup);
 
@@ -365,7 +375,7 @@ template <int tg_mem_size, typename in_T, typename out_T>
   threadgroup_barrier(mem_flags::mem_threadgroup);
 
   p = rader_n;
-  perform_fft(fft_idx, &p, m, n, buf);
+  perform_fft<scalar_T>(fft_idx, &p, m, n, buf);
 
   read_writer.write();
 }
@@ -374,13 +384,16 @@ template <int tg_mem_size, typename in_T, typename out_T>
 [[kernel]] void bluestein_fft(
     const device in_T* in [[buffer(0)]],
     device out_T* out [[buffer(1)]],
-    const device float2* w_q [[buffer(2)]],
-    const device float2* w_k [[buffer(3)]],
+    const device fft_complex_t<typename FFTIOTypeTraits<in_T, out_T>::scalar_T>*
+        w_q [[buffer(2)]],
+    const device fft_complex_t<typename FFTIOTypeTraits<in_T, out_T>::scalar_T>*
+        w_k [[buffer(3)]],
     constant const int& length,
     constant const int& n,
     constant const int& batch_size,
     uint3 elem [[thread_position_in_grid]],
     uint3 grid [[threads_per_grid]]) {
+  using scalar_T = typename FFTIOTypeTraits<in_T, out_T>::scalar_T;
   // Computes arbitrary length FFTs with Bluestein's algorithm
   //
   // In numpy:
@@ -390,7 +403,7 @@ template <int tg_mem_size, typename in_T, typename out_T>
   // Where w_k and w_q are precomputed on CPU in high precision as:
   //   w_k = np.exp(-1j * np.pi / n * (np.arange(-n + 1, n) ** 2))
   //   w_q = np.fft.fft(1/w_k[-n:])
-  threadgroup float2 shared_in[tg_mem_size];
+  threadgroup fft_complex_t<scalar_T> shared_in[tg_mem_size];
 
   thread ReadWriter<in_T, out_T> read_writer = ReadWriter<in_T, out_T>(
       in,
@@ -414,22 +427,22 @@ template <int tg_mem_size, typename in_T, typename out_T>
   int fft_idx = elem.z; // Thread index in DFT
   int m = grid.z; // Threads per DFT
   int tg_idx = elem.y * n; // Index of this DFT in threadgroup
-  threadgroup float2* buf = &shared_in[tg_idx];
+  threadgroup fft_complex_t<scalar_T>* buf = &shared_in[tg_idx];
 
   // fft
-  perform_fft(fft_idx, &p, m, n, buf);
+  perform_fft<scalar_T>(fft_idx, &p, m, n, buf);
 
-  float2 inv = float2(1.0f, -1.0f);
+  auto inv = fft_make_complex<scalar_T>(1.0f, -1.0f);
   for (int t = 0; t < elems_per_thread_; t++) {
     int index = fft_idx + t * m;
-    buf[index] = complex_mul(buf[index], w_q[index]) * inv;
+    buf[index] = complex_mul<scalar_T>(buf[index], w_q[index]) * inv;
   }
 
   threadgroup_barrier(mem_flags::mem_threadgroup);
 
   // ifft
   p = 1;
-  perform_fft(fft_idx, &p, m, n, buf);
+  perform_fft<scalar_T>(fft_idx, &p, m, n, buf);
 
   read_writer.write_padded(length, w_k);
 }
@@ -448,6 +461,7 @@ template <
     constant const int& batch_size,
     uint3 elem [[thread_position_in_grid]],
     uint3 grid [[threads_per_grid]]) {
+  using scalar_T = typename FFTIOTypeTraits<in_T, out_T>::scalar_T;
   // Fast four step FFT implementation for powers of 2.
   int overall_n = n1 * n2;
   int n = step == 0 ? n1 : n2;
@@ -457,8 +471,8 @@ template <
   int m = grid.z;
   int fft_idx = elem.z;
 
-  threadgroup float2 shared_in[tg_mem_size];
-  threadgroup float2* buf = &shared_in[elem.y * n];
+  threadgroup fft_complex_t<scalar_T> shared_in[tg_mem_size];
+  threadgroup fft_complex_t<scalar_T>* buf = &shared_in[elem.y * n];
 
   using read_writer_t = ReadWriter<in_T, out_T, step, real>;
   read_writer_t read_writer = read_writer_t(
@@ -480,7 +494,7 @@ template <
   threadgroup_barrier(mem_flags::mem_threadgroup);
 
   int p = 1;
-  perform_fft(fft_idx, &p, m, n, buf);
+  perform_fft<scalar_T>(fft_idx, &p, m, n, buf);
 
   read_writer.write_strided(stride, overall_n);
 }

--- a/mlx/backend/metal/kernels/fft/radix.h
+++ b/mlx/backend/metal/kernels/fft/radix.h
@@ -16,49 +16,63 @@ them into (n-1)=6,10,12 codelets. */
 #include <metal_math>
 #include <metal_stdlib>
 
-METAL_FUNC float2 complex_mul(float2 a, float2 b) {
-  return float2(a.x * b.x - a.y * b.y, a.x * b.y + a.y * b.x);
+// The codelets are templated over the scalar lane type so reduced-precision
+// complex paths can reuse them; complex values are plain two-lane vectors.
+
+template <typename T>
+METAL_FUNC metal::vec<T, 2> complex_mul(
+    metal::vec<T, 2> a,
+    metal::vec<T, 2> b) {
+  return {a.x * b.x - a.y * b.y, a.x * b.y + a.y * b.x};
 }
 
 // Complex mul followed by conjugate
-METAL_FUNC float2 complex_mul_conj(float2 a, float2 b) {
-  return float2(a.x * b.x - a.y * b.y, -a.x * b.y - a.y * b.x);
+template <typename T>
+METAL_FUNC metal::vec<T, 2> complex_mul_conj(
+    metal::vec<T, 2> a,
+    metal::vec<T, 2> b) {
+  return {a.x * b.x - a.y * b.y, -a.x * b.y - a.y * b.x};
 }
 
 // Compute an FFT twiddle factor
-METAL_FUNC float2 get_twiddle(int k, int p) {
-  float theta = -2.0f * k * M_PI_F / p;
-
-  float2 twiddle = {metal::fast::cos(theta), metal::fast::sin(theta)};
-  return twiddle;
+template <typename T>
+METAL_FUNC metal::vec<T, 2> get_twiddle(int k, int p) {
+  // Derive phase evaluation precision from the scalar lane and Metal's pi
+  // constant. Reduced lanes currently promote to float for fast trig.
+  using phase_T = decltype(M_PI_F * T(0));
+  phase_T theta = -phase_T(2) * phase_T(k) * phase_T(M_PI_F) / phase_T(p);
+  return {metal::fast::cos(theta), metal::fast::sin(theta)};
 }
 
-METAL_FUNC void radix2(thread float2* x, thread float2* y) {
+template <typename T>
+METAL_FUNC void radix2(thread metal::vec<T, 2>* x, thread metal::vec<T, 2>* y) {
   y[0] = x[0] + x[1];
   y[1] = x[0] - x[1];
 }
 
-METAL_FUNC void radix3(thread float2* x, thread float2* y) {
-  float pi_2_3 = -0.8660254037844387;
+template <typename T>
+METAL_FUNC void radix3(thread metal::vec<T, 2>* x, thread metal::vec<T, 2>* y) {
+  T pi_2_3 = -0.8660254037844387;
 
-  float2 a_1 = x[1] + x[2];
-  float2 a_2 = x[1] - x[2];
+  metal::vec<T, 2> a_1 = x[1] + x[2];
+  metal::vec<T, 2> a_2 = x[1] - x[2];
 
   y[0] = x[0] + a_1;
-  float2 b_1 = x[0] - 0.5 * a_1;
-  float2 b_2 = pi_2_3 * a_2;
+  metal::vec<T, 2> b_1 = x[0] - 0.5 * a_1;
+  metal::vec<T, 2> b_2 = pi_2_3 * a_2;
 
-  float2 b_2_j = {-b_2.y, b_2.x};
+  metal::vec<T, 2> b_2_j = {-b_2.y, b_2.x};
   y[1] = b_1 + b_2_j;
   y[2] = b_1 - b_2_j;
 }
 
-METAL_FUNC void radix4(thread float2* x, thread float2* y) {
-  float2 z_0 = x[0] + x[2];
-  float2 z_1 = x[0] - x[2];
-  float2 z_2 = x[1] + x[3];
-  float2 z_3 = x[1] - x[3];
-  float2 z_3_i = {z_3.y, -z_3.x};
+template <typename T>
+METAL_FUNC void radix4(thread metal::vec<T, 2>* x, thread metal::vec<T, 2>* y) {
+  metal::vec<T, 2> z_0 = x[0] + x[2];
+  metal::vec<T, 2> z_1 = x[0] - x[2];
+  metal::vec<T, 2> z_2 = x[1] + x[3];
+  metal::vec<T, 2> z_3 = x[1] - x[3];
+  metal::vec<T, 2> z_3_i = {z_3.y, -z_3.x};
 
   y[0] = z_0 + z_2;
   y[1] = z_1 + z_3_i;
@@ -66,25 +80,26 @@ METAL_FUNC void radix4(thread float2* x, thread float2* y) {
   y[3] = z_1 - z_3_i;
 }
 
-METAL_FUNC void radix5(thread float2* x, thread float2* y) {
-  float2 root_5_4 = 0.5590169943749475;
-  float2 sin_2pi_5 = 0.9510565162951535;
-  float2 sin_1pi_5 = 0.5877852522924731;
+template <typename T>
+METAL_FUNC void radix5(thread metal::vec<T, 2>* x, thread metal::vec<T, 2>* y) {
+  T root_5_4 = 0.5590169943749475;
+  T sin_2pi_5 = 0.9510565162951535;
+  T sin_1pi_5 = 0.5877852522924731;
 
-  float2 a_1 = x[1] + x[4];
-  float2 a_2 = x[2] + x[3];
-  float2 a_3 = x[1] - x[4];
-  float2 a_4 = x[2] - x[3];
+  metal::vec<T, 2> a_1 = x[1] + x[4];
+  metal::vec<T, 2> a_2 = x[2] + x[3];
+  metal::vec<T, 2> a_3 = x[1] - x[4];
+  metal::vec<T, 2> a_4 = x[2] - x[3];
 
-  float2 a_5 = a_1 + a_2;
-  float2 a_6 = root_5_4 * (a_1 - a_2);
-  float2 a_7 = x[0] - a_5 / 4;
-  float2 a_8 = a_7 + a_6;
-  float2 a_9 = a_7 - a_6;
-  float2 a_10 = sin_2pi_5 * a_3 + sin_1pi_5 * a_4;
-  float2 a_11 = sin_1pi_5 * a_3 - sin_2pi_5 * a_4;
-  float2 a_10_j = {a_10.y, -a_10.x};
-  float2 a_11_j = {a_11.y, -a_11.x};
+  metal::vec<T, 2> a_5 = a_1 + a_2;
+  metal::vec<T, 2> a_6 = root_5_4 * (a_1 - a_2);
+  metal::vec<T, 2> a_7 = x[0] - a_5 / 4;
+  metal::vec<T, 2> a_8 = a_7 + a_6;
+  metal::vec<T, 2> a_9 = a_7 - a_6;
+  metal::vec<T, 2> a_10 = sin_2pi_5 * a_3 + sin_1pi_5 * a_4;
+  metal::vec<T, 2> a_11 = sin_1pi_5 * a_3 - sin_2pi_5 * a_4;
+  metal::vec<T, 2> a_10_j = {a_10.y, -a_10.x};
+  metal::vec<T, 2> a_11_j = {a_11.y, -a_11.x};
 
   y[0] = x[0] + a_5;
   y[1] = a_8 + a_10_j;
@@ -93,23 +108,24 @@ METAL_FUNC void radix5(thread float2* x, thread float2* y) {
   y[4] = a_8 - a_10_j;
 }
 
-METAL_FUNC void radix6(thread float2* x, thread float2* y) {
-  float sin_pi_3 = 0.8660254037844387;
-  float2 a_1 = x[2] + x[4];
-  float2 a_2 = x[0] - a_1 / 2;
-  float2 a_3 = sin_pi_3 * (x[2] - x[4]);
-  float2 a_4 = x[5] + x[1];
-  float2 a_5 = x[3] - a_4 / 2;
-  float2 a_6 = sin_pi_3 * (x[5] - x[1]);
-  float2 a_7 = x[0] + a_1;
+template <typename T>
+METAL_FUNC void radix6(thread metal::vec<T, 2>* x, thread metal::vec<T, 2>* y) {
+  T sin_pi_3 = 0.8660254037844387;
+  metal::vec<T, 2> a_1 = x[2] + x[4];
+  metal::vec<T, 2> a_2 = x[0] - a_1 / 2;
+  metal::vec<T, 2> a_3 = sin_pi_3 * (x[2] - x[4]);
+  metal::vec<T, 2> a_4 = x[5] + x[1];
+  metal::vec<T, 2> a_5 = x[3] - a_4 / 2;
+  metal::vec<T, 2> a_6 = sin_pi_3 * (x[5] - x[1]);
+  metal::vec<T, 2> a_7 = x[0] + a_1;
 
-  float2 a_3_i = {a_3.y, -a_3.x};
-  float2 a_6_i = {a_6.y, -a_6.x};
-  float2 a_8 = a_2 + a_3_i;
-  float2 a_9 = a_2 - a_3_i;
-  float2 a_10 = x[3] + a_4;
-  float2 a_11 = a_5 + a_6_i;
-  float2 a_12 = a_5 - a_6_i;
+  metal::vec<T, 2> a_3_i = {a_3.y, -a_3.x};
+  metal::vec<T, 2> a_6_i = {a_6.y, -a_6.x};
+  metal::vec<T, 2> a_8 = a_2 + a_3_i;
+  metal::vec<T, 2> a_9 = a_2 - a_3_i;
+  metal::vec<T, 2> a_10 = x[3] + a_4;
+  metal::vec<T, 2> a_11 = a_5 + a_6_i;
+  metal::vec<T, 2> a_12 = a_5 - a_6_i;
 
   y[0] = a_7 + a_10;
   y[1] = a_8 - a_11;
@@ -119,26 +135,28 @@ METAL_FUNC void radix6(thread float2* x, thread float2* y) {
   y[5] = a_9 - a_12;
 }
 
-METAL_FUNC void radix7(thread float2* x, thread float2* y) {
+template <typename T>
+METAL_FUNC void radix7(thread metal::vec<T, 2>* x, thread metal::vec<T, 2>* y) {
   // Rader's algorithm
-  float2 inv = {1 / 6.0, -1 / 6.0};
+  T inv_r = static_cast<T>(1 / 6.0);
+  metal::vec<T, 2> inv = {inv_r, -inv_r};
 
   // fft
-  float2 in1[6] = {x[1], x[3], x[2], x[6], x[4], x[5]};
-  radix6(in1, y + 1);
+  metal::vec<T, 2> in1[6] = {x[1], x[3], x[2], x[6], x[4], x[5]};
+  radix6<T>(in1, y + 1);
 
   y[0] = y[1] + x[0];
 
   // b_q
-  y[1] = complex_mul_conj(y[1], float2(-1, 0));
-  y[2] = complex_mul_conj(y[2], float2(2.44013336, -1.02261879));
-  y[3] = complex_mul_conj(y[3], float2(2.37046941, -1.17510629));
-  y[4] = complex_mul_conj(y[4], float2(0, -2.64575131));
-  y[5] = complex_mul_conj(y[5], float2(2.37046941, 1.17510629));
-  y[6] = complex_mul_conj(y[6], float2(-2.44013336, -1.02261879));
+  y[1] = complex_mul_conj<T>(y[1], metal::vec<T, 2>(-1, 0));
+  y[2] = complex_mul_conj<T>(y[2], metal::vec<T, 2>(2.44013336, -1.02261879));
+  y[3] = complex_mul_conj<T>(y[3], metal::vec<T, 2>(2.37046941, -1.17510629));
+  y[4] = complex_mul_conj<T>(y[4], metal::vec<T, 2>(0, -2.64575131));
+  y[5] = complex_mul_conj<T>(y[5], metal::vec<T, 2>(2.37046941, 1.17510629));
+  y[6] = complex_mul_conj<T>(y[6], metal::vec<T, 2>(-2.44013336, -1.02261879));
 
   // ifft
-  radix6(y + 1, x + 1);
+  radix6<T>(y + 1, x + 1);
 
   y[1] = x[1] * inv + x[0];
   y[5] = x[2] * inv + x[0];
@@ -148,79 +166,87 @@ METAL_FUNC void radix7(thread float2* x, thread float2* y) {
   y[3] = x[6] * inv + x[0];
 }
 
-METAL_FUNC void radix8(thread float2* x, thread float2* y) {
-  float cos_pi_4 = 0.7071067811865476;
-  float2 w_0 = {cos_pi_4, -cos_pi_4};
-  float2 w_1 = {-cos_pi_4, -cos_pi_4};
-  float2 temp[8] = {x[0], x[2], x[4], x[6], x[1], x[3], x[5], x[7]};
-  radix4(temp, x);
-  radix4(temp + 4, x + 4);
+template <typename T>
+METAL_FUNC void radix8(thread metal::vec<T, 2>* x, thread metal::vec<T, 2>* y) {
+  T cos_pi_4 = 0.7071067811865476;
+  metal::vec<T, 2> w_0 = {cos_pi_4, -cos_pi_4};
+  metal::vec<T, 2> w_1 = {-cos_pi_4, -cos_pi_4};
+  metal::vec<T, 2> temp[8] = {x[0], x[2], x[4], x[6], x[1], x[3], x[5], x[7]};
+  radix4<T>(temp, x);
+  radix4<T>(temp + 4, x + 4);
 
   y[0] = x[0] + x[4];
   y[4] = x[0] - x[4];
-  float2 x_5 = complex_mul(x[5], w_0);
+  metal::vec<T, 2> x_5 = complex_mul<T>(x[5], w_0);
   y[1] = x[1] + x_5;
   y[5] = x[1] - x_5;
-  float2 x_6 = {x[6].y, -x[6].x};
+  metal::vec<T, 2> x_6 = {x[6].y, -x[6].x};
   y[2] = x[2] + x_6;
   y[6] = x[2] - x_6;
-  float2 x_7 = complex_mul(x[7], w_1);
+  metal::vec<T, 2> x_7 = complex_mul<T>(x[7], w_1);
   y[3] = x[3] + x_7;
   y[7] = x[3] - x_7;
 }
 
-template <bool raders_perm>
-METAL_FUNC void radix10(thread float2* x, thread float2* y) {
-  float2 w[4];
+template <typename T, bool raders_perm>
+METAL_FUNC void radix10(
+    thread metal::vec<T, 2>* x,
+    thread metal::vec<T, 2>* y) {
+  metal::vec<T, 2> w[4];
   w[0] = {0.8090169943749475, -0.5877852522924731};
   w[1] = {0.30901699437494745, -0.9510565162951535};
   w[2] = {-w[1].x, w[1].y};
   w[3] = {-w[0].x, w[0].y};
 
   if (raders_perm) {
-    float2 temp[10] = {
+    metal::vec<T, 2> temp[10] = {
         x[0], x[3], x[4], x[8], x[2], x[1], x[7], x[9], x[6], x[5]};
-    radix5(temp, x);
-    radix5(temp + 5, x + 5);
+    radix5<T>(temp, x);
+    radix5<T>(temp + 5, x + 5);
   } else {
-    float2 temp[10] = {
+    metal::vec<T, 2> temp[10] = {
         x[0], x[2], x[4], x[6], x[8], x[1], x[3], x[5], x[7], x[9]};
-    radix5(temp, x);
-    radix5(temp + 5, x + 5);
+    radix5<T>(temp, x);
+    radix5<T>(temp + 5, x + 5);
   }
 
   y[0] = x[0] + x[5];
   y[5] = x[0] - x[5];
   for (int t = 1; t < 5; t++) {
-    float2 a = complex_mul(x[t + 5], w[t - 1]);
+    metal::vec<T, 2> a = complex_mul<T>(x[t + 5], w[t - 1]);
     y[t] = x[t] + a;
     y[t + 5] = x[t] - a;
   }
 }
 
-METAL_FUNC void radix11(thread float2* x, thread float2* y) {
-  // Raders Algorithm
-  float2 inv = {1 / 10.0, -1 / 10.0};
+template <typename T>
+METAL_FUNC void radix11(
+    thread metal::vec<T, 2>* x,
+    thread metal::vec<T, 2>* y) {
+  // Rader's algorithm
+  T inv_r = static_cast<T>(1 / 10.0);
+  metal::vec<T, 2> inv = {inv_r, -inv_r};
 
   // fft
-  radix10<true>(x + 1, y + 1);
+  radix10<T, true>(x + 1, y + 1);
 
   y[0] = y[1] + x[0];
 
   // b_q
-  y[1] = complex_mul_conj(y[1], float2(-1, 0));
-  y[2] = complex_mul_conj(y[2], float2(0.955301878, -3.17606649));
-  y[3] = complex_mul_conj(y[3], float2(2.63610556, 2.01269656));
-  y[4] = complex_mul_conj(y[4], float2(2.54127802, 2.13117479));
-  y[5] = complex_mul_conj(y[5], float2(2.07016210, 2.59122150));
-  y[6] = complex_mul_conj(y[6], float2(0, -3.31662479));
-  y[7] = complex_mul_conj(y[7], float2(2.07016210, -2.59122150));
-  y[8] = complex_mul_conj(y[8], float2(-2.54127802, 2.13117479));
-  y[9] = complex_mul_conj(y[9], float2(2.63610556, -2.01269656));
-  y[10] = complex_mul_conj(y[10], float2(-0.955301878, -3.17606649));
+  y[1] = complex_mul_conj<T>(y[1], metal::vec<T, 2>(-1, 0));
+  y[2] = complex_mul_conj<T>(y[2], metal::vec<T, 2>(0.955301878, -3.17606649));
+  y[3] = complex_mul_conj<T>(y[3], metal::vec<T, 2>(2.63610556, 2.01269656));
+  y[4] = complex_mul_conj<T>(y[4], metal::vec<T, 2>(2.54127802, 2.13117479));
+  y[5] = complex_mul_conj<T>(y[5], metal::vec<T, 2>(2.07016210, 2.59122150));
+  y[6] = complex_mul_conj<T>(y[6], metal::vec<T, 2>(0, -3.31662479));
+  y[7] = complex_mul_conj<T>(y[7], metal::vec<T, 2>(2.07016210, -2.59122150));
+  y[8] = complex_mul_conj<T>(y[8], metal::vec<T, 2>(-2.54127802, 2.13117479));
+  y[9] = complex_mul_conj<T>(y[9], metal::vec<T, 2>(2.63610556, -2.01269656));
+  y[10] =
+      complex_mul_conj<T>(y[10], metal::vec<T, 2>(-0.955301878, -3.17606649));
 
   // ifft
-  radix10<false>(y + 1, x + 1);
+  radix10<T, false>(y + 1, x + 1);
 
   y[1] = x[1] * inv + x[0];
   y[6] = x[2] * inv + x[0];
@@ -234,10 +260,12 @@ METAL_FUNC void radix11(thread float2* x, thread float2* y) {
   y[2] = x[10] * inv + x[0];
 }
 
-template <bool raders_perm>
-METAL_FUNC void radix12(thread float2* x, thread float2* y) {
-  float2 w[6];
-  float sin_pi_3 = 0.8660254037844387;
+template <typename T, bool raders_perm>
+METAL_FUNC void radix12(
+    thread metal::vec<T, 2>* x,
+    thread metal::vec<T, 2>* y) {
+  metal::vec<T, 2> w[6];
+  T sin_pi_3 = 0.8660254037844387;
   w[0] = {sin_pi_3, -0.5};
   w[1] = {0.5, -sin_pi_3};
   w[2] = {0, -1};
@@ -245,7 +273,7 @@ METAL_FUNC void radix12(thread float2* x, thread float2* y) {
   w[4] = {-sin_pi_3, -0.5};
 
   if (raders_perm) {
-    float2 temp[12] = {
+    metal::vec<T, 2> temp[12] = {
         x[0],
         x[3],
         x[2],
@@ -258,10 +286,10 @@ METAL_FUNC void radix12(thread float2* x, thread float2* y) {
         x[10],
         x[4],
         x[6]};
-    radix6(temp, x);
-    radix6(temp + 6, x + 6);
+    radix6<T>(temp, x);
+    radix6<T>(temp + 6, x + 6);
   } else {
-    float2 temp[12] = {
+    metal::vec<T, 2> temp[12] = {
         x[0],
         x[2],
         x[4],
@@ -274,44 +302,50 @@ METAL_FUNC void radix12(thread float2* x, thread float2* y) {
         x[7],
         x[9],
         x[11]};
-    radix6(temp, x);
-    radix6(temp + 6, x + 6);
+    radix6<T>(temp, x);
+    radix6<T>(temp + 6, x + 6);
   }
 
   y[0] = x[0] + x[6];
   y[6] = x[0] - x[6];
   for (int t = 1; t < 6; t++) {
-    float2 a = complex_mul(x[t + 6], w[t - 1]);
+    metal::vec<T, 2> a = complex_mul<T>(x[t + 6], w[t - 1]);
     y[t] = x[t] + a;
     y[t + 6] = x[t] - a;
   }
 }
 
-METAL_FUNC void radix13(thread float2* x, thread float2* y) {
-  // Raders Algorithm
-  float2 inv = {1 / 12.0, -1 / 12.0};
+template <typename T>
+METAL_FUNC void radix13(
+    thread metal::vec<T, 2>* x,
+    thread metal::vec<T, 2>* y) {
+  // Rader's algorithm
+  T inv_r = static_cast<T>(1 / 12.0);
+  metal::vec<T, 2> inv = {inv_r, -inv_r};
 
   // fft
-  radix12<true>(x + 1, y + 1);
+  radix12<T, true>(x + 1, y + 1);
 
   y[0] = y[1] + x[0];
 
   // b_q
-  y[1] = complex_mul_conj(y[1], float2(-1, 0));
-  y[2] = complex_mul_conj(y[2], float2(3.07497206, -1.88269669));
-  y[3] = complex_mul_conj(y[3], float2(3.09912468, 1.84266823));
-  y[4] = complex_mul_conj(y[4], float2(3.45084438, -1.04483161));
-  y[5] = complex_mul_conj(y[5], float2(0.91083583, 3.48860690));
-  y[6] = complex_mul_conj(y[6], float2(-3.60286363, 0.139189267));
-  y[7] = complex_mul_conj(y[7], float2(3.60555128, 0));
-  y[8] = complex_mul_conj(y[8], float2(3.60286363, 0.139189267));
-  y[9] = complex_mul_conj(y[9], float2(0.91083583, -3.48860690));
-  y[10] = complex_mul_conj(y[10], float2(-3.45084438, -1.04483161));
-  y[11] = complex_mul_conj(y[11], float2(3.09912468, -1.84266823));
-  y[12] = complex_mul_conj(y[12], float2(-3.07497206, -1.88269669));
+  y[1] = complex_mul_conj<T>(y[1], metal::vec<T, 2>(-1, 0));
+  y[2] = complex_mul_conj<T>(y[2], metal::vec<T, 2>(3.07497206, -1.88269669));
+  y[3] = complex_mul_conj<T>(y[3], metal::vec<T, 2>(3.09912468, 1.84266823));
+  y[4] = complex_mul_conj<T>(y[4], metal::vec<T, 2>(3.45084438, -1.04483161));
+  y[5] = complex_mul_conj<T>(y[5], metal::vec<T, 2>(0.91083583, 3.48860690));
+  y[6] = complex_mul_conj<T>(y[6], metal::vec<T, 2>(-3.60286363, 0.139189267));
+  y[7] = complex_mul_conj<T>(y[7], metal::vec<T, 2>(3.60555128, 0));
+  y[8] = complex_mul_conj<T>(y[8], metal::vec<T, 2>(3.60286363, 0.139189267));
+  y[9] = complex_mul_conj<T>(y[9], metal::vec<T, 2>(0.91083583, -3.48860690));
+  y[10] =
+      complex_mul_conj<T>(y[10], metal::vec<T, 2>(-3.45084438, -1.04483161));
+  y[11] = complex_mul_conj<T>(y[11], metal::vec<T, 2>(3.09912468, -1.84266823));
+  y[12] =
+      complex_mul_conj<T>(y[12], metal::vec<T, 2>(-3.07497206, -1.88269669));
 
   // ifft
-  radix12<false>(y + 1, x + 1);
+  radix12<T, false>(y + 1, x + 1);
 
   y[1] = x[1] * inv + x[0];
   y[7] = x[2] * inv + x[0];

--- a/mlx/backend/metal/kernels/fft/radix.h
+++ b/mlx/backend/metal/kernels/fft/radix.h
@@ -16,49 +16,101 @@ them into (n-1)=6,10,12 codelets. */
 #include <metal_math>
 #include <metal_stdlib>
 
-METAL_FUNC float2 complex_mul(float2 a, float2 b) {
-  return float2(a.x * b.x - a.y * b.y, a.x * b.y + a.y * b.x);
+// The FFT operates on a pair of floating-point scalar lanes. Keeping the
+// scalar type in the template (rather than spelling float2 through the
+// codelets) makes the butterfly implementation usable by reduced-precision
+// complex storage and compute paths without changing the FFT algorithm.
+template <typename T>
+struct fft_complex {
+  static_assert(
+      metal::is_floating_point_v<T>,
+      "FFT complex lanes must use a floating-point scalar type");
+  using type = metal::vec<T, 2>;
+};
+
+template <typename T>
+using fft_complex_t = typename fft_complex<T>::type;
+
+template <typename T, typename X, typename Y>
+METAL_FUNC fft_complex_t<T> fft_make_complex(X real, Y imag) {
+  return fft_complex_t<T>(static_cast<T>(real), static_cast<T>(imag));
+}
+
+template <typename T, typename X>
+METAL_FUNC fft_complex_t<T> fft_make_real(X real) {
+  return fft_make_complex<T>(real, 0);
+}
+
+template <typename T, typename X>
+METAL_FUNC fft_complex_t<T> fft_splat(X value) {
+  return fft_complex_t<T>(static_cast<T>(value));
+}
+
+template <typename T>
+METAL_FUNC T fft_reciprocal(int divisor) {
+  return static_cast<T>(1) / static_cast<T>(divisor);
+}
+
+template <typename T>
+METAL_FUNC fft_complex_t<T> fft_inverse_factor(int divisor) {
+  auto factor = fft_reciprocal<T>(divisor);
+  return fft_make_complex<T>(factor, -factor);
+}
+
+template <typename T>
+METAL_FUNC fft_complex_t<T> complex_mul(
+    fft_complex_t<T> a,
+    fft_complex_t<T> b) {
+  return fft_make_complex<T>(a.x * b.x - a.y * b.y, a.x * b.y + a.y * b.x);
 }
 
 // Complex mul followed by conjugate
-METAL_FUNC float2 complex_mul_conj(float2 a, float2 b) {
-  return float2(a.x * b.x - a.y * b.y, -a.x * b.y - a.y * b.x);
+template <typename T>
+METAL_FUNC fft_complex_t<T> complex_mul_conj(
+    fft_complex_t<T> a,
+    fft_complex_t<T> b) {
+  return fft_make_complex<T>(a.x * b.x - a.y * b.y, -a.x * b.y - a.y * b.x);
 }
 
 // Compute an FFT twiddle factor
-METAL_FUNC float2 get_twiddle(int k, int p) {
-  float theta = -2.0f * k * M_PI_F / p;
-
-  float2 twiddle = {metal::fast::cos(theta), metal::fast::sin(theta)};
-  return twiddle;
+template <typename T>
+METAL_FUNC fft_complex_t<T> get_twiddle(int k, int p) {
+  // Derive phase evaluation precision from the scalar lane and Metal's pi
+  // constant. Reduced lanes currently promote to float for fast trig.
+  using phase_T = decltype(M_PI_F * T(0));
+  phase_T theta = -phase_T(2) * phase_T(k) * phase_T(M_PI_F) / phase_T(p);
+  return fft_make_complex<T>(metal::fast::cos(theta), metal::fast::sin(theta));
 }
 
-METAL_FUNC void radix2(thread float2* x, thread float2* y) {
+template <typename T>
+METAL_FUNC void radix2(thread fft_complex_t<T>* x, thread fft_complex_t<T>* y) {
   y[0] = x[0] + x[1];
   y[1] = x[0] - x[1];
 }
 
-METAL_FUNC void radix3(thread float2* x, thread float2* y) {
-  float pi_2_3 = -0.8660254037844387;
+template <typename T>
+METAL_FUNC void radix3(thread fft_complex_t<T>* x, thread fft_complex_t<T>* y) {
+  auto pi_2_3 = fft_splat<T>(-0.8660254037844387);
 
-  float2 a_1 = x[1] + x[2];
-  float2 a_2 = x[1] - x[2];
+  fft_complex_t<T> a_1 = x[1] + x[2];
+  fft_complex_t<T> a_2 = x[1] - x[2];
 
   y[0] = x[0] + a_1;
-  float2 b_1 = x[0] - 0.5 * a_1;
-  float2 b_2 = pi_2_3 * a_2;
+  fft_complex_t<T> b_1 = x[0] - fft_splat<T>(0.5) * a_1;
+  fft_complex_t<T> b_2 = pi_2_3 * a_2;
 
-  float2 b_2_j = {-b_2.y, b_2.x};
+  fft_complex_t<T> b_2_j = fft_make_complex<T>(-b_2.y, b_2.x);
   y[1] = b_1 + b_2_j;
   y[2] = b_1 - b_2_j;
 }
 
-METAL_FUNC void radix4(thread float2* x, thread float2* y) {
-  float2 z_0 = x[0] + x[2];
-  float2 z_1 = x[0] - x[2];
-  float2 z_2 = x[1] + x[3];
-  float2 z_3 = x[1] - x[3];
-  float2 z_3_i = {z_3.y, -z_3.x};
+template <typename T>
+METAL_FUNC void radix4(thread fft_complex_t<T>* x, thread fft_complex_t<T>* y) {
+  fft_complex_t<T> z_0 = x[0] + x[2];
+  fft_complex_t<T> z_1 = x[0] - x[2];
+  fft_complex_t<T> z_2 = x[1] + x[3];
+  fft_complex_t<T> z_3 = x[1] - x[3];
+  fft_complex_t<T> z_3_i = fft_make_complex<T>(z_3.y, -z_3.x);
 
   y[0] = z_0 + z_2;
   y[1] = z_1 + z_3_i;
@@ -66,25 +118,26 @@ METAL_FUNC void radix4(thread float2* x, thread float2* y) {
   y[3] = z_1 - z_3_i;
 }
 
-METAL_FUNC void radix5(thread float2* x, thread float2* y) {
-  float2 root_5_4 = 0.5590169943749475;
-  float2 sin_2pi_5 = 0.9510565162951535;
-  float2 sin_1pi_5 = 0.5877852522924731;
+template <typename T>
+METAL_FUNC void radix5(thread fft_complex_t<T>* x, thread fft_complex_t<T>* y) {
+  auto root_5_4 = fft_splat<T>(0.5590169943749475);
+  auto sin_2pi_5 = fft_splat<T>(0.9510565162951535);
+  auto sin_1pi_5 = fft_splat<T>(0.5877852522924731);
 
-  float2 a_1 = x[1] + x[4];
-  float2 a_2 = x[2] + x[3];
-  float2 a_3 = x[1] - x[4];
-  float2 a_4 = x[2] - x[3];
+  fft_complex_t<T> a_1 = x[1] + x[4];
+  fft_complex_t<T> a_2 = x[2] + x[3];
+  fft_complex_t<T> a_3 = x[1] - x[4];
+  fft_complex_t<T> a_4 = x[2] - x[3];
 
-  float2 a_5 = a_1 + a_2;
-  float2 a_6 = root_5_4 * (a_1 - a_2);
-  float2 a_7 = x[0] - a_5 / 4;
-  float2 a_8 = a_7 + a_6;
-  float2 a_9 = a_7 - a_6;
-  float2 a_10 = sin_2pi_5 * a_3 + sin_1pi_5 * a_4;
-  float2 a_11 = sin_1pi_5 * a_3 - sin_2pi_5 * a_4;
-  float2 a_10_j = {a_10.y, -a_10.x};
-  float2 a_11_j = {a_11.y, -a_11.x};
+  fft_complex_t<T> a_5 = a_1 + a_2;
+  fft_complex_t<T> a_6 = root_5_4 * (a_1 - a_2);
+  fft_complex_t<T> a_7 = x[0] - fft_splat<T>(0.25) * a_5;
+  fft_complex_t<T> a_8 = a_7 + a_6;
+  fft_complex_t<T> a_9 = a_7 - a_6;
+  fft_complex_t<T> a_10 = sin_2pi_5 * a_3 + sin_1pi_5 * a_4;
+  fft_complex_t<T> a_11 = sin_1pi_5 * a_3 - sin_2pi_5 * a_4;
+  fft_complex_t<T> a_10_j = fft_make_complex<T>(a_10.y, -a_10.x);
+  fft_complex_t<T> a_11_j = fft_make_complex<T>(a_11.y, -a_11.x);
 
   y[0] = x[0] + a_5;
   y[1] = a_8 + a_10_j;
@@ -93,23 +146,24 @@ METAL_FUNC void radix5(thread float2* x, thread float2* y) {
   y[4] = a_8 - a_10_j;
 }
 
-METAL_FUNC void radix6(thread float2* x, thread float2* y) {
-  float sin_pi_3 = 0.8660254037844387;
-  float2 a_1 = x[2] + x[4];
-  float2 a_2 = x[0] - a_1 / 2;
-  float2 a_3 = sin_pi_3 * (x[2] - x[4]);
-  float2 a_4 = x[5] + x[1];
-  float2 a_5 = x[3] - a_4 / 2;
-  float2 a_6 = sin_pi_3 * (x[5] - x[1]);
-  float2 a_7 = x[0] + a_1;
+template <typename T>
+METAL_FUNC void radix6(thread fft_complex_t<T>* x, thread fft_complex_t<T>* y) {
+  auto sin_pi_3 = fft_splat<T>(0.8660254037844387);
+  fft_complex_t<T> a_1 = x[2] + x[4];
+  fft_complex_t<T> a_2 = x[0] - fft_splat<T>(0.5) * a_1;
+  fft_complex_t<T> a_3 = sin_pi_3 * (x[2] - x[4]);
+  fft_complex_t<T> a_4 = x[5] + x[1];
+  fft_complex_t<T> a_5 = x[3] - fft_splat<T>(0.5) * a_4;
+  fft_complex_t<T> a_6 = sin_pi_3 * (x[5] - x[1]);
+  fft_complex_t<T> a_7 = x[0] + a_1;
 
-  float2 a_3_i = {a_3.y, -a_3.x};
-  float2 a_6_i = {a_6.y, -a_6.x};
-  float2 a_8 = a_2 + a_3_i;
-  float2 a_9 = a_2 - a_3_i;
-  float2 a_10 = x[3] + a_4;
-  float2 a_11 = a_5 + a_6_i;
-  float2 a_12 = a_5 - a_6_i;
+  fft_complex_t<T> a_3_i = fft_make_complex<T>(a_3.y, -a_3.x);
+  fft_complex_t<T> a_6_i = fft_make_complex<T>(a_6.y, -a_6.x);
+  fft_complex_t<T> a_8 = a_2 + a_3_i;
+  fft_complex_t<T> a_9 = a_2 - a_3_i;
+  fft_complex_t<T> a_10 = x[3] + a_4;
+  fft_complex_t<T> a_11 = a_5 + a_6_i;
+  fft_complex_t<T> a_12 = a_5 - a_6_i;
 
   y[0] = a_7 + a_10;
   y[1] = a_8 - a_11;
@@ -119,26 +173,30 @@ METAL_FUNC void radix6(thread float2* x, thread float2* y) {
   y[5] = a_9 - a_12;
 }
 
-METAL_FUNC void radix7(thread float2* x, thread float2* y) {
+template <typename T>
+METAL_FUNC void radix7(thread fft_complex_t<T>* x, thread fft_complex_t<T>* y) {
   // Rader's algorithm
-  float2 inv = {1 / 6.0, -1 / 6.0};
+  auto inv = fft_inverse_factor<T>(6);
 
   // fft
-  float2 in1[6] = {x[1], x[3], x[2], x[6], x[4], x[5]};
-  radix6(in1, y + 1);
+  fft_complex_t<T> in1[6] = {x[1], x[3], x[2], x[6], x[4], x[5]};
+  radix6<T>(in1, y + 1);
 
   y[0] = y[1] + x[0];
 
   // b_q
-  y[1] = complex_mul_conj(y[1], float2(-1, 0));
-  y[2] = complex_mul_conj(y[2], float2(2.44013336, -1.02261879));
-  y[3] = complex_mul_conj(y[3], float2(2.37046941, -1.17510629));
-  y[4] = complex_mul_conj(y[4], float2(0, -2.64575131));
-  y[5] = complex_mul_conj(y[5], float2(2.37046941, 1.17510629));
-  y[6] = complex_mul_conj(y[6], float2(-2.44013336, -1.02261879));
+  y[1] = complex_mul_conj<T>(y[1], fft_make_complex<T>(-1, 0));
+  y[2] =
+      complex_mul_conj<T>(y[2], fft_make_complex<T>(2.44013336, -1.02261879));
+  y[3] =
+      complex_mul_conj<T>(y[3], fft_make_complex<T>(2.37046941, -1.17510629));
+  y[4] = complex_mul_conj<T>(y[4], fft_make_complex<T>(0, -2.64575131));
+  y[5] = complex_mul_conj<T>(y[5], fft_make_complex<T>(2.37046941, 1.17510629));
+  y[6] =
+      complex_mul_conj<T>(y[6], fft_make_complex<T>(-2.44013336, -1.02261879));
 
   // ifft
-  radix6(y + 1, x + 1);
+  radix6<T>(y + 1, x + 1);
 
   y[1] = x[1] * inv + x[0];
   y[5] = x[2] * inv + x[0];
@@ -148,79 +206,90 @@ METAL_FUNC void radix7(thread float2* x, thread float2* y) {
   y[3] = x[6] * inv + x[0];
 }
 
-METAL_FUNC void radix8(thread float2* x, thread float2* y) {
-  float cos_pi_4 = 0.7071067811865476;
-  float2 w_0 = {cos_pi_4, -cos_pi_4};
-  float2 w_1 = {-cos_pi_4, -cos_pi_4};
-  float2 temp[8] = {x[0], x[2], x[4], x[6], x[1], x[3], x[5], x[7]};
-  radix4(temp, x);
-  radix4(temp + 4, x + 4);
+template <typename T>
+METAL_FUNC void radix8(thread fft_complex_t<T>* x, thread fft_complex_t<T>* y) {
+  auto cos_pi_4 = static_cast<T>(0.7071067811865476);
+  auto w_0 = fft_make_complex<T>(cos_pi_4, -cos_pi_4);
+  auto w_1 = fft_make_complex<T>(-cos_pi_4, -cos_pi_4);
+  fft_complex_t<T> temp[8] = {x[0], x[2], x[4], x[6], x[1], x[3], x[5], x[7]};
+  radix4<T>(temp, x);
+  radix4<T>(temp + 4, x + 4);
 
   y[0] = x[0] + x[4];
   y[4] = x[0] - x[4];
-  float2 x_5 = complex_mul(x[5], w_0);
+  fft_complex_t<T> x_5 = complex_mul<T>(x[5], w_0);
   y[1] = x[1] + x_5;
   y[5] = x[1] - x_5;
-  float2 x_6 = {x[6].y, -x[6].x};
+  fft_complex_t<T> x_6 = fft_make_complex<T>(x[6].y, -x[6].x);
   y[2] = x[2] + x_6;
   y[6] = x[2] - x_6;
-  float2 x_7 = complex_mul(x[7], w_1);
+  fft_complex_t<T> x_7 = complex_mul<T>(x[7], w_1);
   y[3] = x[3] + x_7;
   y[7] = x[3] - x_7;
 }
 
-template <bool raders_perm>
-METAL_FUNC void radix10(thread float2* x, thread float2* y) {
-  float2 w[4];
-  w[0] = {0.8090169943749475, -0.5877852522924731};
-  w[1] = {0.30901699437494745, -0.9510565162951535};
-  w[2] = {-w[1].x, w[1].y};
-  w[3] = {-w[0].x, w[0].y};
+template <typename T, bool raders_perm>
+METAL_FUNC void radix10(
+    thread fft_complex_t<T>* x,
+    thread fft_complex_t<T>* y) {
+  fft_complex_t<T> w[4];
+  w[0] = fft_make_complex<T>(0.8090169943749475, -0.5877852522924731);
+  w[1] = fft_make_complex<T>(0.30901699437494745, -0.9510565162951535);
+  w[2] = fft_make_complex<T>(-w[1].x, w[1].y);
+  w[3] = fft_make_complex<T>(-w[0].x, w[0].y);
 
   if (raders_perm) {
-    float2 temp[10] = {
+    fft_complex_t<T> temp[10] = {
         x[0], x[3], x[4], x[8], x[2], x[1], x[7], x[9], x[6], x[5]};
-    radix5(temp, x);
-    radix5(temp + 5, x + 5);
+    radix5<T>(temp, x);
+    radix5<T>(temp + 5, x + 5);
   } else {
-    float2 temp[10] = {
+    fft_complex_t<T> temp[10] = {
         x[0], x[2], x[4], x[6], x[8], x[1], x[3], x[5], x[7], x[9]};
-    radix5(temp, x);
-    radix5(temp + 5, x + 5);
+    radix5<T>(temp, x);
+    radix5<T>(temp + 5, x + 5);
   }
 
   y[0] = x[0] + x[5];
   y[5] = x[0] - x[5];
   for (int t = 1; t < 5; t++) {
-    float2 a = complex_mul(x[t + 5], w[t - 1]);
+    fft_complex_t<T> a = complex_mul<T>(x[t + 5], w[t - 1]);
     y[t] = x[t] + a;
     y[t + 5] = x[t] - a;
   }
 }
 
-METAL_FUNC void radix11(thread float2* x, thread float2* y) {
-  // Raders Algorithm
-  float2 inv = {1 / 10.0, -1 / 10.0};
+template <typename T>
+METAL_FUNC void radix11(
+    thread fft_complex_t<T>* x,
+    thread fft_complex_t<T>* y) {
+  // Rader's algorithm
+  auto inv = fft_inverse_factor<T>(10);
 
   // fft
-  radix10<true>(x + 1, y + 1);
+  radix10<T, true>(x + 1, y + 1);
 
   y[0] = y[1] + x[0];
 
   // b_q
-  y[1] = complex_mul_conj(y[1], float2(-1, 0));
-  y[2] = complex_mul_conj(y[2], float2(0.955301878, -3.17606649));
-  y[3] = complex_mul_conj(y[3], float2(2.63610556, 2.01269656));
-  y[4] = complex_mul_conj(y[4], float2(2.54127802, 2.13117479));
-  y[5] = complex_mul_conj(y[5], float2(2.07016210, 2.59122150));
-  y[6] = complex_mul_conj(y[6], float2(0, -3.31662479));
-  y[7] = complex_mul_conj(y[7], float2(2.07016210, -2.59122150));
-  y[8] = complex_mul_conj(y[8], float2(-2.54127802, 2.13117479));
-  y[9] = complex_mul_conj(y[9], float2(2.63610556, -2.01269656));
-  y[10] = complex_mul_conj(y[10], float2(-0.955301878, -3.17606649));
+  y[1] = complex_mul_conj<T>(y[1], fft_make_complex<T>(-1, 0));
+  y[2] =
+      complex_mul_conj<T>(y[2], fft_make_complex<T>(0.955301878, -3.17606649));
+  y[3] = complex_mul_conj<T>(y[3], fft_make_complex<T>(2.63610556, 2.01269656));
+  y[4] = complex_mul_conj<T>(y[4], fft_make_complex<T>(2.54127802, 2.13117479));
+  y[5] = complex_mul_conj<T>(y[5], fft_make_complex<T>(2.07016210, 2.59122150));
+  y[6] = complex_mul_conj<T>(y[6], fft_make_complex<T>(0, -3.31662479));
+  y[7] =
+      complex_mul_conj<T>(y[7], fft_make_complex<T>(2.07016210, -2.59122150));
+  y[8] =
+      complex_mul_conj<T>(y[8], fft_make_complex<T>(-2.54127802, 2.13117479));
+  y[9] =
+      complex_mul_conj<T>(y[9], fft_make_complex<T>(2.63610556, -2.01269656));
+  y[10] = complex_mul_conj<T>(
+      y[10], fft_make_complex<T>(-0.955301878, -3.17606649));
 
   // ifft
-  radix10<false>(y + 1, x + 1);
+  radix10<T, false>(y + 1, x + 1);
 
   y[1] = x[1] * inv + x[0];
   y[6] = x[2] * inv + x[0];
@@ -234,18 +303,20 @@ METAL_FUNC void radix11(thread float2* x, thread float2* y) {
   y[2] = x[10] * inv + x[0];
 }
 
-template <bool raders_perm>
-METAL_FUNC void radix12(thread float2* x, thread float2* y) {
-  float2 w[6];
-  float sin_pi_3 = 0.8660254037844387;
-  w[0] = {sin_pi_3, -0.5};
-  w[1] = {0.5, -sin_pi_3};
-  w[2] = {0, -1};
-  w[3] = {-0.5, -sin_pi_3};
-  w[4] = {-sin_pi_3, -0.5};
+template <typename T, bool raders_perm>
+METAL_FUNC void radix12(
+    thread fft_complex_t<T>* x,
+    thread fft_complex_t<T>* y) {
+  fft_complex_t<T> w[6];
+  auto sin_pi_3 = static_cast<T>(0.8660254037844387);
+  w[0] = fft_make_complex<T>(sin_pi_3, -0.5);
+  w[1] = fft_make_complex<T>(0.5, -sin_pi_3);
+  w[2] = fft_make_complex<T>(0, -1);
+  w[3] = fft_make_complex<T>(-0.5, -sin_pi_3);
+  w[4] = fft_make_complex<T>(-sin_pi_3, -0.5);
 
   if (raders_perm) {
-    float2 temp[12] = {
+    fft_complex_t<T> temp[12] = {
         x[0],
         x[3],
         x[2],
@@ -258,10 +329,10 @@ METAL_FUNC void radix12(thread float2* x, thread float2* y) {
         x[10],
         x[4],
         x[6]};
-    radix6(temp, x);
-    radix6(temp + 6, x + 6);
+    radix6<T>(temp, x);
+    radix6<T>(temp + 6, x + 6);
   } else {
-    float2 temp[12] = {
+    fft_complex_t<T> temp[12] = {
         x[0],
         x[2],
         x[4],
@@ -274,44 +345,55 @@ METAL_FUNC void radix12(thread float2* x, thread float2* y) {
         x[7],
         x[9],
         x[11]};
-    radix6(temp, x);
-    radix6(temp + 6, x + 6);
+    radix6<T>(temp, x);
+    radix6<T>(temp + 6, x + 6);
   }
 
   y[0] = x[0] + x[6];
   y[6] = x[0] - x[6];
   for (int t = 1; t < 6; t++) {
-    float2 a = complex_mul(x[t + 6], w[t - 1]);
+    fft_complex_t<T> a = complex_mul<T>(x[t + 6], w[t - 1]);
     y[t] = x[t] + a;
     y[t + 6] = x[t] - a;
   }
 }
 
-METAL_FUNC void radix13(thread float2* x, thread float2* y) {
-  // Raders Algorithm
-  float2 inv = {1 / 12.0, -1 / 12.0};
+template <typename T>
+METAL_FUNC void radix13(
+    thread fft_complex_t<T>* x,
+    thread fft_complex_t<T>* y) {
+  // Rader's algorithm
+  auto inv = fft_inverse_factor<T>(12);
 
   // fft
-  radix12<true>(x + 1, y + 1);
+  radix12<T, true>(x + 1, y + 1);
 
   y[0] = y[1] + x[0];
 
   // b_q
-  y[1] = complex_mul_conj(y[1], float2(-1, 0));
-  y[2] = complex_mul_conj(y[2], float2(3.07497206, -1.88269669));
-  y[3] = complex_mul_conj(y[3], float2(3.09912468, 1.84266823));
-  y[4] = complex_mul_conj(y[4], float2(3.45084438, -1.04483161));
-  y[5] = complex_mul_conj(y[5], float2(0.91083583, 3.48860690));
-  y[6] = complex_mul_conj(y[6], float2(-3.60286363, 0.139189267));
-  y[7] = complex_mul_conj(y[7], float2(3.60555128, 0));
-  y[8] = complex_mul_conj(y[8], float2(3.60286363, 0.139189267));
-  y[9] = complex_mul_conj(y[9], float2(0.91083583, -3.48860690));
-  y[10] = complex_mul_conj(y[10], float2(-3.45084438, -1.04483161));
-  y[11] = complex_mul_conj(y[11], float2(3.09912468, -1.84266823));
-  y[12] = complex_mul_conj(y[12], float2(-3.07497206, -1.88269669));
+  y[1] = complex_mul_conj<T>(y[1], fft_make_complex<T>(-1, 0));
+  y[2] =
+      complex_mul_conj<T>(y[2], fft_make_complex<T>(3.07497206, -1.88269669));
+  y[3] = complex_mul_conj<T>(y[3], fft_make_complex<T>(3.09912468, 1.84266823));
+  y[4] =
+      complex_mul_conj<T>(y[4], fft_make_complex<T>(3.45084438, -1.04483161));
+  y[5] = complex_mul_conj<T>(y[5], fft_make_complex<T>(0.91083583, 3.48860690));
+  y[6] =
+      complex_mul_conj<T>(y[6], fft_make_complex<T>(-3.60286363, 0.139189267));
+  y[7] = complex_mul_conj<T>(y[7], fft_make_complex<T>(3.60555128, 0));
+  y[8] =
+      complex_mul_conj<T>(y[8], fft_make_complex<T>(3.60286363, 0.139189267));
+  y[9] =
+      complex_mul_conj<T>(y[9], fft_make_complex<T>(0.91083583, -3.48860690));
+  y[10] =
+      complex_mul_conj<T>(y[10], fft_make_complex<T>(-3.45084438, -1.04483161));
+  y[11] =
+      complex_mul_conj<T>(y[11], fft_make_complex<T>(3.09912468, -1.84266823));
+  y[12] =
+      complex_mul_conj<T>(y[12], fft_make_complex<T>(-3.07497206, -1.88269669));
 
   // ifft
-  radix12<false>(y + 1, x + 1);
+  radix12<T, false>(y + 1, x + 1);
 
   y[1] = x[1] * inv + x[0];
   y[7] = x[2] * inv + x[0];

--- a/mlx/backend/metal/kernels/fft/readwrite.h
+++ b/mlx/backend/metal/kernels/fft/readwrite.h
@@ -27,14 +27,43 @@ Each with support for:
 
 using namespace metal;
 
+// Derives the FFT scalar arithmetic type from a storage type.
+template <typename storage_T>
+struct FFTStorageTraits {
+  using scalar_T = storage_T;
+};
+
+template <typename T>
+struct FFTStorageTraits<vec<T, 2>> {
+  using scalar_T = T;
+};
+
+template <typename in_T, typename out_T>
+struct FFTIOTypeTraits {
+  using scalar_T = typename FFTStorageTraits<in_T>::scalar_T;
+
+  static_assert(
+      metal::is_same_v<scalar_T, typename FFTStorageTraits<out_T>::scalar_T>,
+      "FFT input and output storage must share a scalar arithmetic type");
+  static_assert(
+      sizeof(in_T) <= 16 && 16 % sizeof(in_T) == 0,
+      "FFT input storage must divide the 128-bit sequential access width");
+  static_assert(
+      sizeof(out_T) <= 16 && 16 % sizeof(out_T) == 0,
+      "FFT output storage must divide the 128-bit sequential access width");
+};
+
 template <
     typename in_T,
     typename out_T,
     int step = 0,
     bool four_step_real = false>
 struct ReadWriter {
+  using scalar_T = typename FFTIOTypeTraits<in_T, out_T>::scalar_T;
+  using complex_T = vec<scalar_T, 2>;
+
   const device in_T* in;
-  threadgroup float2* buf;
+  threadgroup complex_T* buf;
   device out_T* out;
   int n;
   int batch_size;
@@ -50,7 +79,7 @@ struct ReadWriter {
 
   METAL_FUNC ReadWriter(
       const device in_T* in_,
-      threadgroup float2* buf_,
+      threadgroup complex_T* buf_,
       device out_T* out_,
       const short n_,
       const int batch_size_,
@@ -73,21 +102,21 @@ struct ReadWriter {
   }
 
   // ifft(x) = 1/n * conj(fft(conj(x)))
-  METAL_FUNC float2 post_in(float2 elem) const thread {
-    return inv ? float2(elem.x, -elem.y) : elem;
+  METAL_FUNC complex_T post_in(complex_T elem) const thread {
+    return inv ? complex_T(elem.x, -elem.y) : elem;
   }
 
   // Handle float case for generic RFFT alg
-  METAL_FUNC float2 post_in(float elem) const thread {
-    return float2(elem, 0);
+  METAL_FUNC complex_T post_in(scalar_T elem) const thread {
+    return complex_T(elem, 0);
   }
 
-  METAL_FUNC float2 pre_out(float2 elem) const thread {
-    return inv ? float2(elem.x / n, -elem.y / n) : elem;
+  METAL_FUNC complex_T pre_out(complex_T elem) const thread {
+    return inv ? complex_T(elem.x / n, -elem.y / n) : elem;
   }
 
-  METAL_FUNC float2 pre_out(float2 elem, int length) const thread {
-    return inv ? float2(elem.x / length, -elem.y / length) : elem;
+  METAL_FUNC complex_T pre_out(complex_T elem, int length) const thread {
+    return inv ? complex_T(elem.x / length, -elem.y / length) : elem;
   }
 
   METAL_FUNC bool out_of_bounds() const thread {
@@ -99,21 +128,22 @@ struct ReadWriter {
   METAL_FUNC void load() const thread {
     size_t batch_idx = size_t(elem.x * grid.y) * n;
     short tg_idx = elem.y * grid.z + elem.z;
-    short max_index = grid.y * n - 2;
-
-    // 2 complex64s = 128 bits
-    constexpr int read_width = 2;
-    for (short e = 0; e < (elems_per_thread / read_width); e++) {
+    // Keep each thread's sequential access at 128 bits where possible.
+    constexpr int read_width = 16 / sizeof(in_T);
+    short max_full_index = grid.y * n - read_width;
+    short full_width_reads = elems_per_thread / read_width;
+    for (short e = 0; e < full_width_reads; e++) {
       short index = read_width * tg_idx + read_width * threads_per_tg * e;
-      index = metal::min(index, max_index);
+      index = metal::min(index, max_full_index);
       // vectorized reads
-      buf[index] = post_in(in[batch_idx + index]);
-      buf[index + 1] = post_in(in[batch_idx + index + 1]);
+      for (short r = 0; r < read_width; r++) {
+        buf[index + r] = post_in(in[batch_idx + index + r]);
+      }
     }
-    max_index += 1;
-    if (elems_per_thread % 2 != 0) {
-      short index = tg_idx +
-          read_width * threads_per_tg * (elems_per_thread / read_width);
+    short max_index = grid.y * n - 1;
+    for (short r = 0; r < elems_per_thread % read_width; r++) {
+      short index = tg_idx + r * threads_per_tg +
+          read_width * threads_per_tg * full_width_reads;
       index = metal::min(index, max_index);
       buf[index] = post_in(in[batch_idx + index]);
     }
@@ -122,57 +152,60 @@ struct ReadWriter {
   METAL_FUNC void write() const thread {
     size_t batch_idx = size_t(elem.x * grid.y) * n;
     short tg_idx = elem.y * grid.z + elem.z;
-    short max_index = grid.y * n - 2;
-
-    constexpr int read_width = 2;
-    for (short e = 0; e < (elems_per_thread / read_width); e++) {
+    constexpr int read_width = 16 / sizeof(out_T);
+    short max_full_index = grid.y * n - read_width;
+    short full_width_reads = elems_per_thread / read_width;
+    for (short e = 0; e < full_width_reads; e++) {
       short index = read_width * tg_idx + read_width * threads_per_tg * e;
-      index = metal::min(index, max_index);
+      index = metal::min(index, max_full_index);
       // vectorized reads
-      out[batch_idx + index] = pre_out(buf[index]);
-      out[batch_idx + index + 1] = pre_out(buf[index + 1]);
+      for (short r = 0; r < read_width; r++) {
+        out[batch_idx + index + r] = pre_out(buf[index + r]);
+      }
     }
-    max_index += 1;
-    if (elems_per_thread % 2 != 0) {
-      short index = tg_idx +
-          read_width * threads_per_tg * (elems_per_thread / read_width);
+    short max_index = grid.y * n - 1;
+    for (short r = 0; r < elems_per_thread % read_width; r++) {
+      short index = tg_idx + r * threads_per_tg +
+          read_width * threads_per_tg * full_width_reads;
       index = metal::min(index, max_index);
       out[batch_idx + index] = pre_out(buf[index]);
     }
   }
 
   // Padded IO for Bluestein's algorithm
-  METAL_FUNC void load_padded(int length, const device float2* w_k)
+  METAL_FUNC void load_padded(int length, const device complex_T* w_k)
       const thread {
     size_t batch_idx = size_t(elem.x * grid.y) * length + elem.y * length;
     int fft_idx = elem.z;
     int m = grid.z;
 
-    threadgroup float2* seq_buf = buf + elem.y * n;
+    threadgroup complex_T* seq_buf = buf + elem.y * n;
     for (int e = 0; e < elems_per_thread; e++) {
       int index = metal::min(fft_idx + e * m, n - 1);
       if (index < length) {
-        float2 elem = post_in(in[batch_idx + index]);
-        seq_buf[index] = complex_mul(elem, w_k[index]);
+        complex_T elem = post_in(in[batch_idx + index]);
+        seq_buf[index] = complex_mul<scalar_T>(elem, w_k[index]);
       } else {
         seq_buf[index] = 0.0;
       }
     }
   }
 
-  METAL_FUNC void write_padded(int length, const device float2* w_k)
+  METAL_FUNC void write_padded(int length, const device complex_T* w_k)
       const thread {
     size_t batch_idx = size_t(elem.x * grid.y) * length + elem.y * length;
     int fft_idx = elem.z;
     int m = grid.z;
-    float2 inv_factor = {1.0f / n, -1.0f / n};
+    scalar_T inv_n = static_cast<scalar_T>(1.0f / n);
+    complex_T inv_factor = {inv_n, -inv_n};
 
-    threadgroup float2* seq_buf = buf + elem.y * n;
+    threadgroup complex_T* seq_buf = buf + elem.y * n;
     for (int e = 0; e < elems_per_thread; e++) {
       int index = metal::min(fft_idx + e * m, n - 1);
       if (index < length) {
-        float2 elem = seq_buf[index + length - 1] * inv_factor;
-        out[batch_idx + index] = pre_out(complex_mul(elem, w_k[index]), length);
+        complex_T elem = seq_buf[index + length - 1] * inv_factor;
+        out[batch_idx + index] =
+            pre_out(complex_mul<scalar_T>(elem, w_k[index]), length);
       }
     }
   }
@@ -199,53 +232,49 @@ struct ReadWriter {
         tg_idx / coalesce_width * elems_per_thread;
   }
 
-  // Four Step FFT First Step
+  // Four-step FFT I/O
   METAL_FUNC void load_strided(int stride, int overall_n) thread {
-    compute_strided_indices(stride, overall_n);
-    for (int e = 0; e < elems_per_thread; e++) {
-      buf[strided_shared_idx + e] =
-          post_in(in[strided_device_idx + e * stride]);
+    if constexpr (step == 1 && !four_step_real) {
+      // Do not invert between C2C four-step passes.
+      (void)stride;
+      (void)overall_n;
+      bool default_inv = inv;
+      inv = false;
+      load();
+      inv = default_inv;
+    } else {
+      compute_strided_indices(stride, overall_n);
+      for (int e = 0; e < elems_per_thread; e++) {
+        buf[strided_shared_idx + e] =
+            post_in(in[strided_device_idx + e * stride]);
+      }
     }
   }
 
   METAL_FUNC void write_strided(int stride, int overall_n) thread {
-    for (int e = 0; e < elems_per_thread; e++) {
-      float2 output = buf[strided_shared_idx + e];
-      int combined_idx = (strided_device_idx + e * stride) % overall_n;
-      int ij = (combined_idx / stride) * (combined_idx % stride);
-      // Apply four step twiddles at end of first step
-      float2 twiddle = get_twiddle(ij, overall_n);
-      out[strided_device_idx + e * stride] = complex_mul(output, twiddle);
+    if constexpr (step == 1 && !four_step_real) {
+      compute_strided_indices(stride, overall_n);
+      for (int e = 0; e < elems_per_thread; e++) {
+        out[strided_device_idx + e * stride] =
+            pre_out(buf[strided_shared_idx + e], overall_n);
+      }
+    } else {
+      for (int e = 0; e < elems_per_thread; e++) {
+        complex_T output = buf[strided_shared_idx + e];
+        int combined_idx = (strided_device_idx + e * stride) % overall_n;
+        int ij = (combined_idx / stride) * (combined_idx % stride);
+        // Apply four step twiddles at end of first step
+        complex_T twiddle = get_twiddle<scalar_T>(ij, overall_n);
+        out[strided_device_idx + e * stride] =
+            complex_mul<scalar_T>(output, twiddle);
+      }
     }
   }
 };
 
-// Four Step FFT Second Step
-template <>
-METAL_FUNC void ReadWriter<float2, float2, /*step=*/1>::load_strided(
-    int stride,
-    int overall_n) thread {
-  // Silence compiler warnings
-  (void)stride;
-  (void)overall_n;
-  // Don't invert between steps
-  bool default_inv = inv;
-  inv = false;
-  load();
-  inv = default_inv;
-}
-
-template <>
-METAL_FUNC void ReadWriter<float2, float2, /*step=*/1>::write_strided(
-    int stride,
-    int overall_n) thread {
-  compute_strided_indices(stride, overall_n);
-  for (int e = 0; e < elems_per_thread; e++) {
-    float2 output = buf[strided_shared_idx + e];
-    out[strided_device_idx + e * stride] = pre_out(output, overall_n);
-  }
-}
-
+// Packed RFFT/IRFFT remains float-specific. This generic foundation covers
+// C2C storage; reduced-precision real transforms need separate host dispatch.
+//
 // For RFFT, we interleave batches of two real sequences into one complex one:
 //
 // z_k = x_k + j.y_k
@@ -310,7 +339,7 @@ METAL_FUNC void ReadWriter<float, float2>::write() const thread {
       float2 x_n_minus_k = seq_buf[n - index] * conj;
       out[batch_idx + index] = (x_k + x_n_minus_k) / 2;
       out[batch_idx + index + next_out] =
-          complex_mul(((x_k - x_n_minus_k) / 2), minus_j);
+          complex_mul<float>(((x_k - x_n_minus_k) / 2), minus_j);
     }
   }
 }
@@ -335,7 +364,7 @@ METAL_FUNC void ReadWriter<float, float2>::load_padded(
     if (index < length) {
       float2 elem =
           float2(in[batch_idx + index], in[batch_idx + index + next_in]);
-      seq_buf[index] = complex_mul(elem, w_k[index]);
+      seq_buf[index] = complex_mul<float>(elem, w_k[index]);
     } else {
       seq_buf[index] = 0;
     }
@@ -368,18 +397,18 @@ METAL_FUNC void ReadWriter<float, float2>::write_padded(
     // x_0 = z_0.real
     // y_0 = z_0.imag
     if (index == 0) {
-      float2 elem = complex_mul(w_k[index], seq_buf[index] * inv_factor);
+      float2 elem = complex_mul<float>(w_k[index], seq_buf[index] * inv_factor);
       out[batch_idx + index] = float2(elem.x, 0);
       out[batch_idx + index + next_out] = float2(elem.y, 0);
     } else {
-      float2 x_k = complex_mul(w_k[index], seq_buf[index] * inv_factor);
-      float2 x_n_minus_k = complex_mul(
+      float2 x_k = complex_mul<float>(w_k[index], seq_buf[index] * inv_factor);
+      float2 x_n_minus_k = complex_mul<float>(
           w_k[length - index], seq_buf[length - index] * inv_factor);
       x_n_minus_k *= conj;
       // w_k should happen before this extraction
       out[batch_idx + index] = (x_k + x_n_minus_k) / 2;
       out[batch_idx + index + next_out] =
-          complex_mul(((x_k - x_n_minus_k) / 2), minus_j);
+          complex_mul<float>(((x_k - x_n_minus_k) / 2), minus_j);
     }
   }
 }
@@ -426,10 +455,10 @@ METAL_FUNC void ReadWriter<float2, float>::load() const thread {
       x = float2(x.x, 0);
       y = float2(y.x, 0);
     }
-    seq_buf[index] = x + complex_mul(y, plus_j);
+    seq_buf[index] = x + complex_mul<float>(y, plus_j);
     seq_buf[index].y = -seq_buf[index].y;
     if (index > 0 && !last_val) {
-      seq_buf[n - index] = (x * conj) + complex_mul(y * conj, plus_j);
+      seq_buf[n - index] = (x * conj) + complex_mul<float>(y * conj, plus_j);
       seq_buf[n - index].y = -seq_buf[n - index].y;
     }
   }
@@ -487,12 +516,12 @@ METAL_FUNC void ReadWriter<float2, float>::load_padded(
         x = float2(x.x, 0);
         y = float2(y.x, 0);
       }
-      float2 elem1 = x + complex_mul(y, plus_j);
-      seq_buf[index] = complex_mul(elem1 * conj, w_k[index]);
+      float2 elem1 = x + complex_mul<float>(y, plus_j);
+      seq_buf[index] = complex_mul<float>(elem1 * conj, w_k[index]);
       if (index > 0 && !last_val) {
-        float2 elem2 = (x * conj) + complex_mul(y * conj, plus_j);
+        float2 elem2 = (x * conj) + complex_mul<float>(y * conj, plus_j);
         seq_buf[length - index] =
-            complex_mul(elem2 * conj, w_k[length - index]);
+            complex_mul<float>(elem2 * conj, w_k[length - index]);
       }
     } else {
       short pad_index = metal::min(length + (index - length_over_2) * 2, n - 2);
@@ -520,7 +549,8 @@ METAL_FUNC void ReadWriter<float2, float>::write_padded(
   for (int e = 0; e < elems_per_thread; e++) {
     int index = fft_idx + e * m;
     if (index < length) {
-      float2 output = complex_mul(seq_buf[index] * inv_factor, w_k[index]);
+      float2 output =
+          complex_mul<float>(seq_buf[index] * inv_factor, w_k[index]);
       out[batch_idx + index] = output.x / length;
       out[batch_idx + index + next_out] = output.y / -length;
     }

--- a/mlx/backend/metal/kernels/fft/readwrite.h
+++ b/mlx/backend/metal/kernels/fft/readwrite.h
@@ -27,14 +27,88 @@ Each with support for:
 
 using namespace metal;
 
+// A value trait supplies the scalar arithmetic type, whether its storage is
+// complex, and the explicit load/store conversion. This lets every FFT layer
+// derive its complex representation from the IO types instead of carrying a
+// manually selected scalar type through the call stack.
+template <typename storage_T>
+struct FFTValueTraits {
+  static_assert(
+      metal::is_floating_point_v<storage_T>,
+      "FFT real storage must use a floating-point scalar type");
+
+  using scalar_T = storage_T;
+  using complex_T = fft_complex_t<scalar_T>;
+  static constexpr constant bool is_complex = false;
+
+  static_assert(
+      sizeof(complex_T) == 2 * sizeof(scalar_T),
+      "FFT complex storage must be exactly two scalar lanes");
+
+  static METAL_FUNC complex_T load(storage_T value) {
+    return fft_make_real<scalar_T>(value);
+  }
+
+  static METAL_FUNC storage_T store(complex_T value) {
+    return value.x;
+  }
+};
+
+template <typename T>
+struct FFTValueTraits<vec<T, 2>> {
+  static_assert(
+      metal::is_floating_point_v<T>,
+      "FFT complex storage must use floating-point scalar lanes");
+
+  using scalar_T = T;
+  using complex_T = fft_complex_t<scalar_T>;
+  static constexpr constant bool is_complex = true;
+
+  static_assert(
+      sizeof(complex_T) == sizeof(vec<T, 2>),
+      "FFT complex storage must preserve the input vector layout");
+
+  static METAL_FUNC complex_T load(complex_T value) {
+    return value;
+  }
+
+  static METAL_FUNC complex_T store(complex_T value) {
+    return value;
+  }
+};
+
+template <typename in_T, typename out_T>
+struct FFTIOTypeTraits {
+  using in_traits = FFTValueTraits<in_T>;
+  using out_traits = FFTValueTraits<out_T>;
+  using scalar_T = typename in_traits::scalar_T;
+
+  static_assert(
+      metal::is_same_v<scalar_T, typename out_traits::scalar_T>,
+      "FFT input and output storage must share a scalar arithmetic type");
+  static_assert(
+      in_traits::is_complex || out_traits::is_complex,
+      "FFT requires complex input or output storage");
+  static_assert(
+      sizeof(in_T) <= 16 && 16 % sizeof(in_T) == 0,
+      "FFT input storage must divide the 128-bit sequential access width");
+  static_assert(
+      sizeof(out_T) <= 16 && 16 % sizeof(out_T) == 0,
+      "FFT output storage must divide the 128-bit sequential access width");
+};
+
 template <
     typename in_T,
     typename out_T,
     int step = 0,
     bool four_step_real = false>
 struct ReadWriter {
+  using io_traits = FFTIOTypeTraits<in_T, out_T>;
+  using scalar_T = typename io_traits::scalar_T;
+  using complex_T = fft_complex_t<scalar_T>;
+
   const device in_T* in;
-  threadgroup float2* buf;
+  threadgroup complex_T* buf;
   device out_T* out;
   int n;
   int batch_size;
@@ -50,7 +124,7 @@ struct ReadWriter {
 
   METAL_FUNC ReadWriter(
       const device in_T* in_,
-      threadgroup float2* buf_,
+      threadgroup complex_T* buf_,
       device out_T* out_,
       const short n_,
       const int batch_size_,
@@ -74,21 +148,22 @@ struct ReadWriter {
   }
 
   // ifft(x) = 1/n * conj(fft(conj(x)))
-  METAL_FUNC float2 post_in(float2 elem) const {
-    return inv ? float2(elem.x, -elem.y) : elem;
+  METAL_FUNC complex_T post_in(in_T elem) const {
+    auto value = FFTValueTraits<in_T>::load(elem);
+    return inv ? fft_make_complex<scalar_T>(value.x, -value.y) : value;
   }
 
-  // Handle float case for generic RFFT alg
-  METAL_FUNC float2 post_in(float elem) const {
-    return float2(elem, 0);
+  METAL_FUNC complex_T pre_out(complex_T elem) const {
+    auto length = static_cast<scalar_T>(n);
+    return inv ? fft_make_complex<scalar_T>(elem.x / length, -elem.y / length)
+               : elem;
   }
 
-  METAL_FUNC float2 pre_out(float2 elem) const {
-    return inv ? float2(elem.x / n, -elem.y / n) : elem;
-  }
-
-  METAL_FUNC float2 pre_out(float2 elem, int length) const {
-    return inv ? float2(elem.x / length, -elem.y / length) : elem;
+  METAL_FUNC complex_T pre_out(complex_T elem, int length) const {
+    auto scalar_length = static_cast<scalar_T>(length);
+    return inv ? fft_make_complex<scalar_T>(
+                     elem.x / scalar_length, -elem.y / scalar_length)
+               : elem;
   }
 
   METAL_FUNC bool out_of_bounds() const {
@@ -100,21 +175,22 @@ struct ReadWriter {
   METAL_FUNC void load() const {
     size_t batch_idx = size_t(elem.x * grid.y) * n;
     short tg_idx = elem.y * grid.z + elem.z;
-    short max_index = grid.y * n - 2;
-
-    // 2 complex64s = 128 bits
-    constexpr int read_width = 2;
-    for (short e = 0; e < (elems_per_thread / read_width); e++) {
+    // Keep each thread's sequential access at 128 bits where possible.
+    constexpr int read_width = 16 / sizeof(in_T);
+    short max_full_index = grid.y * n - read_width;
+    short full_width_reads = elems_per_thread / read_width;
+    for (short e = 0; e < full_width_reads; e++) {
       short index = read_width * tg_idx + read_width * threads_per_tg * e;
-      index = metal::min(index, max_index);
+      index = metal::min(index, max_full_index);
       // vectorized reads
-      buf[index] = post_in(in[batch_idx + index]);
-      buf[index + 1] = post_in(in[batch_idx + index + 1]);
+      for (short r = 0; r < read_width; r++) {
+        buf[index + r] = post_in(in[batch_idx + index + r]);
+      }
     }
-    max_index += 1;
-    if (elems_per_thread % 2 != 0) {
-      short index = tg_idx +
-          read_width * threads_per_tg * (elems_per_thread / read_width);
+    short max_index = grid.y * n - 1;
+    for (short r = 0; r < elems_per_thread % read_width; r++) {
+      short index = tg_idx + r * threads_per_tg +
+          read_width * threads_per_tg * full_width_reads;
       index = metal::min(index, max_index);
       buf[index] = post_in(in[batch_idx + index]);
     }
@@ -123,55 +199,60 @@ struct ReadWriter {
   METAL_FUNC void write() const {
     size_t batch_idx = size_t(elem.x * grid.y) * n;
     short tg_idx = elem.y * grid.z + elem.z;
-    short max_index = grid.y * n - 2;
-
-    constexpr int read_width = 2;
-    for (short e = 0; e < (elems_per_thread / read_width); e++) {
+    constexpr int read_width = 16 / sizeof(out_T);
+    short max_full_index = grid.y * n - read_width;
+    short full_width_reads = elems_per_thread / read_width;
+    for (short e = 0; e < full_width_reads; e++) {
       short index = read_width * tg_idx + read_width * threads_per_tg * e;
-      index = metal::min(index, max_index);
+      index = metal::min(index, max_full_index);
       // vectorized reads
-      out[batch_idx + index] = pre_out(buf[index]);
-      out[batch_idx + index + 1] = pre_out(buf[index + 1]);
+      for (short r = 0; r < read_width; r++) {
+        out[batch_idx + index + r] =
+            FFTValueTraits<out_T>::store(pre_out(buf[index + r]));
+      }
     }
-    max_index += 1;
-    if (elems_per_thread % 2 != 0) {
-      short index = tg_idx +
-          read_width * threads_per_tg * (elems_per_thread / read_width);
+    short max_index = grid.y * n - 1;
+    for (short r = 0; r < elems_per_thread % read_width; r++) {
+      short index = tg_idx + r * threads_per_tg +
+          read_width * threads_per_tg * full_width_reads;
       index = metal::min(index, max_index);
-      out[batch_idx + index] = pre_out(buf[index]);
+      out[batch_idx + index] =
+          FFTValueTraits<out_T>::store(pre_out(buf[index]));
     }
   }
 
   // Padded IO for Bluestein's algorithm
-  METAL_FUNC void load_padded(int length, const device float2* w_k) const {
+  METAL_FUNC void load_padded(int length, const device complex_T* w_k) const {
     size_t batch_idx = size_t(elem.x * grid.y) * length + elem.y * length;
     int fft_idx = elem.z;
     int m = grid.z;
 
-    threadgroup float2* seq_buf = buf + elem.y * n;
+    threadgroup complex_T* seq_buf = buf + elem.y * n;
     for (int e = 0; e < elems_per_thread; e++) {
       int index = metal::min(fft_idx + e * m, n - 1);
       if (index < length) {
-        float2 elem = post_in(in[batch_idx + index]);
-        seq_buf[index] = complex_mul(elem, w_k[index]);
+        complex_T elem = post_in(in[batch_idx + index]);
+        seq_buf[index] = complex_mul<scalar_T>(elem, w_k[index]);
       } else {
-        seq_buf[index] = 0.0;
+        seq_buf[index] = fft_make_real<scalar_T>(0);
       }
     }
   }
 
-  METAL_FUNC void write_padded(int length, const device float2* w_k) const {
+  METAL_FUNC void write_padded(int length, const device complex_T* w_k) const {
     size_t batch_idx = size_t(elem.x * grid.y) * length + elem.y * length;
     int fft_idx = elem.z;
     int m = grid.z;
-    float2 inv_factor = {1.0f / n, -1.0f / n};
+    auto inv_n = fft_reciprocal<scalar_T>(n);
+    complex_T inv_factor = fft_make_complex<scalar_T>(inv_n, -inv_n);
 
-    threadgroup float2* seq_buf = buf + elem.y * n;
+    threadgroup complex_T* seq_buf = buf + elem.y * n;
     for (int e = 0; e < elems_per_thread; e++) {
       int index = metal::min(fft_idx + e * m, n - 1);
       if (index < length) {
-        float2 elem = seq_buf[index + length - 1] * inv_factor;
-        out[batch_idx + index] = pre_out(complex_mul(elem, w_k[index]), length);
+        complex_T elem = seq_buf[index + length - 1] * inv_factor;
+        out[batch_idx + index] = FFTValueTraits<out_T>::store(
+            pre_out(complex_mul<scalar_T>(elem, w_k[index]), length));
       }
     }
   }
@@ -198,53 +279,49 @@ struct ReadWriter {
         tg_idx / coalesce_width * elems_per_thread;
   }
 
-  // Four Step FFT First Step
+  // Four-step FFT I/O
   METAL_FUNC void load_strided(int stride, int overall_n) {
-    compute_strided_indices(stride, overall_n);
-    for (int e = 0; e < elems_per_thread; e++) {
-      buf[strided_shared_idx + e] =
-          post_in(in[strided_device_idx + e * stride]);
+    if constexpr (step == 1 && !four_step_real) {
+      // Do not invert between C2C four-step passes.
+      (void)stride;
+      (void)overall_n;
+      bool default_inv = inv;
+      inv = false;
+      load();
+      inv = default_inv;
+    } else {
+      compute_strided_indices(stride, overall_n);
+      for (int e = 0; e < elems_per_thread; e++) {
+        buf[strided_shared_idx + e] =
+            post_in(in[strided_device_idx + e * stride]);
+      }
     }
   }
 
   METAL_FUNC void write_strided(int stride, int overall_n) {
-    for (int e = 0; e < elems_per_thread; e++) {
-      float2 output = buf[strided_shared_idx + e];
-      int combined_idx = (strided_device_idx + e * stride) % overall_n;
-      int ij = (combined_idx / stride) * (combined_idx % stride);
-      // Apply four step twiddles at end of first step
-      float2 twiddle = get_twiddle(ij, overall_n);
-      out[strided_device_idx + e * stride] = complex_mul(output, twiddle);
+    if constexpr (step == 1 && !four_step_real) {
+      compute_strided_indices(stride, overall_n);
+      for (int e = 0; e < elems_per_thread; e++) {
+        out[strided_device_idx + e * stride] = FFTValueTraits<out_T>::store(
+            pre_out(buf[strided_shared_idx + e], overall_n));
+      }
+    } else {
+      for (int e = 0; e < elems_per_thread; e++) {
+        complex_T output = buf[strided_shared_idx + e];
+        int combined_idx = (strided_device_idx + e * stride) % overall_n;
+        int ij = (combined_idx / stride) * (combined_idx % stride);
+        // Apply four step twiddles at end of first step
+        complex_T twiddle = get_twiddle<scalar_T>(ij, overall_n);
+        out[strided_device_idx + e * stride] = FFTValueTraits<out_T>::store(
+            complex_mul<scalar_T>(output, twiddle));
+      }
     }
   }
 };
 
-// Four Step FFT Second Step
-template <>
-METAL_FUNC void ReadWriter<float2, float2, /*step=*/1>::load_strided(
-    int stride,
-    int overall_n) {
-  // Silence compiler warnings
-  (void)stride;
-  (void)overall_n;
-  // Don't invert between steps
-  bool default_inv = inv;
-  inv = false;
-  load();
-  inv = default_inv;
-}
-
-template <>
-METAL_FUNC void ReadWriter<float2, float2, /*step=*/1>::write_strided(
-    int stride,
-    int overall_n) {
-  compute_strided_indices(stride, overall_n);
-  for (int e = 0; e < elems_per_thread; e++) {
-    float2 output = buf[strided_shared_idx + e];
-    out[strided_device_idx + e * stride] = pre_out(output, overall_n);
-  }
-}
-
+// Packed RFFT/IRFFT remains float-specific. This generic foundation covers
+// C2C storage; reduced-precision real transforms need separate host dispatch.
+//
 // For RFFT, we interleave batches of two real sequences into one complex one:
 //
 // z_k = x_k + j.y_k
@@ -309,7 +386,7 @@ METAL_FUNC void ReadWriter<float, float2>::write() const {
       float2 x_n_minus_k = seq_buf[n - index] * conj;
       out[batch_idx + index] = (x_k + x_n_minus_k) / 2;
       out[batch_idx + index + next_out] =
-          complex_mul(((x_k - x_n_minus_k) / 2), minus_j);
+          complex_mul<float>(((x_k - x_n_minus_k) / 2), minus_j);
     }
   }
 }
@@ -334,7 +411,7 @@ METAL_FUNC void ReadWriter<float, float2>::load_padded(
     if (index < length) {
       float2 elem =
           float2(in[batch_idx + index], in[batch_idx + index + next_in]);
-      seq_buf[index] = complex_mul(elem, w_k[index]);
+      seq_buf[index] = complex_mul<float>(elem, w_k[index]);
     } else {
       seq_buf[index] = 0;
     }
@@ -367,18 +444,18 @@ METAL_FUNC void ReadWriter<float, float2>::write_padded(
     // x_0 = z_0.real
     // y_0 = z_0.imag
     if (index == 0) {
-      float2 elem = complex_mul(w_k[index], seq_buf[index] * inv_factor);
+      float2 elem = complex_mul<float>(w_k[index], seq_buf[index] * inv_factor);
       out[batch_idx + index] = float2(elem.x, 0);
       out[batch_idx + index + next_out] = float2(elem.y, 0);
     } else {
-      float2 x_k = complex_mul(w_k[index], seq_buf[index] * inv_factor);
-      float2 x_n_minus_k = complex_mul(
+      float2 x_k = complex_mul<float>(w_k[index], seq_buf[index] * inv_factor);
+      float2 x_n_minus_k = complex_mul<float>(
           w_k[length - index], seq_buf[length - index] * inv_factor);
       x_n_minus_k *= conj;
       // w_k should happen before this extraction
       out[batch_idx + index] = (x_k + x_n_minus_k) / 2;
       out[batch_idx + index + next_out] =
-          complex_mul(((x_k - x_n_minus_k) / 2), minus_j);
+          complex_mul<float>(((x_k - x_n_minus_k) / 2), minus_j);
     }
   }
 }
@@ -425,10 +502,10 @@ METAL_FUNC void ReadWriter<float2, float>::load() const {
       x = float2(x.x, 0);
       y = float2(y.x, 0);
     }
-    seq_buf[index] = x + complex_mul(y, plus_j);
+    seq_buf[index] = x + complex_mul<float>(y, plus_j);
     seq_buf[index].y = -seq_buf[index].y;
     if (index > 0 && !last_val) {
-      seq_buf[n - index] = (x * conj) + complex_mul(y * conj, plus_j);
+      seq_buf[n - index] = (x * conj) + complex_mul<float>(y * conj, plus_j);
       seq_buf[n - index].y = -seq_buf[n - index].y;
     }
   }
@@ -486,12 +563,12 @@ METAL_FUNC void ReadWriter<float2, float>::load_padded(
         x = float2(x.x, 0);
         y = float2(y.x, 0);
       }
-      float2 elem1 = x + complex_mul(y, plus_j);
-      seq_buf[index] = complex_mul(elem1 * conj, w_k[index]);
+      float2 elem1 = x + complex_mul<float>(y, plus_j);
+      seq_buf[index] = complex_mul<float>(elem1 * conj, w_k[index]);
       if (index > 0 && !last_val) {
-        float2 elem2 = (x * conj) + complex_mul(y * conj, plus_j);
+        float2 elem2 = (x * conj) + complex_mul<float>(y * conj, plus_j);
         seq_buf[length - index] =
-            complex_mul(elem2 * conj, w_k[length - index]);
+            complex_mul<float>(elem2 * conj, w_k[length - index]);
       }
     } else {
       short pad_index = metal::min(length + (index - length_over_2) * 2, n - 2);
@@ -519,7 +596,8 @@ METAL_FUNC void ReadWriter<float2, float>::write_padded(
   for (int e = 0; e < elems_per_thread; e++) {
     int index = fft_idx + e * m;
     if (index < length) {
-      float2 output = complex_mul(seq_buf[index] * inv_factor, w_k[index]);
+      float2 output =
+          complex_mul<float>(seq_buf[index] * inv_factor, w_k[index]);
       out[batch_idx + index] = output.x / length;
       out[batch_idx + index + next_out] = output.y / -length;
     }


### PR DESCRIPTION
## Motivation

MLX's Metal C2C FFT core hard-codes `float2`. This PR is the narrow Metal-kernel foundation for [#2112](https://github.com/ml-explore/mlx/issues/2112): it removes that source-level coupling so a later, end-to-end reduced-precision complex proposal can be evaluated without rewriting the FFT implementation first.

The target use case is complex I/Q and signal-processing workloads, where storing real and imaginary lanes in FP16 or BF16 halves storage and bytes transferred relative to two FP32 lanes. This PR does **not** claim that lower precision is appropriate for every workload; public dtype semantics, host dispatch, operation coverage, accuracy policy, and new static instantiations remain separate work.

## Existing accelerator-library precedent

This is not a novel representation:

- [NVIDIA cuFFT](https://docs.nvidia.com/cuda/cufft/index.html) supports half-complex `CUDA_C_16F` and bfloat16-complex `CUDA_C_16BF` transforms through its type-generic planning API.
- [AMD rocFFT](https://rocm.docs.amd.com/projects/rocFFT/en/develop/reference/api.html) exposes `rocfft_precision_half` together with complex interleaved and planar array layouts.

Those are direct GPU-vendor FFT libraries. This patch only prepares MLX's C2C Metal implementation for equivalent storage lanes; it does not add a public reduced-precision complex type.

## Scope

- Template C2C radix arithmetic, shared memory, and I/O conversion over the scalar lane type.
- Preserve the current public API, host dispatch, static kernel-instantiation table, and packed float32 RFFT/IRFFT paths.
- Generalize the C2C four-step second pass so every eligible lane type retains the current float32 indexing, inversion, and normalization behavior.
- Derive twiddle phase evaluation precision from the scalar lane and Metal's pi constant through the usual arithmetic promotion, rather than naming `float` inside generic FFT code.

## Binary-size impact

No new static kernels or public exports are instantiated.

- Local release `mlx.metallib`: 130,977,720 B → 130,994,264 B
- Delta: **+16,544 B (+0.01263%)**
- `metal-nm -g` exported-symbol output: exact match to the base build

## Validation

- Native `xcrun metal` compile and `metallib` link of the changed `fft.metal` using MLX's build flags.
- Native CMake build with deployment target macOS 15.0 (NAX kernels excluded by the existing build gate): `ctest` **261/261** passed, including all FFT cases.
- Branch-local Metal Python extension: `python -m unittest test_fft -v` — **16 passed, 2 expected skips**.
- Compile-only C2C instantiations for `half2` and `bfloat2` across Stockham, Rader, Bluestein, and four-step planners.
- The phase-typing refinement produces byte-identical production and reduced-precision AIR relative to the previously reviewed generic FFT tree.
- `pre-commit` (clang-format) and `git diff --check` passed.

## Focused float32 regression checks

| Path | Correctness | Generic / base median |
| --- | --- | --- |
| C2C, N=256, batch=4096 | Bit-identical | 0.2952 / 0.2954 ms (0.9993x) |
| Four-step second pass | Bit-identical | 0.2384 / 0.2350 ms (1.0145x) |

The second measurement is a focused dispatch-scale check, not a claim of a material performance change. There is no end-to-end reduced-precision performance claim until a future public dtype and dispatch path exists.

## Downstream half-complex FFT result

[PhysicistJohn/mlx#7](https://github.com/PhysicistJohn/mlx/pull/7) adds one
dependent commit on top of #3969, #3970, and the storage adapter in
[PhysicistJohn/mlx#6](https://github.com/PhysicistJohn/mlx/pull/6). It
instantiates packed `complex_t<half>` C2C Stockham, Rader, Bluestein, and
four-step kernels.

A matched M5 Max benchmark compared the half kernels directly with untouched
`main` FP32 (`fb5133e1`) using identical plans, geometry, inputs, batches,
warmups, samples, and order-balanced runs:

| Plan | Forward half/main | Inverse half/main |
| --- | ---: | ---: |
| Stockham | 2.151x | 2.151x |
| Rader | 1.273x | 1.326x |
| Bluestein | 1.165x | 1.242x |
| Four-step | 2.242x | 2.220x |

The candidate FP32 control was bit-identical to original FP32 on all four paths
and measured 0.992x-1.065x its throughput across forward and inverse. Packed
half-complex storage and external I/O are 50% smaller. A 39-length correctness
sweep through 1,048,576 points remained finite, with worst normalized RMSE of
0.2585% forward and 0.4101% round trip.