### PR TITLE
Fix all_gather benchmark collapsing its input to a scalar

### DIFF
--- a/benchmarks/python/synchronize_bench.py
+++ b/benchmarks/python/synchronize_bench.py
@@ -42,7 +42,7 @@ def all_gather_benchmark():
 
     def fn(x):
         for _ in range(its_per_eval):
-            x = mx.distributed.all_gather(x)[0]
+            x = mx.distributed.all_gather(x)[: a.shape[0]]
         return x
 
     ms = timeit(fn, a) / its_per_eval


### PR DESCRIPTION
## Proposed changes

`synchronize_bench.py` crashes before it can report the all gather timing:

```
File "benchmarks/python/synchronize_bench.py", line 45, in fn
    x = mx.distributed.all_gather(x)[0]
ValueError: too many indices for array: array is 0-dimensional
```

The loop indexes with `[0]` where it means to slice. `all_gather` grows axis 0, but `[0]` removes that axis instead of trimming it, so the array loses a dimension on every pass and runs out after two:

```
start          (5, 5)
iter0: all_gather -> (5, 5)   [0] -> (5,)
iter1: all_gather -> (5,)     [0] -> ()
iter2: all_gather -> ()       [0] -> ValueError
```

Slicing back to the original first dimension keeps the shape fixed, which is what a benchmark loop wants:

```
iter0 -> (5, 5)
iter1 -> (5, 5)
iter2 -> (5, 5)
```

With that change the script completes and prints both numbers:

```
All Reduce: time per iteration 0.004029 (ms)
All gather: time per iteration 0.000597 (ms)
```

Note this is not specific to a single process. `all_gather` only scales axis 0, so `[0]` drops a dimension no matter how many ranks there are, and the third iteration fails either way. I could only run it with a group of one here, so I have not exercised it under `mlx.launch` with several ranks.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

(benchmark script, so no test; verified by running it before and after)

---

honest note on process: freshman contributor, Claude Code helps me sweep, but i found this by running the benchmark scripts, then printed the shape at each iteration to work out why it died rather than guessing at the fix. flagging clearly that the multi rank path is untested on my machine, in case that changes how you want it written.
