### PR TITLE
Export C++20 requirement to CMake consumers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,7 @@ cmake_policy(SET CMP0135 NEW)
 
 add_library(mlx)
 
+target_compile_features(mlx INTERFACE cxx_std_20)
 target_compile_options(mlx PUBLIC ${SANITIZER_COMPILE_FLAGS})
 target_link_options(mlx PUBLIC ${SANITIZER_LINK_FLAGS})
 

--- a/examples/cmake_project/CMakeLists.txt
+++ b/examples/cmake_project/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.27)
 
 project(example LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Comment the following two commands only the MLX C++ library is installed and

--- a/examples/export/CMakeLists.txt
+++ b/examples/export/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.27)
 
 project(import_mlx LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(

--- a/examples/extensions/CMakeLists.txt
+++ b/examples/extensions/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.27)
 project(_ext LANGUAGES CXX)
 
 # ----------------------------- Setup -----------------------------
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 

--- a/mlx.pc.in
+++ b/mlx.pc.in
@@ -44,7 +44,6 @@ if (@MLX_BUILD_METAL@)
 endif()
 
 set_target_properties(mlx PROPERTIES
-    CXX_STANDARD 17
     INTERFACE_COMPILE_OPTIONS "${MLX_CXX_FLAGS}"
 )
 


### PR DESCRIPTION
## Proposed changes

MLX's installed public C++ headers use C++20 defaulted comparisons in
`Device` and `Stream`, but the exported CMake target does not advertise that
requirement.

This exports `cxx_std_20` to CMake C++ consumers, aligns the three shipped
external CMake examples, and removes the stale, non-transitive
`CXX_STANDARD 17` property from the installed target configuration.

Runtime CPU JIT and compiled-preamble compilation remain on C++17.

## Validation

- An installed-package consumer declaring C++17 inherited `-std=c++20`,
  linked, and ran
- A strict C++17 include-only probe fails at `mlx/device.h:28`; the same probe
  passes under C++20
- All three external CMake examples configured and built; the sample ran and
  the extension imported
- CPU-only Release: 244/244 native cases and 3,238/3,238 assertions
- Static Metal Release: 260/260 native cases and 3,490/3,490 assertions
- CPU JIT remains on `g++ -std=c++17`; native compile coverage passed 31/31
  cases and 136/136 assertions
- `pre-commit run --all-files` and `git diff --check` passed

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
