### PR TITLE
Make "stop" optional in arange

### DIFF
--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -1473,21 +1473,25 @@ void init_ops(nb::module_& m) {
   m.def(
       "arange",
       [](Scalar start,
-         Scalar stop,
+         std::optional<Scalar> stop,
          const std::optional<Scalar>& step,
          const std::optional<mx::Dtype>& dtype_,
          mx::StreamOrDevice s) {
+        if (!stop) {
+          stop = start;
+          start = 0;
+        }
         // Determine the final dtype based on input types
         mx::Dtype dtype = dtype_
             ? *dtype_
             : mx::promote_types(
                   scalar_to_dtype(start),
                   step ? mx::promote_types(
-                             scalar_to_dtype(stop), scalar_to_dtype(*step))
-                       : scalar_to_dtype(stop));
+                             scalar_to_dtype(*stop), scalar_to_dtype(*step))
+                       : scalar_to_dtype(*stop));
         return mx::arange(
             scalar_to_double(start),
-            scalar_to_double(stop),
+            scalar_to_double(*stop),
             step ? scalar_to_double(*step) : 1.0,
             dtype,
             s);
@@ -1499,7 +1503,7 @@ void init_ops(nb::module_& m) {
       nb::kw_only(),
       "stream"_a = nb::none(),
       nb::sig(
-          "def arange(start : Union[int, float], stop : Union[int, float], step : Union[None, int, float], dtype: Optional[Dtype] = None, *, stream: Union[None, Stream, Device] = None) -> array"),
+          "def arange(start : Union[int, float], stop : Union[None, int, float], step : Union[None, int, float], dtype: Optional[Dtype] = None, *, stream: Union[None, Stream, Device] = None) -> array"),
       R"pbdoc(
       Generates ranges of numbers.
 
@@ -1508,7 +1512,7 @@ void init_ops(nb::module_& m) {
 
       Args:
           start (float or int, optional): Starting value which defaults to ``0``.
-          stop (float or int): Stopping value.
+          stop (float or int, optional): Stopping value.
           step (float or int, optional): Increment which defaults to ``1``.
           dtype (Dtype, optional): Specifies the data type of the output. If unspecified will default to ``float32`` if any of ``start``, ``stop``, or ``step`` are ``float``. Otherwise will default to ``int32``.
 

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -1501,6 +1501,10 @@ class TestOps(mlx_tests.MLXTestCase):
         expected = [0, -1, -2]
         self.assertListEqual(a.tolist(), expected)
 
+        a = mx.arange(-3, None, -1)
+        expected = [0, -1, -2]
+        self.assertListEqual(a.tolist(), expected)
+
         a = mx.arange(stop=2, step=0.5)
         expected = [0, 0.5, 1.0, 1.5]
         self.assertListEqual(a.tolist(), expected)


### PR DESCRIPTION
Please include a description of the problem or feature this PR is addressing. If there is a corresponding issue, include the issue #.

This pull request updates the `arange` function in the Python bindings to better match the behavior of NumPy by making the `stop` parameter optional. If `stop` is not provided, `start` is treated as the stopping value and the range starts from zero. The changes also update the function signature, documentation, and add a test to verify the new behavior.

**Enhancements to `arange` argument handling:**
* Changed the `arange` function so that `stop` is now optional (`std::optional<Scalar>`). If only one argument is provided, it is treated as `stop` and `start` defaults to zero, matching NumPy's behavior.
* Updated the function signature in the Python binding to reflect that `stop` can be `None`.

**Documentation updates:**
* Modified the docstring to indicate that `stop` is now optional.

**Testing improvements:**
* Added a test case to ensure that calling `arange` with `stop=None` produces the correct output.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

Part of the https://github.com/data-apis/array-api-compat/issues/452 .