### PR TITLE
Reject negative dimensions in broadcast_to and random shapes

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -304,6 +304,10 @@ array as_strided(
     Strides strides,
     size_t offset,
     StreamOrDevice s /* = {} */) {
+  if (std::any_of(shape.begin(), shape.end(), [](auto i) { return i < 0; })) {
+    throw std::invalid_argument(
+        "[as_strided] Negative dimensions not allowed.");
+  }
   auto copied_shape = shape; // |shape| will be moved
   auto dtype = a.dtype(); // |a| will be moved
   return array(

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -1692,6 +1692,11 @@ array broadcast_to(
     const array& a,
     const Shape& shape,
     StreamOrDevice s /* = {} */) {
+  if (std::any_of(shape.begin(), shape.end(), [](auto i) { return i < 0; })) {
+    throw std::invalid_argument(
+        "[broadcast_to] Negative dimensions not allowed.");
+  }
+
   if (a.shape() == shape) {
     return a;
   }

--- a/mlx/random.cpp
+++ b/mlx/random.cpp
@@ -1,5 +1,6 @@
 // Copyright © 2023-2024 Apple Inc.
 
+#include <algorithm>
 #include <cmath>
 #include <sstream>
 
@@ -38,6 +39,10 @@ array bits(
     int width /* 4 */,
     const std::optional<array>& key_ /*= nullopt */,
     StreamOrDevice s /* = {} */) {
+  if (std::any_of(shape.begin(), shape.end(), [](auto i) { return i < 0; })) {
+    throw std::invalid_argument("[bits] Negative dimensions not allowed.");
+  }
+
   auto key = key_ ? *key_ : KeySequence::default_().next();
   if (key.dtype() != uint32) {
     std::ostringstream msg;

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -810,6 +810,9 @@ class TestOps(mlx_tests.MLXTestCase):
         self.assertListEqual(list(b_npy.shape), list(b_mlx.shape))
         self.assertTrue(np.array_equal(b_npy, b_mlx))
 
+        with self.assertRaises(ValueError):
+            mx.broadcast_to(a_mlx, (-1, 10, 20))
+
     def test_logsumexp(self):
         def logsumexp(x, axes=None):
             maxs = mx.max(x, axis=axes, keepdims=True)

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -2227,6 +2227,9 @@ class TestOps(mlx_tests.MLXTestCase):
         y = mx.as_strided(x, (x.size,), (-1,), x.size - 1)
         self.assertTrue(mx.array_equal(y, x[::-1]))
 
+        with self.assertRaises(ValueError):
+            mx.as_strided(x, (-2, 3), (3, 1), 0)
+
     def test_logcumsumexp(self):
         npop = np.logaddexp.accumulate
         mxop = mx.logcumsumexp

--- a/python/tests/test_random.py
+++ b/python/tests/test_random.py
@@ -64,6 +64,9 @@ class TestRandom(mlx_tests.MLXTestCase):
 
         self.assertEqual(mx.random.uniform().dtype, mx.random.uniform(dtype=None).dtype)
 
+        with self.assertRaises(ValueError):
+            mx.random.uniform(shape=(2, -3))
+
     def test_normal_and_laplace(self):
         # Same tests for normal and laplace.
         for distribution_sampler in [mx.random.normal, mx.random.laplace]:


### PR DESCRIPTION
## Proposed changes

`mx.broadcast_to` and every `mx.random.*` sampler accept negative dimensions and hand back an array whose shape is negative. The size is then computed as an unsigned product, so it underflows:

```python
>>> mx.broadcast_to(mx.array(1.0), (2, -3)).size
18446744073709551610
>>> mx.random.uniform(shape=(2, -3)).shape
(2, -3)
```

Reachable without writing a negative literal, since scale factors flow into shapes:

```python
>>> nn.Upsample(scale_factor=-2)(mx.zeros((1, 4, 4, 1))).shape
(1, -8, -8, 1)
```

Everything else in the library already rejects this. `mx.zeros`, `mx.ones` and `mx.full` raise `[full] Negative dimensions not allowed.`, `mx.reshape` raises, and numpy raises `all elements of broadcast shape must be non-negative` for the same `broadcast_to` call. These two paths are the ones that missed the check.

Added the same guard `full` already uses, at the two places a user supplied shape enters:

- `broadcast_to` in `mlx/ops.cpp`
- `random::bits` in `mlx/random.cpp`, which every sampler (`uniform`, `normal`, `randint`, `gumbel`, `laplace`, `truncated_normal`) routes through

```python
>>> mx.broadcast_to(mx.array(1.0), (2, -3))
ValueError: [broadcast_to] Negative dimensions not allowed.
>>> mx.random.uniform(shape=(2, -3))
ValueError: [bits] Negative dimensions not allowed.
```

Zero sized dimensions are untouched: `mx.broadcast_to(mx.ones((3,)), (0, 3))` and `mx.random.uniform(shape=(0,))` still work.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

Tested on a CPU only build (`MLX_BUILD_METAL=OFF`). `test_ops.py`, `test_random.py`, `test_array.py`, `test_nn.py` and `test_autograd.py` all pass; the two new assertions fail on main.

---

freshman contributor, i use Claude Code alongside my own digging. found this by feeding deliberately bad shapes to the array constructors and comparing which ones complained, then traced the two that did not back to the missing check.
