### PR TITLE
Align example projects with the Python 3.10 minimum

### DIFF
--- a/examples/cmake_project/CMakeLists.txt
+++ b/examples/cmake_project/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Comment the following two commands only the MLX C++ library is installed and
 # set(MLX_ROOT "/path/to/mlx") directly if needed.
 find_package(
-  Python 3.9
+  Python 3.10
   COMPONENTS Interpreter Development.Module
   REQUIRED)
 execute_process(

--- a/examples/extensions/setup.py
+++ b/examples/extensions/setup.py
@@ -14,5 +14,5 @@ if __name__ == "__main__":
         packages=["mlx_sample_extensions"],
         package_data={"mlx_sample_extensions": ["*.so", "*.dylib", "*.metallib"]},
         zip_safe=False,
-        python_requires=">=3.8",
+        python_requires=">=3.10",
     )


### PR DESCRIPTION
## Proposed changes

MLX has required Python 3.10 since #2694, but the two example projects still carry the older floors:

- `examples/cmake_project/CMakeLists.txt` asks for `Python 3.9`
- `examples/extensions/setup.py` declares `python_requires=">=3.8"`

For reference, the rest of the tree agrees on 3.10: `setup.py` uses `python_requires=">=3.10"`, the top level `CMakeLists.txt` looks for `Python 3.10`, and `install.rst` states it in three places.

It is only cosmetic on a supported interpreter, but on 3.8 or 3.9 the example projects currently accept the environment and then fail later when MLX turns out not to be installable, rather than saying up front that the interpreter is too old.

Checked that the cmake example still configures, builds and prints the output its README promises:

```
-- Found Python: ... (found suitable version "3.12.13", minimum required is "3.10")
-- Found MLX: .../libmlx.dylib
[100%] Built target example
array([2, 4, 6], dtype=int32)
```

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

(two one word changes; verified by building and running the cmake example before and after)

---

process note as usual: freshman contributor, Claude Code helps me look around, but i traced this by grepping every Python version reference in the tree, found the bump commit that moved the project to 3.10, and confirmed these two were simply left behind rather than intentionally lower. i also rebuilt the example to be sure raising the floor did not break it.
