### PR TITLE
Fix unresolved mx.array docstring references

### DIFF
--- a/python/mlx/nn/layers/base.py
+++ b/python/mlx/nn/layers/base.py
@@ -129,7 +129,7 @@ class Module(dict):
         Update the model's weights from a ``.npz``, a ``.safetensors`` file, or a list.
 
         Args:
-            file_or_weights (str or list(tuple(str, mx.array))): The path to
+            file_or_weights (str or list(tuple(str, array))): The path to
                 the weights ``.npz`` file (``.npz`` or ``.safetensors``) or a list
                 of pairs of parameter names and arrays.
             strict (bool, optional): If ``True`` then checks that the provided

--- a/python/mlx/nn/losses.py
+++ b/python/mlx/nn/losses.py
@@ -540,8 +540,8 @@ def cosine_similarity_loss(
         \frac{x_1 \cdot x_2}{\max(\|x_1\|  \cdot \|x_2\|, \epsilon)}
 
     Args:
-        x1 (mx.array): The first set of inputs.
-        x2 (mx.array): The second set of inputs.
+        x1 (array): The first set of inputs.
+        x2 (array): The second set of inputs.
         axis (int, optional): The embedding axis. Default: ``1``.
         eps (float, optional): The minimum value of the denominator used for
           numerical stability. Default: ``1e-8``.
@@ -549,7 +549,7 @@ def cosine_similarity_loss(
           ``'none'`` | ``'mean'`` | ``'sum'``. Default: ``'none'``.
 
     Returns:
-        mx.array: The computed cosine similarity loss.
+        array: The computed cosine similarity loss.
     """
     x1_norm = mx.linalg.norm(x1, axis=axis)
     x2_norm = mx.linalg.norm(x2, axis=axis)

--- a/python/mlx/optimizers/optimizers.py
+++ b/python/mlx/optimizers/optimizers.py
@@ -77,7 +77,7 @@ class Optimizer:
         state initialization.
 
         Args:
-            parameter (mx.array): A single parameter that will be optimized.
+            parameter (array): A single parameter that will be optimized.
             state (dict): The optimizer's state.
         """
         raise NotImplementedError()
@@ -112,8 +112,8 @@ class Optimizer:
         """To be extended by derived classes to implement the optimizer's update.
 
         Args:
-            gradient (mx.array): The ``parameter`` gradient.
-            parameter (mx.array): The ``parameter`` to update.
+            gradient (array): The ``parameter`` gradient.
+            parameter (array): The ``parameter`` to update.
             state (dict): The optimizer's state.
         """
         raise NotImplementedError()


### PR DESCRIPTION
## Proposed changes

A few docstrings write the array type as `mx.array`, which Sphinx cannot resolve, so those types render as dead links. Building with `-n` reports four of them:

```
docs/src/python/nn/_autosummary_functions/mlx.nn.losses.cosine_similarity_loss.rst:2:
WARNING: py:class reference target not found: mx.array [ref.class]
docs/src/python/nn/_autosummary/mlx.nn.Module.load_weights.rst:2:
WARNING: py:class reference target not found: mx.array [ref.class]
```

The rest of the codebase writes plain `array` in docstrings, which resolves. `losses.py` is a good example of the inconsistency: 29 places write `(array)` and only `cosine_similarity_loss` writes `(mx.array)`, in both its `Args` and its `Returns`.

Changed to `array` in:

- `nn/losses.py`, `cosine_similarity_loss` (`x1`, `x2`, and the return type)
- `nn/layers/base.py`, `Module.load_weights` (`file_or_weights`)
- `optimizers.py`, `init_single` and `apply_single` (`parameter`, `gradient`)

After the change a clean `-n` build reports zero unresolved `mx.array` references, down from four.

Note the type annotations in the signatures still say `mx.array`, which is correct Python since that is how the module is imported. This only touches the docstring text that Sphinx tries to turn into a link.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

(docstring text only, no behavior change; `test_optimizers.py` passes and the docs build is clean of these warnings)

---

process note, same as always: freshman contributor and Claude Code helps me hunt, but i found these by building the docs in nitpick mode, then chased the count from four down to zero one file at a time to make sure i had actually got all of them rather than assuming.
