### PR TITLE
Add softsign to the nn functions docs

### DIFF
--- a/docs/src/python/nn/functions.rst
+++ b/docs/src/python/nn/functions.rst
@@ -36,5 +36,6 @@ simple functions.
    softmin
    softplus
    softshrink
+   softsign
    step
    tanh


### PR DESCRIPTION
## Proposed changes

`nn.softsign` is missing from the neural network functions list, so it has no page in the docs. The `Softsign` layer is documented and its docstring points at the function:

> See :func:`softsign` for the functional equivalent.

Since the function has no target, that link is dead. Building with `-n` shows it:

```
python/mlx/nn/layers/activations.py:docstring of mlx.nn.layers.activations.Softsign:3:
WARNING: py:func reference target not found: softsign [ref.func]
```

Every other activation in that file has its functional form listed, including the neighbours `softmax`, `softmin`, `softplus` and `softshrink`, so this looks like it was just skipped. Adding the entry generates `mlx.nn.softsign.rst` and the warning goes away.

```python
>>> nn.softsign(mx.array([-1.0, 0.0, 1.0]))
array([-0.5, 0, 0.5], dtype=float32)
```

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

(docs only, one line; verified by building the docs before and after)

---

as usual, being straight about process: freshman contributor, Claude Code helps me sweep, but i found this by building the docs in nitpick mode, read the actual warning, and checked that every sibling activation is listed before adding it.
