### PR TITLE
Add Stream and Event APIs with Metal timing

### DIFF
--- a/docs/src/python/devices_and_streams.rst
+++ b/docs/src/python/devices_and_streams.rst
@@ -10,6 +10,7 @@ Devices and Streams
 
    Device
    Stream
+   Event
    default_device
    set_default_device
    default_stream

--- a/docs/src/usage/using_streams.rst
+++ b/docs/src/usage/using_streams.rst
@@ -1,18 +1,111 @@
 .. _using_streams:
 
-Using Streams
-=============
+Using Streams and Events
+========================
 
 .. currentmodule:: mlx.core
 
-Specifying the :obj:`Stream`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Specifying a :obj:`Stream`
+--------------------------
 
 All operations (including random number generation) take an optional
-keyword argument ``stream``. The ``stream`` kwarg specifies which
-:obj:`Stream` the operation should run on. If the stream is unspecified then
-the operation is run on the default stream of the default device:
-``mx.default_stream(mx.default_device())``.  The ``stream`` kwarg can also
-be a :obj:`Device` (e.g. ``stream=my_device``) in which case the operation is
-run on the default stream of the provided device
-``mx.default_stream(my_device)``.
+keyword argument ``stream``. The argument specifies the :obj:`Stream` on which
+the operation runs. If it is unspecified, the operation uses the default stream
+of the default device, ``mx.default_stream(mx.default_device())``. A
+:obj:`Device` can also be used as the ``stream`` argument, in which case the
+operation uses that device's default stream.
+
+Streams are in-order queues. Evaluated operations on the same stream run in
+order, while operations on different streams may overlap. Create a stream
+directly with :class:`Stream`, or use a stream as a context manager to make it
+the default for operations created in the context:
+
+.. code-block:: python
+
+   compute_stream = mx.Stream(mx.gpu)
+
+   with compute_stream:
+       y = mx.exp(x)
+       mx.async_eval(y)
+
+Using ``with mx.stream(compute_stream):`` is equivalent to using
+``with compute_stream:``.
+
+.. note::
+
+   An event records a point in a stream's GPU execution timeline; it does not
+   evaluate lazy arrays. :meth:`Stream.record_event` submits this point even if
+   no computation precedes it. Call :func:`async_eval` on the arrays whose work
+   should precede the event. Similarly, :meth:`Stream.synchronize` only waits
+   for work that has already been scheduled on the stream.
+
+Synchronizing streams
+---------------------
+
+Use an :class:`Event` to order work across streams. Recording an event places
+it after work already scheduled on the recording stream. Waiting for the event
+places it before work subsequently scheduled on the waiting stream:
+
+.. code-block:: python
+
+   producer = mx.Stream(mx.gpu)
+   consumer = mx.Stream(mx.gpu)
+
+   produced = mx.exp(x, stream=producer)
+   mx.async_eval(produced)
+
+   ready = producer.record_event()
+   consumer.wait_event(ready)
+
+   consumed = mx.exp(x, stream=consumer)
+   mx.async_eval(consumed)
+
+On a Metal stream, :meth:`Stream.record_event` commits the current command
+buffer so the event can progress, but it does not wait for completion.
+:meth:`Stream.wait_event` adds a GPU-side dependency and does not block the
+CPU. The dependency applies only to work scheduled on the waiting stream after
+the call.
+
+:meth:`Stream.wait_stream` is shorthand for recording an event on another
+stream and waiting for it:
+
+.. code-block:: python
+
+   consumer.wait_stream(producer)
+
+Only work already scheduled on ``producer`` is included in this dependency.
+Work scheduled on ``producer`` after :meth:`Stream.wait_stream` is not included.
+
+Use :meth:`Stream.query` to check completion without blocking. It does not
+evaluate arrays or submit pending work. Use :meth:`Stream.synchronize` to
+submit pending stream work and block the CPU until it completes:
+
+.. code-block:: python
+
+   if not consumer.query():
+       consumer.synchronize()
+
+Timing GPU work
+---------------
+
+Use timing-enabled events to measure work on a Metal GPU stream:
+
+.. code-block:: python
+
+   timing_stream = mx.Stream(mx.gpu)
+   start = mx.Event(mx.gpu, enable_timing=True)
+   end = mx.Event(mx.gpu, enable_timing=True)
+
+   start.record(timing_stream)
+
+   y = mx.exp(x, stream=timing_stream)
+   mx.async_eval(y)
+
+   end.record(timing_stream)
+   milliseconds = start.elapsed_time(end)
+
+Recording an event submits the recording stream but does not wait for it.
+:meth:`Event.elapsed_time` waits for both events before returning. Metal timing
+events use GPU command-buffer completion timestamps, so the result covers the
+GPU interval between the two record points rather than the execution time of a
+single kernel.

--- a/mlx/backend/cuda/eval.cpp
+++ b/mlx/backend/cuda/eval.cpp
@@ -81,6 +81,11 @@ void finalize(Stream s) {
   cu::get_command_encoder(s).commit();
 }
 
+bool query(Stream) {
+  throw std::runtime_error(
+      "[gpu::query] Stream query is not supported by the CUDA backend.");
+}
+
 void synchronize(Stream s) {
   nvtx3::scoped_range r("gpu::synchronize");
   cu::get_command_encoder(s).synchronize();

--- a/mlx/backend/cuda/event.cu
+++ b/mlx/backend/cuda/event.cu
@@ -365,7 +365,30 @@ Event::Event(Stream s) : stream_(s) {
       new EventImpl(), [](void* ptr) { delete static_cast<EventImpl*>(ptr); });
 }
 
+Event::Event(Stream s, bool enable_timing)
+    : stream_(s), enable_timing_(enable_timing) {
+  if (s.device != Device::gpu) {
+    throw std::invalid_argument(
+        "[Event::Event] Events are only supported on GPU.");
+  }
+  event_ = std::shared_ptr<void>(
+      new EventImpl(), [](void* ptr) { delete static_cast<EventImpl*>(ptr); });
+}
+
+void Event::record(Stream) {
+  throw std::runtime_error(
+      "[Event::record] Events are not supported by the CUDA backend.");
+}
+
+double Event::elapsed_time(const Event&) const {
+  throw std::runtime_error(
+      "[Event::elapsed_time] Event timing is not supported by the CUDA backend.");
+}
+
 void Event::wait() {
+  if (value() == 0) {
+    return;
+  }
   auto* event = static_cast<EventImpl*>(event_.get());
   assert(event->is_created());
   if (event->cuda) {
@@ -378,6 +401,9 @@ void Event::wait() {
 }
 
 void Event::wait(Stream s) {
+  if (value() == 0) {
+    return;
+  }
   auto* event = static_cast<EventImpl*>(event_.get());
   assert(event->is_created());
   if (event->cuda) {

--- a/mlx/backend/gpu/eval.h
+++ b/mlx/backend/gpu/eval.h
@@ -15,6 +15,7 @@ void new_stream(Stream s);
 void new_thread_unsafe_stream(Stream s);
 void eval(array& arr);
 void finalize(Stream s);
+bool query(Stream s);
 void synchronize(Stream s);
 void clear_streams();
 

--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -497,14 +497,29 @@ void CommandEncoder::end_encoding() {
 void CommandEncoder::signal_event(
     std::shared_ptr<EventImpl> event,
     uint64_t value) {
+  has_pending_work_ = true;
   end_encoding();
   buffer_->encodeSignalEvent(event->mtl_event(), value);
+  signal_events_.push_back({std::move(event), value});
+}
+
+void CommandEncoder::record_event(
+    std::shared_ptr<EventImpl> event,
+    uint64_t value,
+    bool enable_timing) {
+  has_pending_work_ = true;
+  end_encoding();
+  buffer_->encodeSignalEvent(event->mtl_event(), value);
+  if (enable_timing) {
+    event->set_command_buffer(buffer_.get());
+  }
   signal_events_.push_back({std::move(event), value});
 }
 
 void CommandEncoder::wait_event(
     std::shared_ptr<EventImpl> event,
     uint64_t value) {
+  has_pending_work_ = true;
   end_encoding();
   buffer_->encodeWait(event->mtl_event(), value);
   wait_events_.push_back(std::move(event));
@@ -515,12 +530,26 @@ bool CommandEncoder::needs_commit() const {
   return (buffer_ops_ > max_ops) || ((buffer_sizes_ >> 20) > max_mb);
 }
 
+bool CommandEncoder::query() const {
+  return !has_pending_work_ &&
+      (!last_submission_ || last_submission_->load(std::memory_order_acquire));
+}
+
 void CommandEncoder::commit(std::function<void()> completion) {
+  auto submission =
+      has_pending_work_ ? std::make_shared<std::atomic<bool>>(false) : nullptr;
+  if (submission) {
+    last_submission_ = submission;
+  }
   buffer_->addCompletedHandler(
       [&error_ = error_,
        wait_events = std::move(wait_events_),
        signal_events = std::move(signal_events_),
+       submission = std::move(submission),
        completion = std::move(completion)](MTL::CommandBuffer* cbuf) {
+        if (submission) {
+          submission->store(true, std::memory_order_release);
+        }
         if (completion) {
           completion();
         }
@@ -556,6 +585,7 @@ void CommandEncoder::commit(std::function<void()> completion) {
   buffer_ = NS::RetainPtr(queue_->commandBufferWithUnretainedReferences());
   buffer_ops_ = 0;
   buffer_sizes_ = 0;
+  has_pending_work_ = false;
 }
 
 void CommandEncoder::synchronize() {
@@ -572,6 +602,7 @@ void CommandEncoder::synchronize() {
 }
 
 MTL::ComputeCommandEncoder* CommandEncoder::get_command_encoder() {
+  has_pending_work_ = true;
   if (!encoder_) {
     encoder_ = NS::RetainPtr(
         buffer_->computeCommandEncoder(MTL::DispatchTypeConcurrent));

--- a/mlx/backend/metal/device.h
+++ b/mlx/backend/metal/device.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <Metal/Metal.hpp>
+#include <atomic>
 #include <functional>
 #include <mutex>
 #include <shared_mutex>
@@ -94,7 +95,12 @@ class MLX_API CommandEncoder {
   void end_encoding();
   void wait_event(std::shared_ptr<EventImpl> event, uint64_t value);
   void signal_event(std::shared_ptr<EventImpl> event, uint64_t value);
+  void record_event(
+      std::shared_ptr<EventImpl> event,
+      uint64_t value,
+      bool enable_timing);
   bool needs_commit() const;
+  bool query() const;
   void commit(std::function<void()> completion = nullptr);
   void synchronize();
 
@@ -113,6 +119,8 @@ class MLX_API CommandEncoder {
   NS::SharedPtr<MTL::CommandBuffer> buffer_;
   int buffer_ops_{0};
   size_t buffer_sizes_{0};
+  bool has_pending_work_{false};
+  std::shared_ptr<std::atomic<bool>> last_submission_;
 
   // The events hooked to current command buffer.
   std::vector<std::shared_ptr<EventImpl>> wait_events_;

--- a/mlx/backend/metal/eval.cpp
+++ b/mlx/backend/metal/eval.cpp
@@ -76,6 +76,10 @@ void finalize(Stream s) {
   encoder.commit();
 }
 
+bool query(Stream s) {
+  return metal::get_command_encoder(s).query();
+}
+
 void synchronize(Stream s) {
   metal::get_command_encoder(s).synchronize();
 }

--- a/mlx/backend/metal/event.cpp
+++ b/mlx/backend/metal/event.cpp
@@ -1,6 +1,7 @@
 // Copyright © 2024 Apple Inc.
 
 #include "mlx/backend/metal/event.h"
+#include "mlx/backend/gpu/eval.h"
 #include "mlx/scheduler.h"
 
 namespace mlx::core {
@@ -22,6 +23,7 @@ EventImpl::EventImpl(Device& d) {
 
 EventImpl::~EventImpl() {
   auto p = new_scoped_memory_pool();
+  command_buffer_.reset();
   mtl_event_.reset();
 }
 
@@ -33,6 +35,24 @@ void EventImpl::wait(uint64_t value) {
 
 void EventImpl::signal(uint64_t value) {
   mtl_event_->setSignaledValue(value);
+}
+
+void EventImpl::set_command_buffer(MTL::CommandBuffer* command_buffer) {
+  command_buffer_ = NS::RetainPtr(command_buffer);
+}
+
+double EventImpl::gpu_end_time() {
+  if (!command_buffer_) {
+    throw std::runtime_error(
+        "[Event::elapsed_time] Event does not have a command buffer.");
+  }
+  command_buffer_->waitUntilCompleted();
+  auto end_time = command_buffer_->GPUEndTime();
+  if (end_time == 0.0) {
+    throw std::runtime_error(
+        "[Event::elapsed_time] Metal GPU end time is unavailable.");
+  }
+  return end_time;
 }
 
 void EventImpl::set_error(std::shared_ptr<std::string> error) {
@@ -56,11 +76,68 @@ Event::Event(Stream stream) : stream_(stream) {
   event_ = std::make_shared<metal::EventImpl>(metal::device(stream.device));
 }
 
+Event::Event(Stream stream, bool enable_timing)
+    : stream_(stream), enable_timing_(enable_timing) {
+  if (stream.device != Device::gpu) {
+    throw std::invalid_argument(
+        "[Event::Event] Events are only supported on GPU.");
+  }
+  event_ = std::make_shared<metal::EventImpl>(metal::device(stream.device));
+}
+
+void Event::record(Stream stream) {
+  if (stream.device != Device::gpu) {
+    throw std::invalid_argument(
+        "[Event::record] Events can only be recorded on GPU streams.");
+  }
+  if (stream.device != stream_.device) {
+    throw std::invalid_argument(
+        "[Event::record] The event and stream must use the same device.");
+  }
+  stream_ = stream;
+  recorded_ = true;
+  value_++;
+
+  auto impl = std::static_pointer_cast<metal::EventImpl>(event_);
+  auto& encoder = metal::get_command_encoder(stream);
+  encoder.record_event(std::move(impl), value(), enable_timing_);
+  gpu::finalize(stream);
+}
+
+double Event::elapsed_time(const Event& end_event) const {
+  if (!enable_timing_ || !end_event.enable_timing_) {
+    throw std::runtime_error(
+        "[Event::elapsed_time] Both events must have timing enabled.");
+  }
+  if (!recorded_ || !end_event.recorded_) {
+    throw std::runtime_error(
+        "[Event::elapsed_time] Both events must be recorded first.");
+  }
+  if (stream_.device != end_event.stream_.device) {
+    throw std::invalid_argument(
+        "[Event::elapsed_time] Events must use the same device.");
+  }
+
+  auto start_impl = std::static_pointer_cast<metal::EventImpl>(event_);
+  auto end_impl = std::static_pointer_cast<metal::EventImpl>(end_event.event_);
+  start_impl->wait(value());
+  end_impl->wait(end_event.value());
+  auto start = start_impl->gpu_end_time();
+  auto end = end_impl->gpu_end_time();
+  return (end - start) * 1e3;
+}
+
 void Event::wait() {
+  if (value() == 0) {
+    return;
+  }
   static_cast<metal::EventImpl*>(event_.get())->wait(value());
 }
 
 void Event::wait(Stream stream) {
+  if (value() == 0) {
+    return;
+  }
   auto impl = std::static_pointer_cast<metal::EventImpl>(event_);
   if (stream.device == Device::cpu) {
     scheduler::enqueue(stream, [impl = std::move(impl), value = value()]() {

--- a/mlx/backend/metal/event.h
+++ b/mlx/backend/metal/event.h
@@ -12,6 +12,8 @@ class EventImpl {
 
   void wait(uint64_t value);
   void signal(uint64_t value);
+  void set_command_buffer(MTL::CommandBuffer* command_buffer);
+  double gpu_end_time();
   void set_error(std::shared_ptr<std::string> error);
   void check_error();
 
@@ -28,6 +30,7 @@ class EventImpl {
   std::shared_ptr<std::string> error_;
 
   NS::SharedPtr<MTL::SharedEvent> mtl_event_;
+  NS::SharedPtr<MTL::CommandBuffer> command_buffer_;
 };
 
 } // namespace mlx::core::metal

--- a/mlx/backend/no_gpu/eval.cpp
+++ b/mlx/backend/no_gpu/eval.cpp
@@ -27,6 +27,10 @@ void finalize(Stream) {
   throw std::runtime_error("[gpu::finalize] GPU backend is not available");
 }
 
+bool query(Stream) {
+  throw std::runtime_error("[gpu::query] GPU backend is not available");
+}
+
 void synchronize(Stream) {
   throw std::runtime_error("[gpu::synchronize]  GPU backend is not available");
 }

--- a/mlx/backend/no_gpu/event.cpp
+++ b/mlx/backend/no_gpu/event.cpp
@@ -19,7 +19,25 @@ Event::Event(Stream stream) : stream_(stream) {
   event_ = std::shared_ptr<void>(new EventCounter{}, dtor);
 }
 
+Event::Event(Stream stream, bool enable_timing)
+    : stream_(stream), enable_timing_(enable_timing) {
+  throw std::invalid_argument(
+      "[Event::Event] Events are only supported on GPU.");
+}
+
+void Event::record(Stream) {
+  throw std::runtime_error("[Event::record] Events are only supported on GPU.");
+}
+
+double Event::elapsed_time(const Event&) const {
+  throw std::runtime_error(
+      "[Event::elapsed_time] Event timing is only supported on GPU.");
+}
+
 void Event::wait() {
+  if (value() == 0) {
+    return;
+  }
   auto ec = static_cast<EventCounter*>(event_.get());
   std::unique_lock<std::mutex> lk(ec->mtx);
   if (ec->value >= value()) {
@@ -29,6 +47,9 @@ void Event::wait() {
 }
 
 void Event::wait(Stream stream) {
+  if (value() == 0) {
+    return;
+  }
   scheduler::enqueue(stream, [*this]() mutable { wait(); });
 }
 

--- a/mlx/event.h
+++ b/mlx/event.h
@@ -5,14 +5,32 @@
 #include <memory>
 #include <stdexcept>
 
+#include "mlx/api.h"
 #include "mlx/stream.h"
 
 namespace mlx::core {
 
-class Event {
+class MLX_API Event {
  public:
   Event() {};
   explicit Event(Stream stream);
+  Event(Stream stream, bool enable_timing);
+
+  // Record the event in the given stream
+  void record(Stream stream);
+
+  // Return the elapsed time to the end event in milliseconds
+  double elapsed_time(const Event& end_event) const;
+
+  // Check if the event has completed. Unrecorded events are complete.
+  bool query() const {
+    return !recorded_ || is_signaled();
+  }
+
+  // Block the CPU until the event completes
+  void synchronize() {
+    wait();
+  }
 
   // Wait for the event to be signaled at its current value
   void wait();
@@ -53,6 +71,8 @@ class Event {
   Stream stream_{0, Device::cpu};
   std::shared_ptr<void> event_{nullptr};
   uint64_t value_{0};
+  bool enable_timing_{false};
+  bool recorded_{false};
 };
 
 } // namespace mlx::core

--- a/mlx/scheduler.cpp
+++ b/mlx/scheduler.cpp
@@ -60,6 +60,12 @@ void Scheduler::enqueue(Stream s, std::function<void()> task) {
   st->enqueue(std::move(task));
 }
 
+bool Scheduler::query(Stream s) {
+  std::shared_lock lock(threads_mtx_);
+  auto it = threads_.find(s.index);
+  return it == threads_.end() || it->second->query();
+}
+
 // Leak the scheduler singleton on all platforms. During static destruction,
 // worker threads may still be executing JIT-compiled code that has been
 // unmapped, causing SIGSEGV (macOS/Linux) or join() deadlocks (Windows/MSVC

--- a/mlx/scheduler.h
+++ b/mlx/scheduler.h
@@ -21,9 +21,11 @@ struct StreamThread {
   std::queue<std::function<void()>> q;
   std::condition_variable cond;
   bool stop;
+  bool running;
   std::thread thread;
 
-  StreamThread() : stop(false), thread(&StreamThread::thread_fn, this) {}
+  StreamThread()
+      : stop(false), running(false), thread(&StreamThread::thread_fn, this) {}
 
   ~StreamThread() {
     {
@@ -45,9 +47,15 @@ struct StreamThread {
         }
         task = std::move(q.front());
         q.pop();
+        running = true;
       }
 
       task();
+
+      {
+        std::lock_guard<std::mutex> lk(mtx);
+        running = false;
+      }
     }
   }
 
@@ -61,6 +69,11 @@ struct StreamThread {
       q.emplace(std::move(f));
     }
     cond.notify_one();
+  }
+
+  bool query() {
+    std::lock_guard<std::mutex> lk(mtx);
+    return q.empty() && !running;
   }
 };
 
@@ -76,6 +89,7 @@ class MLX_API Scheduler {
   Scheduler& operator=(Scheduler&&) = delete;
 
   void enqueue(Stream s, std::function<void()> task);
+  bool query(Stream s);
 
   void notify_new_task(const Stream& stream) {
     {
@@ -122,6 +136,10 @@ MLX_API Scheduler& scheduler();
 template <typename F>
 void enqueue(const Stream& stream, F&& f) {
   scheduler().enqueue(stream, std::forward<F>(f));
+}
+
+inline bool query(const Stream& stream) {
+  return scheduler().query(stream);
 }
 
 inline int n_active_tasks() {

--- a/mlx/stream.cpp
+++ b/mlx/stream.cpp
@@ -5,6 +5,7 @@
 #include "mlx/backend/cpu/eval.h"
 #include "mlx/backend/gpu/device_info.h"
 #include "mlx/backend/gpu/eval.h"
+#include "mlx/scheduler.h"
 
 #include <array>
 #include <map>
@@ -104,6 +105,13 @@ Stream stream_from_thread_local_stream(ThreadLocalStream tls) {
     it = streams.emplace(tls, new_stream(tls.device)).first;
   }
   return it->second;
+}
+
+bool query(Stream s) {
+  if (s.device == Device::cpu) {
+    return scheduler::query(s);
+  }
+  return gpu::query(s);
 }
 
 } // namespace mlx::core

--- a/mlx/stream.h
+++ b/mlx/stream.h
@@ -46,6 +46,9 @@ MLX_API Stream stream_from_thread_local_stream(ThreadLocalStream tls);
 /** Get all available streams. */
 MLX_API std::vector<Stream> get_streams();
 
+/* Return whether all work on the provided stream has completed. */
+MLX_API bool query(Stream);
+
 /* Synchronize with the default stream. */
 MLX_API void synchronize();
 

--- a/python/src/stream.cpp
+++ b/python/src/stream.cpp
@@ -1,18 +1,29 @@
 // Copyright © 2023-2024 Apple Inc.
 
+#include <memory>
 #include <sstream>
+#include <vector>
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/variant.h>
 
+#include "mlx/event.h"
 #include "mlx/stream.h"
 #include "mlx/utils.h"
 
 namespace mx = mlx::core;
 namespace nb = nanobind;
 using namespace nb::literals;
+
+namespace {
+
+thread_local std::vector<
+    std::pair<mx::Stream, std::unique_ptr<mx::StreamContext>>>
+    stream_contexts;
+
+} // namespace
 
 // Create the StreamContext on enter and delete on exit.
 class PyStreamContext {
@@ -46,8 +57,21 @@ void init_stream(nb::module_& m) {
       m,
       "Stream",
       R"pbdoc(
-      A stream for running operations on a given device.
+      An in-order queue of work on a device.
+
+      Evaluated operations on the same stream run in order. Operations on
+      different streams may overlap. MLX operations are lazy, so assigning an
+      operation to a stream does not submit it for execution.
+
+      Args:
+          device (Device, optional): The device for the stream. If ``None``,
+              use the default device. Default: ``None``.
       )pbdoc")
+      .def(
+          nb::new_([](std::optional<mx::Device> d) {
+            return mx::new_stream(d.value_or(mx::default_device()));
+          }),
+          "device"_a = nb::none())
       .def_ro("device", &mx::Stream::device)
       .def(
           "__repr__",
@@ -56,10 +80,125 @@ void init_stream(nb::module_& m) {
             os << s;
             return os.str();
           })
-      .def("__eq__", [](const mx::Stream& s, const nb::object& other) {
-        return nb::isinstance<mx::Stream>(other) &&
-            s == nb::cast<mx::Stream>(other);
-      });
+      .def(
+          "__eq__",
+          [](const mx::Stream& s, const nb::object& other) {
+            return nb::isinstance<mx::Stream>(other) &&
+                s == nb::cast<mx::Stream>(other);
+          })
+      .def(
+          "query",
+          &mx::query,
+          R"pbdoc(
+          Check whether work already scheduled on the stream has completed.
+
+          This method does not block the CPU, evaluate lazy arrays, or submit
+          pending stream work.
+
+          Returns:
+              bool: ``True`` if the stream has no incomplete work.
+      )pbdoc")
+      .def(
+          "record_event",
+          [](const mx::Stream& stream, nb::object event) {
+            if (event.is_none()) {
+              mx::Event recorded(stream, false);
+              recorded.record(stream);
+              return nb::cast(std::move(recorded), nb::rv_policy::move);
+            }
+            auto& recorded = nb::cast<mx::Event&>(event);
+            recorded.record(stream);
+            return event;
+          },
+          "event"_a = nb::none(),
+          R"pbdoc(
+          Record an event after work already scheduled on the stream.
+
+          Recording on a Metal stream submits its current command buffer, but
+          does not wait for completion. This method does not evaluate lazy
+          arrays and is only supported on GPU streams.
+
+          Args:
+              event (Event, optional): The event to record. If ``None``,
+                  allocate a synchronization-only event. Default: ``None``.
+
+          Returns:
+              Event: The recorded event.
+      )pbdoc")
+      .def(
+          "synchronize",
+          [](const mx::Stream& stream) { mx::synchronize(stream); },
+          nb::call_guard<nb::gil_scoped_release>(),
+          R"pbdoc(
+          Submit pending stream work and block the CPU until it completes.
+
+          This method does not evaluate lazy arrays.
+      )pbdoc")
+      .def(
+          "wait_event",
+          [](const mx::Stream& stream, mx::Event& event) {
+            event.wait(stream);
+          },
+          "event"_a,
+          R"pbdoc(
+          Make future work submitted to the stream wait for an event.
+
+          Only work scheduled on the stream after this call waits for the
+          event. This method does not block the calling CPU thread.
+
+          Args:
+              event (Event): The event to wait for.
+      )pbdoc")
+      .def(
+          "wait_stream",
+          [](const mx::Stream& stream, const mx::Stream& other) {
+            if (other.device == mx::Device::gpu) {
+              mx::Event event(other, false);
+              event.record(other);
+              event.wait(stream);
+            } else {
+              mx::Event event(other);
+              event.set_value(1);
+              event.signal(other);
+              event.wait(stream);
+            }
+          },
+          "stream"_a,
+          R"pbdoc(
+          Make future work submitted to this stream wait for work already
+          submitted to another stream.
+
+          Work submitted to the other stream after this call is not included.
+          This method does not block the calling CPU thread or evaluate lazy
+          arrays.
+
+          Args:
+              stream (Stream): The other stream to wait for.
+      )pbdoc")
+      .def(
+          "__enter__",
+          [](mx::Stream& stream) -> mx::Stream& {
+            stream_contexts.emplace_back(
+                stream, std::make_unique<mx::StreamContext>(stream));
+            return stream;
+          },
+          nb::rv_policy::reference_internal)
+      .def(
+          "__exit__",
+          [](const mx::Stream& stream,
+             const std::optional<nb::type_object>&,
+             const std::optional<nb::object>&,
+             const std::optional<nb::object>&) {
+            if (stream_contexts.empty() ||
+                stream_contexts.back().first != stream) {
+              throw std::runtime_error(
+                  "[Stream::__exit__] Stream contexts must exit in order.");
+            }
+            stream_contexts.pop_back();
+          },
+          "exc_type"_a = nb::none(),
+          "exc_value"_a = nb::none(),
+          "traceback"_a = nb::none());
 
   nb::class_<mx::ThreadLocalStream>(
       m,
@@ -81,6 +220,97 @@ void init_stream(nb::module_& m) {
             return nb::isinstance<mx::ThreadLocalStream>(other) &&
                 s == nb::cast<mx::ThreadLocalStream>(other);
           });
+
+  nb::class_<mx::Event>(m, "Event", R"pbdoc(
+        Query and record Stream status to identify or control dependencies across Stream and measure timing.
+
+        Args:
+            device (Device, optional): The GPU device for the event. If
+                ``None``, use the default GPU device. Default: ``None``.
+            enable_timing (bool, optional): Whether the event can measure
+                elapsed time. Default: ``False``.
+  )pbdoc")
+      .def(
+          nb::new_([](std::optional<mx::Device> d, bool enable_timing) {
+            auto device = d.value_or(mx::Device(mx::Device::gpu));
+            return mx::Event(mx::default_stream(device), enable_timing);
+          }),
+          "device"_a = nb::none(),
+          nb::kw_only(),
+          "enable_timing"_a = false)
+      .def(
+          "record",
+          [](mx::Event& event, mx::StreamOrDevice s) {
+            auto stream = std::holds_alternative<std::monostate>(s)
+                ? mx::default_stream(event.stream().device)
+                : mx::to_stream(s);
+            event.record(stream);
+          },
+          "stream"_a = nb::none(),
+          R"pbdoc(
+          Record the event at the current position in the stream.
+
+          Args:
+              stream (Stream or Device, optional): The GPU stream or device to
+                  record on. If ``None``, use the default stream for the
+                  event's GPU device. Default: ``None``.
+      )pbdoc")
+      .def(
+          "query",
+          &mx::Event::query,
+          R"pbdoc(
+          Check whether all work captured by the event has completed.
+
+          An event that has not been recorded is considered complete.
+
+          Returns:
+              bool: ``True`` if the event has completed.
+      )pbdoc")
+      .def(
+          "wait",
+          [](mx::Event& event, mx::StreamOrDevice s) {
+            auto stream = std::holds_alternative<std::monostate>(s)
+                ? mx::default_stream(event.stream().device)
+                : mx::to_stream(s);
+            event.wait(stream);
+          },
+          "stream"_a = nb::none(),
+          R"pbdoc(
+          Make future work on a stream wait for this event.
+
+          This method does not block the CPU.
+
+          Args:
+              stream (Stream or Device, optional): The stream or device to
+                  wait on. If ``None``, use the default stream for the event's
+                  device. Default: ``None``.
+      )pbdoc")
+      .def(
+          "synchronize",
+          &mx::Event::synchronize,
+          nb::call_guard<nb::gil_scoped_release>(),
+          R"pbdoc(
+          Wait for the event to complete.
+
+          This method blocks the CPU until all work captured by the event has
+          completed.
+      )pbdoc")
+      .def(
+          "elapsed_time",
+          &mx::Event::elapsed_time,
+          "end_event"_a,
+          nb::call_guard<nb::gil_scoped_release>(),
+          R"pbdoc(
+          Wait for both events and return the elapsed time in milliseconds.
+
+          Both events must be created with ``enable_timing=True``.
+
+          Args:
+              end_event (Event): The ending event.
+
+          Returns:
+              float: The elapsed time in milliseconds.
+      )pbdoc");
 
   nb::implicitly_convertible<mx::Device::DeviceType, mx::Device>();
 

--- a/python/src/transforms.cpp
+++ b/python/src/transforms.cpp
@@ -1216,6 +1216,13 @@ void init_transforms(nb::module_& m) {
       R"pbdoc(
         Asynchronously evaluate an :class:`array` or tree of :class:`array`.
 
+        This function schedules the computations needed to produce its
+        arguments and returns without waiting for them to complete. On a GPU
+        stream, the corresponding command buffers are committed before this
+        function returns, so an :class:`Event` subsequently recorded on the
+        same stream is ordered after that work. Accessing an unfinished result
+        may wait for completion.
+
         .. note::
 
           This is an experimental API and may change in future versions.

--- a/python/tests/test_device.py
+++ b/python/tests/test_device.py
@@ -93,6 +93,53 @@ class TestStream(mlx_tests.MLXTestCase):
             with self.assertRaises(ValueError):
                 mx.new_stream(mx.gpu)
 
+    def test_stream_api(self):
+        stream = mx.Stream(mx.cpu)
+        self.assertEqual(stream.device, mx.cpu)
+        self.assertTrue(stream.query())
+        stream.synchronize()
+        self.assertTrue(stream.query())
+
+        default_stream = mx.Stream()
+        self.assertEqual(default_stream.device, mx.default_device())
+        with self.assertRaises(ValueError):
+            stream.record_event()
+
+        other = mx.Stream(mx.cpu)
+        stream.wait_stream(other)
+        stream.synchronize()
+
+        default_device = mx.default_device()
+        default_stream = mx.default_stream(default_device)
+        with stream as current:
+            self.assertIs(current, stream)
+            self.assertEqual(mx.default_device(), mx.cpu)
+            self.assertEqual(mx.default_stream(mx.cpu), stream)
+        self.assertEqual(mx.default_device(), default_device)
+        self.assertEqual(mx.default_stream(default_device), default_stream)
+
+    @unittest.skipIf(not mx.is_available(mx.gpu), "GPU is not available")
+    def test_gpu_stream_api(self):
+        producer = mx.Stream(mx.gpu)
+        consumer = mx.Stream(mx.gpu)
+        self.assertTrue(producer.query())
+        self.assertTrue(consumer.query())
+
+        event = producer.record_event()
+        self.assertIsInstance(event, mx.Event)
+        same_event = mx.Event()
+        self.assertIs(producer.record_event(same_event), same_event)
+
+        consumer.wait_event(event)
+        self.assertFalse(consumer.query())
+        consumer.synchronize()
+        self.assertTrue(consumer.query())
+
+        consumer.wait_stream(producer)
+        self.assertFalse(consumer.query())
+        consumer.synchronize()
+        self.assertTrue(consumer.query())
+
     def test_op_on_stream(self):
         x = mx.array(1.0)
         y = mx.array(1.0)
@@ -111,6 +158,70 @@ class TestStream(mlx_tests.MLXTestCase):
         s_cpu = mx.new_stream(mx.cpu)
         b = mx.add(x, y, stream=s_cpu)
         self.assertEqual(a.item(), b.item())
+
+
+class TestEvent(mlx_tests.MLXTestCase):
+    def test_event_requires_gpu(self):
+        with self.assertRaises(TypeError):
+            mx.Event(mx.gpu, True)
+        with self.assertRaises(ValueError):
+            mx.Event(mx.cpu)
+        with self.assertRaises(ValueError):
+            mx.Event(mx.cpu, enable_timing=True)
+
+    @unittest.skipIf(not mx.is_available(mx.gpu), "GPU is not available")
+    def test_event_synchronization(self):
+        record_stream = mx.new_stream(mx.gpu)
+        wait_stream = mx.new_stream(mx.gpu)
+        event = mx.Event()
+
+        self.assertTrue(event.query())
+        event.wait(wait_stream)
+        event.synchronize()
+
+        out = mx.exp(
+            mx.arange(1 << 20, dtype=mx.float32, stream=record_stream),
+            stream=record_stream,
+        )
+        mx.async_eval(out)
+        event.record(record_stream)
+        event.wait(wait_stream)
+        waited_out = mx.exp(
+            mx.arange(1 << 20, dtype=mx.float32, stream=wait_stream),
+            stream=wait_stream,
+        )
+        mx.async_eval(waited_out)
+        mx.synchronize(wait_stream)
+
+        self.assertTrue(event.query())
+        event.record(record_stream)
+        event.synchronize()
+        self.assertTrue(event.query())
+
+        end_event = mx.Event()
+        end_event.record(record_stream)
+        with self.assertRaises(RuntimeError):
+            event.elapsed_time(end_event)
+
+    @unittest.skipIf(not mx.is_available(mx.gpu), "GPU is not available")
+    def test_event(self):
+        start = mx.Event(mx.gpu, enable_timing=True)
+        end = mx.Event(mx.gpu, enable_timing=True)
+        start.record()
+        out = mx.exp(
+            mx.arange(1 << 20, dtype=mx.float32, stream=mx.gpu),
+            stream=mx.gpu,
+        )
+        mx.async_eval(out)
+        end.record()
+        self.assertGreater(start.elapsed_time(end), 0.0)
+
+    @unittest.skipIf(not mx.is_available(mx.gpu), "GPU is not available")
+    def test_unrecorded_event(self):
+        with self.assertRaises(RuntimeError):
+            mx.Event(mx.gpu, enable_timing=True).elapsed_time(
+                mx.Event(mx.gpu, enable_timing=True)
+            )
 
 
 class TestDeviceInfo(mlx_tests.MLXTestCase):

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(
           creations_tests.cpp
           device_tests.cpp
           einsum_tests.cpp
+          event_tests.cpp
           export_import_tests.cpp
           eval_tests.cpp
           fft_tests.cpp

--- a/tests/event_tests.cpp
+++ b/tests/event_tests.cpp
@@ -1,0 +1,77 @@
+// Copyright © 2026 Apple Inc.
+
+#include <chrono>
+
+#include "doctest/doctest.h"
+#include "mlx/backend/gpu/device_info.h"
+#include "mlx/event.h"
+#include "mlx/mlx.h"
+
+using namespace mlx::core;
+
+TEST_CASE("test public event requires gpu") {
+  auto stream = default_stream(Device::cpu);
+  Event internal_event(stream);
+  CHECK(internal_event.valid());
+  CHECK_THROWS_AS(Event(stream, false), std::invalid_argument);
+  CHECK_THROWS_AS(Event(stream, true), std::invalid_argument);
+}
+
+TEST_CASE("test metal event synchronization") {
+  if (!gpu::is_available()) {
+    return;
+  }
+
+  auto record_stream = new_stream(Device::gpu);
+  auto wait_stream = new_stream(Device::gpu);
+  Event event(record_stream, false);
+  Event end_event(record_stream, false);
+
+  CHECK(query(record_stream));
+  CHECK(query(wait_stream));
+  CHECK(event.query());
+  CHECK_NOTHROW(event.wait(wait_stream));
+  CHECK_NOTHROW(event.synchronize());
+
+  auto out = exp(arange(1 << 20, float32, record_stream), record_stream);
+  async_eval(out);
+  event.record(record_stream);
+  event.wait(wait_stream);
+  CHECK_FALSE(query(wait_stream));
+  auto waited_out = exp(arange(1 << 20, float32, wait_stream), wait_stream);
+  async_eval(waited_out);
+  synchronize(wait_stream);
+
+  CHECK(query(wait_stream));
+  CHECK(event.query());
+  event.record(record_stream);
+  event.synchronize();
+  CHECK(event.query());
+
+  end_event.record(record_stream);
+  CHECK_THROWS_AS(event.elapsed_time(end_event), std::runtime_error);
+}
+
+TEST_CASE("test metal event elapsed time") {
+  if (!gpu::is_available()) {
+    return;
+  }
+
+  auto stream = default_stream(Device::gpu);
+  Event start(stream, true);
+  Event end(stream, true);
+  CHECK_THROWS_AS(start.elapsed_time(end), std::runtime_error);
+
+  auto before = std::chrono::steady_clock::now();
+  start.record(stream);
+  auto out = exp(arange(1 << 20, float32, stream), stream);
+  async_eval(out);
+  end.record(stream);
+  auto elapsed = start.elapsed_time(end);
+  auto wall_time = std::chrono::duration<double, std::milli>(
+                       std::chrono::steady_clock::now() - before)
+                       .count();
+
+  CHECK(elapsed > 0.0);
+  CHECK(elapsed <= wall_time);
+}

--- a/tests/scheduler_tests.cpp
+++ b/tests/scheduler_tests.cpp
@@ -196,6 +196,20 @@ TEST_CASE("test asynchronous launch") {
   CHECK_EQ(x, 10);
 }
 
+TEST_CASE("test cpu stream query") {
+  auto stream = new_stream(Device::cpu);
+  CHECK(query(stream));
+
+  auto release = std::make_shared<std::promise<void>>();
+  auto ready = release->get_future().share();
+  scheduler::enqueue(stream, [ready = std::move(ready)]() { ready.wait(); });
+
+  CHECK_FALSE(query(stream));
+  release->set_value();
+  synchronize(stream);
+  CHECK(query(stream));
+}
+
 TEST_CASE("test stream placement") {
   auto s1 = default_stream(Device::cpu);
   auto s2 = new_stream(Device::cpu);


### PR DESCRIPTION
## Proposed changes

This PR adds Python APIs for stream management, event synchronization, and
Metal GPU timing.

- Add Stream construction, context-manager support, completion queries, and
  synchronization methods.
- Add a GPU Event API with recording, waiting, querying, synchronization, and
  elapsed-time measurement.
- Implement Metal event ordering with `MTLSharedEvent` and timing with
  command-buffer `GPUEndTime`.
- Document the interaction between events, streams, and MLX lazy evaluation.
- Add C++ and Python tests for the new APIs.

CUDA Event functionality is not implemented. The CUDA and no-GPU backend
changes only report unsupported operations through the shared interface.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
