### PR TITLE
Fix copy bug in mlx.core.asarray

### DIFF
--- a/python/src/convert.cpp
+++ b/python/src/convert.cpp
@@ -707,37 +707,37 @@ mx::array create_array(
     return mx::astype(arr, dtype, copy);
   }
 
-  if (copy.has_value() && copy.value() == false)
+  if (copy.has_value() && copy.value() == false) {
     throw std::invalid_argument(
         "Unable to avoid copy while creating an array as requested.");
-}
-
-if (nb::isinstance<nb::bool_>(v)) {
-  return mx::array(nb::cast<bool>(v), t.value_or(mx::bool_));
-} else if (nb::isinstance<nb::int_>(v)) {
-  auto val = nb::cast<int64_t>(v);
-  auto default_type = (val > std::numeric_limits<int>::max() ||
-                       val < std::numeric_limits<int>::min())
-      ? mx::int64
-      : mx::int32;
-  return mx::array(val, t.value_or(default_type));
-} else if (nb::isinstance<nb::float_>(v)) {
-  auto out_type = t.value_or(mx::float32);
-  if (out_type == mx::float64) {
-    return mx::array(nb::cast<double>(v), out_type);
-  } else {
-    return mx::array(nb::cast<float>(v), out_type);
   }
-} else if (PyComplex_Check(v.ptr())) {
-  return mx::array(
-      static_cast<mx::complex64_t>(nb::cast<std::complex<float>>(v)),
-      t.value_or(mx::complex64));
-} else if (nb::isinstance<nb::list>(v)) {
-  return array_from_list(nb::cast<nb::list>(v), t);
-} else if (nb::isinstance<nb::tuple>(v)) {
-  return array_from_list(nb::cast<nb::tuple>(v), t);
-} else {
-  auto arr = to_array_with_accessor(v);
-  return mx::astype(arr, t.value_or(arr.dtype()), copy);
-}
+
+  if (nb::isinstance<nb::bool_>(v)) {
+    return mx::array(nb::cast<bool>(v), t.value_or(mx::bool_));
+  } else if (nb::isinstance<nb::int_>(v)) {
+    auto val = nb::cast<int64_t>(v);
+    auto default_type = (val > std::numeric_limits<int>::max() ||
+                         val < std::numeric_limits<int>::min())
+        ? mx::int64
+        : mx::int32;
+    return mx::array(val, t.value_or(default_type));
+  } else if (nb::isinstance<nb::float_>(v)) {
+    auto out_type = t.value_or(mx::float32);
+    if (out_type == mx::float64) {
+      return mx::array(nb::cast<double>(v), out_type);
+    } else {
+      return mx::array(nb::cast<float>(v), out_type);
+    }
+  } else if (PyComplex_Check(v.ptr())) {
+    return mx::array(
+        static_cast<mx::complex64_t>(nb::cast<std::complex<float>>(v)),
+        t.value_or(mx::complex64));
+  } else if (nb::isinstance<nb::list>(v)) {
+    return array_from_list(nb::cast<nb::list>(v), t);
+  } else if (nb::isinstance<nb::tuple>(v)) {
+    return array_from_list(nb::cast<nb::tuple>(v), t);
+  } else {
+    auto arr = to_array_with_accessor(v);
+    return mx::astype(arr, t.value_or(arr.dtype()), copy);
+  }
 }

--- a/python/src/convert.cpp
+++ b/python/src/convert.cpp
@@ -696,41 +696,48 @@ mx::array create_array(
     return nd_array_to_mlx(nd, t, nb_dtype, copy);
   }
 
-  if (copy.has_value() && copy.value() == false) {
-    throw std::invalid_argument(
-        "Unable to avoid copy while creating an array as requested.");
-  }
-
-  if (nb::isinstance<nb::bool_>(v)) {
-    return mx::array(nb::cast<bool>(v), t.value_or(mx::bool_));
-  } else if (nb::isinstance<nb::int_>(v)) {
-    auto val = nb::cast<int64_t>(v);
-    auto default_type = (val > std::numeric_limits<int>::max() ||
-                         val < std::numeric_limits<int>::min())
-        ? mx::int64
-        : mx::int32;
-    return mx::array(val, t.value_or(default_type));
-  } else if (nb::isinstance<nb::float_>(v)) {
-    auto out_type = t.value_or(mx::float32);
-    if (out_type == mx::float64) {
-      return mx::array(nb::cast<double>(v), out_type);
-    } else {
-      return mx::array(nb::cast<float>(v), out_type);
-    }
-  } else if (PyComplex_Check(v.ptr())) {
-    return mx::array(
-        static_cast<mx::complex64_t>(nb::cast<std::complex<float>>(v)),
-        t.value_or(mx::complex64));
-  } else if (nb::isinstance<nb::list>(v)) {
-    return array_from_list(nb::cast<nb::list>(v), t);
-  } else if (nb::isinstance<nb::tuple>(v)) {
-    return array_from_list(nb::cast<nb::tuple>(v), t);
-  } else if (nb::isinstance<mx::array>(v)) {
+  if (nb::isinstance<mx::array>(v)) {
     auto arr = nb::cast<mx::array>(v);
+    if (copy.has_value() && copy.value() == false &&
+        arr.dtype() != t.value_or(arr.dtype())) {
+      throw std::invalid_argument(
+          "Unable to avoid copy while creating an array as requested.");
+    }
     auto dtype = t.value_or(arr.dtype());
     return mx::astype(arr, dtype, copy);
-  } else {
-    auto arr = to_array_with_accessor(v);
-    return mx::astype(arr, t.value_or(arr.dtype()), copy);
   }
+
+  if (copy.has_value() && copy.value() == false)
+    throw std::invalid_argument(
+        "Unable to avoid copy while creating an array as requested.");
+}
+
+if (nb::isinstance<nb::bool_>(v)) {
+  return mx::array(nb::cast<bool>(v), t.value_or(mx::bool_));
+} else if (nb::isinstance<nb::int_>(v)) {
+  auto val = nb::cast<int64_t>(v);
+  auto default_type = (val > std::numeric_limits<int>::max() ||
+                       val < std::numeric_limits<int>::min())
+      ? mx::int64
+      : mx::int32;
+  return mx::array(val, t.value_or(default_type));
+} else if (nb::isinstance<nb::float_>(v)) {
+  auto out_type = t.value_or(mx::float32);
+  if (out_type == mx::float64) {
+    return mx::array(nb::cast<double>(v), out_type);
+  } else {
+    return mx::array(nb::cast<float>(v), out_type);
+  }
+} else if (PyComplex_Check(v.ptr())) {
+  return mx::array(
+      static_cast<mx::complex64_t>(nb::cast<std::complex<float>>(v)),
+      t.value_or(mx::complex64));
+} else if (nb::isinstance<nb::list>(v)) {
+  return array_from_list(nb::cast<nb::list>(v), t);
+} else if (nb::isinstance<nb::tuple>(v)) {
+  return array_from_list(nb::cast<nb::tuple>(v), t);
+} else {
+  auto arr = to_array_with_accessor(v);
+  return mx::astype(arr, t.value_or(arr.dtype()), copy);
+}
 }

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -2610,8 +2610,15 @@ class TestArray(mlx_tests.MLXTestCase):
         self.assertEqual(
             mx.asarray(existing, dtype=mx.float32, copy=True).dtype, mx.float32
         )
-        with self.assertRaises(ValueError):
-            mx.asarray(existing, copy=False)
+        # Same dtype does not require a copy.
+        result = mx.asarray(existing, copy=False)
+        self.assertEqual(result.tolist(), [1, 2, 3])
+        self.assertEqual(result.dtype, existing.dtype)
+
+        result = mx.asarray(existing, dtype=existing.dtype, copy=False)
+        self.assertEqual(result.tolist(), [1, 2, 3])
+        self.assertEqual(result.dtype, existing.dtype)
+
         with self.assertRaises(ValueError):
             mx.asarray(existing, dtype=mx.float32, copy=False)
 
@@ -2638,8 +2645,6 @@ class TestArray(mlx_tests.MLXTestCase):
         arr = mx.array([1, 2, 3])
         self.assertEqual(mx.asarray(arr).tolist(), [1, 2, 3])
         self.assertEqual(mx.asarray(arr, copy=True).tolist(), [1, 2, 3])
-        with self.assertRaises(ValueError):
-            mx.asarray(arr, copy=False)
 
         arr_int = mx.array([1, 2, 3], dtype=mx.int32)
         arr_float = mx.asarray(arr_int, dtype=mx.float32)


### PR DESCRIPTION
Please include a description of the problem or feature this PR is addressing. If there is a corresponding issue, include the issue #.

This pull request refines how the `mx.asarray` and `mx.array` functions handle the `copy=False` option when given an existing `mx::array`. Now, if the input array already matches the requested dtype, a copy is avoided as expected. If a dtype conversion would be needed, an error is raised if `copy=False` is specified. The test suite is updated to verify this improved behavior.

### Improvements to array creation logic

* Updated `create_array` in `python/src/convert.cpp` to only raise an error for `copy=False` when a dtype conversion is required, otherwise returning the original array without copying.
* Removed redundant code handling for `mx::array` instances in the type dispatch, consolidating logic for clarity and correctness.

### Test suite updates

* Changed `test_asarray_copy` and `test_asarray` in `python/tests/test_array.py` to confirm that no error is raised when `copy=False` is used with an array of the same dtype, and that errors are still raised if a dtype conversion is required without copying. [[1]](diffhunk://#diff-cfd104f77ff7a0bdc64e75551b6e228eefd980865b0083bde29203951f1dc6adL2613-R2621) [[2]](diffhunk://#diff-cfd104f77ff7a0bdc64e75551b6e228eefd980865b0083bde29203951f1dc6adL2641-L2642)## Proposed changes

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
