### PR TITLE
python: fix bfloat16 buffer format itemsize mismatch

### DIFF
--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -539,6 +539,17 @@ void init_array(nb::module_& m) {
               return nb::make_tuple(1, 0);
             }
           })
+      .def(
+          "__array__",
+          [](const mx::array& self, nb::object dtype, nb::object copy) {
+            if (self.dtype() == mx::bfloat16) {
+              throw nb::type_error(
+                  "bfloat16 arrays cannot be converted to NumPy.");
+            }
+            return mlx_to_np_array(self);
+          },
+          "dtype"_a = nb::none(),
+          "copy"_a = nb::none())
       .def("__copy__", [](const mx::array& self) { return mx::array(self); })
       .def(
           "__deepcopy__",

--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -542,10 +542,6 @@ void init_array(nb::module_& m) {
       .def(
           "__array__",
           [](const mx::array& self, nb::object dtype, nb::object copy) {
-            if (self.dtype() == mx::bfloat16) {
-              throw nb::type_error(
-                  "bfloat16 arrays cannot be converted to NumPy.");
-            }
             return mlx_to_np_array(self);
           },
           "dtype"_a = nb::none(),

--- a/python/src/buffer.h
+++ b/python/src/buffer.h
@@ -43,7 +43,7 @@ std::string buffer_format(const mx::array& a) {
     case mx::float32:
       return "f";
     case mx::bfloat16:
-      return "H";
+      return "bfloat16";
     case mx::float64:
       return "d";
     case mx::complex64:

--- a/python/src/buffer.h
+++ b/python/src/buffer.h
@@ -43,7 +43,7 @@ std::string buffer_format(const mx::array& a) {
     case mx::float32:
       return "f";
     case mx::bfloat16:
-      return "B";
+      return "H";
     case mx::float64:
       return "d";
     case mx::complex64:

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -1868,10 +1868,10 @@ class TestArray(mlx_tests.MLXTestCase):
         mv_mx = memoryview(a_mx)
         self.assertEqual(mv_mx.strides, (8, 2))
         self.assertEqual(mv_mx.shape, (3, 4))
-        self.assertEqual(mv_mx.format, "H")
-        with self.assertRaises(TypeError) as cm:
+        self.assertIn(mv_mx.format, "bfloat16")
+        with self.assertRaises(ValueError) as cm:
             np.array(a_mx)
-        self.assertIn("bfloat16 arrays cannot be converted to NumPy", str(cm.exception))
+        self.assertIn("bfloat16", str(cm.exception))
 
         # Test buffer protocol with non-arrays ie bytes
         a = ord("a") * 257 + mx.arange(10).astype(mx.int16)

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -1868,11 +1868,9 @@ class TestArray(mlx_tests.MLXTestCase):
         mv_mx = memoryview(a_mx)
         self.assertEqual(mv_mx.strides, (8, 2))
         self.assertEqual(mv_mx.shape, (3, 4))
-        self.assertEqual(mv_mx.format, "B")
-        with self.assertRaises(RuntimeError) as cm:
-            np.array(a_mx)
-        e = cm.exception
-        self.assertTrue("Item size 2 for PEP 3118 buffer format string" in str(e))
+        self.assertEqual(mv_mx.format, "H")
+        self.assertEqual(mv_mx.itemsize, 2)
+        self.assertEqual(np.asarray(mv_mx).dtype, np.uint16)
 
         # Test buffer protocol with non-arrays ie bytes
         a = ord("a") * 257 + mx.arange(10).astype(mx.int16)

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -1869,8 +1869,9 @@ class TestArray(mlx_tests.MLXTestCase):
         self.assertEqual(mv_mx.strides, (8, 2))
         self.assertEqual(mv_mx.shape, (3, 4))
         self.assertEqual(mv_mx.format, "H")
-        self.assertEqual(mv_mx.itemsize, 2)
-        self.assertEqual(np.asarray(mv_mx).dtype, np.uint16)
+        with self.assertRaises(TypeError) as cm:
+            np.array(a_mx)
+        self.assertIn("bfloat16 arrays cannot be converted to NumPy", str(cm.exception))
 
         # Test buffer protocol with non-arrays ie bytes
         a = ord("a") * 257 + mx.arange(10).astype(mx.int16)

--- a/python/tests/test_zero_copy.py
+++ b/python/tests/test_zero_copy.py
@@ -83,15 +83,6 @@ class TestZeroCopy(mlx_tests.MLXTestCase):
             mx.eval(r)
         self.assertTrue(True)  # reaching here without crashing is the assertion
 
-    def test_bfloat16_buffer_protocol(self):
-        x = mx.ones((5,), dtype=mx.bfloat16)
-        mx.eval(x)
-        mv = memoryview(x)
-        self.assertEqual(mv.itemsize, 2)
-        self.assertEqual(mv.format, "H")
-        arr = np.asarray(x)
-        self.assertEqual(arr.shape, (5,))
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/test_zero_copy.py
+++ b/python/tests/test_zero_copy.py
@@ -83,6 +83,15 @@ class TestZeroCopy(mlx_tests.MLXTestCase):
             mx.eval(r)
         self.assertTrue(True)  # reaching here without crashing is the assertion
 
+    def test_bfloat16_buffer_protocol(self):
+        x = mx.ones((5,), dtype=mx.bfloat16)
+        mx.eval(x)
+        mv = memoryview(x)
+        self.assertEqual(mv.itemsize, 2)
+        self.assertEqual(mv.format, "H")
+        arr = np.asarray(x)
+        self.assertEqual(arr.shape, (5,))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Proposed changes
Fixes #3974 

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
