### PR TITLE
Report bad hostfiles as CLI errors in mlx.launch

### DIFF
--- a/python/mlx/_distributed_utils/launch.py
+++ b/python/mlx/_distributed_utils/launch.py
@@ -332,7 +332,7 @@ def launch_ring(parser, hosts, args, command):
 
 def launch_nccl(parser, hosts, args, command):
     if not hosts[0].ips:
-        raise ValueError("Rank 0 should have an IP reachable from all other ranks")
+        parser.error("Rank 0 should have an IP reachable from all other ranks")
 
     master_host = hosts[0].ips[0]
     master_port = args.nccl_port
@@ -371,13 +371,13 @@ def launch_nccl(parser, hosts, args, command):
 
 def launch_jaccl(parser, hosts, args, command):
     if not hosts[0].ips:
-        raise ValueError("Rank 0 should have an IP reachable from all other ranks")
+        parser.error("Rank 0 should have an IP reachable from all other ranks")
 
     jaccl_ring = args.backend == "jaccl-ring"
     have_rdmas = all(len(h.rdma) == len(hosts) for h in hosts)
     have_nulls = all(h.rdma[i] is None for i, h in enumerate(hosts))
     if not have_rdmas or not have_nulls:
-        raise ValueError("Malformed hostfile for jaccl backend")
+        parser.error("Malformed hostfile for jaccl backend")
 
     coordinator = hosts[0].ips[0]
     env = args.env


### PR DESCRIPTION
## Proposed changes

`mlx.launch` reports the same kind of bad hostfile two different ways depending on the backend. With a hostfile whose rank 0 has no IP:

ring, which uses `parser.error`:

```
mlx.launch: error: The ring backend requires IPs to be provided instead of hostnames
```

nccl, which raises:

```
Traceback (most recent call last):
  ...
  File "python/mlx/_distributed_utils/launch.py", line 335, in launch_nccl
    raise ValueError("Rank 0 should have an IP reachable from all other ranks")
ValueError: Rank 0 should have an IP reachable from all other ranks
```

Same user mistake, but one path prints a traceback. Switched the three raises in `launch_nccl` and `launch_jaccl` to `parser.error`, which is what `launch_ring` and the rest of `main` already use. `parser` is already a parameter of both functions.

Now both print a normal CLI error and exit 2:

```
mlx.launch: error: Rank 0 should have an IP reachable from all other ranks
exit code: 2
```

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

(error reporting only, no behaviour change beyond how the message is printed; checked both backends before and after)

---

process note: freshman contributor and Claude Code helps me sweep, but i drove `mlx.launch` with a deliberately broken hostfile against each backend to see what a user actually gets, which is what made the inconsistency obvious. i only exercised the argument checking, not a real multi host launch.
