### PR TITLE
Fix NAX tile bugs and make the gather_qmm block tile tunable

### DIFF
--- a/mlx/backend/metal/kernels/quantized_nax.h
+++ b/mlx/backend/metal/kernels/quantized_nax.h
@@ -563,6 +563,15 @@ dequantize(const device uint8_t* w, U scale, U bias, threadgroup U* w_local) {
   }
 }
 
+// The loader indexes the scales in one of three ways, by where a thread's
+// n_reads packed words fall inside a quantization group:
+//  1. group_size >= BCOLS: a tile row sits in one group, so next() advances
+//     the scales every group_steps = group_size / BCOLS tiles.
+//  2. BCOLS > group_size, read inside one group: a tile row covers
+//     n_groups = BCOLS / group_size groups, group_id picks one, and each
+//     tile advances the scales by n_groups.
+//  3. The read covers whole groups: the thread walks groups_per_read of
+//     them, taking a scale and bias for each.
 template <
     typename T,
     short BROWS,
@@ -574,11 +583,8 @@ template <
     short bits>
 struct QuantizedBlockLoader {
   static_assert(
-      BCOLS <= group_size,
-      "The group size should be larger than the columns");
-  static_assert(
-      group_size % BCOLS == 0,
-      "The group size should be divisible by the columns");
+      BCOLS % group_size == 0 || group_size % BCOLS == 0,
+      "The tile columns and the group size must divide one another");
   static_assert(
       bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
           bits == 8,
@@ -589,7 +595,28 @@ struct QuantizedBlockLoader {
   MLX_MTL_CONST short BCOLS_PACKED = BCOLS / pack_factor;
   MLX_MTL_CONST short n_reads =
       (BCOLS_PACKED * BROWS < tgp_size) ? 1 : (BCOLS_PACKED * BROWS) / tgp_size;
-  MLX_MTL_CONST short group_steps = group_size / BCOLS;
+
+  // Groups covered by one tile row.
+  MLX_MTL_CONST short n_groups = (BCOLS > group_size) ? BCOLS / group_size : 1;
+  // Tiles that share one group.
+  MLX_MTL_CONST short group_steps =
+      (group_size > BCOLS) ? group_size / BCOLS : 1;
+
+  // Values one thread reads.
+  MLX_MTL_CONST short n_elems = n_reads * pack_factor;
+  // Groups per read, and packed reads in each.
+  MLX_MTL_CONST short groups_per_read =
+      (n_elems > group_size) ? n_elems / group_size : 1;
+  MLX_MTL_CONST short reads_per_group = n_reads / groups_per_read;
+
+  static_assert(
+      BCOLS_PACKED % n_reads == 0,
+      "The packed columns of the block tile must be a multiple of the "
+      "reads of one thread.");
+  static_assert(
+      n_elems % group_size == 0 || group_size % n_elems == 0,
+      "The read of one thread must cover full quantization groups, or it "
+      "must divide one quantization group exactly.");
 
   const int src_ld;
   const int tile_stride;
@@ -599,6 +626,9 @@ struct QuantizedBlockLoader {
   const short thread_idx;
   const short bi;
   const short bj;
+
+  // First group this thread reads from.
+  const short group_id;
 
   threadgroup T* dst;
   const device uint8_t* src;
@@ -622,23 +652,40 @@ struct QuantizedBlockLoader {
         thread_idx(simd_group_id * 32 + simd_lane_id),
         bi(n_reads* thread_idx / BCOLS_PACKED),
         bj((n_reads * thread_idx) % BCOLS_PACKED),
+        group_id((bj * pack_factor) / group_size),
         dst(dst_ + bi * dst_ld + bj * pack_factor),
         src(src_ + bi * src_ld * bytes_per_pack / pack_factor +
             bj * bytes_per_pack),
-        scales(scales_ + bi * src_ld / group_size),
-        biases(biases_ + bi * src_ld / group_size) {}
+        scales(scales_ + bi * src_ld / group_size + group_id),
+        biases(biases_ + bi * src_ld / group_size + group_id) {}
+
+  void dequantize_reads() const thread {
+    if (groups_per_read == 1) {
+      T scale = *scales;
+      T bias = *biases;
+      for (int i = 0; i < n_reads; i++) {
+        dequantize<T, pack_factor, bits>(
+            src + i * bytes_per_pack, scale, bias, dst + i * pack_factor);
+      }
+    } else {
+      for (int g = 0; g < groups_per_read; g++) {
+        T scale = scales[g];
+        T bias = biases[g];
+        for (int i = 0; i < reads_per_group; i++) {
+          const int r = g * reads_per_group + i;
+          dequantize<T, pack_factor, bits>(
+              src + r * bytes_per_pack, scale, bias, dst + r * pack_factor);
+        }
+      }
+    }
+  }
 
   void load_unsafe() const thread {
     if (BCOLS_PACKED * BROWS < tgp_size && bi >= BROWS) {
       return;
     }
 
-    T scale = *scales;
-    T bias = *biases;
-    for (int i = 0; i < n_reads; i++) {
-      dequantize<T, pack_factor, bits>(
-          src + i * bytes_per_pack, scale, bias, dst + i * pack_factor);
-    }
+    dequantize_reads();
   }
 
   void load_safe(short2 src_tile_dim) const thread {
@@ -660,15 +707,7 @@ struct QuantizedBlockLoader {
       return;
     }
 
-    T scale = *scales;
-    T bias = *biases;
-    for (int i = 0; i < n_reads; i++) {
-      dequantize<T, pack_factor, bits>(
-          (device uint8_t*)(src + i * bytes_per_pack),
-          scale,
-          bias,
-          dst + i * pack_factor);
-    }
+    dequantize_reads();
   }
 
   void next() thread {
@@ -682,152 +721,12 @@ struct QuantizedBlockLoader {
           biases++;
         }
       } else {
-        scales++;
-        biases++;
+        scales += n_groups;
+        biases += n_groups;
       }
     } else {
       scales += group_stride;
       biases += group_stride;
-    }
-  }
-};
-
-template <
-    typename T,
-    short BROWS,
-    short BCOLS,
-    short dst_ld,
-    short reduction_dim,
-    short tgp_size,
-    short bits>
-struct QuantizedBlockLoader<
-    T,
-    BROWS,
-    BCOLS,
-    dst_ld,
-    reduction_dim,
-    tgp_size,
-    32,
-    bits> {
-  MLX_MTL_CONST short group_size = 32;
-
-  static_assert(
-      BCOLS % group_size == 0,
-      "The group size should be divisible by the columns");
-  static_assert(
-      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
-          bits == 8,
-      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
-
-  MLX_MTL_CONST short pack_factor = get_pack_factor<bits, 8>();
-  MLX_MTL_CONST short bytes_per_pack = get_bytes_per_pack<bits>();
-  MLX_MTL_CONST short BCOLS_PACKED = BCOLS / pack_factor;
-  MLX_MTL_CONST short n_reads =
-      (BCOLS_PACKED * BROWS < tgp_size) ? 1 : (BCOLS_PACKED * BROWS) / tgp_size;
-  MLX_MTL_CONST short n_groups = BCOLS / group_size;
-
-  static_assert(
-      (BCOLS_PACKED / n_reads) == n_groups,
-      "Other configurations are not yet supported");
-
-  const int src_ld;
-  const int tile_stride;
-  const int group_stride;
-
-  const short thread_idx;
-  const short bi;
-  const short bj;
-
-  const short group_id;
-
-  threadgroup T* dst;
-  const device uint8_t* src;
-  const device T* scales;
-  const device T* biases;
-
-  QuantizedBlockLoader(
-      const device uint8_t* src_,
-      const device T* scales_,
-      const device T* biases_,
-      const int src_ld_,
-      threadgroup T* dst_,
-      ushort simd_group_id [[simdgroup_index_in_threadgroup]],
-      ushort simd_lane_id [[thread_index_in_simdgroup]]) thread
-      : src_ld(src_ld_),
-        tile_stride(
-            reduction_dim ? BCOLS_PACKED* bytes_per_pack
-                          : BROWS * src_ld * bytes_per_pack / pack_factor),
-        group_stride(BROWS* src_ld / group_size),
-        thread_idx(simd_group_id * 32 + simd_lane_id),
-        bi(n_reads* thread_idx / BCOLS_PACKED),
-        bj((n_reads * thread_idx) % BCOLS_PACKED),
-        group_id((bj * pack_factor) / group_size),
-        dst(dst_ + bi * dst_ld + bj * pack_factor),
-        src(src_ + bi * src_ld * bytes_per_pack / pack_factor +
-            bj * bytes_per_pack),
-        scales(scales_ + bi * src_ld / group_size + group_id),
-        biases(biases_ + bi * src_ld / group_size + group_id) {}
-
-  void load_unsafe() const thread {
-    if (BCOLS_PACKED * BROWS < tgp_size && bi >= BROWS) {
-      return;
-    }
-
-    T scale = *scales;
-    T bias = *biases;
-    for (int i = 0; i < n_reads; i++) {
-      dequantize<T, pack_factor, bits>(
-          src + i * bytes_per_pack, scale, bias, dst + i * pack_factor);
-    }
-  }
-
-  void load_safe(short2 src_tile_dim) const thread {
-    if (BCOLS_PACKED * BROWS < tgp_size && bi >= BROWS) {
-      return;
-    }
-
-    if (reduction_dim == 1 && bi >= src_tile_dim.x) {
-      for (int i = 0; i < n_reads * pack_factor; i++) {
-        dst[i] = T(0);
-      }
-      return;
-    }
-
-    if (reduction_dim == 0 && bi >= src_tile_dim.y) {
-      for (int i = 0; i < n_reads * pack_factor; i++) {
-        dst[i] = T(0);
-      }
-      return;
-    }
-
-    T scale = *scales;
-    T bias = *biases;
-    for (int i = 0; i < n_reads; i++) {
-      dequantize<T, pack_factor, bits>(
-          (device uint8_t*)(src + i * bytes_per_pack),
-          scale,
-          bias,
-          dst + i * pack_factor);
-    }
-  }
-
-  void next() thread {
-    src += tile_stride;
-    if (reduction_dim == 1) {
-      // if (group_steps > 1) {
-      //   group_step_cnt++;
-      //   if (group_step_cnt == group_steps) {
-      //     group_step_cnt = 0;
-      //     scales++;
-      //     biases++;
-      //   }
-      // } else {
-      scales += n_groups;
-      biases += n_groups;
-      // }
-    } else {
-      scales += n_groups * group_stride;
-      biases += n_groups * group_stride;
     }
   }
 };

--- a/mlx/backend/metal/kernels/quantized_nax.metal
+++ b/mlx/backend/metal/kernels/quantized_nax.metal
@@ -76,9 +76,20 @@
   instantiate_quantized_aligned_batched(affine_qmm_t_nax, type, group_size, bits, 64, 64, 64, 2, 2, false, 1) \
   instantiate_quantized_aligned_batched(affine_qmm_t_nax, type, group_size, bits, 64, 64, 64, 2, 2, false, 0)
 
+#define instantiate_gather_qmm_rhs_tile(type, group_size, bits, bm, bn, bk, wm, wn) \
+  instantiate_gather_qmm_rhs(affine_gather_qmm_rhs_nax, affine_gather_qmm_rhs_nax_nt, type, group_size, bits, bm, bn, bk, wm, wn, true) \
+  instantiate_gather_qmm_rhs(affine_gather_qmm_rhs_nax, affine_gather_qmm_rhs_nax_nn, type, group_size, bits, bm, bn, bk, wm, wn, false)
+
+// Block tiles for the gather kernel, default first. The rest are selected
+// with MLX_QMM_TILE_NAX. Keep in sync with gather_qmm_rhs_nax_tiles in
+// mlx/backend/metal/quantized.cpp.
 #define instantiate_quantized_all_rhs(type, group_size, bits) \
-  instantiate_gather_qmm_rhs(affine_gather_qmm_rhs_nax, affine_gather_qmm_rhs_nax_nt, type, group_size, bits, 64, 64, 64, 2, 2, true) \
-  instantiate_gather_qmm_rhs(affine_gather_qmm_rhs_nax, affine_gather_qmm_rhs_nax_nn, type, group_size, bits, 64, 64, 64, 2, 2, false)
+  instantiate_gather_qmm_rhs_tile(type, group_size, bits, 64, 64, 64, 2, 2) \
+  instantiate_gather_qmm_rhs_tile(type, group_size, bits, 32, 64, 64, 2, 2) \
+  instantiate_gather_qmm_rhs_tile(type, group_size, bits, 16, 64, 64, 1, 2) \
+  instantiate_gather_qmm_rhs_tile(type, group_size, bits, 128, 64, 64, 2, 2) \
+  instantiate_gather_qmm_rhs_tile(type, group_size, bits, 64, 32, 64, 2, 2) \
+  instantiate_gather_qmm_rhs_tile(type, group_size, bits, 32, 32, 64, 2, 2)
 
 #define instantiate_quantized_funcs(type, group_size, bits) \
   instantiate_quantized_all_batched(type, group_size, bits) \

--- a/mlx/backend/metal/kernels/steel/gemm/nax.h
+++ b/mlx/backend/metal/kernels/steel/gemm/nax.h
@@ -469,10 +469,12 @@ struct BaseNAXFrag {
       metal::bool_constant<transpose_a>,
       const thread dtype_frag_t<BType>& B,
       metal::bool_constant<transpose_b>) {
-    // Create Matmul descriptor
+    // Create Matmul descriptor. This overload pairs two fragments along M and
+    // takes one fragment along N, so the problem shape is 32x16x16. The
+    // overload above pairs along N, and its problem shape is 16x32x16.
     constexpr auto desc = mpp::tensor_ops::matmul2d_descriptor(
-        16,
         32,
+        16,
         16,
         transpose_a,
         transpose_b,
@@ -524,6 +526,70 @@ struct BaseNAXFrag {
     for (short i = 0; i < kElemsPerFrag; i++) {
       Cm0[i] = ct_c[i];
       Cm1[i] = ct_c[kElemsPerFrag + i];
+    }
+  }
+
+  // Pairs along K, for tiles with odd TM and odd TN where a simdgroup holds
+  // one fragment each way. MPP needs 32 in M, N or K when both inputs are
+  // cooperative tensors, so 16x16x16 is not expressible and only K is left.
+  template <
+      typename CType,
+      typename AType,
+      typename BType,
+      bool transpose_a = false,
+      bool transpose_b = false>
+  METAL_FUNC static constexpr void mma(
+      thread dtype_frag_t<CType>& C,
+      const thread dtype_frag_t<AType>& Ak0,
+      const thread dtype_frag_t<AType>& Ak1,
+      metal::bool_constant<transpose_a>,
+      const thread dtype_frag_t<BType>& Bk0,
+      const thread dtype_frag_t<BType>& Bk1,
+      metal::bool_constant<transpose_b>) {
+    constexpr auto desc = mpp::tensor_ops::matmul2d_descriptor(
+        16,
+        16,
+        32,
+        transpose_a,
+        transpose_b,
+        true,
+        mpp::tensor_ops::matmul2d_descriptor::mode::multiply_accumulate);
+
+    mpp::tensor_ops::matmul2d<desc, metal::execution_simdgroup> gemm_op;
+
+    auto ct_a =
+        gemm_op
+            .template get_left_input_cooperative_tensor<AType, BType, CType>();
+    auto ct_b =
+        gemm_op
+            .template get_right_input_cooperative_tensor<AType, BType, CType>();
+    auto ct_c = gemm_op.template get_destination_cooperative_tensor<
+        decltype(ct_a),
+        decltype(ct_b),
+        CType>();
+
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < kElemsPerFrag; i++) {
+      ct_a[i] = Ak0[i];
+      ct_a[kElemsPerFrag + i] = Ak1[i];
+    }
+
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < kElemsPerFrag; i++) {
+      ct_b[i] = Bk0[i];
+      ct_b[kElemsPerFrag + i] = Bk1[i];
+    }
+
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < kElemsPerFrag; i++) {
+      ct_c[i] = C[i];
+    }
+
+    gemm_op.run(ct_a, ct_b, ct_c);
+
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < kElemsPerFrag; i++) {
+      C[i] = ct_c[i];
     }
   }
 };
@@ -887,6 +953,30 @@ METAL_FUNC void tile_matmad_nax(
               metal::bool_constant<transpose_a>{},
               B.frag_at(kk, nn, tb),
               B.frag_at(kk, nn + 1, tb),
+              metal::bool_constant<transpose_b>{});
+        }
+      }
+    }
+  } else {
+    // TM and TN both odd, so pair along K. Without this branch the matmul
+    // did not run at all and the tile kept its cleared value.
+    static_assert(
+        TK % 2 == 0,
+        "MXU tile matmul: a block tile with one fragment along M and one "
+        "fragment along N needs an even number of K fragments.");
+    STEEL_PRAGMA_UNROLL
+    for (short mm = 0; mm < TM; ++mm) {
+      STEEL_PRAGMA_UNROLL
+      for (short nn = 0; nn < TN; ++nn) {
+        STEEL_PRAGMA_UNROLL
+        for (short kk = 0; kk < TK; kk += 2) {
+          CTile::NAXFrag_t::mma(
+              C.frag_at(mm, nn),
+              A.frag_at(mm, kk, ta),
+              A.frag_at(mm, kk + 1, ta),
+              metal::bool_constant<transpose_a>{},
+              B.frag_at(kk, nn, tb),
+              B.frag_at(kk + 1, nn, tb),
               metal::bool_constant<transpose_b>{});
         }
       }

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -375,6 +375,60 @@ array quantize_dequantize_input(
   return xhat;
 }
 
+struct GatherQmmNaxTile {
+  int bm;
+  int bn;
+  int bk;
+  int wm;
+  int wn;
+};
+
+// Block tiles the affine NAX gather kernel is built for, default first.
+// Keep in sync with instantiate_quantized_all_rhs in
+// mlx/backend/metal/kernels/quantized_nax.metal.
+constexpr GatherQmmNaxTile gather_qmm_rhs_nax_tiles[] = {
+    {64, 64, 64, 2, 2},
+    {32, 64, 64, 2, 2},
+    {16, 64, 64, 1, 2},
+    {128, 64, 64, 2, 2},
+    {64, 32, 64, 2, 2},
+    {32, 32, 64, 2, 2},
+};
+
+std::string tile_to_string(const GatherQmmNaxTile& tile) {
+  std::string s;
+  concatenate(
+      s, tile.bm, ",", tile.bn, ",", tile.bk, ",", tile.wm, ",", tile.wn);
+  return s;
+}
+
+// Picks the block tile for the NAX gather kernel. MLX_QMM_TILE_NAX names one
+// of the tiles above as "BM,BN,BK,WM,WN". Only the affine kernels are built
+// for the extra tiles, so other modes always use the default.
+GatherQmmNaxTile gather_qmm_rhs_nax_tile(const std::string& mode) {
+  if (mode != "affine") {
+    return gather_qmm_rhs_nax_tiles[0];
+  }
+  auto requested = env::get_var("MLX_QMM_TILE_NAX", "");
+  if (requested.empty()) {
+    return gather_qmm_rhs_nax_tiles[0];
+  }
+  for (const auto& tile : gather_qmm_rhs_nax_tiles) {
+    if (requested == tile_to_string(tile)) {
+      return tile;
+    }
+  }
+  std::ostringstream msg;
+  msg << "[gather_qmm] MLX_QMM_TILE_NAX is set to '" << requested
+      << "', but MLX did not build this block tile. These block "
+         "tiles are available:";
+  for (const auto& tile : gather_qmm_rhs_nax_tiles) {
+    msg << " " << tile_to_string(tile);
+  }
+  msg << ".";
+  throw std::invalid_argument(msg.str());
+}
+
 } // namespace
 
 void qmv_quad(
@@ -1454,9 +1508,12 @@ void gather_qmm_rhs_nax(
   array w = ensure_row_contiguous(w_, d, s);
   array scales = ensure_row_contiguous(scales_, d, s);
 
-  // TODO: Tune the block sizes
-  int bm = 64, bn = 64, bk = 64;
-  int wm = 2, wn = 2;
+  // TODO: Choose the block tile automatically from the shape of the problem.
+  // MLX now uses the default block tile, unless MLX_QMM_TILE_NAX selects a
+  // different one.
+  auto tile = gather_qmm_rhs_nax_tile(mode);
+  int bm = tile.bm, bn = tile.bn, bk = tile.bk;
+  int wm = tile.wm, wn = tile.wn;
 
   const bool align_M = (M % bm) == 0;
   const bool align_N = (N % bn) == 0;

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -4804,6 +4804,16 @@ void init_ops(nb::module_& m) {
         Returns:
             array: The result of the multiplication of ``x`` with ``w``
               after gathering using ``lhs_indices`` and ``rhs_indices``.
+
+        .. note::
+           On hardware with matrix coprocessors, a sorted affine call runs a
+           special kernel. The environment variable ``MLX_QMM_TILE_NAX``
+           selects the block tile of this kernel, in the form
+           ``"BM,BN,BK,WM,WN"``. The best block tile depends on the shape of
+           the problem and on the distribution of the rows over the matrices.
+           Because of this, MLX keeps the default block tile. If you set a
+           block tile that MLX did not build, MLX raises an error that lists
+           the available block tiles.
       )pbdoc");
   m.def(
       "gather_qqmm",

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -1,6 +1,8 @@
 # Copyright © 2023 Apple Inc.
 
+import os
 import platform
+import re
 import subprocess
 import unittest
 from itertools import product
@@ -15,6 +17,19 @@ def is_m1_mac():
     cmd = "sysctl -n machdep.cpu.brand_string"
     cpu = subprocess.check_output(cmd, shell=True).decode().strip()
     return cpu.startswith("Apple M1")
+
+
+def has_nax():
+    # The kernels for the matrix coprocessors need an Apple GPU of generation
+    # 17 or later, and macOS 26.2 or later.
+    if platform.system() != "Darwin" or not mx.metal.is_available():
+        return False
+    arch = mx.device_info(mx.gpu).get("architecture", "")
+    match = re.search(r"(\d+)[a-z]$", str(arch))
+    if match is None or int(match.group(1)) < 17:
+        return False
+    version = tuple(int(v) for v in platform.mac_ver()[0].split(".")[:2])
+    return version >= (26, 2)
 
 
 class TestQuantized(mlx_tests.MLXTestCase):
@@ -1402,6 +1417,86 @@ class TestQuantized(mlx_tests.MLXTestCase):
                 self.assertTrue(mx.allclose(y1, y2, atol=tol))
                 self.assertTrue(mx.allclose(y1, y3, atol=tol))
                 self.assertTrue(mx.allclose(y1, y4, atol=tol))
+
+    @unittest.skipUnless(has_nax(), "requires a GPU with matrix coprocessors")
+    def test_gather_qmm_rhs_nax_tiles(self):
+        # A mixture of experts layer uses the gather kernel, which MLX builds
+        # with several block tiles, and MLX_QMM_TILE_NAX selects one of them.
+        # Each block tile must give the same result as a plain gather_mm on
+        # the dequantized weights.
+        #
+        # The last two block tiles give each simdgroup one fragment of 16
+        # values along N. These block tiles use matmul paths that the default
+        # block tile does not use. A group size of 32 makes one row of the
+        # block tile cover more than one quantization group, and the block
+        # loader must handle this.
+        tiles = [
+            "64,64,64,2,2",
+            "32,64,64,2,2",
+            "16,64,64,1,2",
+            "128,64,64,2,2",
+            "64,32,64,2,2",
+            "32,32,64,2,2",
+        ]
+
+        E, K, N = 4, 512, 512
+        key = mx.random.key(0)
+        k1, k2, k3 = mx.random.split(key, 3)
+
+        for L, group_size in product([256, 133], [32, 64]):
+            indices = mx.sort(mx.random.randint(0, E, shape=(L,), key=k1)).astype(
+                mx.uint32
+            )
+            x = (mx.random.normal((L, 1, K), key=k2) / K**0.5).astype(mx.float16)
+            w = (mx.random.normal((E, N, K), key=k3) / K**0.5).astype(mx.float16)
+            wq, s, b = mx.quantize(w, group_size=group_size, bits=4)
+            w_hat = mx.dequantize(wq, s, b, group_size=group_size, bits=4)
+            expected = mx.gather_mm(
+                x, w_hat.swapaxes(-1, -2), rhs_indices=indices, sorted_indices=True
+            )
+            mx.eval(expected)
+
+            for tile in tiles:
+                with self.subTest(L=L, group_size=group_size, tile=tile):
+                    os.environ["MLX_QMM_TILE_NAX"] = tile
+                    try:
+                        y = mx.gather_qmm(
+                            x,
+                            wq,
+                            s,
+                            b,
+                            rhs_indices=indices,
+                            transpose=True,
+                            group_size=group_size,
+                            bits=4,
+                            sorted_indices=True,
+                        )
+                        mx.eval(y)
+                    finally:
+                        del os.environ["MLX_QMM_TILE_NAX"]
+                    self.assertEqual(y.shape, expected.shape)
+                    self.assertLess((y - expected).abs().max().item(), 2e-3)
+
+        # MLX must report an unknown block tile with an error, and it must not
+        # fail later when it looks for a kernel.
+        os.environ["MLX_QMM_TILE_NAX"] = "8,8,8,1,1"
+        try:
+            with self.assertRaises(ValueError):
+                mx.eval(
+                    mx.gather_qmm(
+                        x,
+                        wq,
+                        s,
+                        b,
+                        rhs_indices=indices,
+                        transpose=True,
+                        group_size=group_size,
+                        bits=4,
+                        sorted_indices=True,
+                    )
+                )
+        finally:
+            del os.environ["MLX_QMM_TILE_NAX"]
 
     def test_gather_qmm_grad(self):
         def gather_qmm_ref(x, w, s, b, lhs, rhs, trans, sort):


### PR DESCRIPTION
## Proposed changes

A mixture of experts layer calls the NAX kernel for `gather_qmm` during
prefill, and that kernel is built for a single block tile: 64,64,64,2,2. The
block tile has a large effect on how fast the kernel runs, but you cannot
change it, because two bugs stop you as soon as you try.

This pull request lets you tune the block tile, and corrects both bugs.

### Why the block tile matters

Each threadgroup handles a range of rows, and the rows arrive sorted by
expert. A threadgroup that starts in one expert and ends in the next must
repeat its whole K loop for the second expert, so a block tile with fewer rows
produces fewer threadgroups that cross a boundary.

We measured this on a mixture of experts prefill shape, where M is 20480, K is
3072, N is 2048, and there are 256 experts. The weights use affine
quantization with 2 bits and a group size of 128. The machine is an M5 Max.

| Rows in the block tile | Speed |
|---|---|
| 128 | 0.73x |
| 64 (the default, 8.85 ms) | 1.00x |
| 32 (8.13 ms) | 1.09x |
| 16 | 0.83x |

A block tile with 32 rows takes the full layer from 13.17 ms to 12.12 ms,
which is 8 percent, and makes end to end prefill 2 to 5 percent faster.

The best block tile differs between models, and it also depends on how many
rows each expert receives, so this pull request does not change the default.
It builds the kernel for 6 block tiles, and the environment variable
`MLX_QMM_TILE_NAX` selects one of them in the format `"BM,BN,BK,WM,WN"`.
`quantized.cpp` reads the variable with `env::get_var` at dispatch time, in
the same way that `scaled_dot_product_attention.cpp` reads `MLX_SDPA_BLOCKS`.
If the value is not one of the 6 block tiles, MLX raises an error that lists
the ones you can use.

The kernel for hardware without NAX behaves the same way, and it already
carries a `TODO: Tune the block sizes` comment. A rule that picks the block
tile from the shape would help both kernels, and this pull request gives you
the tool to measure such a rule.

### The first bug: the block loader accepts one shape

The block loader dequantizes the weights into threadgroup memory, but it
accepted only a block tile no wider than one quantization group. A second copy
of the loader handled the special case of a group size of 32, and that copy
contained this line:

```
static_assert(..., "Other configurations are not yet supported");
```

Every new block tile stops there first.

The first commit merges all the cases into one loader and deletes the copy. A
thread can now read less than one quantization group, part of one group, or
several whole groups. The block tiles that MLX builds today still take the
path they took before.

### The second bug: the matmul does nothing

`tile_matmad_nax` used the M paired path when `TN == 1 && TM % 2 == 0`, and
the N paired path when `TN % 2 == 0`, but it had no other case. A block tile
with an odd `TN` matched neither, so the body of the function was empty: the
matmul never ran, and the output tile kept the zeros that `clear()` wrote. The
kernel still compiled and still ran, and it looked much faster than it was.

You can see this without building MLX. Put this file in the root of the
repository:

```cpp
// probe.metal
#include "mlx/backend/metal/kernels/utils.h"
#include "mlx/backend/metal/kernels/steel/gemm/nax.h"
using namespace mlx::steel;

kernel void probe(device float* out [[buffer(0)]]) {
  NAXTile<float, 1, 1> C;          // TM is 1, TN is 1
  NAXTile<bfloat16_t, 1, 2> A;     // TK is 2
  NAXTile<bfloat16_t, 2, 1> B;
  C.clear(); A.clear(); B.clear();
  tile_matmad_nax(C, A, metal::bool_constant<false>{},
                     B, metal::bool_constant<false>{});
  out[0] = C.val_frags[0][0];
}
```

Then count the matmul instructions:

```
xcrun metal -c probe.metal -I . -S -o out.air
grep -c "matmul\|mma" out.air
```

On main this prints **0**, and with the second commit it prints **41**.

The same commit corrects the descriptor of the M paired fragment matmul. That
overload takes 2 fragments along M and 1 fragment along N, so the problem is
32x16x16, but the code built the descriptor as
`matmul2d_descriptor(16, 32, 16)`, which is the shape of the N paired
overload. The copy into the left input tensor then ran past the end of that
tensor.

The block tile that MLX selects today reaches neither bug, but any other block
tile reaches both.

### Tests

`test_gather_qmm_rhs_nax_tiles` in `python/tests/test_quantized.py` calls
`gather_qmm` with all 6 block tiles, at a group size of 32 and of 64, and with
a row count that divides the rows of the block tile as well as one that does
not. It compares every result against `dequantize` followed by `gather_mm`,
and it checks that an unknown block tile raises an error. The test skips on
hardware without matrix coprocessors.

Two of the 6 block tiles give each simdgroup a single fragment along N, so
they take the paths that the second commit corrects, and the group size of 32
makes one row of a block tile span several quantization groups, which is the
case the first commit adds.

These are the results on an M5 Max with macOS 26.5:

- `test_quantized.py`: 34 tests, all pass.
- `test_blas.py`: 28 tests, all pass.
- If you remove the second commit, the new test fails on exactly the block
  tiles that give one fragment along N, because the kernel returns zeros.
- If you remove the first commit, `quantized_nax.metal` does not compile.

The `gather_qmm` docstring documents `MLX_QMM_TILE_NAX`.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
