### PR TITLE
Fix build error caused by TMA macro guard

### DIFF
--- a/mlx/backend/cuda/ptx.cuh
+++ b/mlx/backend/cuda/ptx.cuh
@@ -1,14 +1,12 @@
 #pragma once
 
-#include <cuda.h>
-#include <cuda_runtime.h>
+#include <cute/arch/config.hpp>
 
 namespace mlx::core {
 
 namespace ptx {
 
-#if (CUDART_VERSION >= 12080) && (__CUDA_ARCH__ >= 1000) && \
-    defined(__CUDA_ARCH_SPECIFIC__)
+#if defined(CUTE_ARCH_TMA_SM90_ENABLED)
 
 __device__ __forceinline__ void mbarrier_init(uint64_t* mbar, uint32_t count) {
   uint32_t mbar_ptr = __cvta_generic_to_shared(mbar);
@@ -121,7 +119,7 @@ __device__ __forceinline__ void fence_proxy_async_shared_cta() {
   asm volatile("fence.proxy.async.shared::cta;");
 }
 
-#endif // (CUDART_VERSION >= 12080) && (__CUDA_ARCH__ >= 1000) &&
-       // (__CUDA_ARCH_FAMILY_SPECIFIC__ >= 1000)
+#endif // defined(CUTE_ARCH_TMA_SM90_ENABLED)
+
 } // namespace ptx
 } // namespace mlx::core

--- a/mlx/backend/cuda/quantized/fp_quantize.cuh
+++ b/mlx/backend/cuda/quantized/fp_quantize.cuh
@@ -55,7 +55,7 @@ __device__ __forceinline__ void copy_2d_to_shared(
     uint32_t num_bytes,
     uint64_t* barrier,
     const bool is_master_thread) {
-#if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+#if defined(CUTE_ARCH_TMA_SM90_ENABLED)
   if (is_master_thread) {
     // Arrive and tell how many bytes are expected
     ptx::mbarrier_arrive_expect_tx(barrier, num_bytes);
@@ -66,7 +66,7 @@ __device__ __forceinline__ void copy_2d_to_shared(
     // Other threads just arrive
     ptx::mbarrier_arrive(barrier);
   }
-#endif // #if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+#endif // defined(CUTE_ARCH_TMA_SM90_ENABLED)
 }
 
 namespace cg = cooperative_groups;
@@ -228,7 +228,7 @@ __global__ void __launch_bounds__(THREADS_PER_BLOCK)
         uint8_t* __restrict__ scales,
         const size_t rows,
         const size_t cols) {
-#if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1000)
+#if defined(CUTE_ARCH_TMA_SM90_ENABLED)
   using Tx2 = Vector2_t<T>;
   using Tx4 = Vector4_t<T>;
 
@@ -408,7 +408,7 @@ __global__ void __launch_bounds__(THREADS_PER_BLOCK)
       ptx::mbarrier_invalidate(&mbar[iter]);
     }
   }
-#endif // __CUDA_ARCH__ >= 1000
+#endif // defined(CUTE_ARCH_TMA_SM90_ENABLED)
 }
 
 // TODO: add kernel with tma instructions


### PR DESCRIPTION
The [release build is failing](https://github.com/ml-explore/mlx/actions/runs/30613074114/job/91100039025) because the macros guarding TMA related PTX code are not strictly correct, reuse the macro guard of cutlass to save time defining our own.