### PR TITLE
added __complex__ support

### DIFF
--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -1035,11 +1035,7 @@ void init_array(nb::module_& m) {
       .def(
           "__complex__",
           [](mx::array& a) {
-            auto value = PyComplex_AsCComplex(to_scalar(a).ptr());
-            if (PyErr_Occurred()) {
-              throw nb::python_error();
-            }
-            return std::complex<double>(value.real, value.imag);
+            return nb::cast<std::complex<double>>(to_scalar(a));
           })
       .def(
           "__format__",

--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -1036,6 +1036,9 @@ void init_array(nb::module_& m) {
           "__complex__",
           [](mx::array& a) {
             auto value = PyComplex_AsCComplex(to_scalar(a).ptr());
+            if (PyErr_Occurred()) {
+              throw nb::python_error();
+            }
             return std::complex<double>(value.real, value.imag);
           })
       .def(

--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -1033,6 +1033,12 @@ void init_array(nb::module_& m) {
       .def("__int__", [](mx::array& a) { return nb::int_(to_scalar(a)); })
       .def("__float__", [](mx::array& a) { return nb::float_(to_scalar(a)); })
       .def(
+          "__complex__",
+          [](mx::array& a) {
+            auto value = PyComplex_AsCComplex(to_scalar(a).ptr());
+            return std::complex<double>(value.real, value.imag);
+          })
+      .def(
           "__format__",
           [](mx::array& a, nb::object format_spec) {
             if (nb::len(nb::str(format_spec)) > 0 && a.ndim() > 0) {

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -15,8 +15,6 @@ import mlx.core as mx
 import mlx_tests
 import numpy as np
 
-from examples.python.logistic_regression import w
-
 try:
     import tensorflow as tf
 

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -15,6 +15,8 @@ import mlx.core as mx
 import mlx_tests
 import numpy as np
 
+from examples.python.logistic_regression import w
+
 try:
     import tensorflow as tf
 
@@ -2673,16 +2675,23 @@ class TestArray(mlx_tests.MLXTestCase):
         a = mx.array(1)
         self.assertEqual(int(a), 1)
         self.assertEqual(float(a), 1)
+        self.assertEqual(complex(a), 1 + 0j)
 
         a = mx.array(1.5)
         self.assertEqual(float(a), 1.5)
         self.assertEqual(int(a), 1)
+        self.assertEqual(complex(a), 1.5 + 0j)
+
+        a = mx.array(1 + 2j, dtype=mx.complex64)  # type: ignore
+        self.assertEqual(complex(a), 1 + 2j)
 
         a = mx.zeros((2, 1))
         with self.assertRaises(ValueError):
             float(a)
         with self.assertRaises(ValueError):
             int(a)
+        with self.assertRaises(ValueError):
+            complex(a)
 
     def test_format(self):
         a = mx.arange(3)


### PR DESCRIPTION
This pull request adds support for converting `mx::array` objects to Python complex numbers by implementing the 

Please include a description of the problem or feature this PR is addressing. If there is a corresponding issue, include the issue #.

`__complex__` method. It also extends the test suite to verify this new functionality, ensuring that both real and complex arrays behave as expected when converted to complex numbers.

#### New feature: Python complex conversion support

* Added a `__complex__` method to the `mx::array` Python bindings, allowing `mx::array` instances to be converted to Python complex numbers using the built-in `complex()` function.

#### Test improvements

* Extended the `test_to_scalar` test to check that `complex(mx.array(...))` returns the correct complex value for real and complex arrays, and raises a `ValueError` for non-scalar arrays.


## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)

Part of the https://github.com/data-apis/array-api-compat/issues/452 .
