### PR TITLE
Fix segfault in expand_dims for out of bounds negative axes

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -562,26 +562,50 @@ array hadamard_transform(
       {astype(a, dtype, s)});
 }
 
+namespace {
+
+std::vector<int> normalize_squeeze_axes(
+    const array& a,
+    const std::vector<int>& axes) {
+  int ndim = a.ndim();
+  std::set<int> unique_axes;
+  for (auto ax : axes) {
+    int new_ax = normalize_axis_index(ax, ndim, "[squeeze] ");
+    if (a.shape(new_ax) != 1) {
+      std::ostringstream msg;
+      msg << "[squeeze] Cannot squeeze axis " << ax << " with size "
+          << a.shape(new_ax) << " which is not equal to 1.";
+      throw std::invalid_argument(msg.str());
+    }
+    unique_axes.insert(new_ax);
+  }
+  if (unique_axes.size() != axes.size()) {
+    throw std::invalid_argument("[squeeze] Received duplicate axes.");
+  }
+  return std::vector<int>(unique_axes.begin(), unique_axes.end());
+}
+
+std::vector<int> normalize_expand_dims_axes(
+    const array& a,
+    const std::vector<int>& axes) {
+  int out_ndim = a.ndim() + axes.size();
+  std::set<int> unique_axes;
+  for (auto ax : axes) {
+    unique_axes.insert(normalize_axis_index(ax, out_ndim, "[expand_dims] "));
+  }
+  if (unique_axes.size() != axes.size()) {
+    throw std::invalid_argument("[expand_dims] Received duplicate axes.");
+  }
+  return std::vector<int>(unique_axes.begin(), unique_axes.end());
+}
+
+} // namespace
+
+// Assumes the axes are non-negative, sorted, unique, and valid for a.
 array squeeze_impl(
     const array& a,
     std::vector<int> axes,
     StreamOrDevice s /* = {} */) {
-  for (auto& ax : axes) {
-    auto new_ax = ax < 0 ? ax + a.ndim() : ax;
-    if (new_ax < 0 || new_ax >= a.ndim()) {
-      std::ostringstream msg;
-      msg << "[squeeze] Invalid axes " << ax << " for array with " << a.ndim()
-          << " dimensions.";
-      throw std::invalid_argument(msg.str());
-    }
-    if (a.shape(new_ax) != 1) {
-      std::ostringstream msg;
-      msg << "[squeeze] Cannot squeeze axis " << ax << " with size "
-          << a.shape(ax) << " which is not equal to 1.";
-      throw std::invalid_argument(msg.str());
-    }
-    ax = new_ax;
-  }
   auto shape = Squeeze::output_shape(a, axes);
   return array(
       std::move(shape),
@@ -597,19 +621,11 @@ array squeeze(
   if (axes.empty()) {
     return a;
   }
-  std::set<int> unique_axes;
-  for (auto ax : axes) {
-    unique_axes.insert(ax < 0 ? ax + a.ndim() : ax);
-  }
-  if (unique_axes.size() != axes.size()) {
-    throw std::invalid_argument("[squeeze] Received duplicate axes.");
-  }
-  std::vector<int> sorted_axes(unique_axes.begin(), unique_axes.end());
-  return squeeze_impl(a, std::move(sorted_axes), s);
+  return squeeze_impl(a, normalize_squeeze_axes(a, axes), s);
 }
 
 array squeeze(const array& a, int axis, StreamOrDevice s /* = {} */) {
-  return squeeze_impl(a, {axis}, s);
+  return squeeze_impl(a, normalize_squeeze_axes(a, {axis}), s);
 }
 
 array squeeze(const array& a, StreamOrDevice s /* = {} */) {
@@ -622,21 +638,11 @@ array squeeze(const array& a, StreamOrDevice s /* = {} */) {
   return squeeze_impl(a, std::move(axes), s);
 }
 
+// Assumes the axes are non-negative, sorted, unique and valid for the output.
 array expand_dims_impl(
     const array& a,
     std::vector<int> axes,
     StreamOrDevice s /* = {} */) {
-  auto out_ndim = a.ndim() + axes.size();
-  for (auto& ax : axes) {
-    auto new_ax = ax < 0 ? ax + out_ndim : ax;
-    if (new_ax < 0 || new_ax >= out_ndim) {
-      std::ostringstream msg;
-      msg << "[expand_dims] Invalid axis " << ax << " for output array with "
-          << a.ndim() << " dimensions.";
-      throw std::invalid_argument(msg.str());
-    }
-    ax = new_ax;
-  }
   auto shape = ExpandDims::output_shape(a, axes);
   return array(
       std::move(shape),
@@ -646,7 +652,7 @@ array expand_dims_impl(
 }
 
 array expand_dims(const array& a, int axis, StreamOrDevice s /* = {} */) {
-  return expand_dims_impl(a, {axis}, s);
+  return expand_dims_impl(a, normalize_expand_dims_axes(a, {axis}), s);
 }
 
 array expand_dims(
@@ -656,23 +662,7 @@ array expand_dims(
   if (axes.empty()) {
     return a;
   }
-  { // Check for repeats
-    std::set<int> unique_axes(axes.begin(), axes.end());
-    if (unique_axes.size() != axes.size()) {
-      throw std::invalid_argument("[expand_dims] Received duplicate axes.");
-    }
-  }
-  // Check for repeats again
-  auto out_ndim = a.ndim() + axes.size();
-  std::set<int> unique_axes;
-  for (auto ax : axes) {
-    unique_axes.insert(ax < 0 ? ax + out_ndim : ax);
-  }
-  if (unique_axes.size() != axes.size()) {
-    throw std::invalid_argument("[expand_dims] Received duplicate axes.");
-  }
-  std::vector<int> sorted_axes(unique_axes.begin(), unique_axes.end());
-  return expand_dims_impl(a, std::move(sorted_axes), s);
+  return expand_dims_impl(a, normalize_expand_dims_axes(a, axes), s);
 }
 
 array flip(

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -2352,6 +2352,24 @@ class TestOps(mlx_tests.MLXTestCase):
         self.assertEqual(mx.expand_dims(a, 0).shape, (1, 2, 2))
         self.assertEqual(mx.expand_dims(a, (0, 1)).shape, (1, 1, 2, 2))
         self.assertEqual(mx.expand_dims(a, [0, -1]).shape, (1, 2, 2, 1))
+        self.assertEqual(mx.expand_dims(a, [-1, -4]).shape, (1, 2, 2, 1))
+
+    def test_squeeze_expand_invalid_axes(self):
+        # Out of bounds negative axes must raise instead of wrapping around
+        a = mx.zeros(())
+        self.assertEqual(mx.expand_dims(a, (-2, -1)).shape, (1, 1))
+        with self.assertRaises(ValueError):
+            mx.expand_dims(a, (-3, -2))
+
+        a = mx.zeros((2, 2))
+        for axes in [(-5, -4), (-6, 0), (0, 5)]:
+            with self.assertRaises(ValueError):
+                mx.expand_dims(a, axes)
+
+        a = mx.zeros((1, 1, 1))
+        for axes in [(-4,), (-5, 0), (0, 4)]:
+            with self.assertRaises(ValueError):
+                mx.squeeze(a, axes)
 
     def test_sort(self):
         shape = (6, 4, 10)

--- a/tests/ops_tests.cpp
+++ b/tests/ops_tests.cpp
@@ -195,7 +195,7 @@ TEST_CASE("test squeeze and expand") {
 
   // Out of bounds negative axes must throw and not wrap around
   x = zeros({1, 1, 1});
-  CHECK_THROWS(squeeze(x, {-4}));
+  CHECK_THROWS(squeeze(x, std::vector<int>{-4}));
   CHECK_THROWS(squeeze(x, {-5, 0}));
   CHECK_THROWS(squeeze(x, {0, 4}));
 

--- a/tests/ops_tests.cpp
+++ b/tests/ops_tests.cpp
@@ -193,6 +193,12 @@ TEST_CASE("test squeeze and expand") {
   CHECK_THROWS(squeeze(x, {1, 3, 1}));
   CHECK_THROWS(squeeze(x, {1, 3, -3}));
 
+  // Out of bounds negative axes must throw and not wrap around
+  x = zeros({1, 1, 1});
+  CHECK_THROWS(squeeze(x, {-4}));
+  CHECK_THROWS(squeeze(x, {-5, 0}));
+  CHECK_THROWS(squeeze(x, {0, 4}));
+
   x = zeros({2, 2});
   CHECK_EQ(expand_dims(x, 0).shape(), Shape{1, 2, 2});
   CHECK_EQ(expand_dims(x, -1).shape(), Shape{2, 2, 1});
@@ -206,6 +212,18 @@ TEST_CASE("test squeeze and expand") {
   CHECK_THROWS(expand_dims(x, -4));
   CHECK_THROWS(expand_dims(x, {0, 1, 0}));
   CHECK_THROWS(expand_dims(x, {0, 1, -4}));
+
+  // Negative axes are resolved against the output shape and sorted
+  CHECK_EQ(expand_dims(x, {3, -4}).shape(), Shape{1, 2, 2, 1});
+  CHECK_EQ(expand_dims(x, {-1, -4}).shape(), Shape{1, 2, 2, 1});
+
+  // Out of bounds negative axes must throw and not wrap around
+  CHECK_THROWS(expand_dims(x, {-5, -4}));
+  CHECK_THROWS(expand_dims(x, {-6, 0}));
+
+  x = zeros({});
+  CHECK_EQ(expand_dims(x, {-2, -1}).shape(), Shape{1, 1});
+  CHECK_THROWS(expand_dims(x, {-3, -2}));
 }
 
 TEST_CASE("test slice") {


### PR DESCRIPTION
## Proposed changes

Closes #4011

`mx.expand_dims(mx.zeros(()), axis=(-3, -2))` segfaults.

### Cause

`expand_dims(a, axes)` normalized negative axes against the output rank and
then passed them to `expand_dims_impl`, which normalized them a second time
(`-3 + 2 = -1`, still negative and never range checked, then `-1 + 2 = 1`). An
out of bounds axis therefore turned silently into a valid but wrong one, and
the axes ended up as `{1, 0}` instead of sorted. `ExpandDims::output_shape`
assumes sorted, in bounds axes, so this inserted past the end of an empty shape
and crashed. `out_ndim` was also `size_t`, so the `new_ax < 0` guard could
never fire.

### Fix

Normalize, validate and sort the axes exactly once, in a single helper per op,
reusing the existing `normalize_axis_index`. Error wording now comes from that
helper; no tests asserted on the old strings.

`squeeze` had the same double normalization, but failed silently rather than
crashing: `mx.squeeze(mx.zeros((1, 1, 1)), (-5,))` returned shape `(1, 1)`
instead of raising, because `-5` mapped to axis `1`. Fixed the same way, though
happy to split it out if you would prefer this PR stay scoped to the crash.

### Testing

Extended the C++ `test squeeze and expand` case and added
`test_squeeze_expand_invalid_axes` in Python, covering out of bounds negative
axes for both ops plus the valid negative axis cases that must keep working.
Both segfault against unpatched `ops.cpp` and pass with the fix.

Full C++ and Python suites pass on a Metal build; the only failures are torch
MPS DLPack tests, which fail identically without this change.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)