### PR TITLE
Fix broken fully_shard reference in FullyShardedModule docstring

### DIFF
--- a/python/mlx/nn/layers/distributed.py
+++ b/python/mlx/nn/layers/distributed.py
@@ -669,7 +669,7 @@ class FullyShardedModule(Module):
     Every parameter is sharded along axis 0, so each parameter's size along
     that axis must be divisible by the size of ``group``.
 
-    Use :func:`fully_shard` to wrap a module.
+    Use :func:`~mlx.nn.layers.distributed.fully_shard` to wrap a module.
 
     Args:
         module (mlx.nn.Module): The module whose parameters will be sharded.


### PR DESCRIPTION
## Proposed changes

`FullyShardedModule`'s docstring says "Use :func:`fully_shard` to wrap a module", but that link is dead:

```
python/mlx/nn/layers/distributed.py:docstring of
mlx.nn.layers.distributed.FullyShardedModule:11:
WARNING: py:func reference target not found: fully_shard [ref.func]
```

The two are documented under different module contexts in `nn/distributed.rst`. `fully_shard` sits under `.. currentmodule:: mlx.nn.layers.distributed`, while `FullyShardedModule` is under `.. currentmodule:: mlx.nn`, so on that page the bare name resolves against `mlx.nn` and finds nothing.

Qualified it, using the `~` form that the same file already uses for `:func:`~mlx.core.quantize``, so the rendered text stays `fully_shard`. After the change the reference resolves.

One thing worth flagging: I noticed the commit that added this landed as "[WIP] [CUDA] fsdp" (#3768). I still thought this was worth sending because both `fully_shard` and `FullyShardedModule` are already listed in `nn/distributed.rst`, so this only repairs a link between two pages you have already made public rather than exposing anything new. If you would rather leave the fsdp docs untouched until that work settles, please just close this, no problem at all.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

(one line, docstring text only; verified by building the docs before and after)

---

context on me: freshman contributor, i use Claude Code to help sweep for this kind of thing. you closed my `gather_qqmm` docs PR earlier today because that API is still in progress, which was a fair call and taught me to check whether something is meant to be public before touching it. that is why i checked here that both names are already in the docs, and why i am flagging the WIP origin rather than quietly shipping it.
