### PR TITLE
Fix crash when reporting partial rings in mlx.distributed_config

### DIFF
--- a/python/mlx/_distributed_utils/config.py
+++ b/python/mlx/_distributed_utils/config.py
@@ -361,7 +361,7 @@ def check_valid_ring(hosts, rings, strict=True):
         log_error("Try passing --dot to visualize the connectivity")
         if len(rings) > 0:
             log_error("Rings found:")
-            for r in rings:
+            for r, _ in rings:
                 log_error(f" - {','.join(hosts[i].ssh_hostname for i in r)}")
         sys.exit(1)
     return has_ring


### PR DESCRIPTION
## Proposed changes

When `mlx.distributed_config` cannot find a full ring it tries to print the partial rings it did find, but that diagnostic path raises `TypeError` instead:

```
TypeError: list indices must be integers or slices, not list
```

`extract_rings` returns `(path, count)` pairs:

```python
rings.append((r, cnt))
...
return sorted(rings, key=lambda x: -len(x[0]))
```

`check_valid_ring` already unpacks correctly when testing for a full ring (`len(rings[0][0]) == len(hosts)`), but the error branch iterates the pairs as if each element were a bare path and indexes `hosts` with it:

```python
for r in rings:
    log_error(f" - {&#39;,&#39;.join(hosts[i].ssh_hostname for i in r)}")
```

so `i` is the path list itself rather than a node index.

This means the failure is worst exactly when the diagnostic matters most: a user whose fabric is miswired gets a traceback instead of the list of rings that were found, and loses the hint to run `--dot`.

## Repro

The branch is on the error path whenever a partial ring exists and no full ring does:

```python
class H:
    def __init__(self, n): self.ssh_hostname = n

hosts = [H("h1"), H("h2"), H("h3")]
rings = [([0, 1], 2)]                     # partial ring, shape as returned by extract_rings

for r in rings:                           # current code
    print(" - " + ",".join(hosts[i].ssh_hostname for i in r))
# TypeError: list indices must be integers or slices, not list
```

After the change the same input prints what was intended:

```
 - h1,h2
```

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

No test added: this is a one-line fix in an error-reporting branch that needs a miswired multi-host Thunderbolt fabric to reach naturally, and this repo has trimmed tests from small fixes of this size before (#3914). Happy to add one if you would prefer.