### PR TITLE
Add gather_qqmm to the ops docs

### DIFF
--- a/docs/src/python/ops.rst
+++ b/docs/src/python/ops.rst
@@ -93,6 +93,7 @@ Operations
    from_fp8
    gather_mm
    gather_qmm
+   gather_qqmm
    greater
    greater_equal
    hadamard_transform


### PR DESCRIPTION
## Proposed changes

`gather_qqmm` was added in #3757 with a full docstring, but the autosummary entry never went in, so it has no page in the ops reference. Its sibling `gather_qmm` is listed right above where this goes.

```python
>>> mx.gather_qqmm.__doc__.splitlines()[0]
"gather_qqmm(x: array, w: array, /, scales: Optional[array] = None, ...)"
```

Adding the entry generates `mlx.core.gather_qqmm.rst` as expected. The only warnings on the new page are the usual `target not found: optional` ones that every function with optional arguments produces (524 of them repo wide, 8 on the neighbouring `gather_qmm` page), so this does not add a new kind of warning.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

(docs only, one line; verified by building the docs and checking the generated stub)

---

quick note on how i got here: freshman contributor using Claude Code to help me sweep, but i checked that #3757 touched `python/src/ops.cpp` without touching `docs/src/python/ops.rst`, confirmed the docstring has no experimental or internal wording that would explain leaving it out, and built the docs to see the page appear. if it was left out on purpose, happy to close this.
