### PR TITLE
fix(cuda): pad non-aligned matmul inputs for cublasLt performance (#2712)

### DIFF
--- a/mlx/backend/cuda/matmul.cpp
+++ b/mlx/backend/cuda/matmul.cpp
@@ -93,7 +93,14 @@ void gemm_and_bias(
   // Safe fix: zero-pad inputs, run GEMM on aligned dimensions, slice back.
   int Mp = round_up_align(M);
   int Np = round_up_align(N);
-  bool needs_padding = (Mp != M) || (Np != N);
+
+  // Blackwell's cuBLASLt kernels do not exhibit the non-aligned-dimension
+  // regression that motivated this workaround for sufficiently large K.
+  // Avoiding the two input padding copies matters there because they cost
+  // more than the non-aligned GEMM itself.  Keep padding for small K values,
+  // where cuBLASLt may not find a native algorithm at all.
+  bool needs_padding = ((Mp != M) || (Np != N)) &&
+      (encoder.device().compute_capability_major() < 12 || K < 64);
 
   array a_work = a;
   array b_work = b;

--- a/mlx/backend/cuda/matmul.cpp
+++ b/mlx/backend/cuda/matmul.cpp
@@ -162,8 +162,8 @@ void gemm_and_bias(
   auto [batch_shape, a_batch_strides, b_batch_strides] =
       collapse_batches(a_work, b_work);
 
-  int Mwork = Mp;
-  int Nwork = Np;
+  int Mwork = needs_padding ? Mp : M;
+  int Nwork = needs_padding ? Np : N;
   auto batch_count = (int)(out.size() / (M * N));
 
   // Collapse batches into M if needed

--- a/mlx/backend/cuda/matmul.cpp
+++ b/mlx/backend/cuda/matmul.cpp
@@ -95,12 +95,11 @@ void gemm_and_bias(
   int Np = round_up_align(N);
 
   // Blackwell's cuBLASLt kernels do not exhibit the non-aligned-dimension
-  // regression that motivated this workaround for sufficiently large K.
-  // Avoiding the two input padding copies matters there because they cost
-  // more than the non-aligned GEMM itself.  Keep padding for small K values,
-  // where cuBLASLt may not find a native algorithm at all.
+  // regression that motivated this workaround.  Avoiding the two input
+  // padding copies matters there because they cost more than the non-aligned
+  // GEMM itself.
   bool needs_padding = ((Mp != M) || (Np != N)) &&
-      (encoder.device().compute_capability_major() < 12 || K < 64);
+      encoder.device().compute_capability_major() < 12;
 
   array a_work = a;
   array b_work = b;

--- a/mlx/backend/cuda/matmul.cpp
+++ b/mlx/backend/cuda/matmul.cpp
@@ -8,6 +8,7 @@
 #include "mlx/backend/cuda/gemms/gemv.h"
 #include "mlx/backend/cuda/gemms/grouped_gemm.h"
 #include "mlx/backend/gpu/copy.h"
+#include "mlx/backend/gpu/slicing.h"
 #include "mlx/primitives.h"
 
 #include <nvtx3/nvtx3.hpp>
@@ -64,8 +65,17 @@ array ensure_row_contiguous(
   }
 }
 
+// cublasLt selects significantly slower kernels when M or N are not
+// multiples of 32 (GitHub issue #2712).
+static constexpr int GEMM_ALIGN = 32;
+
+static inline int round_up_align(int v) {
+  return (v + GEMM_ALIGN - 1) / GEMM_ALIGN * GEMM_ALIGN;
+}
+
 void gemm_and_bias(
     cu::CommandEncoder& encoder,
+    const Stream& s,
     int M,
     int N,
     int K,
@@ -78,16 +88,83 @@ void gemm_and_bias(
     const array& b,
     const std::optional<array>& bias = std::nullopt,
     float alpha = 1.0f) {
-  // Check and collapse batch dimensions
-  auto [batch_shape, a_batch_strides, b_batch_strides] = collapse_batches(a, b);
+  // --- Align M/N to GEMM_ALIGN (32) if needed ---
+  // cublasLt selects significantly slower kernels for non-multiple dimensions.
+  // Safe fix: zero-pad inputs, run GEMM on aligned dimensions, slice back.
+  int Mp = round_up_align(M);
+  int Np = round_up_align(N);
+  bool needs_padding = (Mp != M) || (Np != N);
 
-  auto batch_count = out.size() / (M * N);
+  array a_work = a;
+  array b_work = b;
+  std::optional<array> bias_work = bias;
+
+  if (needs_padding) {
+    // Build padded shapes: preserve all batch dims, only change last two.
+    // A: (..., M, K) -> (..., Mp, K)  [pad axis -2]
+    // B: (..., K, N) -> (..., K, Np) [pad axis -1]
+    Shape a_pshape(a.shape().begin(), a.shape().end());
+    a_pshape[a_pshape.size() - 2] = Mp;
+
+    Shape b_pshape(b.shape().begin(), b.shape().end());
+    b_pshape[b_pshape.size() - 1] = Np;
+
+    // Zero-pad A using pad_gpu
+    array a_padded(a_pshape, a.dtype(), nullptr, {});
+    a_padded.set_data(cu::malloc_async(a_padded.nbytes(), encoder));
+    encoder.add_temporary(a_padded);
+    {
+      array zero(0, a.dtype());
+      encoder.add_temporary(zero);
+      pad_gpu(a, zero, a_padded, {-2}, {0}, s);
+    }
+    a_work = a_padded;
+
+    // Zero-pad B using pad_gpu
+    array b_padded(b_pshape, b.dtype(), nullptr, {});
+    b_padded.set_data(cu::malloc_async(b_padded.nbytes(), encoder));
+    encoder.add_temporary(b_padded);
+    {
+      array zero(0, b.dtype());
+      encoder.add_temporary(zero);
+      pad_gpu(b, zero, b_padded, {-1}, {0}, s);
+    }
+    b_work = b_padded;
+
+    // Pad bias last dimension if N was padded
+    if (bias_work.has_value() && Np != N) {
+      Shape bpshape(bias->shape().begin(), bias->shape().end());
+      bpshape[bpshape.size() - 1] = Np;
+      array bias_padded(bpshape, bias->dtype(), nullptr, {});
+      bias_padded.set_data(cu::malloc_async(bias_padded.nbytes(), encoder));
+      encoder.add_temporary(bias_padded);
+      {
+        array zero(0, bias->dtype());
+        encoder.add_temporary(zero);
+        pad_gpu(*bias, zero, bias_padded, {-1}, {0}, s);
+      }
+      bias_work = bias_padded;
+    }
+
+    // Recompute layout for padded arrays (they are row-contiguous).
+    std::tie(a_transposed, lda, a_work) = check_transpose(encoder, s, a_work);
+    std::tie(b_transposed, ldb, b_work) = check_transpose(encoder, s, b_work);
+  }
+
+  // Check and collapse batch dimensions
+  auto [batch_shape, a_batch_strides, b_batch_strides] =
+      collapse_batches(a_work, b_work);
+
+  int Mwork = Mp;
+  int Nwork = Np;
+  auto batch_count = (int)(out.size() / (M * N));
 
   // Collapse batches into M if needed
   if (batch_count > 1 && !a_transposed && batch_shape.size() == 1 &&
-      a.strides()[a.ndim() - 2] == K && a_batch_strides.back() == M * K &&
+      a_work.strides()[a_work.ndim() - 2] == K &&
+      a_batch_strides.back() == Mwork * K &&
       b_batch_strides.back() == 0) {
-    M *= batch_shape.back();
+    Mwork *= batch_shape.back();
     batch_count = 1;
 
     a_batch_strides = {0};
@@ -95,14 +172,29 @@ void gemm_and_bias(
     batch_shape = {1};
   }
 
-  // Use gemmv when possible
-  if (!bias && cu::can_use_gemv(M, N, K, a_transposed, b_transposed)) {
+  // --- Handle output for padded path ---
+  array* out_target = &out;
+  std::optional<array> out_padded_opt;
+  if (needs_padding) {
+    Shape opshape(out.shape().begin(), out.shape().end());
+    opshape[opshape.size() - 2] = Mp;
+    opshape[opshape.size() - 1] = Np;
+
+    out_padded_opt = array(opshape, out.dtype(), nullptr, {});
+    out_padded_opt->set_data(cu::malloc_async(out_padded_opt->nbytes(), encoder));
+    encoder.add_temporary(*out_padded_opt);
+    out_target = &(*out_padded_opt);
+  }
+
+  // Use gemmv when possible (only for unpadded path to keep logic simple)
+  if (!needs_padding && !bias_work &&
+      cu::can_use_gemv(Mwork, Nwork, K, a_transposed, b_transposed)) {
     cu::gemv(
-        a,
-        b,
-        out,
-        M,
-        N,
+        a_work,
+        b_work,
+        *out_target,
+        Mwork,
+        Nwork,
         K,
         batch_count,
         batch_shape,
@@ -115,27 +207,35 @@ void gemm_and_bias(
   // Invoke cublasLt
   CublasGemm gemm(
       encoder.device(),
-      a.dtype(),
+      a_work.dtype(),
       a_transposed,
-      M,
+      Mwork,
       K,
       lda,
       b_transposed,
       K,
-      N,
+      Nwork,
       ldb,
       batch_shape.back(),
       a_batch_strides.back(),
       b_batch_strides.back());
-  if (bias) {
-    if (a.dtype() == complex64) {
+  if (bias_work) {
+    if (a_work.dtype() == complex64) {
       throw std::runtime_error(
-          "[gemm_and_bias] complex64 bias epilogue isn’t supported in cublasLtMatmul.");
+          "[gemm_and_bias] complex64 bias epilogue isn't supported in cublasLtMatmul.");
     }
-    gemm.set_bias(encoder, *bias);
+    gemm.set_bias(encoder, *bias_work);
   }
   gemm.run(
-      encoder, out, a, b, batch_shape, a_batch_strides, b_batch_strides, alpha);
+      encoder, *out_target, a_work, b_work, batch_shape, a_batch_strides,
+      b_batch_strides, alpha);
+
+  // --- Slice padded output back to original M x N ---
+  if (needs_padding) {
+    copy_gpu_inplace(
+        *out_padded_opt, out, out.shape(), out_padded_opt->strides(),
+        out.strides(), 0, 0, CopyType::General, s);
+  }
 }
 
 } // namespace
@@ -168,7 +268,7 @@ void Matmul::eval_gpu(const std::vector<array>& inputs, array& out) {
   auto [b_transposed, ldb, b] = check_transpose(encoder, s, b_pre);
 
   gemm_and_bias(
-      encoder, M, N, K, a_transposed, lda, b_transposed, ldb, out, a, b);
+      encoder, s, M, N, K, a_transposed, lda, b_transposed, ldb, out, a, b);
 }
 
 void BlockMaskedMM::eval_gpu(const std::vector<array>& inputs, array& out) {
@@ -238,7 +338,7 @@ void BlockMaskedMM::eval_gpu(const std::vector<array>& inputs, array& out) {
 
   // Run GEMM.
   gemm_and_bias(
-      encoder, M, N, K, a_transposed, lda, b_transposed, ldb, out, a, b);
+      encoder, s, M, N, K, a_transposed, lda, b_transposed, ldb, out, a, b);
 
   // Apply output mask.
   if (has_out_mask) {
@@ -277,6 +377,7 @@ void AddMM::eval_gpu(const std::vector<array>& inputs, array& out) {
     out.set_data(cu::malloc_async(out.nbytes(), encoder));
     gemm_and_bias(
         encoder,
+        s,
         M,
         N,
         K,

--- a/mlx/backend/cuda/matmul.cpp
+++ b/mlx/backend/cuda/matmul.cpp
@@ -94,12 +94,12 @@ void gemm_and_bias(
   int Mp = round_up_align(M);
   int Np = round_up_align(N);
 
-  // Blackwell's cuBLASLt kernels do not exhibit the non-aligned-dimension
+  // Turing and newer cuBLASLt kernels do not exhibit the non-aligned-dimension
   // regression that motivated this workaround.  Avoiding the two input
   // padding copies matters there because they cost more than the non-aligned
-  // GEMM itself.
+  // GEMM itself.  Keep the workaround limited to Pascal and older devices.
   bool needs_padding = ((Mp != M) || (Np != N)) &&
-      encoder.device().compute_capability_major() < 12;
+      encoder.device().compute_capability_major() < 7;
 
   array a_work = a;
   array b_work = b;

--- a/tests/gpu_tests.cpp
+++ b/tests/gpu_tests.cpp
@@ -512,6 +512,37 @@ TEST_CASE("test gpu matmul") {
     auto out = matmul(a, b, Device::gpu);
     CHECK(array_equal(out, ones({2047, 4095}), Device::cpu).item<bool>());
   }
+
+  // Exercise dimensions immediately below, at, and above common GEMM
+  // alignment boundaries, including asymmetric issue-scale dimensions.
+  const std::array<std::array<int, 3>, 14> cases = {{
+      {31, 31, 31},
+      {31, 32, 33},
+      {32, 33, 31},
+      {33, 35, 32},
+      {33, 35, 33},
+      {63, 65, 63},
+      {63, 65, 64},
+      {63, 65, 65},
+      {127, 129, 64},
+      {127, 129, 65},
+      {128, 127, 128},
+      {129, 127, 129},
+      {2047, 33, 31},
+      {33, 4095, 31},
+  }};
+  for (const auto& dims : cases) {
+    const auto [m, n, k] = dims;
+    auto a = multiply(
+        reshape(arange(0, m * k, 1.0f, float32), {m, k}), array(0.01f));
+    auto b = multiply(
+        reshape(arange(1, 1 + k * n, 1.0f, float32), {k, n}),
+        array(-0.02f));
+    auto expected = matmul(a, b, Device::cpu);
+    auto out = matmul(a, b, Device::gpu);
+    CHECK(
+        allclose(expected, out, 1e-3, 1e-3, false, Device::cpu).item<bool>());
+  }
 }
 
 TEST_CASE("test gpu validation") {

--- a/tests/gpu_tests.cpp
+++ b/tests/gpu_tests.cpp
@@ -448,38 +448,57 @@ TEST_CASE("test gpu matmul") {
 
   // Non-aligned dimensions exercise the CUDA padding path.
   {
-    auto a = ones({33, 31});
-    auto b = ones({31, 35});
+    auto a = multiply(
+        reshape(arange(0, 33 * 31, 1.0f, float32), {33, 31}), array(0.01f));
+    auto b = multiply(
+        reshape(arange(1, 1 + 31 * 35, 1.0f, float32), {31, 35}),
+        array(-0.02f));
+    auto expected = matmul(a, b, Device::cpu);
     auto out = matmul(a, b, Device::gpu);
-    CHECK(array_equal(out, full({33, 35}, 31.0f), Device::cpu).item<bool>());
+    CHECK(allclose(expected, out, 1e-3, 1e-3, false, Device::cpu).item<bool>());
 
-    auto c = ones({33, 35});
+    auto c = multiply(
+        reshape(arange(1, 1 + 33 * 35, 1.0f, float32), {33, 35}), array(0.03f));
+    expected = addmm(c, a, b, 2.0f, 3.0f, Device::cpu);
     out = addmm(c, a, b, 2.0f, 3.0f, Device::gpu);
-    CHECK(array_equal(out, full({33, 35}, 65.0f), Device::cpu).item<bool>());
+    CHECK(allclose(expected, out, 1e-3, 1e-3, false, Device::cpu).item<bool>());
   }
 
   // Transposed non-aligned inputs.
   {
-    auto a = transpose(ones({31, 33}));
-    auto b = transpose(ones({35, 31}));
+    auto a = transpose(multiply(
+        reshape(arange(0, 31 * 33, 1.0f, float32), {31, 33}), array(0.01f)));
+    auto b = transpose(multiply(
+        reshape(arange(1, 1 + 35 * 31, 1.0f, float32), {35, 31}),
+        array(-0.02f)));
+    auto expected = matmul(a, b, Device::cpu);
     auto out = matmul(a, b, Device::gpu);
-    CHECK(array_equal(out, full({33, 35}, 31.0f), Device::cpu).item<bool>());
+    CHECK(allclose(expected, out, 1e-3, 1e-3, false, Device::cpu).item<bool>());
   }
 
   // Batched non-aligned inputs.
   {
-    auto a = ones({2, 33, 31});
-    auto b = ones({2, 31, 35});
+    auto a = multiply(
+        reshape(arange(0, 2 * 33 * 31, 1.0f, float32), {2, 33, 31}),
+        array(0.01f));
+    auto b = multiply(
+        reshape(arange(1, 1 + 2 * 31 * 35, 1.0f, float32), {2, 31, 35}),
+        array(-0.02f));
+    auto expected = matmul(a, b, Device::cpu);
     auto out = matmul(a, b, Device::gpu);
-    CHECK(array_equal(out, full({2, 33, 35}, 31.0f), Device::cpu).item<bool>());
+    CHECK(allclose(expected, out, 1e-3, 1e-3, false, Device::cpu).item<bool>());
   }
 
   // Non-aligned M/N with a large K exercises the native Blackwell path.
   {
-    auto a = ones({33, 64});
-    auto b = ones({64, 35});
+    auto a = multiply(
+        reshape(arange(0, 33 * 64, 1.0f, float32), {33, 64}), array(0.01f));
+    auto b = multiply(
+        reshape(arange(1, 1 + 64 * 35, 1.0f, float32), {64, 35}),
+        array(-0.02f));
+    auto expected = matmul(a, b, Device::cpu);
     auto out = matmul(a, b, Device::gpu);
-    CHECK(array_equal(out, full({33, 35}, 64.0f), Device::cpu).item<bool>());
+    CHECK(allclose(expected, out, 1e-3, 1e-3, false, Device::cpu).item<bool>());
   }
 }
 

--- a/tests/gpu_tests.cpp
+++ b/tests/gpu_tests.cpp
@@ -452,6 +452,34 @@ TEST_CASE("test gpu matmul") {
     auto b = ones({31, 35});
     auto out = matmul(a, b, Device::gpu);
     CHECK(array_equal(out, full({33, 35}, 31.0f), Device::cpu).item<bool>());
+
+    auto c = ones({33, 35});
+    out = addmm(c, a, b, 2.0f, 3.0f, Device::gpu);
+    CHECK(array_equal(out, full({33, 35}, 65.0f), Device::cpu).item<bool>());
+  }
+
+  // Transposed non-aligned inputs.
+  {
+    auto a = transpose(ones({31, 33}));
+    auto b = transpose(ones({35, 31}));
+    auto out = matmul(a, b, Device::gpu);
+    CHECK(array_equal(out, full({33, 35}, 31.0f), Device::cpu).item<bool>());
+  }
+
+  // Batched non-aligned inputs.
+  {
+    auto a = ones({2, 33, 31});
+    auto b = ones({2, 31, 35});
+    auto out = matmul(a, b, Device::gpu);
+    CHECK(array_equal(out, full({2, 33, 35}, 31.0f), Device::cpu).item<bool>());
+  }
+
+  // Non-aligned M/N with a large K exercises the native Blackwell path.
+  {
+    auto a = ones({33, 64});
+    auto b = ones({64, 35});
+    auto out = matmul(a, b, Device::gpu);
+    CHECK(array_equal(out, full({33, 35}, 64.0f), Device::cpu).item<bool>());
   }
 }
 

--- a/tests/gpu_tests.cpp
+++ b/tests/gpu_tests.cpp
@@ -445,6 +445,14 @@ TEST_CASE("test gpu matmul") {
     auto out = matmul(a, b, Device::gpu);
     CHECK(array_equal(out, full({3, 3, 2, 2}, 2.0f), Device::cpu).item<bool>());
   }
+
+  // Non-aligned dimensions exercise the CUDA padding path.
+  {
+    auto a = ones({33, 31});
+    auto b = ones({31, 35});
+    auto out = matmul(a, b, Device::gpu);
+    CHECK(array_equal(out, full({33, 35}, 31.0f), Device::cpu).item<bool>());
+  }
 }
 
 TEST_CASE("test gpu validation") {

--- a/tests/gpu_tests.cpp
+++ b/tests/gpu_tests.cpp
@@ -515,10 +515,17 @@ TEST_CASE("test gpu matmul") {
 
   // Exercise dimensions immediately below, at, and above common GEMM
   // alignment boundaries, including asymmetric issue-scale dimensions.
-  const std::array<std::array<int, 3>, 14> cases = {{
+  const std::array<std::array<int, 3>, 28> cases = {{
+      {1, 31, 1},
+      {31, 1, 1},
+      {31, 33, 1},
+      {33, 31, 2},
+      {63, 65, 3},
+      {65, 63, 4},
       {31, 31, 31},
       {31, 32, 33},
       {32, 33, 31},
+      {32, 32, 32},
       {33, 35, 32},
       {33, 35, 33},
       {63, 65, 63},
@@ -528,8 +535,15 @@ TEST_CASE("test gpu matmul") {
       {127, 129, 65},
       {128, 127, 128},
       {129, 127, 129},
+      {129, 129, 255},
+      {255, 257, 31},
+      {257, 255, 64},
       {2047, 33, 31},
       {33, 4095, 31},
+      {2047, 2048, 1},
+      {2048, 2047, 1},
+      {4095, 4096, 1},
+      {4096, 4095, 1},
   }};
   for (const auto& dims : cases) {
     const auto [m, n, k] = dims;
@@ -537,6 +551,20 @@ TEST_CASE("test gpu matmul") {
         reshape(arange(0, m * k, 1.0f, float32), {m, k}), array(0.01f));
     auto b = multiply(
         reshape(arange(1, 1 + k * n, 1.0f, float32), {k, n}),
+        array(-0.02f));
+    auto expected = matmul(a, b, Device::cpu);
+    auto out = matmul(a, b, Device::gpu);
+    CHECK(
+        allclose(expected, out, 1e-3, 1e-3, false, Device::cpu).item<bool>());
+  }
+
+  // Broadcast the right-hand operand across non-aligned batches.
+  {
+    auto a = multiply(
+        reshape(arange(0, 2 * 33 * 31, 1.0f, float32), {2, 33, 31}),
+        array(0.01f));
+    auto b = multiply(
+        reshape(arange(1, 1 + 31 * 35, 1.0f, float32), {31, 35}),
         array(-0.02f));
     auto expected = matmul(a, b, Device::cpu);
     auto out = matmul(a, b, Device::gpu);

--- a/tests/gpu_tests.cpp
+++ b/tests/gpu_tests.cpp
@@ -455,13 +455,15 @@ TEST_CASE("test gpu matmul") {
         array(-0.02f));
     auto expected = matmul(a, b, Device::cpu);
     auto out = matmul(a, b, Device::gpu);
-    CHECK(allclose(expected, out, 1e-3, 1e-3, false, Device::cpu).item<bool>());
+    CHECK(
+        allclose(expected, out, 1e-3, 1e-3, false, Device::cpu).item<bool>());
 
     auto c = multiply(
         reshape(arange(1, 1 + 33 * 35, 1.0f, float32), {33, 35}), array(0.03f));
     expected = addmm(c, a, b, 2.0f, 3.0f, Device::cpu);
     out = addmm(c, a, b, 2.0f, 3.0f, Device::gpu);
-    CHECK(allclose(expected, out, 1e-3, 1e-3, false, Device::cpu).item<bool>());
+    CHECK(
+        allclose(expected, out, 1e-3, 1e-3, false, Device::cpu).item<bool>());
   }
 
   // Transposed non-aligned inputs.
@@ -473,7 +475,8 @@ TEST_CASE("test gpu matmul") {
         array(-0.02f)));
     auto expected = matmul(a, b, Device::cpu);
     auto out = matmul(a, b, Device::gpu);
-    CHECK(allclose(expected, out, 1e-3, 1e-3, false, Device::cpu).item<bool>());
+    CHECK(
+        allclose(expected, out, 1e-3, 1e-3, false, Device::cpu).item<bool>());
   }
 
   // Batched non-aligned inputs.
@@ -486,7 +489,8 @@ TEST_CASE("test gpu matmul") {
         array(-0.02f));
     auto expected = matmul(a, b, Device::cpu);
     auto out = matmul(a, b, Device::gpu);
-    CHECK(allclose(expected, out, 1e-3, 1e-3, false, Device::cpu).item<bool>());
+    CHECK(
+        allclose(expected, out, 1e-3, 1e-3, false, Device::cpu).item<bool>());
   }
 
   // Non-aligned M/N with a large K exercises the native Blackwell path.

--- a/tests/gpu_tests.cpp
+++ b/tests/gpu_tests.cpp
@@ -446,7 +446,7 @@ TEST_CASE("test gpu matmul") {
     CHECK(array_equal(out, full({3, 3, 2, 2}, 2.0f), Device::cpu).item<bool>());
   }
 
-  // Non-aligned dimensions exercise the CUDA padding path.
+  // Non-aligned dimensions exercise the CUDA architecture policy.
   {
     auto a = multiply(
         reshape(arange(0, 33 * 31, 1.0f, float32), {33, 31}), array(0.01f));

--- a/tests/gpu_tests.cpp
+++ b/tests/gpu_tests.cpp
@@ -504,6 +504,14 @@ TEST_CASE("test gpu matmul") {
     auto out = matmul(a, b, Device::gpu);
     CHECK(allclose(expected, out, 1e-3, 1e-3, false, Device::cpu).item<bool>());
   }
+
+  // Issue-sized non-aligned output dimensions exercise allocation and slicing.
+  {
+    auto a = ones({2047, 1});
+    auto b = ones({1, 4095});
+    auto out = matmul(a, b, Device::gpu);
+    CHECK(array_equal(out, ones({2047, 4095}), Device::cpu).item<bool>());
+  }
 }
 
 TEST_CASE("test gpu validation") {


### PR DESCRIPTION
## Summary

This PR is a draft candidate for GitHub issue #2712. It implements a safe zero-padding path for non-aligned GEMMs: A and B are padded to multiples of 32, cuBLASLt runs on aligned working dimensions, and only the logical M×N result is copied back.

This is not claimed as a complete performance fix. The GPU and cuBLASLt configuration affected by #2712 are not specified in the issue, and the workaround must demonstrate a speedup on that configuration before merge.

## Implementation

- Pads A and B into zero-filled arrays with `pad_gpu()`.
- Preserves batch dimensions, transposes, leading dimensions, and batch strides.
- Pads the bias epilogue input when N is padded.
- Copies only the logical result back to the requested output.
- Keeps temporary arrays registered with the command encoder.
- Adds broad non-aligned M/N/K, bias, transpose, batch, and boundary coverage.

## Validation

### RTX 2060 / Turing

- CUDA library build passed with CUDA 12.6 and SM 7.5.
- Focused PR test: 38/38 assertions passed.
- Clean baseline focused test: 3/3 assertions passed.
- The padding path regressed performance on this GPU, so the current code bypasses padding for Turing and newer devices.
- The exact 16-head issue graph exceeds the 6 GiB allocator budget; no exact RTX 2060 issue-loop timing is claimed.

### RTX PRO 4000 / Blackwell

- Focused PR test: 38/38 assertions passed.
- The exact issue-shaped workload completed, but padding showed no measurable benefit and is bypassed.

### Quadro P2000 / Pascal SM 6.1

The full MLX CUDA library and tests were built after applying temporary local SM 6.1 compatibility workarounds outside this PR. The PR focused test passed with 38/38 assertions; the clean baseline passed with 3/3 assertions.

The individual GEMM comparison showed a substantial regression from input padding:

| Case | Baseline | PR padded path |
|---|---:|---:|
| 2047×2047, K=1 | 271 µs | 1,191 µs |
| 2047×2047, K=128 | 1,056 µs | 5,441 µs |
| 2047×4095, K=1 | 443 µs | 2,147 µs |
| 4095×4095, K=1 | 752 µs | 4,045 µs |

Increasing the cuBLASLt workspace from 4 MiB to 32 MiB did not remove this regression. These results show that the current Pascal-wide policy is not suitable for production.

### Apple CPU

The synchronized CPU-only build passed 244/244 test cases and 3238/3238 assertions. This is portability validation, not CUDA validation.

## Limitations and status

- The current Pascal-wide padding policy is known to regress on the tested P2000 and must not be treated as a general Pascal fix.
- Turing and Blackwell did not show a benefit from padding.
- The affected GPU from issue #2712 remains unknown.
- The exact repeated issue-loop baseline could not be measured on the P2000 because the temporary Pascal compatibility build crashed in the benchmark harness; the individual-GEMM matrix above is valid.
- `git diff --check` passes.

This PR remains draft-only and is not merge-ready. Further work requires reproducing the original slowdown on the affected GPU, then narrowing the workaround to that validated configuration without regressing other architectures.