### PR TITLE
Fix Metal FFT for sizes above 2**20

### DIFF
--- a/mlx/backend/metal/fft.cpp
+++ b/mlx/backend/metal/fft.cpp
@@ -4,6 +4,7 @@
 #include <map>
 #include <numeric>
 #include <set>
+#include <sstream>
 
 #include "mlx/3rdparty/pocketfft.h"
 #include "mlx/backend/common/utils.h"
@@ -127,6 +128,21 @@ FFTPlan plan_fft(int n) {
     // Rough heuristic for choosing faster powers of two when we can
     plan.n2 = n > 65536 ? 1024 : 64;
     plan.n1 = n / plan.n2;
+    // Each step is a single threadgroup FFT, so neither factor can be larger
+    // than the largest Stockham size. The no transpose kernels cannot
+    // decompose a step any further, so grow n2 instead of nesting four step.
+    if (plan.n1 > MAX_STOCKHAM_FFT_SIZE) {
+      plan.n1 = MAX_STOCKHAM_FFT_SIZE;
+      plan.n2 = n / plan.n1;
+    }
+    if (plan.n2 > MAX_STOCKHAM_FFT_SIZE) {
+      std::ostringstream msg;
+      msg << "[FFT] GPU FFT is not supported for size " << n
+          << ", the largest supported size is "
+          << MAX_STOCKHAM_FFT_SIZE * MAX_STOCKHAM_FFT_SIZE
+          << ". Run the FFT on the CPU stream instead.";
+      throw std::runtime_error(msg.str());
+    }
     return plan;
   } else if (n > MAX_STOCKHAM_FFT_SIZE) {
     // Otherwise we use a multi-upload Bluestein's
@@ -638,13 +654,14 @@ void fft_op(
   // We batch among threadgroups for improved efficiency when n is small
   int threadgroup_batch_size = std::max(MIN_THREADGROUP_MEM_SIZE / fft_size, 1);
   if (four_step_params.required) {
-    // Require a threadgroup batch size of at least 4 for four step FFT
-    // so we can coalesce the memory accesses.
-    threadgroup_batch_size =
-        std::max(threadgroup_batch_size, MIN_COALESCE_WIDTH);
+    // Batch the four step FFT so we can coalesce the memory accesses, but
+    // never past what fits in threadgroup memory.
+    threadgroup_batch_size = std::max(
+        threadgroup_batch_size,
+        std::min(MIN_COALESCE_WIDTH, MAX_STOCKHAM_FFT_SIZE / fft_size));
   }
   int threadgroup_mem_size = next_power_of_2(threadgroup_batch_size * fft_size);
-  // FFTs up to 2^20 are currently supported
+  // The plan keeps every step within the threadgroup memory limit
   assert(threadgroup_mem_size <= MAX_STOCKHAM_FFT_SIZE);
 
   // ceil divide

--- a/python/tests/test_fft.py
+++ b/python/tests/test_fft.py
@@ -185,6 +185,19 @@ class TestFFT(mlx_tests.MLXTestCase):
         for k in range(17, 20):
             self._run_ffts((3, 2**k), atol=1e-2)
 
+        # Past 2**20 the four step plan has to grow n2 to keep both factors
+        # inside threadgroup memory
+        for k in range(20, 25):
+            self._run_ffts((1, 2**k), atol=1e-2, rtol=1e-3)
+
+    def test_fft_too_large(self):
+        if mx.default_device() != mx.gpu:
+            return
+        # Larger than the four step plan can decompose, so it has to throw
+        # rather than run a kernel that silently returns the wrong answer
+        with self.assertRaises(RuntimeError):
+            mx.eval(mx.fft.fft(mx.zeros(2**25)))
+
     def test_fft_large_numbers(self):
         numbers = [
             1037,  # prime > 2048

--- a/python/tests/test_fft.py
+++ b/python/tests/test_fft.py
@@ -190,11 +190,13 @@ class TestFFT(mlx_tests.MLXTestCase):
         for k in range(20, 25):
             self._run_ffts((1, 2**k), atol=1e-2, rtol=1e-3)
 
+    @unittest.skipIf(
+        not mx.metal.is_available(), "the size limit is specific to the Metal FFT plan"
+    )
     def test_fft_too_large(self):
-        if mx.default_device() != mx.gpu:
-            return
         # Larger than the four step plan can decompose, so it has to throw
-        # rather than run a kernel that silently returns the wrong answer
+        # rather than run a kernel that silently returns the wrong answer.
+        # CUDA hands this to cuFFT instead and has no such limit.
         with self.assertRaises(RuntimeError):
             mx.eval(mx.fft.fft(mx.zeros(2**25)))
 


### PR DESCRIPTION
On Metal, a 1D FFT larger than `2**20` either fails to launch or returns a wrong answer without any error. #1800 reports the launch failure, and the silent part is worse:

```
n=1048576    2**20   rel_err=8.67e-07   ok
n=2097152    2**21   [metal::Device] Unable to load function four_step_mem_8192_float2_float2_0_false
n=4194304    2**22   [metal::Device] Unable to load function four_step_mem_16384_float2_float2_0_false
n=8388608    2**23   rel_err=1.454      wrong
n=16777216   2**24   rel_err=1.546      wrong
```

Non power of two sizes are affected too, since Bluestein pads up to `next_power_of_2(2n - 1)` and that padded length runs through the same path.

Root cause. `plan_fft` splits a large power of two as `n2 = 1024` and `n1 = n / n2` and hands both to the no transpose four step kernels. Each step runs one FFT per threadgroup out of a `threadgroup float2 shared_in[tg_mem_size]` buffer, and for the four step path the batch is forced to `MIN_COALESCE_WIDTH`, so the buffer needs `4 * n1` complex entries. At `n1 = 2048` that is 8192 entries, past the largest instantiated kernel and past the 32 KB of threadgroup memory the hardware has, hence the missing `four_step_mem_8192` function. The release build does not catch it because the guard next to it is an `assert`.

Above `n1 = 4096` the failure changes shape. `fft_op` re-plans each step with `plan_fft(n1)`, and once `n1` is itself over `MAX_STOCKHAM_FFT_SIZE` that returns another four step plan and recurses. The nested call re-derives its own `n1`, `n2` and batch from the full array while the outer stride and twiddle factors are gone, so it launches successfully and computes something unrelated to the requested transform. That is the `2**23` and `2**24` rows above.

The fix is two parts.

The four step batch is a coalescing heuristic, not a correctness requirement: `compute_strided_indices` derives everything from `coalesce_width = grid.y`, so a batch of 1 or 2 is laid out correctly, it just reads less efficiently. Capping the batch at what threadgroup memory can hold lets `n1` reach 4096 instead of 1024. Sizes at or below `2**20` keep a batch of 4 and are byte for byte unchanged.

`plan_fft` then caps `n1` at `MAX_STOCKHAM_FFT_SIZE` and grows `n2` to match, so the two factors stay within one threadgroup FFT each and the plan never nests. Together these make every power of two up to `4096 * 4096 = 2**24` correct. Beyond that the two step decomposition cannot cover the size at all, so the planner throws with the limit in the message instead of returning a wrong answer.

Measured on an M3 Pro, macOS 26, against numpy, complex input, relative error on the max element.

Before:

```
mlx 0.32.1.dev20260805+2c46b953  device=Device(gpu, 0)

powers of two
  n=65536        2**16        rel_err=6.207e-07   ok
  n=131072       2**17        rel_err=6.269e-07   ok
  n=262144       2**18        rel_err=8.056e-07   ok
  n=524288       2**19        rel_err=8.288e-07   ok
  n=1048576      2**20        rel_err=8.67e-07    ok
  n=2097152      2**21        raised  [metal::Device] Unable to load function four_step_mem_8192_float2_float2_0_false Function four_step_
  n=4194304      2**22        raised  [metal::Device] Unable to load function four_step_mem_16384_float2_float2_0_false Function four_step
  n=8388608      2**23        rel_err=1.454       WRONG
  n=16777216     2**24        rel_err=1.546       WRONG

non powers of two, these pad into the same path
  n=700000       bluestein    raised  [metal::Device] Unable to load function four_step_mem_8192_float2_float2_0_false Function four_step_
  n=1500000      bluestein    raised  [metal::Device] Unable to load function four_step_mem_16384_float2_float2_0_false Function four_step
  n=3000000      bluestein    rel_err=1           WRONG
  n=5000000      bluestein    rel_err=1           WRONG

small sizes must be unchanged
  n=7                         rel_err=5.04e-08    ok
  n=64                        rel_err=1.968e-07   ok
  n=100                       rel_err=3.182e-07   ok
  n=1021                      rel_err=4.96e-07    ok
  n=4096                      rel_err=4.517e-07   ok
  n=65536                     rel_err=6.207e-07   ok
  n=1048576                   rel_err=8.67e-07    ok

batched rfft on a large last axis
  rfft (2, 2**21) raised [metal::Device] Unable to load function four_step_mem_8192_float_float2_0_true
Function four_step_me
  rfft (2, 2**22) raised [metal::Device] Unable to load function four_step_mem_16384_float_float2_0_true
Function four_step_m
  rfft (2, 2**23) rel_err=1.372 WRONG

ifft round trip
  2**20 ifft(fft(x)) max_abs_err=5.007e-06 ok
  2**22 ifft(fft(x)) raised [metal::Device] Unable to load function four_step_mem_16384_float2_float2_0_false
Function four_step
  2**24 ifft(fft(x)) max_abs_err=5.22 WRONG

beyond the two step limit
  2**25 no error, dc=0j
  2**26 no error, dc=0j
```

After:

```
mlx 0.32.1.dev20260805+2c46b953  device=Device(gpu, 0)

powers of two
  n=65536        2**16        rel_err=6.207e-07   ok
  n=131072       2**17        rel_err=6.269e-07   ok
  n=262144       2**18        rel_err=8.056e-07   ok
  n=524288       2**19        rel_err=8.288e-07   ok
  n=1048576      2**20        rel_err=8.67e-07    ok
  n=2097152      2**21        rel_err=8.71e-07    ok
  n=4194304      2**22        rel_err=9.449e-07   ok
  n=8388608      2**23        rel_err=9.099e-07   ok
  n=16777216     2**24        rel_err=9.445e-07   ok

non powers of two, these pad into the same path
  n=700000       bluestein    rel_err=1.095e-06   ok
  n=1500000      bluestein    rel_err=1.069e-06   ok
  n=3000000      bluestein    rel_err=1.004e-06   ok
  n=5000000      bluestein    rel_err=1.085e-06   ok

small sizes must be unchanged
  n=7                         rel_err=5.04e-08    ok
  n=64                        rel_err=1.968e-07   ok
  n=100                       rel_err=3.182e-07   ok
  n=1021                      rel_err=4.96e-07    ok
  n=4096                      rel_err=4.517e-07   ok
  n=65536                     rel_err=6.207e-07   ok
  n=1048576                   rel_err=8.67e-07    ok

batched rfft on a large last axis
  rfft (2, 2**21) rel_err=8.637e-07 ok
  rfft (2, 2**22) rel_err=9.756e-07 ok
  rfft (2, 2**23) rel_err=1.034e-06 ok

ifft round trip
  2**20 ifft(fft(x)) max_abs_err=4.768e-06 ok
  2**22 ifft(fft(x)) max_abs_err=5.245e-06 ok
  2**24 ifft(fft(x)) max_abs_err=5.245e-06 ok

beyond the two step limit
  2**25 raised: [FFT] GPU FFT is not supported for size 33554432, the largest supported size is 16777216. Run the FFT on the CPU stream 
  2**26 raised: [FFT] GPU FFT is not supported for size 67108864, the largest supported size is 16777216. Run the FFT on the CPU stream
```

`test_fft_big_powers_of_two` now runs up to `2**24`, and `test_fft_too_large` pins the new error. The rest of `python/tests/test_fft.py` passes unchanged.

Fixes #1800
