### PR TITLE
Report bad host arguments as CLI errors instead of tracebacks

### DIFF
--- a/python/mlx/_distributed_utils/config.py
+++ b/python/mlx/_distributed_utils/config.py
@@ -615,10 +615,13 @@ def main():
     )
     args = parser.parse_args()
 
-    if args.hostfile is not None:
-        hosts = Hostfile.from_file(args.hostfile).hosts
-    else:
-        hosts = Hostfile.from_list(args.hosts).hosts
+    try:
+        if args.hostfile is not None:
+            hosts = Hostfile.from_file(args.hostfile).hosts
+        else:
+            hosts = Hostfile.from_list(args.hosts).hosts
+    except ValueError as e:
+        parser.error(str(e))
 
     # Check that we can ssh
     log(

--- a/python/mlx/_distributed_utils/launch.py
+++ b/python/mlx/_distributed_utils/launch.py
@@ -537,10 +537,13 @@ def main():
         rest.pop(0)
 
     # Try to extract a list of hosts and corresponding ips
-    if args.hostfile is not None:
-        hostfile = Hostfile.from_file(args.hostfile)
-    else:
-        hostfile = Hostfile.from_list(args.hosts, args.repeat_hosts)
+    try:
+        if args.hostfile is not None:
+            hostfile = Hostfile.from_file(args.hostfile)
+        else:
+            hostfile = Hostfile.from_list(args.hosts, args.repeat_hosts)
+    except ValueError as e:
+        parser.error(str(e))
 
     # Extract extra arguments from the hostfile
     if hostfile.backend != "" and args.backend is None:


### PR DESCRIPTION
## Proposed changes

Both distributed CLIs print a Python traceback when the user passes a bad `--hosts` or `--hostfile`, because `Hostfile.from_list` and `Hostfile.from_file` raise `ValueError` and neither entry point catches it.

```
$ mlx.launch --hosts '' script.py
Traceback (most recent call last):
  ...
  File "python/mlx/_distributed_utils/common.py", line 95, in from_list
    raise ValueError("Hostname cannot be empty")
ValueError: Hostname cannot be empty
```

A missing hostfile behaves the same way, and `mlx.distributed_config --hosts ''` does too. Meanwhile the rest of both tools reports user mistakes cleanly, for example the ssh check exits with `[ERROR] Could not ssh to the following hosts`, and the argument checks use `parser.error`.

Wrapped the hostfile construction in both `main` functions so these surface the same way as every other bad argument:

```
$ mlx.launch --hosts '' script.py
mlx.launch: error: Hostname cannot be empty            (exit 2)

$ mlx.launch --hostfile /tmp/nope.json script.py
mlx.launch: error: Hostfile /tmp/nope.json doesn't exist   (exit 2)

$ mlx.distributed_config --hosts ''
mlx.distributed_config: error: Hostname cannot be empty    (exit 2)
```

The messages themselves are unchanged, only how they reach the user. A valid hostfile still parses and proceeds to launch.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

Same idea as #4040, applied at the hostfile parsing boundary rather than inside the backend launchers, which covers `mlx.distributed_config` as well.

---

freshman contributor here, i use Claude Code while hunting. i drove both CLIs with an empty host list and a missing hostfile to see what a user actually gets, and confirmed a valid hostfile still reaches the launch stage afterwards.
