### PR TITLE
Fix missing printoptions doc page from autosummary filename collision

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -28,7 +28,10 @@ extensions = [
 
 python_use_unqualified_type_names = True
 autosummary_generate = True
-autosummary_filename_map = {"mlx.core.Stream": "stream_class"}
+autosummary_filename_map = {
+    "mlx.core.Stream": "stream_class",
+    "mlx.core.PrintOptions": "printoptions_class",
+}
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),


### PR DESCRIPTION
## Proposed changes

Building the docs warns:

```
docs/src/python/printoptions.rst:6: WARNING: autosummary: stub file not found
'mlx.core.printoptions'. Check your autosummary_generate setting.
```

`PrintOptions` (the class) and `printoptions` (the context manager) differ only in case, so autosummary wants to write `mlx.core.PrintOptions.rst` and `mlx.core.printoptions.rst` into the same directory. On a case insensitive filesystem, which macOS is by default, those are the same path, so one clobbers the other and `printoptions` ends up with no page.

Before this change `_autosummary` contains three files and the function is missing:

```
mlx.core.PrintOptions.rst  mlx.core.get_printoptions.rst  mlx.core.set_printoptions.rst
```

After, all four exist:

```
printoptions_class.rst  mlx.core.printoptions.rst  mlx.core.get_printoptions.rst  mlx.core.set_printoptions.rst
```

This is the same collision `mlx.core.Stream` and `mlx.core.stream` already had, so I fixed it the same way the existing entry does, by mapping the class to its own filename. Reverting the change brings the warning back, so it is the cause.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

(docs config only; verified by building the docs before and after)

---

quick disclosure: freshman contributor, i use Claude Code when hunting, but i found this by actually building the docs and reading the warnings, then confirmed the case collision by listing the generated stubs both ways. i picked `printoptions_class` to match the existing `stream_class` naming, happy to rename if you prefer something else.
