### PR TITLE
Bucket compile cache entries by hash instead of scanning linearly

### DIFF
--- a/mlx/compile.cpp
+++ b/mlx/compile.cpp
@@ -320,8 +320,14 @@ class CompilerCache {
       const std::vector<array>& inputs,
       bool shapeless,
       const std::vector<uint64_t>& constants) {
-    // Find the cache entries for |fun_id|.
-    std::vector<CacheEntry>& entries = cache_[fun_id];
+    // Bucket the entries for |fun_id| by a hash of everything that has to
+    // match, so a lookup only compares against entries that can actually be
+    // equal. Without this, functions called with a per-call scalar (e.g. a
+    // KV-cache offset during decode) accumulate one entry per distinct value
+    // and every call scans all of them.
+    auto stream = default_stream(default_device());
+    std::vector<CacheEntry>& entries =
+        cache_[fun_id][hash_key(stream, inputs, shapeless, constants)];
 
     // Compare if 2 arrays have same shape and dtype.
     auto has_same_shape_and_dtype = [shapeless](
@@ -343,10 +349,11 @@ class CompilerCache {
       }
       return true;
     };
-    // Loop over entries and check:
+    // Loop over the entries in this bucket and check:
     // - Default stream and device match the entry's default stream
     // - Inputs match i.e. shapes and types must be equal.
-    auto stream = default_stream(default_device());
+    // The checks are kept in full so a hash collision cannot return a
+    // mismatched entry.
     for (CacheEntry& entry : entries) {
       // Check that the default stream and device match
       if (entry.stream != stream) {
@@ -386,8 +393,42 @@ class CompilerCache {
     allocator::allocator();
   }
 
+  // Hash of everything find() requires to be equal. Only used to pick a
+  // bucket; equality is still checked in full on the way out.
+  static size_t hash_key(
+      Stream stream,
+      const std::vector<array>& inputs,
+      bool shapeless,
+      const std::vector<uint64_t>& constants) {
+    auto combine = [](size_t seed, size_t value) {
+      return seed ^ (value + 0x9e3779b97f4a7c15ULL + (seed << 6) + (seed >> 2));
+    };
+    size_t h = combine(0, static_cast<size_t>(stream.index));
+    h = combine(h, static_cast<size_t>(stream.device.type));
+    h = combine(h, static_cast<size_t>(stream.device.index));
+    h = combine(h, static_cast<size_t>(shapeless));
+    h = combine(h, inputs.size());
+    for (const auto& in : inputs) {
+      h = combine(h, in.ndim());
+      h = combine(h, static_cast<size_t>(in.dtype().val()));
+      // Shapes are only compared when not shapeless, so only hash them then.
+      if (!shapeless) {
+        for (auto d : in.shape()) {
+          h = combine(h, static_cast<size_t>(d));
+        }
+      }
+    }
+    for (auto c : constants) {
+      h = combine(h, static_cast<size_t>(c));
+    }
+    return h;
+  }
+
   friend CompilerCache& compiler_cache();
-  std::unordered_map<std::uintptr_t, std::vector<CacheEntry>> cache_;
+  std::unordered_map<
+      std::uintptr_t,
+      std::unordered_map<size_t, std::vector<CacheEntry>>>
+      cache_;
 };
 
 CompilerCache& compiler_cache() {

--- a/python/tests/test_compile.py
+++ b/python/tests/test_compile.py
@@ -518,6 +518,34 @@ class TestCompile(mlx_tests.MLXTestCase):
         out = fun(x, y=y, z=z)
         self.assertEqual(out.item(), 6)
 
+    def test_compile_many_distinct_constants(self):
+        # Cache entries keyed on scalar arguments are bucketed by a hash of
+        # everything the lookup requires to be equal. A key that is too strict
+        # would re-trace an entry that should have been reused, and a re-trace
+        # is observable because it picks up the current value of a captured
+        # variable.
+        y = 1
+
+        @mx.compile
+        def fun(x, offset):
+            return x + offset + y
+
+        x = mx.array([1, 2])
+        self.assertTrue(mx.array_equal(fun(x, 0), mx.array([2, 3])))
+
+        # Accumulate many entries under the same function id
+        for i in range(1, 50):
+            self.assertTrue(mx.array_equal(fun(x, i), mx.array([2 + i, 3 + i])))
+
+        # Revisiting a constant must reuse its entry rather than re-trace, so
+        # the new y must not be reflected
+        y = 100
+        self.assertTrue(mx.array_equal(fun(x, 0), mx.array([2, 3])))
+        self.assertTrue(mx.array_equal(fun(x, 7), mx.array([9, 10])))
+
+        # A constant not seen before still traces, and does see the new y
+        self.assertTrue(mx.array_equal(fun(x, 50), mx.array([151, 152])))
+
     def test_shapeless_compile(self):
         y = 1
 


### PR DESCRIPTION
## Proposed changes

Fixes #3964.

`CompilerCache::find` locates a cache entry with a linear scan over every entry
retained for a function id. Because `mx.compile` keys its cache on non-array
(scalar) arguments, a compiled function called with a per-call scalar — the
classic case being a KV-cache offset during LLM decode — appends one entry per
distinct value and **never hits**, so every call scans the entire accumulated
list. Per-call lookup cost grows linearly with calls made, making the aggregate
cost quadratic.

This PR buckets the entries by a hash of everything the lookup requires to be
equal (stream, `shapeless`, per-input ndim/shape/dtype, and the constants blob).
The full equality comparison is **kept inside the bucket**, so a hash collision
can never return a mismatched entry — the hash only narrows the candidate set.

### Why

Reproducer — a compiled function called in a loop with an incrementing int:

```python
import mlx.core as mx

@mx.compile
def step(x, offset):
    return (x * 2) + offset

x = mx.zeros((64,), mx.float32)
for i in range(32000):
    step(x, i)          # each call is a cache miss
```

### Results

Apple M4 Pro (14-core), macOS 26.6, Metal backend, `0.32.1.dev20260803+fb5133e`.
Fresh process per size, median of 3 runs. "per-call" is the median of the last
500 calls at that size.

| distinct constants | total before | total after | speedup | per-call before | per-call after | speedup |
|---:|---:|---:|---:|---:|---:|---:|
| 1,000  |    12.6 ms |  10.5 ms | 1.20× |  13.5 µs | 10.4 µs |  1.30× |
| 2,000  |    31.6 ms |  21.6 ms | 1.46× |  19.1 µs | 11.4 µs |  1.68× |
| 4,000  |    88.3 ms |  54.2 ms | 1.63× |  31.7 µs | 15.7 µs |  2.02× |
| 8,000  |   278.0 ms | 119.1 ms | 2.33× |  62.2 µs | 15.8 µs |  3.93× |
| 16,000 | 1,172.7 ms | 255.5 ms | 4.59× | 137.1 µs | 16.6 µs |  8.27× |
| 32,000 | 4,904.1 ms | 543.2 ms | 9.03× | 322.5 µs | 18.0 µs | 17.87× |

The complexity change is visible in how total time scales as the size doubles:

| | ratio per doubling |
|---|---|
| before | 2.51, 2.79, 3.15, 4.22, 4.18 → approaching 4× (quadratic) |
| after  | 2.06, 2.51, 2.20, 2.15, 2.13 → steady 2× (linear) |

Per-call lookup latency — before it grows without bound, after it is flat:

```mermaid
xychart-beta
    title "Per-call compile-cache lookup latency"
    x-axis "distinct scalar constants seen" [1000, 2000, 4000, 8000, 16000, 32000]
    y-axis "microseconds per call" 0 --> 340
    line "before (linear scan)" [13.5, 19.1, 31.7, 62.2, 137.1, 322.5]
    line "after (hash bucketed)" [10.4, 11.4, 15.7, 15.8, 16.6, 18.0]
```

### Alternative considered and rejected

The issue suggests move-to-front on hit as a cheaper remedy. I implemented and
measured it: **it makes no difference**, because this workload never produces a
hit. The offset is new on every call, so every lookup is a miss, a miss scans the
whole list by definition, and the reordering never executes.

| | degradation over 4,000 calls | added cost per retained entry |
|---|---|---|
| before          | 3.27× | 6.29 ns |
| move-to-front   | 2.96× | 5.74 ns |
| hash bucketing  | 1.54× | 1.54 ns |

The move-to-front column is within run-to-run noise of the baseline; I am not
claiming it as an improvement.

### Not addressed here

Entries are still retained without bound — measured at **~7 KB per distinct
constant, never reclaimed** (28 MB over 4,000 calls). This PR changes lookup cost
only, not retention. Capping or evicting is a semantics change that deserves its
own discussion, so I have left it out rather than fold it in silently; I have
noted the measurement on #3964.

### Validation

```bash
python -m unittest discover -s python/tests          # 792 passed, 3 skipped
pre-commit run --files mlx/compile.cpp python/tests/test_compile.py
```

`test_compile_many_distinct_constants` accumulates many entries under one
function id, then re-uses an earlier constant and asserts the entry is reused
rather than re-traced (a re-trace is observable because it would pick up the
current value of a captured variable). I verified the test is not vacuous by
deliberately corrupting the hash key so every lookup misses: the new test fails,
along with 5 existing ones (`test_compile_with_constant`, `test_compile_with_closure`,
`test_shapeless_compile`, `test_shapeless_compile_with_reduction`,
`test_shapeless_compile_with_reshape`).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed) — no API or documented behaviour changes
