### PR TITLE
Document ThreadLocalStream and iinfo in the API reference

### DIFF
--- a/docs/src/python/data_types.rst
+++ b/docs/src/python/data_types.rst
@@ -76,3 +76,4 @@ documentation for more information. Use :func:`issubdtype` to determine if one
    DtypeCategory
    issubdtype
    finfo
+   iinfo

--- a/docs/src/python/devices_and_streams.rst
+++ b/docs/src/python/devices_and_streams.rst
@@ -10,6 +10,7 @@ Devices and Streams
 
    Device
    Stream
+   ThreadLocalStream
    default_device
    set_default_device
    default_stream


### PR DESCRIPTION
## Proposed changes

Two public classes are missing from the API reference while their direct counterparts are already listed.

`ThreadLocalStream` is what `new_thread_local_stream` returns, and it shows up in the type stubs as an accepted `stream` argument in essentially every op:

```python
stream: mlx.core.Stream | mlx.core.ThreadLocalStream | mlx.core.Device | None = None
```

`Stream` and `Device` are both on the devices and streams page, so one of the three types a user can pass has no page to click through to. Building the docs with `-n` reports `target not found: mlx.core.ThreadLocalStream` 65 times, which is what led me here.

`iinfo` is the integer counterpart of `finfo` and works the same way, but only `finfo` is listed on the data types page:

```python
mx.finfo(mx.float32)   # finfo(min=-3.40282e+38, max=3.40282e+38, dtype=float32)
mx.iinfo(mx.int32)     # iinfo(min=-2147483648, max=2147483647, dtype=int32)
```

Both entries generate their stub pages cleanly and the build adds no new warnings.

I left a few other unlisted names alone since omitting them looks deliberate rather than accidental: `ArrayAt`, `ArrayIterator`, `ArrayLike`, `DeviceType`, `StreamContext` and `FunctionExporter` are mostly internal or helper types. Glad to add any of them if you would rather they were listed.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

(docs only; built the docs before and after and checked the generated stubs)

---

being upfront as usual: freshman here and Claude Code helps me sweep, but i found these by building the docs in nitpick mode and reading the unresolved references, then checked each class actually exists and runs before adding it. the list of ones i deliberately skipped is a real question, not filler.
