### PR TITLE
Fix matmul precision with broadcast RHS

### DIFF
--- a/mlx/backend/metal/matmul.cpp
+++ b/mlx/backend/metal/matmul.cpp
@@ -1441,7 +1441,7 @@ void Matmul::eval_gpu(const std::vector<array>& inputs, array& out) {
   auto batch_size_out = out.size() / (size_t(M) * size_t(N));
 
   // Collapse batches into M if needed
-  if (batch_size_out > 1 && !a_transposed && batch_shape.size() == 1 &&
+  if (M > 1 && batch_size_out > 1 && !a_transposed && batch_shape.size() == 1 &&
       a.strides()[a.ndim() - 2] == K && A_batch_stride.back() == M * K &&
       B_batch_stride.back() == 0) {
     M *= batch_shape.back();

--- a/python/tests/test_blas.py
+++ b/python/tests/test_blas.py
@@ -1,6 +1,9 @@
 # Copyright © 2023-2024 Apple Inc.
 
 import math
+import os
+import subprocess
+import sys
 import unittest
 from itertools import permutations
 
@@ -261,6 +264,40 @@ class TestBlas(mlx_tests.MLXTestCase):
         c_mlx = a_mlx @ mx.transpose(b_mlx, (0, 1, 3, 2))
         self.assertListEqual(list(c_npy.shape), list(c_mlx.shape))
         self.assertTrue(np.allclose(c_mlx, c_npy, atol=1e-6))
+
+    def test_matmul_broadcast_rhs_k1_precision(self):
+        if not mx.is_available(mx.gpu):
+            self.skipTest("requires GPU")
+
+        code = """
+import mlx.core as mx
+
+mx.set_default_device(mx.gpu)
+
+rhs = mx.full((1, 1, 1, 512), 1.0 + 2**-12).astype(mx.float32)
+lhs = mx.ones((1, 16, 1, 1)).astype(mx.float32)
+
+out = lhs @ rhs
+error = mx.max(mx.abs(out - rhs)).item()
+
+assert error == 0.0, f"max error: {error}"
+"""
+
+        env = os.environ.copy()
+        env["MLX_ENABLE_TF32"] = "1"
+
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=result.stdout + result.stderr,
+        )
 
     def __gemv_test(
         self,


### PR DESCRIPTION
## Proposed changes

Fixes #3953.

The Metal matmul backend was collapsing a broadcast batch dimension into `M` even when the original operation had `M == 1`.

For a float32 batched matrix-vector product with a stride-zero broadcasted right-hand operand, this changed the operation from the GEMV path to the TF32-enabled GEMM path. As a result, multiplying by exactly `1.0` could reduce the precision of the right-hand operand.

This change prevents the batch-into-`M` collapse when the original `M` dimension is `1`, allowing the operation to remain on the existing GEMV path.

A regression test is included that runs the operation with TF32 enabled in a separate process.

## Testing

* Focused regression test passed:
  `PYTHONPATH=python/tests python -m unittest test_blas.TestBlas.test_matmul_broadcast_rhs_k1_precision -v`
* Complete BLAS test suite passed:
  `PYTHONPATH=python/tests python -m unittest test_blas -v`
* 29 BLAS tests passed.
* Pre-commit hooks passed for the modified files.
* The original issue reproduction now reports a maximum error of `0.0` with `MLX_ENABLE_TF32=1`.

## Checklist

* [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
* [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] I have updated the necessary documentation (if needed)

