### PR TITLE
Pick BM from rows per expert in gather_qmm_rhs_nax

### DIFF
--- a/benchmarks/python/gather_qmm_bench.py
+++ b/benchmarks/python/gather_qmm_bench.py
@@ -80,5 +80,26 @@ def time_gather_qmm():
     time_fn(equivalent_matmul, x, w1, w2)
 
 
+def time_gather_qmm_short_runs():
+    # Many experts and few tokens, so each expert gets N * I / E = 16 rows.
+    N, E, I = 512, 256, 8
+    x = mx.random.normal((N, 1, 1, D)) / 1024**0.5
+    w1 = mx.random.normal((E, M, D)) / 1024**0.5
+    w2 = mx.random.normal((E, D, M)) / 1024**0.5
+    w1 = mx.quantize(w1)
+    w2 = mx.quantize(w2)
+    indices = (mx.random.uniform(shape=(N, I)) * E).astype(mx.uint32)
+    mx.eval(x, w1, w2, indices)
+
+    def gather_mm(x, w1, w2, indices):
+        x, idx, inv_order = gather_sort(x, indices)
+        x = mx.gather_qmm(x, *w1, transpose=True, rhs_indices=idx, sorted_indices=True)
+        x = mx.gather_qmm(x, *w2, transpose=True, rhs_indices=idx, sorted_indices=True)
+        return scatter_unsort(x, inv_order, indices.shape)
+
+    time_fn(gather_mm, x, w1, w2, indices)
+
+
 if __name__ == "__main__":
     time_gather_qmm()
+    time_gather_qmm_short_runs()

--- a/mlx/backend/metal/kernels/fp_quantized_nax.metal
+++ b/mlx/backend/metal/kernels/fp_quantized_nax.metal
@@ -62,7 +62,9 @@
 
 #define instantiate_quantized_all_rhs(type, mode, group_size, bits) \
   instantiate_gather_qmm_rhs(fp_gather_qmm_rhs_nax, gather_qmm_rhs_nax_nt, type, 64, 64, 64, 2, 2, true, mode, group_size, bits) \
-  instantiate_gather_qmm_rhs(fp_gather_qmm_rhs_nax, gather_qmm_rhs_nax_nn, type, 64, 64, 64, 2, 2, false, mode, group_size, bits)
+  instantiate_gather_qmm_rhs(fp_gather_qmm_rhs_nax, gather_qmm_rhs_nax_nn, type, 64, 64, 64, 2, 2, false, mode, group_size, bits) \
+  instantiate_gather_qmm_rhs(fp_gather_qmm_rhs_nax, gather_qmm_rhs_nax_nt, type, 32, 64, 64, 2, 2, true, mode, group_size, bits) \
+  instantiate_gather_qmm_rhs(fp_gather_qmm_rhs_nax, gather_qmm_rhs_nax_nn, type, 32, 64, 64, 2, 2, false, mode, group_size, bits)
 
 #define instantiate_quantized_modes(type, mode, group_size, bits) \
   instantiate_quantized_all_aligned(type, mode, group_size, bits) \

--- a/mlx/backend/metal/kernels/quantized_nax.metal
+++ b/mlx/backend/metal/kernels/quantized_nax.metal
@@ -78,7 +78,9 @@
 
 #define instantiate_quantized_all_rhs(type, group_size, bits) \
   instantiate_gather_qmm_rhs(affine_gather_qmm_rhs_nax, affine_gather_qmm_rhs_nax_nt, type, group_size, bits, 64, 64, 64, 2, 2, true) \
-  instantiate_gather_qmm_rhs(affine_gather_qmm_rhs_nax, affine_gather_qmm_rhs_nax_nn, type, group_size, bits, 64, 64, 64, 2, 2, false)
+  instantiate_gather_qmm_rhs(affine_gather_qmm_rhs_nax, affine_gather_qmm_rhs_nax_nn, type, group_size, bits, 64, 64, 64, 2, 2, false) \
+  instantiate_gather_qmm_rhs(affine_gather_qmm_rhs_nax, affine_gather_qmm_rhs_nax_nt, type, group_size, bits, 32, 64, 64, 2, 2, true) \
+  instantiate_gather_qmm_rhs(affine_gather_qmm_rhs_nax, affine_gather_qmm_rhs_nax_nn, type, group_size, bits, 32, 64, 64, 2, 2, false)
 
 #define instantiate_quantized_funcs(type, group_size, bits) \
   instantiate_quantized_all_batched(type, group_size, bits) \

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -1489,12 +1489,9 @@ void gather_qmm_rhs_nax(
     biases = ensure_row_contiguous(*biases_, d, s);
   }
 
-  // The kernel re-runs the whole K loop for each distinct expert in a BM
-  // row block and keeps only that expert's rows, so a block taller than the
-  // average run throws away most of its arithmetic. Weight traffic does not
-  // depend on BM, so we use a shorter block when the runs are short.
+  // Use smaller bm for many experts and few tokens.
   int E = w.size() / w.shape(-1) / w.shape(-2);
-  int bm = M / E < 64 ? 32 : 64;
+  int bm = (M / E < 64) ? 32 : 64;
   int bn = 64, bk = 64;
   int wm = 2, wn = 2;
 

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -1489,8 +1489,13 @@ void gather_qmm_rhs_nax(
     biases = ensure_row_contiguous(*biases_, d, s);
   }
 
-  // TODO: Tune the block sizes
-  int bm = 64, bn = 64, bk = 64;
+  // The kernel re-runs the whole K loop for each distinct expert in a BM
+  // row block and keeps only that expert's rows, so a block taller than the
+  // average run throws away most of its arithmetic. Weight traffic does not
+  // depend on BM, so we use a shorter block when the runs are short.
+  int E = w.size() / w.shape(-1) / w.shape(-2);
+  int bm = M / E < 64 ? 32 : 64;
+  int bn = 64, bk = 64;
   int wm = 2, wn = 2;
 
   const bool align_M = (M % bm) == 0;

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -1,9 +1,7 @@
 # Copyright © 2023-2026 Apple Inc.
 
-import os
 import platform
 import subprocess
-import sys
 import unittest
 from itertools import product
 
@@ -1358,6 +1356,8 @@ class TestQuantized(mlx_tests.MLXTestCase):
             (32, 512, 544, 4, 2, True, "mxfp4"),
             (32, 512, 544, 4, 2, True, "nvfp4"),
             (32, 512, 544, 4, 2, True, "mxfp8"),
+            (39, 512, 512, 4, 2, True, "affine"),
+            (128, 512, 512, 4, 2, True, "affine"),
             (133, 512, 512, 4, 2, True, "affine"),
             (133, 512, 555, 4, 2, True, "affine"),
             (133, 512, 512, 4, 2, True, "affine"),
@@ -1467,112 +1467,6 @@ class TestQuantized(mlx_tests.MLXTestCase):
                     atol=1e-4,
                 )
             )
-
-    def test_gather_qmm_sorted_block_sizes(self):
-        # The sorted-indices path picks its block height from the average
-        # rows per expert: BM=32 below 64 rows per expert, BM=64 at or
-        # above. Cover every mode, group size, bit width and dtype in both
-        # regimes so each kernel instantiation is exercised, plus one
-        # unaligned batch for the short-block path.
-        def gather_sort(x, indices):
-            N, M = indices.shape
-            indices = indices.flatten()
-            order = mx.argsort(indices)
-            inv_order = mx.argsort(order)
-            return x.flatten(0, -3)[order // M], indices[order], inv_order
-
-        def scatter_unsort(x, inv_order, shape=None):
-            x = x[inv_order]
-            if shape is not None:
-                x = mx.unflatten(x, 0, shape)
-            return x
-
-        E = 4
-        K = 512
-        D = 512
-        configs = [
-            ("affine", gs, b) for gs in (32, 64, 128) for b in (2, 3, 4, 5, 6, 8)
-        ]
-        configs += [("mxfp4", None, None), ("nvfp4", None, None), ("mxfp8", None, None)]
-        # L * I tokens against E experts: 64 tokens give 16 rows per expert
-        # (BM=32), 256 give 64 (BM=64), 78 give 19.5 and a batch that is not
-        # a multiple of the block height.
-        regimes = [(32, 2), (128, 2), (39, 2)]
-
-        key = mx.random.key(0)
-        k1, k2, k3 = mx.random.split(key, 3)
-
-        for mode, group_size, bits in configs:
-            dtypes = (
-                [mx.float16, mx.bfloat16, mx.float32]
-                if mx.default_device() == mx.gpu
-                else [mx.float32]
-            )
-            for dtype in dtypes:
-                for L, I in regimes:
-                    with self.subTest(
-                        mode=mode, group_size=group_size, bits=bits, dtype=dtype, L=L
-                    ):
-                        indices = (mx.random.uniform(shape=(L, I), key=k1) * E).astype(
-                            mx.uint32
-                        )
-                        x = (mx.random.normal((L, 1, 1, K), key=k2) / K**0.5).astype(
-                            dtype
-                        )
-                        w = (mx.random.normal((E, D, K), key=k3) / K**0.5).astype(dtype)
-
-                        if mode == "affine":
-                            wq = mx.quantize(w, group_size=group_size, bits=bits)
-                        else:
-                            wq = mx.quantize(w, mode=mode)
-                        w_hat = mx.dequantize(
-                            *wq, group_size=group_size, bits=bits, mode=mode
-                        ).swapaxes(-1, -2)
-
-                        xs, idx, inv_order = gather_sort(x, indices)
-                        y1 = mx.gather_mm(
-                            xs, w_hat, rhs_indices=idx, sorted_indices=True
-                        )
-                        y2 = mx.gather_qmm(
-                            xs,
-                            *wq,
-                            group_size=group_size,
-                            bits=bits,
-                            mode=mode,
-                            rhs_indices=idx,
-                            transpose=True,
-                            sorted_indices=True,
-                        )
-                        y1 = scatter_unsort(y1, inv_order, indices.shape)
-                        y2 = scatter_unsort(y2, inv_order, indices.shape)
-
-                        tol = 1.5e-5 if dtype == mx.float32 else 1e-3
-                        self.assertLess((y1 - y2).abs().max(), tol)
-
-    def test_gather_qmm_sorted_float32_tf32(self):
-        # mlx_tests.py pins MLX_ENABLE_TF32=0 and the flag is cached on first
-        # read, so the float32 variants of the sorted-indices kernels can only
-        # run in a fresh process with TF32 enabled.
-        script = """
-import mlx.core as mx
-E, K, D = 4, 512, 512
-for B in (64, 256):
-    idx = mx.sort((mx.random.uniform(shape=(B,)) * E).astype(mx.uint32))
-    x = mx.random.normal((B, 1, K)) / K**0.5
-    w = mx.random.normal((E, D, K)) / K**0.5
-    wq = mx.quantize(w, group_size=64, bits=4)
-    w_hat = mx.dequantize(*wq, group_size=64, bits=4).swapaxes(-1, -2)
-    y1 = mx.gather_mm(x, w_hat, rhs_indices=idx, sorted_indices=True)
-    y2 = mx.gather_qmm(x, *wq, group_size=64, bits=4, rhs_indices=idx,
-                       transpose=True, sorted_indices=True)
-    assert (y1 - y2).abs().max().item() < 1e-3, B
-"""
-        env = os.environ.copy()
-        env["MLX_ENABLE_TF32"] = "1"
-        result = subprocess.run(
-            [sys.executable, "-c", script], env=env, capture_output=True, text=True
-        )
-        self.assertEqual(result.returncode, 0, result.stderr)
 
     def test_gather_qmm_grad(self):
         def gather_qmm_ref(x, w, s, b, lhs, rhs, trans, sort):

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -1467,6 +1467,7 @@ class TestQuantized(mlx_tests.MLXTestCase):
                     atol=1e-4,
                 )
             )
+
     def test_gather_qmm_sorted_block_sizes(self):
         # The sorted-indices path picks its block height from the average
         # rows per expert: BM=32 below 64 rows per expert, BM=64 at or
@@ -1489,7 +1490,9 @@ class TestQuantized(mlx_tests.MLXTestCase):
         E = 4
         K = 512
         D = 512
-        configs = [("affine", gs, b) for gs in (32, 64, 128) for b in (2, 3, 4, 5, 6, 8)]
+        configs = [
+            ("affine", gs, b) for gs in (32, 64, 128) for b in (2, 3, 4, 5, 6, 8)
+        ]
         configs += [("mxfp4", None, None), ("nvfp4", None, None), ("mxfp8", None, None)]
         # L * I tokens against E experts: 64 tokens give 16 rows per expert
         # (BM=32), 256 give 64 (BM=64), 78 give 19.5 and a batch that is not
@@ -1500,9 +1503,11 @@ class TestQuantized(mlx_tests.MLXTestCase):
         k1, k2, k3 = mx.random.split(key, 3)
 
         for mode, group_size, bits in configs:
-            dtypes = [mx.float16, mx.bfloat16, mx.float32]
-            if mx.default_device() == mx.cpu:
-                dtypes = [mx.float32]
+            dtypes = (
+                [mx.float16, mx.bfloat16, mx.float32]
+                if mx.default_device() == mx.gpu
+                else [mx.float32]
+            )
             for dtype in dtypes:
                 for L, I in regimes:
                     with self.subTest(
@@ -1525,7 +1530,9 @@ class TestQuantized(mlx_tests.MLXTestCase):
                         ).swapaxes(-1, -2)
 
                         xs, idx, inv_order = gather_sort(x, indices)
-                        y1 = mx.gather_mm(xs, w_hat, rhs_indices=idx, sorted_indices=True)
+                        y1 = mx.gather_mm(
+                            xs, w_hat, rhs_indices=idx, sorted_indices=True
+                        )
                         y2 = mx.gather_qmm(
                             xs,
                             *wq,

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -1465,6 +1465,80 @@ class TestQuantized(mlx_tests.MLXTestCase):
                     atol=1e-4,
                 )
             )
+    def test_gather_qmm_sorted_block_sizes(self):
+        # The sorted-indices path picks its block height from the average
+        # rows per expert: BM=32 below 64 rows per expert, BM=64 at or
+        # above. Cover every mode, group size, bit width and dtype in both
+        # regimes so each kernel instantiation is exercised, plus one
+        # unaligned batch for the short-block path.
+        def gather_sort(x, indices):
+            N, M = indices.shape
+            indices = indices.flatten()
+            order = mx.argsort(indices)
+            inv_order = mx.argsort(order)
+            return x.flatten(0, -3)[order // M], indices[order], inv_order
+
+        def scatter_unsort(x, inv_order, shape=None):
+            x = x[inv_order]
+            if shape is not None:
+                x = mx.unflatten(x, 0, shape)
+            return x
+
+        E = 4
+        K = 512
+        D = 512
+        configs = [("affine", gs, b) for gs in (32, 64, 128) for b in (2, 3, 4, 5, 6, 8)]
+        configs += [("mxfp4", None, None), ("nvfp4", None, None), ("mxfp8", None, None)]
+        # L * I tokens against E experts: 64 tokens give 16 rows per expert
+        # (BM=32), 256 give 64 (BM=64), 78 give 19.5 and a batch that is not
+        # a multiple of the block height.
+        regimes = [(32, 2), (128, 2), (39, 2)]
+
+        key = mx.random.key(0)
+        k1, k2, k3 = mx.random.split(key, 3)
+
+        for mode, group_size, bits in configs:
+            dtypes = [mx.float16, mx.bfloat16, mx.float32]
+            if mx.default_device() == mx.cpu:
+                dtypes = [mx.float32]
+            for dtype in dtypes:
+                for L, I in regimes:
+                    with self.subTest(
+                        mode=mode, group_size=group_size, bits=bits, dtype=dtype, L=L
+                    ):
+                        indices = (mx.random.uniform(shape=(L, I), key=k1) * E).astype(
+                            mx.uint32
+                        )
+                        x = (mx.random.normal((L, 1, 1, K), key=k2) / K**0.5).astype(
+                            dtype
+                        )
+                        w = (mx.random.normal((E, D, K), key=k3) / K**0.5).astype(dtype)
+
+                        if mode == "affine":
+                            wq = mx.quantize(w, group_size=group_size, bits=bits)
+                        else:
+                            wq = mx.quantize(w, mode=mode)
+                        w_hat = mx.dequantize(
+                            *wq, group_size=group_size, bits=bits, mode=mode
+                        ).swapaxes(-1, -2)
+
+                        xs, idx, inv_order = gather_sort(x, indices)
+                        y1 = mx.gather_mm(xs, w_hat, rhs_indices=idx, sorted_indices=True)
+                        y2 = mx.gather_qmm(
+                            xs,
+                            *wq,
+                            group_size=group_size,
+                            bits=bits,
+                            mode=mode,
+                            rhs_indices=idx,
+                            transpose=True,
+                            sorted_indices=True,
+                        )
+                        y1 = scatter_unsort(y1, inv_order, indices.shape)
+                        y2 = scatter_unsort(y2, inv_order, indices.shape)
+
+                        tol = 1.5e-5 if dtype == mx.float32 else 1e-3
+                        self.assertLess((y1 - y2).abs().max(), tol)
 
     def test_gather_qmm_grad(self):
         def gather_qmm_ref(x, w, s, b, lhs, rhs, trans, sort):

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -1,7 +1,9 @@
 # Copyright © 2023-2026 Apple Inc.
 
+import os
 import platform
 import subprocess
+import sys
 import unittest
 from itertools import product
 
@@ -1539,6 +1541,31 @@ class TestQuantized(mlx_tests.MLXTestCase):
 
                         tol = 1.5e-5 if dtype == mx.float32 else 1e-3
                         self.assertLess((y1 - y2).abs().max(), tol)
+
+    def test_gather_qmm_sorted_float32_tf32(self):
+        # mlx_tests.py pins MLX_ENABLE_TF32=0 and the flag is cached on first
+        # read, so the float32 variants of the sorted-indices kernels can only
+        # run in a fresh process with TF32 enabled.
+        script = """
+import mlx.core as mx
+E, K, D = 4, 512, 512
+for B in (64, 256):
+    idx = mx.sort((mx.random.uniform(shape=(B,)) * E).astype(mx.uint32))
+    x = mx.random.normal((B, 1, K)) / K**0.5
+    w = mx.random.normal((E, D, K)) / K**0.5
+    wq = mx.quantize(w, group_size=64, bits=4)
+    w_hat = mx.dequantize(*wq, group_size=64, bits=4).swapaxes(-1, -2)
+    y1 = mx.gather_mm(x, w_hat, rhs_indices=idx, sorted_indices=True)
+    y2 = mx.gather_qmm(x, *wq, group_size=64, bits=4, rhs_indices=idx,
+                       transpose=True, sorted_indices=True)
+    assert (y1 - y2).abs().max().item() < 1e-3, B
+"""
+        env = os.environ.copy()
+        env["MLX_ENABLE_TF32"] = "1"
+        result = subprocess.run(
+            [sys.executable, "-c", script], env=env, capture_output=True, text=True
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
 
     def test_gather_qmm_grad(self):
         def gather_qmm_ref(x, w, s, b, lhs, rhs, trans, sort):


### PR DESCRIPTION
Following up on #3925, where you invited a PR that tunes the block sizes.

`affine_gather_qmm_rhs_nax` walks the sorted index array and re-runs its entire K loop once per distinct expert inside a BM-row block, computing all BM rows on each pass and keeping only that expert's rows through `store_slice`. Useful arithmetic is therefore about `min(1, rows_per_expert / BM)`. The run length is a caller-side quantity: for MoE prefill it is `tokens * top_k / num_experts`. A 256-expert top-8 model prefilling 512-token chunks presents runs of 16 rows against a block of 64, so three quarters of the arithmetic is computed and discarded.

Bandwidth is set by the number of experts a block touches rather than by BM. Each expert's BN by K slab is read once per block it appears in, and a 16-row run sits inside one block whether that block is 32 rows or 64. A shorter block removes arithmetic and adds no traffic.

**The change.** Dispatch BM=32 when the average run is shorter than 64 rows, and add the matching instantiations for the affine and fp modes. Runs of 64 rows and longer keep BM=64 and the kernel they use today.

**Measurement.** Both arms were built from this tree one after the other and measured in the same session by one script: chained up and down projection pairs, 4-bit gs64, E=256, K=2048, N=512, median of five dependent strips after a warmup pass. Percentages are of this device's measured fp16 tensor-core peak of 15.4 TFLOPS, on a base M5 with a 10-core GPU. Within-arm sigma stayed at or below 0.9%.

| rows/expert | main | this PR | ratio |
| --- | --- | --- | --- |
| 4 | 5.3% | 7.7% | 1.45x |
| 8 | 10.5% | 15.3% | 1.46x |
| 16 | 20.8% | 29.5% | 1.42x |
| 32 | 41.5% | 53.1% | 1.28x |
| 64 | 75.1% | 76.6% | 1.02x |
| 128 | 84.3% | 84.4% | 1.00x |

The last two rows take the unchanged path in both builds, so they act as a control: they agree within 2%, which is the process-to-process floor I see on this machine. Read the rows above against that floor rather than against the within-arm sigma. The curve also tracks `min(1, run / BM)` across the whole range, which is the evidence that the block height drives the gap.

The benchmark case added here, which is the same shape at 16 rows per expert, reads 9.56 ms on main and 7.45 ms with the patch. Its `equivalent_matmul` control reads 1.814 ms and 1.818 ms across the two builds.

**End to end.** On a 4-bit Qwen3.6-35B-A3B under mlx-lm at 32k context with 512-token prefill chunks, warm, time to first token went from 62.8 s to 58.9 s, and prefill from 523.6 to 557.9 tokens/s. Decode was unchanged, which is the expected null because single-token decode does not take this path. That measurement predates this patch and used an earlier build where an environment variable chose BM instead of the heuristic. The dispatch decision was the same one, but I have not re-run it against this branch.

**Costs and things I left out.** The extra instantiations grow the metallib from 164,587,560 to 171,001,000 bytes, or 3.9%. If that is too much, dropping the fp-mode instantiations and dispatching only the affine path would cut it. I also built and measured BM=16 with WM=1 and WN=2: it reached parity with BM=32 at runs of 8 and below and fell behind at 16, so nothing dispatches it.

All of the above comes from one machine, and the crossover between block sizes may well sit elsewhere on other devices. I am happy to re-run the sweep with different thresholds, or to narrow the condition, if you have a shape in mind.

`python -m pytest python/tests/test_quantized.py` passes: 33 tests, 3014 subtests.
