### PR TITLE
Fix ast.metal_kernel typo in the custom Metal kernels guide

### DIFF
--- a/docs/src/dev/custom_metal_kernels.rst
+++ b/docs/src/dev/custom_metal_kernels.rst
@@ -92,8 +92,8 @@ function. This means we will launch ``mx.prod(grid)`` threads, subdivided into
 ``threadgroup`` size threadgroups.  For optimal performance, each thread group
 dimension should be less than or equal to the corresponding grid dimension.
 
-Passing ``verbose=True`` to :func:`ast.metal_kernel.__call__` will print the
-generated code for debugging purposes.
+Passing ``verbose=True`` when calling the kernel returned by
+:func:`fast.metal_kernel` will print the generated code for debugging purposes.
 
 Math Mode
 ---------


### PR DESCRIPTION
## Proposed changes

The custom Metal kernels guide refers to `ast.metal_kernel.__call__`, which does not exist, so the link is dead:

```
docs/src/dev/custom_metal_kernels.rst:95: WARNING: py:func reference target not found:
ast.metal_kernel.__call__ [ref.func]
```

Looks like a typo for `fast.metal_kernel`, which is how the same page refers to it in five other places.

While fixing the name I also adjusted the wording, because `verbose` is not an argument to `fast.metal_kernel` itself. It is passed when calling the kernel that `metal_kernel` returns, which is what the example further up the page does:

```python
kernel = mx.fast.metal_kernel(...)
outputs = kernel(
    inputs=[a],
    grid=(a.size, 1, 1),
    threadgroup=(256, 1, 1),
    verbose=True,
)
```

So the sentence now says "when calling the kernel returned by :func:`fast.metal_kernel`" rather than pointing at the factory function.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

(docs only; the page now builds with no unresolved references)

---

small disclosure, same as my other PRs: freshman contributor and Claude Code helps me sweep, but i built the docs in nitpick mode to find this, then checked the metal_kernel docstring to confirm where `verbose` actually belongs before rewording rather than just swapping the typo.
