### PR TITLE
Fix ceil error message to say ceil instead of floor

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -3101,7 +3101,7 @@ array floor(const array& a, StreamOrDevice s /* = {} */) {
 
 array ceil(const array& a, StreamOrDevice s /* = {} */) {
   if (a.dtype() == complex64) {
-    throw std::invalid_argument("[floor] Not supported for complex64.");
+    throw std::invalid_argument("[ceil] Not supported for complex64.");
   }
   return array(a.shape(), a.dtype(), std::make_shared<Ceil>(to_stream(s)), {a});
 }


### PR DESCRIPTION
mx.ceil on a complex64 input raises an error that says `[floor]` instead of `[ceil]` — a copy-paste from the adjacent floor implementation (#150). This corrects the op name in the message; no behavior change otherwise.