### PR TITLE
Fix fp16/bf16 divmod and floor_divide precision (divide in float before rounding)

### DIFF
--- a/mlx/backend/cpu/binary.cpp
+++ b/mlx/backend/cpu/binary.cpp
@@ -48,7 +48,14 @@ void DivMod::eval_cpu(
       return std::make_pair(x / y, x % y);
     };
     auto float_op = [](auto x, auto y) {
-      return std::make_pair(std::trunc(x / y), std::fmod(x, y));
+      // fp16/bf16: divide in float so the quotient isn't narrowed before trunc
+      using T = std::decay_t<decltype(x)>;
+      using C = std::conditional_t<sizeof(T) == 2, float, T>;
+      auto xc = static_cast<C>(x);
+      auto yc = static_cast<C>(y);
+      return std::make_pair(
+          static_cast<T>(std::trunc(xc / yc)),
+          static_cast<T>(std::fmod(xc, yc)));
     };
 
     switch (out_a.dtype()) {

--- a/mlx/backend/cuda/device/binary_ops.cuh
+++ b/mlx/backend/cuda/device/binary_ops.cuh
@@ -18,6 +18,10 @@ struct FloorDivide {
   __device__ T operator()(T x, T y) {
     if constexpr (cuda::std::is_integral_v<T>) {
       return x / y;
+    } else if constexpr (sizeof(T) == 2) {
+      // fp16/bf16: divide in float so the quotient isn't narrowed before trunc
+      return static_cast<T>(
+          cuda::std::trunc(static_cast<float>(x) / static_cast<float>(y)));
     } else {
       return cuda::std::trunc(x / y);
     }

--- a/mlx/backend/metal/kernels/binary_ops.h
+++ b/mlx/backend/metal/kernels/binary_ops.h
@@ -25,11 +25,13 @@ struct FloorDivide {
   }
   template <>
   half operator()(half x, half y) thread {
-    return trunc(x / y);
+    return static_cast<half>(
+        trunc(static_cast<float>(x) / static_cast<float>(y)));
   }
   template <>
   bfloat16_t operator()(bfloat16_t x, bfloat16_t y) thread {
-    return trunc(x / y);
+    return static_cast<bfloat16_t>(
+        trunc(static_cast<float>(x) / static_cast<float>(y)));
   }
 };
 

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -3008,6 +3008,13 @@ array floor_divide(
     StreamOrDevice s /* = {} */) {
   auto dtype = promote_types(a.dtype(), b.dtype());
   if (issubdtype(dtype, inexact)) {
+    // fp16/bf16: divide in float so the quotient isn't narrowed before floor.
+    // narrow to the promoted dtype first so rounding matches divmod.
+    if (dtype == float16 || dtype == bfloat16) {
+      auto af = astype(astype(a, dtype, s), float32, s);
+      auto bf = astype(astype(b, dtype, s), float32, s);
+      return astype(floor(divide(af, bf, s), s), dtype, s);
+    }
     return floor(divide(a, b, s), s);
   }
 

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -2763,6 +2763,26 @@ class TestOps(mlx_tests.MLXTestCase):
                     np.allclose(np_out[0], mx_out[0]), msg=f"Shapes {s1} {s2}, Type {t}"
                 )
 
+        # boundary case: a / b is just under 3, but narrowing the quotient to
+        # fp16/bf16 before trunc rounds it up to 3. divmod divides in float, so
+        # it stays 2.
+        for dt in (mx.float16, mx.bfloat16):
+            q = mx.divmod(
+                mx.array([86.5625], dtype=dt), mx.array([28.859375], dtype=dt)
+            )[0]
+            self.assertEqual(q.item(), 2.0)
+
+        # bfloat16 has no numpy dtype; compare the quotient against a float32
+        # reference over a seeded batch.
+        rng = np.random.default_rng(0)
+        a_np = rng.uniform(1, 100, size=(4096,)).astype(np.float32)
+        b_np = rng.uniform(1, 100, size=(4096,)).astype(np.float32)
+        a = mx.array(a_np).astype(mx.bfloat16)
+        b = mx.array(b_np).astype(mx.bfloat16)
+        q = mx.divmod(a, b)[0]
+        ref = mx.trunc(a.astype(mx.float32) / b.astype(mx.float32)).astype(mx.bfloat16)
+        self.assertTrue(mx.array_equal(q, ref))
+
     def test_tile(self):
         self.assertCmpNumpy([(2,), [2]], mx.tile, np.tile)
         self.assertCmpNumpy([(2, 3, 4), [2]], mx.tile, np.tile)


### PR DESCRIPTION
On fp16/bf16, `mx.divmod` and `mx.floor_divide` divided `x / y` in the input precision
and narrowed the quotient to fp16/bf16 before `trunc`/`floor`. A true quotient just
below an integer rounds up when narrowed, so the result is one too high.

```python
a = mx.array([86.5625], dtype=mx.float16)    # a / b = 2.99946
b = mx.array([28.859375], dtype=mx.float16)
mx.divmod(a, b)[0]        # before: 3    after: 2
mx.floor_divide(a, b)     # before: 3    after: 2
```

The fix computes the division in float32 for the half types before rounding: on CPU in
`DivMod`'s `trunc`/`fmod` op, on Metal and CUDA in the `FloorDivide` functor that
`divmod` reuses, and in the `floor_divide` lowering in `ops.cpp`. float32, float64,
integer, and sign behavior are untouched (`divmod` still truncates). For non-negative
fp16/bf16 operands `divmod` and `floor_divide` now agree with each other, and with numpy
for same-dtype operands; for negatives `divmod` still truncates while `floor_divide`
floors.

This is also why `test_divmod` is flaky: it compares fp16 `mx.divmod` against numpy with
unseeded random inputs, and near an integer boundary they disagreed (about 0.04% of
fp16 pairs, more for bf16). With the division in float they match. The test gets a
deterministic boundary case for fp16 and bf16, plus a seeded bf16 batch checked against
a float32 reference (numpy has no bf16).

Part of #3994 (the fp16/bf16 precision part); the floored-vs-truncated sign defects are
a separate change.

## Verification

- CPU (Linux x86): fp16/bf16 divmod and floor_divide match a float-wide reference on
  0/200000 random pairs; `1e300 / 1e299` float64 stays `10` (no downcast); `-7 / 3`
  stays `(-2, -1)` (sign unchanged); full `test_ops.py` passes.
- CUDA (RTX 5050, sm_120): fp16/bf16 divmod and floor_divide give `2` at the boundary,
  0/100000 divergence, sign unchanged.
- Metal (M3 Ultra): fp16/bf16 divmod and floor_divide give `2` at the boundary,
  0/100000 divergence, sign unchanged; `test_divmod` passes.
