### PR TITLE
Make the gather_qmm_rhs dispatch thresholds overridable

### DIFF
--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -1583,8 +1583,16 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
   // We are walking x in order and w is also in order so we can batch up the
   // matmuls and reuse reading x and w.
   //
-  // TODO: Tune 16 and 4 here a bit better.
-  if (M == 1 && B >= 16 && right_sorted_ == true && B / E >= 4) {
+  // The two thresholds are overridable so they can be tuned, and so a
+  // configuration that never reaches this path can be measured against it
+  // without a rebuild. Defaults are the previous hard-coded 16 and 4, so
+  // behaviour is unchanged unless the environment says otherwise.
+  //
+  // Note `B / E` is an average: MoE decode at batch size 1 gathers
+  // `top_k` rows over `E` experts, so with a large expert count both
+  // conditions are unsatisfiable no matter how the routing is distributed.
+  if (M == 1 && B >= env::gather_qmm_rhs_min_rows() && right_sorted_ == true &&
+      B / E >= env::gather_qmm_rhs_min_rows_per_expert()) {
     gather_qmm_rhs(
         x,
         w,

--- a/mlx/utils.h
+++ b/mlx/utils.h
@@ -207,6 +207,22 @@ inline const std::string& metal_gpu_arch() {
   return gpu_arch_;
 }
 
+/// Minimum number of gathered rows before `GatherQMM` uses the batched
+/// `gather_qmm_rhs` path. Default 16, matching the previous hard-coded value.
+inline int gather_qmm_rhs_min_rows() {
+  static int gather_qmm_rhs_min_rows_ =
+      get_var("MLX_GATHER_QMM_RHS_MIN_ROWS", 16);
+  return gather_qmm_rhs_min_rows_;
+}
+
+/// Minimum average rows per expert before `GatherQMM` uses the batched
+/// `gather_qmm_rhs` path. Default 4, matching the previous hard-coded value.
+inline int gather_qmm_rhs_min_rows_per_expert() {
+  static int gather_qmm_rhs_min_rows_per_expert_ =
+      get_var("MLX_GATHER_QMM_RHS_MIN_ROWS_PER_EXPERT", 4);
+  return gather_qmm_rhs_min_rows_per_expert_;
+}
+
 } // namespace env
 
 } // namespace mlx::core


### PR DESCRIPTION
## The situation

`GatherQMM::eval_gpu` picks the batched `gather_qmm_rhs` path from two hard-coded thresholds that the code itself flags as unturned — `mlx/backend/metal/quantized.cpp`:

```cpp
  // TODO: Tune 16 and 4 here a bit better.
  if (M == 1 && B >= 16 && right_sorted_ == true && B / E >= 4) {
```

For MoE decode at batch size 1 with a large expert count, **both conditions are unsatisfiable regardless of how routing is distributed**, so the batched path can never be selected and never measured against.

Concretely, for a 35B-A3B-shaped model — 256 experts, top-8 routing, single-token decode:

```
M = 1                      (one token)
B = 8                      (8 gathered rows)
E = 256                    (experts)

B >= 16          ->  8 >= 16            false
B / E >= 4       ->  needs B >= 1024    false   (8/256 = 0)
```

`B / E` is an *average* rows-per-expert, so satisfying it needs 1024 gathered rows — 128 tokens at top-8. That is a batch-decode regime, not single-token decode. The threshold isn't merely conservative for this shape; it is unreachable.

I am not claiming the current defaults are wrong. I am claiming that with them hard-coded there is no way to find out, short of patching and rebuilding MLX — which is the position I am in, and why this is the first thing I would like to change.

## The change

Two `env::`-namespace accessors in `mlx/utils.h`, following the existing pattern used by `bfs_max_width`, `max_ops_per_buffer`, `metal_fast_synch`, `enable_tf32`, `nccl_timeout` and `metal_gpu_arch`:

- `MLX_GATHER_QMM_RHS_MIN_ROWS` — default **16**
- `MLX_GATHER_QMM_RHS_MIN_ROWS_PER_EXPERT` — default **4**

**Defaults are the previous hard-coded values, so behaviour is unchanged unless the environment says otherwise.** No kernel changes, no API changes, no new dependencies.

I also expanded the comment to record *why* the second condition behaves the way it does for large expert counts, since that is the part that surprised me.

### One thing I deliberately did not do

An earlier draft of mine rewrote `B / E >= 4` as `B >= 4 * E`, on the grounds that it reads better. The two are equivalent for positive integers, but once the multiplier is settable the product form can overflow `int` where the division form cannot, so I kept the division. Mentioning it in case the rewrite looks like an oversight.

## Evidence

- **Compiles clean.** I compiled the affected translation unit to an object using the compile command MLX's own CMake build recorded in `compile_commands.json` — exit 0, 273 KB object, **zero errors and zero warnings**. Also `-fsyntax-only`, exit 0, no diagnostics.
- **READ** `mlx/utils.cpp:253-259` — `get_var(const char*, int)` is `std::getenv` + `atoi` with a default fallback, so an unset variable yields exactly the previous constant.
- **READ** `mlx/utils.h:141-176` — the six existing accessors use the identical `static`-cached form; these two are written the same way.
- **Verified not stale:** the `TODO` comment and the dispatch condition are unchanged on `main` at `quantized.cpp:1586-1587` as of today.

**What I did not do, stated plainly:** I have not run a full `libmlx` build or an end-to-end A/B of the two dispatch paths. The A/B is the thing this PR unblocks — I cannot produce that number until the thresholds are reachable without a fork, which is the whole request. If you would rather see a full build plus benchmark numbers before merging, I am happy to do that; it just has to come after something like this lands, or against a temporary fork whose numbers you would reasonably discount.

## Why I want it

I am running a 35B-A3B MoE with experts streamed from SSD on a 24 GB Apple M4, and the per-expert quantized gather is the largest single term I have measured in the decode path. I would like to find out whether the batched path helps at `B = 8`, and at present I cannot ask the question. If the answer turns out to be "the defaults are right, the batched path is worse here", that is a useful result too — and I would be glad to send it back as a tuning follow-up with real numbers.
