### PR TITLE
Fix broken all_sum and Group references in the data parallelism example

### DIFF
--- a/docs/src/examples/data_parallelism.rst
+++ b/docs/src/examples/data_parallelism.rst
@@ -34,7 +34,8 @@ dataset, and optimizer initialization.
         mx.eval(loss, model.parameters())
 
 All we have to do to average the gradients across machines is perform an
-:func:`all_sum` and divide by the size of the :class:`Group`. Namely we
+:func:`mlx.core.distributed.all_sum` and divide by the size of the
+:class:`mlx.core.distributed.Group`. Namely we
 have to :func:`mlx.utils.tree_map` the gradients with following function.
 
 .. code:: python


### PR DESCRIPTION
## Proposed changes

The data parallelism example links to `all_sum` and `Group` with bare names, but that page has no `currentmodule` directive, so neither resolves and both render as plain text instead of links:

```
docs/src/examples/data_parallelism.rst:36: WARNING: py:func reference target not found: all_sum
docs/src/examples/data_parallelism.rst:36: WARNING: py:class reference target not found: Group
```

Both live under `mlx.core.distributed`, and the sibling page `tensor_parallelism.rst` already writes them fully qualified, so this brings the two pages in line. The other two references on the page were already fully qualified (`mlx.nn.average_gradients`, `mlx.utils.tree_map`), so these two were the odd ones out.

After the change the page builds with no unresolved references.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

(docs only; verified by building the docs with `-n` before and after)

---

usual note on process: freshman contributor, i lean on Claude Code for the sweeping, but i built the docs in nitpick mode myself, read the warnings, and checked how the neighbouring tensor parallelism page writes the same two references before picking the fix.
