### PR TITLE
Use the current interpreter in the comparative benchmark runner

### DIFF
--- a/benchmarks/python/comparative/compare.py
+++ b/benchmarks/python/comparative/compare.py
@@ -4,6 +4,7 @@
 
 import argparse
 import re
+import sys
 from pathlib import Path
 from subprocess import run
 
@@ -22,15 +23,15 @@ def run_or_raise(*args, **kwargs):
 
 
 def compare(args):
-    t_mlx = run_or_raise(["python", BENCH_MLX] + args)
-    t_torch = run_or_raise(["python", BENCH_TORCH] + args)
+    t_mlx = run_or_raise([sys.executable, BENCH_MLX] + args)
+    t_torch = run_or_raise([sys.executable, BENCH_TORCH] + args)
 
     print((t_torch - t_mlx) / t_torch, " ".join(args), sep="\t")
 
 
 def compare_mlx_dtypes(args, dt1, dt2):
-    t_mlx_dt1 = run_or_raise(["python", BENCH_MLX] + args + ["--dtype", dt1])
-    t_mlx_dt2 = run_or_raise(["python", BENCH_MLX] + args + ["--dtype", dt2])
+    t_mlx_dt1 = run_or_raise([sys.executable, BENCH_MLX] + args + ["--dtype", dt1])
+    t_mlx_dt2 = run_or_raise([sys.executable, BENCH_MLX] + args + ["--dtype", dt2])
 
     print((t_mlx_dt2 - t_mlx_dt1) / t_mlx_dt2, " ".join(args), sep="\t")
 


### PR DESCRIPTION
## Proposed changes

`benchmarks/python/comparative/compare.py` shells out to a literal `"python"`, so it fails immediately on any setup where only `python3` is on PATH, which includes a stock macOS shell:

```
$ python benchmarks/python/comparative/compare.py ...
FileNotFoundError: [Errno 2] No such file or directory: 'python'
```

Switched the four subprocess calls to `sys.executable`. Besides fixing the crash, this makes the child benchmarks run under the same interpreter as the parent, so running `compare.py` from a virtualenv now benchmarks that environment's MLX rather than whatever `python` happens to resolve to.

`mlx.launch` already does the same thing for the same reason (`--python` defaults to `sys.executable`).

After the change the subprocesses actually start, which you can see because `bench_mlx.py` gets far enough to parse its own arguments. On this machine the run then stops in `bench_torch.py` because torch is not installed, which is the expected behaviour for a comparison benchmark without torch.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

(no tests since this is a benchmark helper script; verified by running it before and after)

---

as always, being clear about process: freshman contributor and i use Claude Code to help me look around, but i hit this by actually running the benchmark scripts, and i checked that `sys.executable` is the pattern already used elsewhere in the repo before picking it. i also grepped for other hardcoded `"python"` subprocess calls and did not find any, so this looks like the only spot.
