### PR TITLE
Give each host a unique rank in Hostfile.from_list

### DIFF
--- a/python/mlx/_distributed_utils/common.py
+++ b/python/mlx/_distributed_utils/common.py
@@ -90,7 +90,7 @@ class Hostfile:
     @classmethod
     def from_list(cls, hostlist, repeats=1):
         hosts = []
-        for i, h in enumerate(hostlist.split(",")):
+        for h in hostlist.split(","):
             if h == "":
                 raise ValueError("Hostname cannot be empty")
             try:
@@ -98,8 +98,8 @@ class Hostfile:
                 ips = [h]
             except ValueError:
                 ips = []
-            for i in range(repeats):
-                hosts.append(Host(i, h, ips, []))
+            for _ in range(repeats):
+                hosts.append(Host(len(hosts), h, ips, []))
         return cls(hosts)
 
 


### PR DESCRIPTION
## Proposed changes

`Hostfile.from_list` builds every `Host` with the wrong rank. The inner `repeats` loop reuses the name of the `enumerate` index:

```python
for i, h in enumerate(hostlist.split(",")):
    ...
    for i in range(repeats):        # shadows the enumerate index
        hosts.append(Host(i, h, ips, []))
```

so the value passed to `Host` is the repeat counter, never the position in the list. With the default `repeats=1` the range is always `range(1)`, so **every host gets rank 0**.

`from_file`, the sibling constructor, assigns `Host(i, ...)` straight from `enumerate`, so a unique sequential rank is clearly the intent.

## Repro

```python
from mlx._distributed_utils.common import Hostfile

[(h.rank, h.ssh_hostname) for h in Hostfile.from_list("hostA,hostB,hostC").hosts]
# before: [(0, &#39;hostA&#39;), (0, &#39;hostB&#39;), (0, &#39;hostC&#39;)]
# after:  [(0, &#39;hostA&#39;), (1, &#39;hostB&#39;), (2, &#39;hostC&#39;)]

[(h.rank, h.ssh_hostname) for h in Hostfile.from_list("hostA,hostB", 3).hosts]
# before: [(0, &#39;hostA&#39;), (1, &#39;hostA&#39;), (2, &#39;hostA&#39;), (0, &#39;hostB&#39;), (1, &#39;hostB&#39;), (2, &#39;hostB&#39;)]
# after:  [(0, &#39;hostA&#39;), (1, &#39;hostA&#39;), (2, &#39;hostA&#39;), (3, &#39;hostB&#39;), (4, &#39;hostB&#39;), (5, &#39;hostB&#39;)]
```

Using the running length of the list keeps ranks unique across repeats too.

## Scope

To be upfront: nothing reads `Host.rank` today, so this is latent rather than a live failure — I found it while reading the launcher, not from a bug report. It is still a wrong value on a public dataclass field that `from_file` populates correctly, so it seemed worth correcting before something starts depending on it. Close it if you would rather leave the field alone.

Behaviour that is unchanged: empty hostnames still raise, and literal IPs are still detected and stored in `ips`.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)