### PR TITLE
Increase ccache size in CI

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -92,15 +92,16 @@ runs:
         key: v7-${{ inputs.ccache-key }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.ccache-toolkit || inputs.toolkit }}
         max-size: |-
           ${{ case(inputs.ccache-key == 'release',
-                   case(startsWith(inputs.toolkit, 'cuda'), '150MB',
+                   case(startsWith(inputs.toolkit, 'cuda'),
+                        case(runner.os == 'Linux', '300MB',
+                             '160MB'),
                         '60MB'),
                    case(startsWith(inputs.toolkit, 'cuda'),
-                        case(runner.os == 'Linux' && runner.arch == 'x64', '500MB',
-                             runner.os == 'Linux', '240MB',
-                             '120MB'),
-                        runner.os == 'macOS' && inputs.toolkit == 'metal', '200MB',
-                        runner.os == 'macOS', '150MB',
-                        '60MB'))
+                        case(runner.os == 'Linux' && runner.arch == 'x64', '600MB',
+                             runner.os == 'Linux', '400MB',
+                             '320MB'),
+                        runner.os == 'macOS' && inputs.toolkit == 'metal', '300MB',
+                        '200MB'))
           }}
         save: ${{ !startsWith(github.ref, 'refs/pull/') && (inputs.ccache-save != 'false') }}
         # ccache-action bug: running "apt-get update" fails on large arm runner.


### PR DESCRIPTION
When the cache is full and `ccache` does cleanup, it does not necessarily remove the oldest cache because it does not keep precise records. So if the cache limit is not big enough `ccache` would keep erasing cache of recent build and end up with bad cache hit rate.