### PR TITLE
Fix C++ benchmarks failing to build on overloaded astype

### DIFF
--- a/benchmarks/cpp/irregular_strides.cpp
+++ b/benchmarks/cpp/irregular_strides.cpp
@@ -9,6 +9,12 @@
 
 namespace mx = mlx::core;
 
+// mx::astype is overloaded, so it cannot be passed directly to the timing
+// helpers. Wrap the three argument form instead.
+auto astype = [](const mx::array& a, mx::Dtype dtype, mx::StreamOrDevice s) {
+  return mx::astype(a, dtype, s);
+};
+
 void time_irregular_binary_ops_1D() {
   auto device = mx::default_device();
   int size = 1000000;
@@ -164,7 +170,7 @@ void time_irregular_astype_1D() {
   int step = 2;
   auto a = mx::random::uniform({size});
   a = slice(a, {0}, {size}, {step});
-  TIMEM("1D strided", mx::astype, a, mx::int32, device);
+  TIMEM("1D strided", astype, a, mx::int32, device);
 }
 
 void time_irregular_astype_2D() {
@@ -173,16 +179,16 @@ void time_irregular_astype_2D() {
   mx::Shape shape = {size, size};
 
   auto a = mx::random::uniform(shape);
-  TIMEM("2D regular", mx::astype, a, mx::int32, device);
+  TIMEM("2D regular", astype, a, mx::int32, device);
 
   a = mx::transpose(a);
-  TIMEM("2D mx::transpose", mx::astype, a, mx::int32, device);
+  TIMEM("2D mx::transpose", astype, a, mx::int32, device);
 
   a = mx::broadcast_to(mx::random::uniform({size}), shape);
-  TIMEM("2D broadcast dim 0", mx::astype, a, mx::int32, device);
+  TIMEM("2D broadcast dim 0", astype, a, mx::int32, device);
 
   a = mx::broadcast_to(mx::random::uniform({size, 1}), shape);
-  TIMEM("2D broadcast dim 1", mx::astype, a, mx::int32, device);
+  TIMEM("2D broadcast dim 1", astype, a, mx::int32, device);
 }
 
 int main(int argc, char** argv) {

--- a/benchmarks/cpp/single_ops.cpp
+++ b/benchmarks/cpp/single_ops.cpp
@@ -5,6 +5,12 @@
 
 namespace mx = mlx::core;
 
+// mx::astype is overloaded, so it cannot be passed directly to the timing
+// helpers. Wrap the three argument form instead.
+auto astype = [](const mx::array& a, mx::Dtype dtype, mx::StreamOrDevice s) {
+  return mx::astype(a, dtype, s);
+};
+
 void time_creation_ops() {
   int M = 2000;
   int N = 500;
@@ -28,18 +34,18 @@ void time_type_conversions() {
 
   auto a = mx::zeros(shape, mx::float32);
   mx::eval(a);
-  TIMEM("mx::float32 to mx::int32", mx::astype, a, mx::int32, device);
-  TIMEM("mx::float32 to mx::uint32", mx::astype, a, mx::uint32, device);
+  TIMEM("mx::float32 to mx::int32", astype, a, mx::int32, device);
+  TIMEM("mx::float32 to mx::uint32", astype, a, mx::uint32, device);
 
   a = mx::zeros(shape, mx::int32);
   mx::eval(a);
-  TIMEM("mx::int32 to mx::float32", mx::astype, a, mx::float32, device);
+  TIMEM("mx::int32 to mx::float32", astype, a, mx::float32, device);
 
   a = mx::zeros(shape, mx::bool_);
   mx::eval(a);
-  TIMEM("bool to mx::float32", mx::astype, a, mx::float32, device);
-  TIMEM("bool to mx::int32", mx::astype, a, mx::int32, device);
-  TIMEM("bool to mx::uint32", mx::astype, a, mx::uint32, device);
+  TIMEM("bool to mx::float32", astype, a, mx::float32, device);
+  TIMEM("bool to mx::int32", astype, a, mx::int32, device);
+  TIMEM("bool to mx::uint32", astype, a, mx::uint32, device);
 }
 
 void time_random_generation() {


### PR DESCRIPTION
## Proposed changes

The C++ benchmarks do not compile:

```
$ cmake -B build -DMLX_BUILD_BENCHMARKS=ON && cmake --build build
benchmarks/cpp/single_ops.cpp:31:3: error: no matching function for call to 'time_fn'
   31 |   TIMEM("mx::float32 to mx::int32", mx::astype, a, mx::int32, device);
benchmarks/cpp/time_utils.h:26:8: note: candidate template ignored: couldn't infer template argument 'F'
   26 | double time_fn(F fn, Args&&... args) {
```

`mx::astype` has two overloads (`ops.h:51` and `ops.h:52`), so the bare name cannot be deduced as the template argument of `time_fn`. There are 11 of these across `single_ops.cpp` and `irregular_strides.cpp`, and they are the only errors in the target.

Wrapped the three argument form in a small lambda per file, which is the same style the rest of these files already use for ops that need adapting, and left the call sites otherwise unchanged.

With that, `MLX_BUILD_BENCHMARKS=ON` builds all four binaries and they run:

```
Timing (mx::float32 to mx::int32) astype ... 0.079649 msec
Timing (1D strided) astype ... 0.14269 msec
```

Since the benchmarks default to `OFF`, this looks like it went unnoticed for a while rather than being a recent regression.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

(benchmark sources, so no test; verified by building with benchmarks enabled and running both binaries)

---

honest note: freshman contributor and Claude Code helps me hunt, but i found this by turning the benchmarks on and building them, read the actual overload resolution error, checked `ops.h` to confirm astype really is overloaded, and then reran both binaries to make sure they produce numbers rather than just compiling. built CPU only here, so i have not exercised the Metal paths of these benchmarks.
