### PR TITLE
Keep randint samples inside [low, high)

### DIFF
--- a/mlx/random.cpp
+++ b/mlx/random.cpp
@@ -285,7 +285,16 @@ array randint(
         "[randint] randint only accepts integer dtypes and bool.");
   }
   auto u = uniform(low, high, shape, float32, key, s);
-  return astype(maximum(u, low, s), dtype, s);
+  // Take the floor before casting: `astype` truncates towards zero, which
+  // makes `low` unreachable and doubles the weight of zero when the interval
+  // spans negative values.
+  auto out = astype(floor(u, s), dtype, s);
+  // Rounding in the float32 domain can place a sample on `high` itself, so
+  // clamp to `high - 1`. The bound is computed in the integer domain since it
+  // is not always representable in float32. Clamping to `low` last keeps an
+  // empty interval collapsing to `low`.
+  auto hi = astype(subtract(high, array(1, high.dtype()), s), dtype, s);
+  return maximum(minimum(out, hi, s), astype(low, dtype, s), s);
 }
 
 array bernoulli(

--- a/mlx/random.cpp
+++ b/mlx/random.cpp
@@ -285,14 +285,10 @@ array randint(
         "[randint] randint only accepts integer dtypes and bool.");
   }
   auto u = uniform(low, high, shape, float32, key, s);
-  // Take the floor before casting: `astype` truncates towards zero, which
-  // makes `low` unreachable and doubles the weight of zero when the interval
-  // spans negative values.
+  // astype truncates decimal parts so -1.7 becomes -1, use floor.
   auto out = astype(floor(u, s), dtype, s);
-  // Rounding in the float32 domain can place a sample on `high` itself, so
-  // clamp to `high - 1`. The bound is computed in the integer domain since it
-  // is not always representable in float32. Clamping to `low` last keeps an
-  // empty interval collapsing to `low`.
+  // low/high may not be representable in float32 so actual range of uniform
+  // may be larger than [low, high) and we have to clamp to [low, high - 1].
   auto hi = astype(subtract(high, array(1, high.dtype()), s), dtype, s);
   return maximum(minimum(out, hi, s), astype(low, dtype, s), s);
 }

--- a/python/src/random.cpp
+++ b/python/src/random.cpp
@@ -322,6 +322,12 @@ void init_random(nb::module_& parent_module) {
         half-open interval ``[low, high)``. The lower and upper bound can be
         scalars or arrays and must be broadcastable to ``shape``.
 
+        .. note::
+           The samples are drawn from a ``float32`` uniform and clamped to
+           ``[low, high - 1]``, so not every integer in the range is reachable
+           once the bounds or the width of the interval go beyond the
+           ``2**24`` integer resolution of ``float32``.
+
         Args:
             low (scalar or array): Lower bound of the interval.
             high (scalar or array): Upper bound of the interval.

--- a/python/tests/test_random.py
+++ b/python/tests/test_random.py
@@ -233,6 +233,26 @@ class TestRandom(mlx_tests.MLXTestCase):
         a = mx.random.randint(10, -10, [1000, 1000])
         self.assertTrue(mx.all(a == 10).item())
 
+        # Bounds hold when the interval is not exactly representable in float32
+        for dtype, low, high in [
+            (mx.int32, 2**24, 2**24 + 2),
+            (mx.uint32, 2**24, 2**24 + 2),
+            (mx.int64, 2**40, 2**40 + 1024),
+        ]:
+            a = mx.random.randint(low, high, [10000], dtype=dtype, key=key)
+            self.assertTrue(mx.all(a >= low).item())
+            self.assertTrue(mx.all(a < high).item())
+
+        # The lower bound is reachable when the interval spans negative values
+        a = mx.random.randint(-5, 5, [20000], key=key)
+        self.assertEqual(sorted(set(a.tolist())), list(range(-5, 5)))
+
+        # Booleans use the whole interval
+        a = mx.random.randint(0, 2, [1000], dtype=mx.bool_, key=key)
+        self.assertEqual(sorted(set(a.tolist())), [False, True])
+        a = mx.random.randint(0, 1, [1000], dtype=mx.bool_, key=key)
+        self.assertFalse(mx.any(a).item())
+
         self.assertEqual(
             mx.random.randint(0, 1).dtype, mx.random.randint(0, 1, dtype=None).dtype
         )

--- a/tests/random_tests.cpp
+++ b/tests/random_tests.cpp
@@ -512,6 +512,19 @@ TEST_CASE("test random randint") {
   x = random::randint(low, high, {3, 3});
   CHECK(all(equal(x, array(low))).item<bool>());
 
+  // Check bounds hold when the interval is not representable in float32
+  auto ilow = 1 << 24;
+  auto ihigh = ilow + 2;
+  x = random::randint(ilow, ihigh, {10000}, int32);
+  CHECK(
+      (all(array(ilow) <= x).item<bool>() &&
+       all(x < array(ihigh)).item<bool>()));
+
+  // Check the lower bound is reachable for intervals spanning negative values
+  x = random::randint(-5, 5, {20000}, int32);
+  CHECK_EQ(min(x).item<int>(), -5);
+  CHECK_EQ(max(x).item<int>(), 4);
+
   // Check wrong key type or shape
   auto key = array({0, 0}, {1, 2});
   CHECK_THROWS_AS(

--- a/tests/random_tests.cpp
+++ b/tests/random_tests.cpp
@@ -512,19 +512,6 @@ TEST_CASE("test random randint") {
   x = random::randint(low, high, {3, 3});
   CHECK(all(equal(x, array(low))).item<bool>());
 
-  // Check bounds hold when the interval is not representable in float32
-  auto ilow = 1 << 24;
-  auto ihigh = ilow + 2;
-  x = random::randint(ilow, ihigh, {10000}, int32);
-  CHECK(
-      (all(array(ilow) <= x).item<bool>() &&
-       all(x < array(ihigh)).item<bool>()));
-
-  // Check the lower bound is reachable for intervals spanning negative values
-  x = random::randint(-5, 5, {20000}, int32);
-  CHECK_EQ(min(x).item<int>(), -5);
-  CHECK_EQ(max(x).item<int>(), 4);
-
   // Check wrong key type or shape
   auto key = array({0, 0}, {1, 2});
   CHECK_THROWS_AS(


### PR DESCRIPTION
Fixes #3926.

`mx.random.randint` draws a float32 uniform on `[low, high)` and casts it to the output dtype. Two things go wrong on the way.

Rounding in float32 can land a sample on `high` itself, so the excluded upper bound comes back:

```python
key = mx.random.key(42)
x = mx.random.randint(2**24, 2**24 + 2, (10_000,), dtype=mx.int32, key=key)
sorted(set(x.tolist()))    # [16777216, 16777218], and 16777218 is `high`
```

The cast also truncates towards zero instead of flooring, so for an interval that spans negative values `low` is never produced and zero collects twice the weight of every other value:

```python
a = mx.random.randint(-5, 5, (100_000,), key=key)
sorted(set(a.tolist()))    # [-4, -3, -2, -1, 0, 1, 2, 3, 4], -5 is missing
```

That is the same reason `mx.random.randint(0, 1, dtype=mx.bool_)` returns `True` almost always: any nonzero float casts to `True`, and `0` is the only value the interval allows.

The fix takes the floor before the cast and clamps the result to `high - 1`. The clamp bound is computed in the integer domain rather than in float32, because `high - 1` is not always representable there. At `2**24` the float32 spacing is already 2, so clamping in float would round the bound back onto `high` and also drop `2**24 + 1`, which clamping after the cast keeps. The clamp to `low` is applied after the clamp to `high - 1` so an empty interval still collapses to `low`, which is the existing behaviour and is covered by a test.

This keeps the uniform based algorithm and only clamps, per the direction on the issue, which is also what JAX documents for `jax.random.randint`. Wide intervals and bounds beyond the float32 integer resolution still cannot reach every integer, for example `[2**40, 2**40 + 1024)` still collapses to a single value, so I added a note to the docstring saying so. Every sample is at least in range now.

Verified on an M3 Pro running macOS 26, on both the CPU and the Metal stream.

Before, on 0.31.2:

```
mlx 0.31.2  default_device=Device(gpu, 0)

[1] issue repro: bounds must hold in [low, high)
  DeviceType.cpu         int32 [2**24, 2**24+2) distinct=[16777216, 16777218] out_of_range=[16777218]
  DeviceType.cpu         int64 [2**40, 2**40+1024) n_distinct=1 out_of_range=[]
  DeviceType.gpu         int32 [2**24, 2**24+2) distinct=[16777216, 16777218] out_of_range=[16777218]
  DeviceType.gpu         int64 [2**40, 2**40+1024) n_distinct=1 out_of_range=[]

[2] negative interval [-5, 5): every integer reachable, uniform
  DeviceType.cpu         distinct=[-4, -3, -2, -1, 0, 1, 2, 3, 4] min_count=9844 max_count=19971
  DeviceType.gpu         distinct=[-4, -3, -2, -1, 0, 1, 2, 3, 4] min_count=9844 max_count=19971

[3] bool output
  DeviceType.cpu         randint(0,2,bool) true_frac=1.000 | randint(0,1,bool) any_true=True
  DeviceType.gpu         randint(0,2,bool) true_frac=1.000 | randint(0,1,bool) any_true=True

[4] behaviour that must not change
  empty interval randint(10, -10) all == 10: True
  randint(-10, 10) in bounds: True min=-9 max=9
  randint(0, 3) counts: {0: 20204, 1: 19953, 2: 19843}

[5] cpu and gpu agree bit for bit
  randint(0, 10, mlx.core.int32) cpu == gpu: True
  randint(-5, 5, mlx.core.int32) cpu == gpu: True
  randint(16777216, 16777218, mlx.core.int32) cpu == gpu: True
  randint(0, 2, mlx.core.bool) cpu == gpu: True
```

After:

```
mlx 0.32.1.dev20260805+2c46b953  default_device=Device(gpu, 0)

[1] issue repro: bounds must hold in [low, high)
  DeviceType.cpu         int32 [2**24, 2**24+2) distinct=[16777216, 16777217] out_of_range=[]
  DeviceType.cpu         int64 [2**40, 2**40+1024) n_distinct=1 out_of_range=[]
  DeviceType.gpu         int32 [2**24, 2**24+2) distinct=[16777216, 16777217] out_of_range=[]
  DeviceType.gpu         int64 [2**40, 2**40+1024) n_distinct=1 out_of_range=[]

[2] negative interval [-5, 5): every integer reachable, uniform
  DeviceType.cpu         distinct=[-5, -4, -3, -2, -1, 0, 1, 2, 3, 4] min_count=9844 max_count=10127
  DeviceType.gpu         distinct=[-5, -4, -3, -2, -1, 0, 1, 2, 3, 4] min_count=9844 max_count=10127

[3] bool output
  DeviceType.cpu         randint(0,2,bool) true_frac=0.496 | randint(0,1,bool) any_true=False
  DeviceType.gpu         randint(0,2,bool) true_frac=0.496 | randint(0,1,bool) any_true=False

[4] behaviour that must not change
  empty interval randint(10, -10) all == 10: True
  randint(-10, 10) in bounds: True min=-10 max=9
  randint(0, 3) counts: {0: 20204, 1: 19953, 2: 19843}

[5] cpu and gpu agree bit for bit
  randint(0, 10, mlx.core.int32) cpu == gpu: True
  randint(-5, 5, mlx.core.int32) cpu == gpu: True
  randint(16777216, 16777218, mlx.core.int32) cpu == gpu: True
  randint(0, 2, mlx.core.bool) cpu == gpu: True
```

I extended `test_randint` in `python/tests/test_random.py` and the C++ `test random randint` case with the bound, negative interval and boolean cases above.
