### PR TITLE
Template Metal complex scalar lanes

### DIFF
--- a/mlx/backend/metal/kernels/complex.h
+++ b/mlx/backend/metal/kernels/complex.h
@@ -4,164 +4,263 @@
 
 #include <metal_stdlib>
 
+#include "mlx/backend/metal/kernels/bf16.h"
+
 using namespace metal;
 
-struct complex64_t;
+template <typename T>
+struct complex_t;
 
 template <typename T>
-static constexpr constant bool can_convert_to_complex64 =
-    !is_same_v<T, complex64_t> && is_convertible_v<T, float>;
+static constexpr constant bool is_complex_v = false;
 
 template <typename T>
-static constexpr constant bool can_convert_from_complex64 =
-    !is_same_v<T, complex64_t> &&
-    (is_convertible_v<float, T> || is_convertible_v<bfloat16_t, T>);
+static constexpr constant bool is_complex_v<complex_t<T>> = true;
 
-struct complex64_t {
-  float real;
-  float imag;
+// Metal accepts explicit bfloat casts that is_convertible_v reports as false.
+template <typename From, typename To>
+static constexpr constant bool is_lane_convertible_v =
+    is_convertible_v<From, To> ||
+    (is_same_v<To, bfloat16_t> && is_convertible_v<From, float>) ||
+    (is_same_v<From, bfloat16_t> && is_convertible_v<float, To>);
+
+template <typename T>
+struct complex_t {
+  using value_type = T;
+
+  T real;
+  T imag;
 
   // Constructors
-  constexpr complex64_t(float real, float imag) thread : real(real),
-                                                         imag(imag) {};
-  constexpr complex64_t() thread : real(0), imag(0) {};
-  constexpr complex64_t() threadgroup : real(0), imag(0) {};
+  constexpr complex_t(T real, T imag) thread : real(real), imag(imag) {};
+  constexpr complex_t() thread : real(0), imag(0) {};
+  constexpr complex_t() threadgroup : real(0), imag(0) {};
 
-  // Conversions to complex64_t
+  // Conversions from scalar types
   template <
-      typename T,
-      typename = typename enable_if<can_convert_to_complex64<T>>::type>
-  constexpr complex64_t(T x) thread : real(x), imag(0) {}
-
-  template <
-      typename T,
-      typename = typename enable_if<can_convert_to_complex64<T>>::type>
-  constexpr complex64_t(T x) threadgroup : real(x), imag(0) {}
+      typename U,
+      typename = typename enable_if<
+          !is_complex_v<U> && is_lane_convertible_v<U, T>>::type>
+  constexpr complex_t(U x) thread : real(static_cast<T>(x)),
+                                    imag(static_cast<T>(0)) {}
 
   template <
-      typename T,
-      typename = typename enable_if<can_convert_to_complex64<T>>::type>
-  constexpr complex64_t(T x) device : real(x), imag(0) {}
+      typename U,
+      typename = typename enable_if<
+          !is_complex_v<U> && is_lane_convertible_v<U, T>>::type>
+  constexpr complex_t(U x) threadgroup : real(static_cast<T>(x)),
+                                         imag(static_cast<T>(0)) {}
 
   template <
-      typename T,
-      typename = typename enable_if<can_convert_to_complex64<T>>::type>
-  constexpr complex64_t(T x) constant : real(x), imag(0) {}
+      typename U,
+      typename = typename enable_if<
+          !is_complex_v<U> && is_lane_convertible_v<U, T>>::type>
+  constexpr complex_t(U x) device : real(static_cast<T>(x)),
+                                    imag(static_cast<T>(0)) {}
 
-  // Conversions from complex64_t
   template <
-      typename T,
-      typename = typename enable_if<can_convert_from_complex64<T>>::type>
-  constexpr operator T() const thread {
-    return static_cast<T>(real);
+      typename U,
+      typename = typename enable_if<
+          !is_complex_v<U> && is_lane_convertible_v<U, T>>::type>
+  constexpr complex_t(U x) constant : real(static_cast<T>(x)),
+                                      imag(static_cast<T>(0)) {}
+
+  // Conversions between complex types
+  template <
+      typename U,
+      typename = typename enable_if<
+          !is_same_v<U, T> && is_lane_convertible_v<U, T>>::type>
+  constexpr complex_t(complex_t<U> x) thread : real(static_cast<T>(x.real)),
+                                               imag(static_cast<T>(x.imag)) {}
+
+  template <
+      typename U,
+      typename = typename enable_if<
+          !is_same_v<U, T> && is_lane_convertible_v<U, T>>::type>
+  constexpr complex_t(complex_t<U> x) threadgroup
+      : real(static_cast<T>(x.real)),
+        imag(static_cast<T>(x.imag)) {}
+
+  template <
+      typename U,
+      typename = typename enable_if<
+          !is_same_v<U, T> && is_lane_convertible_v<U, T>>::type>
+  constexpr complex_t(complex_t<U> x) device : real(static_cast<T>(x.real)),
+                                               imag(static_cast<T>(x.imag)) {}
+
+  template <
+      typename U,
+      typename = typename enable_if<
+          !is_same_v<U, T> && is_lane_convertible_v<U, T>>::type>
+  constexpr complex_t(complex_t<U> x) constant : real(static_cast<T>(x.real)),
+                                                 imag(static_cast<T>(x.imag)) {}
+
+  // Conversions to scalar types
+  template <
+      typename U,
+      typename = typename enable_if<
+          !is_complex_v<U> && is_lane_convertible_v<T, U>>::type>
+  constexpr operator U() const thread {
+    return static_cast<U>(real);
   }
 
   template <
-      typename T,
-      typename = typename enable_if<can_convert_from_complex64<T>>::type>
-  constexpr operator T() const threadgroup {
-    return static_cast<T>(real);
+      typename U,
+      typename = typename enable_if<
+          !is_complex_v<U> && is_lane_convertible_v<T, U>>::type>
+  constexpr operator U() const threadgroup {
+    return static_cast<U>(real);
   }
 
   template <
-      typename T,
-      typename = typename enable_if<can_convert_from_complex64<T>>::type>
-  constexpr operator T() const device {
-    return static_cast<T>(real);
+      typename U,
+      typename = typename enable_if<
+          !is_complex_v<U> && is_lane_convertible_v<T, U>>::type>
+  constexpr operator U() const device {
+    return static_cast<U>(real);
   }
 
   template <
-      typename T,
-      typename = typename enable_if<can_convert_from_complex64<T>>::type>
-  constexpr operator T() const constant {
-    return static_cast<T>(real);
+      typename U,
+      typename = typename enable_if<
+          !is_complex_v<U> && is_lane_convertible_v<T, U>>::type>
+  constexpr operator U() const constant {
+    return static_cast<U>(real);
   }
 };
 
-constexpr complex64_t operator-(complex64_t x) {
+using complex64_t = complex_t<float>;
+
+static_assert(sizeof(complex64_t) == 2 * sizeof(float));
+static_assert(sizeof(complex_t<half>) == 2 * sizeof(half));
+static_assert(sizeof(complex_t<bfloat16_t>) == 2 * sizeof(bfloat16_t));
+
+template <typename T>
+constexpr complex_t<T> operator-(complex_t<T> x) {
   return {-x.real, -x.imag};
 }
 
-constexpr bool operator>=(complex64_t a, complex64_t b) {
+template <typename T>
+constexpr bool operator>=(complex_t<T> a, complex_t<T> b) {
   return (a.real > b.real) || (a.real == b.real && a.imag >= b.imag);
 }
 
-constexpr bool operator>(complex64_t a, complex64_t b) {
+template <typename T>
+constexpr bool operator>(complex_t<T> a, complex_t<T> b) {
   return (a.real > b.real) || (a.real == b.real && a.imag > b.imag);
 }
 
-constexpr bool operator<=(complex64_t a, complex64_t b) {
+template <typename T>
+constexpr bool operator<=(complex_t<T> a, complex_t<T> b) {
   return operator>=(b, a);
 }
 
-constexpr bool operator<(complex64_t a, complex64_t b) {
+template <typename T>
+constexpr bool operator<(complex_t<T> a, complex_t<T> b) {
   return operator>(b, a);
 }
 
-constexpr bool operator==(complex64_t a, complex64_t b) {
+template <typename T>
+constexpr bool operator==(complex_t<T> a, complex_t<T> b) {
   return a.real == b.real && a.imag == b.imag;
 }
 
-constexpr complex64_t operator+(complex64_t a, complex64_t b) {
+template <typename T>
+constexpr complex_t<T> operator+(complex_t<T> a, complex_t<T> b) {
   return {a.real + b.real, a.imag + b.imag};
 }
 
-constexpr thread complex64_t& operator+=(thread complex64_t& a, complex64_t b) {
+template <typename T>
+constexpr thread complex_t<T>& operator+=(
+    thread complex_t<T>& a,
+    complex_t<T> b) {
   a.real += b.real;
   a.imag += b.imag;
   return a;
 }
 
-constexpr threadgroup complex64_t& operator+=(
-    threadgroup complex64_t& a,
-    complex64_t b) {
+template <typename T>
+constexpr threadgroup complex_t<T>& operator+=(
+    threadgroup complex_t<T>& a,
+    complex_t<T> b) {
   a.real += b.real;
   a.imag += b.imag;
   return a;
 }
 
-constexpr device complex64_t& operator+=(device complex64_t& a, complex64_t b) {
+template <typename T>
+constexpr device complex_t<T>& operator+=(
+    device complex_t<T>& a,
+    complex_t<T> b) {
   a.real += b.real;
   a.imag += b.imag;
   return a;
 }
 
-constexpr complex64_t operator+(float a, complex64_t b) {
-  return {a + b.real, b.imag};
-}
-constexpr complex64_t operator+(complex64_t a, float b) {
-  return {a.real + b, a.imag};
+template <
+    typename T,
+    typename U,
+    enable_if_t<!is_complex_v<U> && is_lane_convertible_v<U, T>, bool> = true>
+constexpr complex_t<T> operator+(U a, complex_t<T> b) {
+  return {static_cast<T>(a) + b.real, b.imag};
 }
 
-constexpr complex64_t operator-(complex64_t a, complex64_t b) {
+template <
+    typename T,
+    typename U,
+    enable_if_t<!is_complex_v<U> && is_lane_convertible_v<U, T>, bool> = true>
+constexpr complex_t<T> operator+(complex_t<T> a, U b) {
+  return {a.real + static_cast<T>(b), a.imag};
+}
+
+template <typename T>
+constexpr complex_t<T> operator-(complex_t<T> a, complex_t<T> b) {
   return {a.real - b.real, a.imag - b.imag};
 }
-constexpr complex64_t operator-(float a, complex64_t b) {
-  return {a - b.real, -b.imag};
-}
-constexpr complex64_t operator-(complex64_t a, float b) {
-  return {a.real - b, a.imag};
+
+template <
+    typename T,
+    typename U,
+    enable_if_t<!is_complex_v<U> && is_lane_convertible_v<U, T>, bool> = true>
+constexpr complex_t<T> operator-(U a, complex_t<T> b) {
+  return {static_cast<T>(a) - b.real, -b.imag};
 }
 
-constexpr complex64_t operator*(complex64_t a, complex64_t b) {
+template <
+    typename T,
+    typename U,
+    enable_if_t<!is_complex_v<U> && is_lane_convertible_v<U, T>, bool> = true>
+constexpr complex_t<T> operator-(complex_t<T> a, U b) {
+  return {a.real - static_cast<T>(b), a.imag};
+}
+
+template <typename T>
+constexpr complex_t<T> operator*(complex_t<T> a, complex_t<T> b) {
   return {a.real * b.real - a.imag * b.imag, a.real * b.imag + a.imag * b.real};
 }
 
-constexpr complex64_t operator/(complex64_t a, complex64_t b) {
+template <typename T>
+constexpr complex_t<T> operator/(complex_t<T> a, complex_t<T> b) {
   auto denom = b.real * b.real + b.imag * b.imag;
   auto x = a.real * b.real + a.imag * b.imag;
   auto y = a.imag * b.real - a.real * b.imag;
   return {x / denom, y / denom};
 }
 
-constexpr complex64_t operator/(float a, complex64_t b) {
+template <
+    typename T,
+    typename U,
+    enable_if_t<!is_complex_v<U> && is_lane_convertible_v<U, T>, bool> = true>
+constexpr complex_t<T> operator/(U a, complex_t<T> b) {
+  auto scalar = static_cast<T>(a);
   auto denom = b.real * b.real + b.imag * b.imag;
-  auto x = a * b.real;
-  auto y = -a * b.imag;
+  auto x = scalar * b.real;
+  auto y = -scalar * b.imag;
   return {x / denom, y / denom};
 }
 
-constexpr complex64_t operator%(complex64_t a, complex64_t b) {
+template <typename T>
+constexpr complex_t<T> operator%(complex_t<T> a, complex_t<T> b) {
   auto real = a.real - (b.real * static_cast<int64_t>(a.real / b.real));
   auto imag = a.imag - (b.imag * static_cast<int64_t>(a.imag / b.imag));
   if (real != 0 && (real < 0 != b.real < 0)) {
@@ -172,3 +271,10 @@ constexpr complex64_t operator%(complex64_t a, complex64_t b) {
   }
   return {real, imag};
 }
+
+static_assert(
+    (complex_t<half>{1.0h, 2.0h} * complex_t<half>{3.0h, 4.0h}).real == -5.0h);
+static_assert(
+    (complex_t<bfloat16_t>{bfloat16_t(1.0f), bfloat16_t(2.0f)} *
+     complex_t<bfloat16_t>{bfloat16_t(3.0f), bfloat16_t(4.0f)})
+        .real == bfloat16_t(-5.0f));

--- a/mlx/backend/metal/kernels/utils.h
+++ b/mlx/backend/metal/kernels/utils.h
@@ -75,14 +75,14 @@ struct Limits<bool> {
   static constexpr constant bool min = false;
 };
 
-template <>
-struct Limits<complex64_t> {
-  static constexpr constant complex64_t max = complex64_t(
-      metal::numeric_limits<float>::infinity(),
-      metal::numeric_limits<float>::infinity());
-  static constexpr constant complex64_t min = complex64_t(
-      -metal::numeric_limits<float>::infinity(),
-      -metal::numeric_limits<float>::infinity());
+template <typename T>
+struct Limits<complex_t<T>> {
+  inline static constexpr constant complex_t<T> max = complex_t<T>(
+      metal::numeric_limits<T>::infinity(),
+      metal::numeric_limits<T>::infinity());
+  inline static constexpr constant complex_t<T> min = complex_t<T>(
+      -metal::numeric_limits<T>::infinity(),
+      -metal::numeric_limits<T>::infinity());
 };
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Motivation

MLX Metal currently defines complex storage and arithmetic only through the float-specific `complex64_t`, while MLX CUDA already uses the lane-generic `complex_t<T> = cuda::std::complex<T>`. This PR independently gives the Metal backend the same extensible type foundation while preserving all current complex64 behavior and kernel entry points.

It complements upstream [#3969](https://github.com/ml-explore/mlx/pull/3969), which independently templates the Metal C2C FFT scalar lane. Together, the two narrowly scoped changes establish the orthogonal type and FFT foundations needed to evaluate reduced-precision complex support in MLX. That closes a capability gap with accelerator stacks that already provide reduced-precision complex transforms: [NVIDIA cuFFT](https://docs.nvidia.com/cuda/cufft/index.html) supports FP16 and BF16 complex transforms, and [AMD rocFFT](https://rocm.docs.amd.com/projects/rocFFT/en/develop/reference/api.html) supports FP16 complex transforms.

Neither PR introduces a user-facing dtype or commits MLX to promotion, dispatch, or accuracy semantics; those remain separate design decisions.

## Summary

- Replace the float-specific Metal complex structure with lane-generic `complex_t<T>`.
- Preserve every existing kernel entry point through `using complex64_t = complex_t<float>`.
- Generalize scalar and cross-complex conversions, arithmetic, and `Limits` for packed half and bfloat lane types.
- Add compile-time layout and reduced-lane arithmetic checks.

## Scope boundaries

This patch intentionally does not add public complex32/complex16 dtypes, host promotion rules, Python API, production half/BF16 kernel instantiations, FFT integration, or FP8. Those should be separate proposals after this primitive is accepted.

The current Metal compiler accepts the template implementation but rejects C++20 `concept` declarations, so mixed scalar operators use narrow `enable_if` constraints.

## Compatibility checks

| Check | Result |
| --- | --- |
| Release Metal build | Pass |
| Minimum-target Metal compile/link (macOS 14.0 deployment target) | Pass |
| CTest, serial | 261/261 pass on rebased `a79332de` |
| Focused conversion probe | float, half, and bfloat cross-lane conversion, same-lane copying, mixed scalar operations, and complex-to-scalar conversion compiled successfully |
| Existing complex64 output (original `fb5133e1` base) | Bit-identical for 8 operators across 65,536 deterministic values |
| Exported Metal symbols | Exact match to rebased `a79332de`: 15,809 lines and identical SHA-256 |
| Existing complex64 latency (original `fb5133e1` base) | Add -0.49%, multiply +0.06%, divide -0.10%; no material regression |
| Metallib size | 132,415,080 B -> 132,428,520 B; +13,440 B (+0.01015%) |

No new public kernel symbols are emitted.

## Reduced-lane proof

Both `complex_t<half>` and `complex_t<bfloat16_t>` are exactly 4 bytes. A linked on-device probe produced the expected `(-2, 14)` result for both types.

LLVM AIR inspection shows native half and bfloat loads, stores, arithmetic, division, and FMA instructions. The reduced paths do not promote their internal arithmetic to float.

A focused on-device streaming complex multiply-add benchmark over 2^24 elements measured:

| Lane type | Median kernel time | Relative to float |
| --- | ---: | ---: |
| float | 0.8095 ms | 1.00x |
| half | 0.3819 ms | 2.12x faster |
| bfloat | 0.3826 ms | 2.12x faster |

This is a raw-type bandwidth-oriented microbenchmark, not an end-to-end MLX dtype performance claim.

## Downstream half-complex FFT result

[PhysicistJohn/mlx#7](https://github.com/PhysicistJohn/mlx/pull/7) adds one
dependent commit on top of #3969, #3970, and the storage adapter in
[PhysicistJohn/mlx#6](https://github.com/PhysicistJohn/mlx/pull/6). It
instantiates packed `complex_t<half>` C2C Stockham, Rader, Bluestein, and
four-step kernels.

A matched M5 Max benchmark compared the half kernels directly with untouched
`main` FP32 (`fb5133e1`) using identical plans, geometry, inputs, batches,
warmups, samples, and order-balanced runs:

| Plan | Forward half/main | Inverse half/main |
| --- | ---: | ---: |
| Stockham | 2.151x | 2.151x |
| Rader | 1.273x | 1.326x |
| Bluestein | 1.165x | 1.242x |
| Four-step | 2.242x | 2.220x |

The candidate FP32 control was bit-identical to original FP32 on all four paths
and measured 0.992x-1.065x its throughput across forward and inverse. Packed
half-complex storage and external I/O are 50% smaller. A 39-length correctness
sweep through 1,048,576 points remained finite, with worst normalized RMSE of
0.2585% forward and 0.4101% round trip.