### PR TITLE
Fix sorted gather_qmm on ragged K

### DIFF
--- a/mlx/backend/metal/kernels/fp_quantized_nax.h
+++ b/mlx/backend/metal/kernels/fp_quantized_nax.h
@@ -149,14 +149,11 @@ struct QuantizedBlockLoader {
       return;
     }
 
-    if (reduction_dim == 1 && bi >= src_tile_dim.x) {
-      for (int i = 0; i < n_reads * pack_factor; i++) {
-        dst[i] = T(0);
-      }
-      return;
-    }
-
-    if (reduction_dim == 0 && bi >= src_tile_dim.y) {
+    // src_tile_dim.y bounds the rows of the tile and src_tile_dim.x bounds the
+    // columns, for both reduction dims. When the reduction axis runs along the
+    // columns (reduction_dim == 1), a partial tile needs the columns past the
+    // edge zeroed rather than the rows.
+    if (bi >= src_tile_dim.y) {
       for (int i = 0; i < n_reads * pack_factor; i++) {
         dst[i] = T(0);
       }
@@ -978,7 +975,7 @@ template <
 
               volatile int compiler_barrier;
 
-              const short psk = min(int(SK), max(0, (BK - kk1)));
+              const short psk = min(int(SK), max(0, (k_remain - kk1)));
               Atile.load_safe(xn + kk1, K, short2(psk, sgp_sm));
 
               if constexpr (transpose) {

--- a/mlx/backend/metal/kernels/fp_quantized_nax.h
+++ b/mlx/backend/metal/kernels/fp_quantized_nax.h
@@ -149,10 +149,6 @@ struct QuantizedBlockLoader {
       return;
     }
 
-    // src_tile_dim.y bounds the rows of the tile and src_tile_dim.x bounds the
-    // columns, for both reduction dims. When the reduction axis runs along the
-    // columns (reduction_dim == 1), a partial tile needs the columns past the
-    // edge zeroed rather than the rows.
     if (bi >= src_tile_dim.y) {
       for (int i = 0; i < n_reads * pack_factor; i++) {
         dst[i] = T(0);

--- a/mlx/backend/metal/kernels/quantized_nax.h
+++ b/mlx/backend/metal/kernels/quantized_nax.h
@@ -653,10 +653,6 @@ struct QuantizedBlockLoader {
       return;
     }
 
-    // src_tile_dim.y bounds the rows of the tile and src_tile_dim.x bounds the
-    // columns, for both reduction dims. When the reduction axis runs along the
-    // columns (reduction_dim == 1), a partial tile needs the columns past the
-    // edge zeroed rather than the rows.
     if (bi >= src_tile_dim.y) {
       for (int i = 0; i < n_reads * pack_factor; i++) {
         dst[i] = T(0);
@@ -790,10 +786,6 @@ struct QuantizedBlockLoader<
       return;
     }
 
-    // src_tile_dim.y bounds the rows of the tile and src_tile_dim.x bounds the
-    // columns, for both reduction dims. When the reduction axis runs along the
-    // columns (reduction_dim == 1), a partial tile needs the columns past the
-    // edge zeroed rather than the rows.
     if (bi >= src_tile_dim.y) {
       for (int i = 0; i < n_reads * pack_factor; i++) {
         dst[i] = T(0);

--- a/mlx/backend/metal/kernels/quantized_nax.h
+++ b/mlx/backend/metal/kernels/quantized_nax.h
@@ -653,14 +653,11 @@ struct QuantizedBlockLoader {
       return;
     }
 
-    if (reduction_dim == 1 && bi >= src_tile_dim.x) {
-      for (int i = 0; i < n_reads * pack_factor; i++) {
-        dst[i] = T(0);
-      }
-      return;
-    }
-
-    if (reduction_dim == 0 && bi >= src_tile_dim.y) {
+    // src_tile_dim.y bounds the rows of the tile and src_tile_dim.x bounds the
+    // columns, for both reduction dims. When the reduction axis runs along the
+    // columns (reduction_dim == 1), a partial tile needs the columns past the
+    // edge zeroed rather than the rows.
+    if (bi >= src_tile_dim.y) {
       for (int i = 0; i < n_reads * pack_factor; i++) {
         dst[i] = T(0);
       }
@@ -793,14 +790,11 @@ struct QuantizedBlockLoader<
       return;
     }
 
-    if (reduction_dim == 1 && bi >= src_tile_dim.x) {
-      for (int i = 0; i < n_reads * pack_factor; i++) {
-        dst[i] = T(0);
-      }
-      return;
-    }
-
-    if (reduction_dim == 0 && bi >= src_tile_dim.y) {
+    // src_tile_dim.y bounds the rows of the tile and src_tile_dim.x bounds the
+    // columns, for both reduction dims. When the reduction axis runs along the
+    // columns (reduction_dim == 1), a partial tile needs the columns past the
+    // edge zeroed rather than the rows.
+    if (bi >= src_tile_dim.y) {
       for (int i = 0; i < n_reads * pack_factor; i++) {
         dst[i] = T(0);
       }
@@ -1655,7 +1649,7 @@ template <
 
               volatile int compiler_barrier;
 
-              const short psk = min(int(SK), max(0, (BK - kk1)));
+              const short psk = min(int(SK), max(0, (k_remain - kk1)));
               Atile.load_safe(xn + kk1, K, short2(psk, sgp_sm));
 
               if constexpr (transpose) {

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -1670,6 +1670,49 @@ class TestQuantized(mlx_tests.MLXTestCase):
                 )
             )
 
+    def test_gather_qmm_sorted_unaligned_k(self):
+        # Every case in test_gather_qmm_sorted uses K % 64 == 0, so the tail of
+        # the K loop is never exercised. When K is not a multiple of the block
+        # size the sorted path has to zero the partial tile correctly, otherwise
+        # it silently drops the tail contribution for part of the output.
+        L, D, E = 128, 256, 4
+        key = mx.random.key(0)
+        k1, k2, k3 = mx.random.split(key, 3)
+        on_gpu = mx.default_device() == mx.gpu
+
+        dtype = mx.float16 if on_gpu else mx.float32
+
+        for mode, group_size in (
+            ("affine", 32),
+            ("mxfp4", None),
+            ("mxfp8", None),
+            ("nvfp4", None),
+        ):
+            for K in (160, 288, 544):
+                with self.subTest(mode=mode, K=K):
+                    indices = mx.sort(
+                        (mx.random.uniform(shape=(L,), key=k1) * E).astype(mx.uint32)
+                    )
+                    x = (mx.random.normal((L, 1, K), key=k2) / K**0.5).astype(dtype)
+                    w = (mx.random.normal((E, D, K), key=k3) / K**0.5).astype(dtype)
+
+                    if mode == "affine":
+                        wq = mx.quantize(w, group_size=group_size, mode=mode)
+                    else:
+                        wq = mx.quantize(w, mode=mode)
+
+                    kwargs = dict(
+                        group_size=group_size,
+                        mode=mode,
+                        transpose=True,
+                        rhs_indices=indices,
+                    )
+                    y_sorted = mx.gather_qmm(x, *wq, sorted_indices=True, **kwargs)
+                    y_unsorted = mx.gather_qmm(x, *wq, sorted_indices=False, **kwargs)
+
+                    tol = 1e-3 if on_gpu else 1.5e-5
+                    self.assertLess((y_sorted - y_unsorted).abs().max(), tol)
+
     def test_gather_qmm_grad(self):
         def gather_qmm_ref(x, w, s, b, lhs, rhs, trans, sort):
             if lhs is not None:


### PR DESCRIPTION
Fixes #3887.

`mx.gather_qmm(..., sorted_indices=True)` returns silently wrong results on M5 whenever `K % BK != 0`. Aligned K is unaffected and `sorted_indices=False` is unaffected, so quantized MoE inference degrades quietly instead of failing.

## Root cause

There are two separate bounds defects in the NAX path, both in the K tail.

**1. Activation tile bounded with `BK` instead of the K remainder.** In `affine_gather_qmm_rhs_nax` and its fp counterpart:

```cpp
const short psk = min(int(SK), max(0, (BK - kk1)));
```

`k_remain` is already computed higher up and used for the weight tile (`tile_w`), so the tail simply needs to use it here too.

**2. `QuantizedBlockLoader::load_safe` zeroes partial tiles on the wrong axis.** `src_tile_dim.y` bounds the rows of the tile and `src_tile_dim.x` bounds the columns, for both reduction dims. The `reduction_dim == 1` branch compares the row index against the column bound:

```cpp
if (reduction_dim == 1 && bi >= src_tile_dim.x) {
```

In the transpose case `BROWS = BN`, and `tile_w = short2(k_remain, tgp_bn)`. With `k_remain = 32` this zeroes tile rows 32 to 63, which are output columns, instead of masking the columns past the K edge. Those rows are exactly one of the two N direction simdgroups (`SN = BN / WN = 32`), so half the output columns lose their tail contribution entirely.

Fixing only the first defect is not sufficient. It narrows the corruption from every output column to the `tn = 32` half, which is why the columns with `col % 64 >= 32` are the ones left wrong.

## Evidence

Measured on an M5 Max (40 core, `applegpu_g17s`), on 0.32.0 and at 2c46b95. The check compares `sorted_indices=True` against `sorted_indices=False` on identical, already sorted inputs. The flag is only a performance hint, so the two must agree and there is no reference implementation ambiguity. E=8, N=256, M=512, group_size=32, fp16.

Max absolute difference relative to `mean(abs(unsorted))`, and the fraction of output elements that differ:

| mode | K | K % 64 | before | after |
| --- | --- | --- | --- | --- |
| affine 4 bit | 512 | 0 | 0.005 (0.0%) | 0.005 (0.0%) |
| affine 4 bit | 160 | 32 | 3.198 (97.1%) | 0.006 (0.0%) |
| affine 4 bit | 288 | 32 | 2.394 (96.1%) | 0.005 (0.0%) |
| affine 4 bit | 544 | 32 | 1.474 (94.5%) | 0.005 (0.0%) |
| affine 4 bit | 1056 | 32 | 1.071 (92.2%) | 0.005 (0.0%) |
| affine 8 bit | 160 | 32 | 3.187 (97.1%) | 0.003 (0.0%) |
| affine 8 bit | 544 | 32 | 1.431 (94.5%) | 0.003 (0.0%) |
| mxfp4 | 160 | 32 | 3.452 (96.9%) | 0.001 (0.0%) |
| mxfp4 | 544 | 32 | 1.469 (94.5%) | 0.002 (0.0%) |

Across the full sweep of 21 configurations, every failure had `K % 64 != 0` and `sorted_indices=True`, and no configuration with those two properties passed. After the change all 21 agree.

The relative error shrinks as K grows, which is consistent with a fixed size corrupted tail region while the correct aligned bulk grows around it.

## Test

`test_gather_qmm_sorted` parameterizes over K, but every case uses `K = 512`, and the affine cases use `group_size = 64`, which forces K to be a multiple of 64. The K tail was therefore never exercised for this kernel.

Added `test_gather_qmm_sorted_unaligned_k` covering K in {160, 288, 544} for affine (group_size 32) and mxfp4. On 0.32.0 all six subtests fail, one of them producing `5.24887e+29` from uninitialized threadgroup memory. All pass with this change.

`test_quantized.py`, `test_blas.py`, `test_nn.py` and `test_ops.py` pass (278 tests) on top of the new one.

## Performance

No measurable change. On a `gather_qmm` benchmark (E=8, N=4096, M=4096, 4 bit, group_size=32, sorted) the run to run variance at a fixed build was larger than the difference between the patched and unpatched builds at the same commit, so I would not claim a delta in either direction.
