### PR TITLE
Add optional dtype parameter to zeros_like and ones_like

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -363,7 +363,11 @@ array zeros(const Shape& shape, Dtype dtype, StreamOrDevice s /* = {} */) {
 }
 
 array zeros_like(const array& a, StreamOrDevice s /* = {} */) {
-  return full_like(a, 0, a.dtype(), to_stream(s));
+  return zeros_like(a, a.dtype(), s);
+}
+
+array zeros_like(const array& a, Dtype dtype, StreamOrDevice s /* = {} */) {
+  return full_like(a, 0, dtype, to_stream(s));
 }
 
 array ones(const Shape& shape, Dtype dtype, StreamOrDevice s /* = {} */) {
@@ -371,7 +375,11 @@ array ones(const Shape& shape, Dtype dtype, StreamOrDevice s /* = {} */) {
 }
 
 array ones_like(const array& a, StreamOrDevice s /* = {} */) {
-  return full_like(a, 1, a.dtype(), to_stream(s));
+  return ones_like(a, a.dtype(), s);
+}
+
+array ones_like(const array& a, Dtype dtype, StreamOrDevice s /* = {} */) {
+  return full_like(a, 1, dtype, to_stream(s));
 }
 
 array eye(int n, int m, int k, Dtype dtype, StreamOrDevice s /* = {} */) {

--- a/mlx/ops.h
+++ b/mlx/ops.h
@@ -93,6 +93,7 @@ MLX_API array zeros(const Shape& shape, Dtype dtype, StreamOrDevice s = {});
 inline array zeros(const Shape& shape, StreamOrDevice s = {}) {
   return zeros(shape, float32, s);
 }
+/** Create an array of zeros with the shape of `a`. */
 MLX_API array zeros_like(const array& a, StreamOrDevice s = {});
 MLX_API array zeros_like(const array& a, Dtype dtype, StreamOrDevice s = {});
 
@@ -101,6 +102,7 @@ MLX_API array ones(const Shape& shape, Dtype dtype, StreamOrDevice s = {});
 inline array ones(const Shape& shape, StreamOrDevice s = {}) {
   return ones(shape, float32, s);
 }
+/** Create an array of ones with the shape of `a`. */
 MLX_API array ones_like(const array& a, StreamOrDevice s = {});
 MLX_API array ones_like(const array& a, Dtype dtype, StreamOrDevice s = {});
 

--- a/mlx/ops.h
+++ b/mlx/ops.h
@@ -94,6 +94,7 @@ inline array zeros(const Shape& shape, StreamOrDevice s = {}) {
   return zeros(shape, float32, s);
 }
 MLX_API array zeros_like(const array& a, StreamOrDevice s = {});
+MLX_API array zeros_like(const array& a, Dtype dtype, StreamOrDevice s = {});
 
 /** Fill an array of the given shape with ones. */
 MLX_API array ones(const Shape& shape, Dtype dtype, StreamOrDevice s = {});
@@ -101,6 +102,7 @@ inline array ones(const Shape& shape, StreamOrDevice s = {}) {
   return ones(shape, float32, s);
 }
 MLX_API array ones_like(const array& a, StreamOrDevice s = {});
+MLX_API array ones_like(const array& a, Dtype dtype, StreamOrDevice s = {});
 
 /** Fill an array of the given shape (n,m) with ones in the specified diagonal
  * k, and zeros everywhere else. */

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -1959,17 +1959,24 @@ void init_ops(nb::module_& m) {
       )pbdoc");
   m.def(
       "zeros_like",
-      &mx::zeros_like,
+      [](const mx::array& a,
+         std::optional<mx::Dtype> dtype,
+         mx::StreamOrDevice s) {
+        return mx::zeros_like(a, dtype.value_or(a.dtype()), s);
+      },
       nb::arg(),
+      "dtype"_a = nb::none(),
       nb::kw_only(),
       "stream"_a = nb::none(),
       nb::sig(
-          "def zeros_like(a: array, /, *, stream: Union[None, Stream, Device] = None) -> array"),
+          "def zeros_like(a: array, /, dtype: Optional[Dtype] = None, *, stream: Union[None, Stream, Device] = None) -> array"),
       R"pbdoc(
         An array of zeros like the input.
 
         Args:
-            a (array): The input to take the shape and type from.
+            a (array): The input to take the shape from.
+            dtype (Dtype, optional): Output data type. If ``None``, the output
+              type defaults to the input array's data type.
 
         Returns:
             array: The output array filled with zeros.
@@ -2001,17 +2008,24 @@ void init_ops(nb::module_& m) {
       )pbdoc");
   m.def(
       "ones_like",
-      &mx::ones_like,
+      [](const mx::array& a,
+         std::optional<mx::Dtype> dtype,
+         mx::StreamOrDevice s) {
+        return mx::ones_like(a, dtype.value_or(a.dtype()), s);
+      },
       nb::arg(),
+      "dtype"_a = nb::none(),
       nb::kw_only(),
       "stream"_a = nb::none(),
       nb::sig(
-          "def ones_like(a: array, /, *, stream: Union[None, Stream, Device] = None) -> array"),
+          "def ones_like(a: array, /, dtype: Optional[Dtype] = None, *, stream: Union[None, Stream, Device] = None) -> array"),
       R"pbdoc(
         An array of ones like the input.
 
         Args:
-            a (array): The input to take the shape and type from.
+            a (array): The input to take the shape from.
+            dtype (Dtype, optional): Output data type. If ``None``, the output
+              type defaults to the input array's data type.
 
         Returns:
             array: The output array filled with ones.

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -3550,6 +3550,41 @@ class TestOps(mlx_tests.MLXTestCase):
         self.assertTrue(mx.array_equal(mx.from_fp8(mx.to_fp8(vals)), vals))
         self.assertTrue(mx.array_equal(mx.from_fp8(mx.to_fp8(-vals)), -vals))
 
+    def test_zeros_ones_empty_like_dtype(self):
+        x = mx.array([1, 2, 3], dtype=mx.int32)
+
+        # Default dtype (should match x)
+        z = mx.zeros_like(x)
+        self.assertEqual(z.dtype, mx.int32)
+        o = mx.ones_like(x)
+        self.assertEqual(o.dtype, mx.int32)
+        e = mx.empty_like(x)
+        self.assertEqual(e.dtype, mx.int32)
+
+        # Positional dtype
+        z = mx.zeros_like(x, mx.float16)
+        self.assertEqual(z.dtype, mx.float16)
+        self.assertTrue(mx.array_equal(z, mx.zeros((3,), mx.float16)))
+
+        o = mx.ones_like(x, mx.float16)
+        self.assertEqual(o.dtype, mx.float16)
+        self.assertTrue(mx.array_equal(o, mx.ones((3,), mx.float16)))
+
+        e = mx.empty_like(x, mx.float16)
+        self.assertEqual(e.dtype, mx.float16)
+
+        # Keyword dtype
+        z = mx.zeros_like(x, dtype=mx.float32)
+        self.assertEqual(z.dtype, mx.float32)
+        self.assertTrue(mx.array_equal(z, mx.zeros((3,), mx.float32)))
+
+        o = mx.ones_like(x, dtype=mx.float32)
+        self.assertEqual(o.dtype, mx.float32)
+        self.assertTrue(mx.array_equal(o, mx.ones((3,), mx.float32)))
+
+        e = mx.empty_like(x, dtype=mx.float32)
+        self.assertEqual(e.dtype, mx.float32)
+
 
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner()

--- a/tests/creations_tests.cpp
+++ b/tests/creations_tests.cpp
@@ -218,10 +218,18 @@ TEST_CASE("test full") {
     CHECK_EQ(y.dtype(), int32);
     CHECK(array_equal(x, y).item<bool>());
 
+    auto z = zeros_like(x, float16);
+    CHECK_EQ(z.dtype(), float16);
+    CHECK(array_equal(z, zeros({2, 2}, float16)).item<bool>());
+
     x = ones({2, 2}, int32);
     y = ones_like(x);
     CHECK_EQ(y.dtype(), int32);
     CHECK(array_equal(x, y).item<bool>());
+
+    z = ones_like(x, float16);
+    CHECK_EQ(z.dtype(), float16);
+    CHECK(array_equal(z, ones({2, 2}, float16)).item<bool>());
   }
 
   // Works for empty shape and empty array


### PR DESCRIPTION
## Proposed changes
Solves #4001 

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
