### PR TITLE
docs: Do not pass MLX_METAL_FAST_SYNCH=1 by default

### DIFF
--- a/docs/src/usage/distributed.rst
+++ b/docs/src/usage/distributed.rst
@@ -335,8 +335,7 @@ of a gigantic model using MLX LM.
 
 .. code-block::
 
-   mlx.launch --verbose --backend jaccl --hostfile m3-ultra-jaccl.json \
-        --env MLX_METAL_FAST_SYNCH=1 -- \  # <--- important
+   mlx.launch --verbose --backend jaccl --hostfile m3-ultra-jaccl.json -- \
         /path/to/remote/python -m mlx_lm chat --model mlx-community/DeepSeek-R1-0528-4bit
 
 .. note::
@@ -344,9 +343,15 @@ of a gigantic model using MLX LM.
    Defining the environment variable :envvar:`MLX_METAL_FAST_SYNCH` to ``1``
    enables a different, faster way of synchronizing between the GPU and the
    CPU. It is not specific to the JACCL backend and can be used in all cases
-   where the CPU and GPU need to collaborate for some computation and is pretty
-   critical for low-latency communication since the communication is done by
+   where the CPU and GPU need to collaborate for some computation, and it
+   matters for low-latency communication since the communication is done by
    the CPU.
+
+   It is however not reliable. The fast synchronization can deadlock and leave
+   the GPU wedged, both in distributed runs and in any workload that crosses
+   streams (see `#3142 <https://github.com/ml-explore/mlx/issues/3142>`_ and
+   `#3830 <https://github.com/ml-explore/mlx/issues/3830>`_), so it is off by
+   default and best left unset.
 
 Custom side channel
 ^^^^^^^^^^^^^^^^^^^

--- a/docs/src/usage/distributed.rst
+++ b/docs/src/usage/distributed.rst
@@ -341,17 +341,15 @@ of a gigantic model using MLX LM.
 .. note::
 
    Defining the environment variable :envvar:`MLX_METAL_FAST_SYNCH` to ``1``
-   enables a different, faster way of synchronizing between the GPU and the
-   CPU. It is not specific to the JACCL backend and can be used in all cases
-   where the CPU and GPU need to collaborate for some computation, and it
-   matters for low-latency communication since the communication is done by
-   the CPU.
+   by passing ``--env MLX_METAL_FAST_SYNCH=1`` enables a different, faster way
+   of synchronizing between the GPU and the CPU. It is not specific to the
+   JACCL backend and can be used in all cases where the CPU and GPU need to
+   collaborate for some computation, and it matters for low-latency
+   communication since the communication is done by the CPU.
 
-   It is however not reliable. The fast synchronization can deadlock and leave
-   the GPU wedged, both in distributed runs and in any workload that crosses
-   streams (see `#3142 <https://github.com/ml-explore/mlx/issues/3142>`_ and
-   `#3830 <https://github.com/ml-explore/mlx/issues/3830>`_), so it is off by
-   default and best left unset.
+   It is however not reliable that can lead to deadlock and leave the GPU wedged
+   (see `#3142 <https://github.com/ml-explore/mlx/issues/3142>`_), so it is off
+   by default and best left unset.
 
 Custom side channel
 ^^^^^^^^^^^^^^^^^^^

--- a/mlx/backend/metal/fence.cpp
+++ b/mlx/backend/metal/fence.cpp
@@ -1,6 +1,8 @@
 // Copyright © 2024 Apple Inc.
-#include "mlx/fence.h"
+#include <iostream>
+
 #include "mlx/backend/metal/device.h"
+#include "mlx/fence.h"
 #include "mlx/scheduler.h"
 #include "mlx/utils.h"
 
@@ -18,6 +20,15 @@ struct FenceImpl {
     if (!use_fast) {
       event = std::make_unique<Event>(stream);
     } else {
+      static bool warned = []() {
+        std::cerr << "[fence] MLX_METAL_FAST_SYNCH=1: the fast fence's GPU "
+                  << "spin-wait has no guaranteed CPU/GPU memory coherence and "
+                  << "can deadlock, leaving the GPU wedged until reboot (see "
+                  << "issues #3142 and #3830). Unset MLX_METAL_FAST_SYNCH if "
+                  << "you see hangs." << std::endl;
+        return true;
+      }();
+      (void)warned;
       auto buf = allocator::malloc(sizeof(uint32_t)).ptr();
       fence = static_cast<void*>(buf);
       cpu_value()[0] = 0;

--- a/mlx/backend/metal/fence.cpp
+++ b/mlx/backend/metal/fence.cpp
@@ -1,8 +1,6 @@
 // Copyright © 2024 Apple Inc.
-#include <iostream>
-
-#include "mlx/backend/metal/device.h"
 #include "mlx/fence.h"
+#include "mlx/backend/metal/device.h"
 #include "mlx/scheduler.h"
 #include "mlx/utils.h"
 
@@ -20,15 +18,6 @@ struct FenceImpl {
     if (!use_fast) {
       event = std::make_unique<Event>(stream);
     } else {
-      static bool warned = []() {
-        std::cerr << "[fence] MLX_METAL_FAST_SYNCH=1: the fast fence's GPU "
-                  << "spin-wait has no guaranteed CPU/GPU memory coherence and "
-                  << "can deadlock, leaving the GPU wedged until reboot (see "
-                  << "issues #3142 and #3830). Unset MLX_METAL_FAST_SYNCH if "
-                  << "you see hangs." << std::endl;
-        return true;
-      }();
-      (void)warned;
       auto buf = allocator::malloc(sizeof(uint32_t)).ptr();
       fence = static_cast<void*>(buf);
       cpu_value()[0] = 0;


### PR DESCRIPTION
Following up on #3830: since fast synch is not reliable and there is no fix in sight (per the discussion there and in #3142), this adds a one-time stderr warning the first time a fence is actually created in fast mode, so users hitting the wedge can find the cause without bisecting env vars. It fires on any multi-stream workload, not just distributed, matching the single-node report in #3830. One file, +12/−1, no behavior change beyond the message.