### PR TITLE
Treat backend and envs as optional when parsing a hostfile

### DIFF
--- a/python/mlx/_distributed_utils/common.py
+++ b/python/mlx/_distributed_utils/common.py
@@ -69,8 +69,8 @@ class Hostfile:
             envs = []
             hosts = []
             if isinstance(data, dict):
-                backend = data["backend"]
-                envs = data["envs"]
+                backend = data.get("backend", backend)
+                envs = data.get("envs", envs)
                 hosts = data["hosts"]
             elif isinstance(data, list):
                 hosts = data


### PR DESCRIPTION
## Proposed changes

A hostfile written as a dict has to spell out `backend` and `envs` or parsing fails:

```json
{"hosts": [{"ssh": "host1", "ips": ["10.0.0.1"]}]}
```

```
ValueError: Failed to parse hostfile /tmp/hf_min.json ('backend')
```

The same hosts written as a plain list parse fine and pick up the defaults, and `Hostfile` declares both fields as optional (`backend: str = ""`, `envs: list[str] = field(default_factory=list)`), so the dict path looks like it was meant to default them too. The error is also just a bare `KeyError` repr, which does not say which key is missing in a useful way.

Switched those two lookups to fall back to the existing defaults. `hosts` stays required.

After the change:

```
hf_full     OK  backend='ring' envs=[] hosts=1
hf_list     OK  backend='' envs=[] hosts=2
hf_min      OK  backend='' envs=[] hosts=2
hf_nohosts  still errors as expected: Failed to parse hostfile ... ('hosts')
```

Files written by `mlx.distributed_config` always contain all three keys, so this only affects hand written hostfiles.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

(happy to add a test if you want one, though i noticed `_distributed_utils` has no test module today so i did not want to add one unprompted)

---

usual disclosure: freshman contributor, i use Claude Code while looking around, but i found this by writing the three hostfile shapes out and parsing each one, and i checked that a missing `hosts` key still raises so the change does not loosen anything else.
