### PR TITLE
Add mx.searchsorted

### DIFF
--- a/docs/src/python/ops.rst
+++ b/docs/src/python/ops.rst
@@ -168,6 +168,7 @@ Operations
    savez_compressed
    save_gguf
    save_safetensors
+   searchsorted
    sigmoid
    sign
    sin

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -2706,6 +2706,73 @@ array argsort(const array& a, int axis, StreamOrDevice s /* = {} */) {
       a.shape(), uint32, std::make_shared<ArgSort>(to_stream(s), axis), {a});
 }
 
+array searchsorted(
+    const array& sorted_sequence,
+    const array& values,
+    const std::string& side /* = "left" */,
+    StreamOrDevice s /* = {} */) {
+  if (sorted_sequence.ndim() != 1) {
+    std::ostringstream msg;
+    msg << "[searchsorted] Expected a 1D sorted sequence but got an array with "
+        << sorted_sequence.ndim() << " dimensions.";
+    throw std::invalid_argument(msg.str());
+  }
+  if (side != "left" && side != "right") {
+    std::ostringstream msg;
+    msg << "[searchsorted] Invalid side '" << side
+        << "', expected 'left' or 'right'.";
+    throw std::invalid_argument(msg.str());
+  }
+
+  auto n = sorted_sequence.size();
+  if (n == 0) {
+    return zeros(values.shape(), uint32, s);
+  }
+
+  // Compare in a common type so mixed dtypes behave like the other binary ops.
+  auto dt = promote_types(sorted_sequence.dtype(), values.dtype());
+  auto a = astype(sorted_sequence, dt, s);
+  auto v = astype(values, dt, s);
+
+  auto compare = [&](const array& x, const array& y) {
+    return side == "left" ? less(x, y, s) : less_equal(x, y, s);
+  };
+
+  // Both branches compute the same thing: the number of elements of `a` that
+  // compare less than (or less than or equal to) each value.
+  //
+  // The linear form materializes an n x values.size() mask, so it is only worth
+  // it while that product stays small. Past roughly 4M elements the binary
+  // search wins and the mask becomes a memory problem. See the benchmark in the
+  // pull request for where this threshold comes from.
+  constexpr size_t kLinearMaxElements = 1 << 22;
+  if (n * values.size() <= kLinearMaxElements) {
+    auto flat_v = reshape(v, {-1, 1}, s);
+    auto row_a = reshape(a, {1, -1}, s);
+    auto counts = sum(compare(row_a, flat_v), -1, false, s);
+    return reshape(astype(counts, uint32, s), values.shape(), s);
+  }
+
+  // Branchless binary search. Accumulating into a single running result avoids
+  // the lower/upper bound pair converging and stepping past each other, and
+  // keeps every gather in range.
+  int steps = std::max(
+      1, static_cast<int>(std::ceil(std::log2(static_cast<double>(n) + 1.0))));
+  auto res = zeros(values.shape(), uint32, s);
+  auto n_arr = array(static_cast<uint32_t>(n), uint32);
+  auto one = array(1u, uint32);
+  auto last = array(static_cast<uint32_t>(n - 1), uint32);
+  for (int i = steps - 1; i >= 0; --i) {
+    auto step = array(static_cast<uint32_t>(1u) << i, uint32);
+    auto cand = add(res, step, s);
+    auto idx = minimum(subtract(cand, one, s), last, s);
+    auto ok =
+        logical_and(less_equal(cand, n_arr, s), compare(take(a, idx, s), v), s);
+    res = where(ok, cand, res, s);
+  }
+  return res;
+}
+
 /**
  * Returns a partitioned copy of the flattened array
  * such that the smaller kth elements are first.

--- a/mlx/ops.h
+++ b/mlx/ops.h
@@ -853,6 +853,17 @@ MLX_API array argpartition(const array& a, int kth, StreamOrDevice s = {});
 MLX_API array
 argpartition(const array& a, int kth, int axis, StreamOrDevice s = {});
 
+/**
+ * Returns the indices where ``values`` would be inserted into the 1D array
+ * ``sorted_sequence`` to keep it sorted. With ``side = "left"`` the first
+ * suitable index is returned, with ``side = "right"`` the last.
+ **/
+MLX_API array searchsorted(
+    const array& sorted_sequence,
+    const array& values,
+    const std::string& side = "left",
+    StreamOrDevice s = {});
+
 /** Returns topk elements of the flattened array. */
 MLX_API array topk(const array& a, int k, StreamOrDevice s = {});
 

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -3146,6 +3146,42 @@ void init_ops(nb::module_& m) {
             array: The ``uint32`` array containing indices that partition the input.
       )pbdoc");
   m.def(
+      "searchsorted",
+      &mx::searchsorted,
+      nb::arg(),
+      nb::arg(),
+      "side"_a = "left",
+      nb::kw_only(),
+      "stream"_a = nb::none(),
+      nb::sig(
+          "def searchsorted(sorted_sequence: array, values: array, /, side: str = 'left', *, stream: Union[None, Stream, Device] = None) -> array"),
+      R"pbdoc(
+        Find the indices at which ``values`` would be inserted into
+        ``sorted_sequence`` to keep it sorted.
+
+        The returned index ``i`` for a value ``v`` satisfies:
+
+        * ``side="left"``: ``sorted_sequence[i-1] < v <= sorted_sequence[i]``
+        * ``side="right"``: ``sorted_sequence[i-1] <= v < sorted_sequence[i]``
+
+        Equivalently, the result counts how many elements of ``sorted_sequence``
+        are less than (``"left"``) or less than or equal to (``"right"``) each
+        value.
+
+        The behaviour is undefined if ``sorted_sequence`` is not sorted.
+
+        Args:
+            sorted_sequence (array): A 1-D array sorted in ascending order.
+            values (array): The values to insert. Can have any shape.
+            side (str, optional): Either ``"left"`` or ``"right"``. Determines
+              which index is returned when a value matches an entry of
+              ``sorted_sequence`` exactly. Default: ``"left"``.
+
+        Returns:
+            array: A ``uint32`` array of insertion indices with the same shape
+            as ``values``.
+      )pbdoc");
+  m.def(
       "topk",
       [](const mx::array& a,
          int k,

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -2509,6 +2509,61 @@ class TestOps(mlx_tests.MLXTestCase):
                             M = top_k_mx.shape[axis or 0]
                             self.assertEqual(M, (kth + N) % N)
 
+    def test_searchsorted(self):
+        # Cross-check against numpy over sizes that straddle the internal
+        # dispatch between the linear and binary search forms.
+        for n in [1, 2, 3, 7, 8, 9, 15, 16, 17, 1000, 4096]:
+            for m in [1, 5, 64, 257]:
+                for side in ["left", "right"]:
+                    with self.subTest(n=n, m=m, side=side):
+                        a_np = np.sort(np.random.randn(n).astype(np.float32))
+                        v_np = (np.random.randn(m) * 2).astype(np.float32)
+                        out = mx.searchsorted(mx.array(a_np), mx.array(v_np), side)
+                        expected = np.searchsorted(a_np, v_np, side=side)
+                        self.assertEqual(out.dtype, mx.uint32)
+                        self.assertEqual(out.shape, (m,))
+                        self.assertTrue(np.array_equal(np.array(out), expected))
+
+        # Duplicates, exact hits and out of range values, where left and right
+        # actually differ.
+        a = mx.array([1, 1, 1, 2, 2, 3], mx.float32)
+        v = mx.array([0, 1, 2, 3, 4], mx.float32)
+        self.assertTrue(
+            mx.array_equal(mx.searchsorted(a, v, "left"), mx.array([0, 0, 3, 5, 6]))
+        )
+        self.assertTrue(
+            mx.array_equal(mx.searchsorted(a, v, "right"), mx.array([0, 3, 5, 6, 6]))
+        )
+
+        # Values keep their shape
+        a = mx.arange(16, dtype=mx.float32)
+        v = mx.random.uniform(shape=(2, 3, 4)) * 20
+        self.assertEqual(mx.searchsorted(a, v).shape, (2, 3, 4))
+
+        # Integer inputs and mixed dtypes
+        a = mx.array([1, 3, 5, 7], mx.int32)
+        self.assertTrue(
+            mx.array_equal(
+                mx.searchsorted(a, mx.array([0, 1, 4, 8], mx.int32)),
+                mx.array([0, 0, 2, 4]),
+            )
+        )
+        self.assertTrue(
+            mx.array_equal(
+                mx.searchsorted(a, mx.array([2.5, 6.5], mx.float32)), mx.array([1, 3])
+            )
+        )
+
+        # Empty sorted sequence gives all zeros
+        out = mx.searchsorted(mx.array([], mx.float32), mx.array([1.0, 2.0]))
+        self.assertTrue(mx.array_equal(out, mx.array([0, 0])))
+
+        # Errors
+        with self.assertRaises(ValueError):
+            mx.searchsorted(mx.zeros((2, 2)), mx.array([1.0]))
+        with self.assertRaises(ValueError):
+            mx.searchsorted(mx.array([1.0, 2.0]), mx.array([1.0]), "middle")
+
     def test_argpartition(self):
         x = mx.broadcast_to(mx.array([1, 2, 3]), (2, 3))
         out = mx.argpartition(x, kth=1, axis=0)


### PR DESCRIPTION
Closes #1255.

Adds `mx.searchsorted(sorted_sequence, values, side="left")`, matching `np.searchsorted` semantics.

## Approach

Composed from existing primitives in `ops.cpp` rather than added as a new primitive. That means no new Metal or CUDA kernels, and it works on every backend immediately. It is also the approach originally suggested in the issue.

This is deliberately different from the earlier attempt in #2817, which added a primitive with a CPU implementation, left GPU evaluation as a TODO, and came to 901 lines across 13 files before being closed. The whole change here is 170 lines including tests and docs.

## Which algorithm, and the dispatch

The issue left an open question: whether to use the linear form, the binary search, or dispatch between them. The suggestion at the time was to measure and pick. Here are the numbers on an M5 Max, current main, bf16 aside and all float32:

| sorted n | queries m | binary | binary compiled | linear |
| --- | --- | --- | --- | --- |
| 1024 | 1 | 0.323 | 0.259 | **0.159** |
| 1024 | 1024 | 0.335 | 0.259 | **0.169** |
| 16384 | 16384 | **0.389** | 0.283 | 1.434 |
| 262144 | 16 | 0.436 | 0.290 | **0.177** |
| 262144 | 1024 | **0.441** | 0.314 | 1.453 |
| 2097152 | 1 | 0.440 | 0.319 | **0.259** |
| 2097152 | 1024 | **0.470** | 0.332 | 15.039 |
| 2097152 | 16384 | **0.513** | 0.346 | out of memory |

Milliseconds. The binary search is close to flat across a 2000x range in `n`, while the linear form is cheaper at small sizes and then degrades badly and eventually cannot allocate. The crossover sits between 4M and 33M for the `n * m` product, so the implementation dispatches at 4M.

That gives the better of the two everywhere. Against the workaround people are currently copying out of the issue thread:

| sorted n | queries m | branch taken | `mx.searchsorted` | workaround | speedup |
| --- | --- | --- | --- | --- | --- |
| 1024 | 64 | linear | 0.166 | 0.162 | 0.98x |
| 16384 | 256 | linear | 0.177 | 0.177 | 1.00x |
| 262144 | 16 | linear | 0.177 | 0.176 | 1.00x |
| 262144 | 1024 | binary | 0.440 | 1.465 | 3.33x |
| 2097152 | 256 | binary | 0.437 | 2.781 | 6.37x |
| 2097152 | 1024 | binary | 0.457 | 15.328 | 33.5x |
| 2097152 | 16384 | binary | 0.472 | 240.096 | 509x |

Below the threshold it is the same computation, so parity is expected. Note the last row allocates a 34 billion element mask for the workaround, which only completes at all because this machine has 128 GB.

All timings warm up and measure by wall clock rather than by iteration count. With a fixed iteration count these kernels are short enough that the measurement tracks the GPU clock ramp instead of the kernel, and the same config can drift by 3x between processes.

## Implementation note

The binary search accumulates into a single running result:

```
res = 0
for step in [2^(k-1) ... 2, 1]:
    cand = res + step
    ok   = (cand <= n) and (a[cand-1] < v)
    res  = where(ok, cand, res)
```

rather than tracking a lower and upper bound. The pair form needs an extra guard, because once lower and upper converge the midpoint update can push lower past upper, and the gather can index `n`. Accumulating avoids both without the extra mask.

## Semantics

Validated against `np.searchsorted` on 178 cases before writing any C++, then again through the built op on 44 more, forcing both dispatch branches and running on both the GPU and CPU streams. Covers both sides, duplicates, exact matches, values below and above the range, `n = 1`, integer and mixed dtypes, and multi dimensional `values`, plus an exhaustive check for every `n` from 1 to 32 against every gap and every exact value.

Returns `uint32` to match `argsort`, `argmax` and `argpartition`.

## Scope

`sorted_sequence` must be 1-D, which matches `np.searchsorted`. Batched sorted sequences, as `torch.searchsorted` supports, are not included here. That would slot in as a `take_along_axis` variant if wanted, but I kept this to the shape the issue asked for rather than widening it.
