### PR TITLE
Add graph-based GPU Timer API

### DIFF
--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -47,6 +47,7 @@ are the CPU and GPU.
    usage/environment_variables
    usage/distributed
    usage/using_streams
+   usage/timing
    usage/export
 
 .. toctree::

--- a/docs/src/python/devices_and_streams.rst
+++ b/docs/src/python/devices_and_streams.rst
@@ -11,6 +11,7 @@ Devices and Streams
    Device
    Stream
    ThreadLocalStream
+   Timer
    default_device
    set_default_device
    default_stream

--- a/docs/src/usage/timing.rst
+++ b/docs/src/usage/timing.rst
@@ -1,0 +1,64 @@
+.. _timing_gpu_work:
+
+Timing GPU Work
+===============
+
+.. currentmodule:: mlx.core
+
+Use :class:`Timer` to measure the GPU execution time between two points in a
+lazy graph:
+
+.. code-block:: python
+
+   import mlx.core as mx
+
+   x = mx.random.uniform(shape=(1024, 1024))
+   y = mx.random.uniform(shape=(1024, 1024))
+   mx.eval(x, y)
+
+   timer = mx.Timer()
+   x, y = timer.start(x, y)
+   z = x @ y
+   z = timer.stop(z)
+
+   mx.async_eval(z)
+   print(timer.elapsed_time())  # Synchronizes and returns milliseconds.
+
+The timer reports the elapsed GPU time between the start and stop markers on
+its stream. It does not report the lifetime of an individual argument or the
+sum of individual kernel durations. GPU work ordered between the markers is
+included, as are idle gaps if the work is scheduled in separate evaluations.
+
+Each marker is a single pass-through graph operation, even when it receives
+multiple arguments. The start marker runs only after all of its arguments are
+ready, and the stop marker runs only after all of its arguments are produced.
+Thus, independently produced branches which consume the start outputs and feed
+the stop inputs are all inside the timed interval, regardless of their argument
+order or relative production times.
+
+Operations which produce the arguments to :meth:`Timer.start` are outside the
+timed interval. Only graph operations ordered after the start marker and needed
+to produce the arguments to :meth:`Timer.stop` are guaranteed to be inside it.
+A timer measures one interval and only supports GPU streams.
+
+The timing markers and measured operations must use the same stream. This is
+automatic for the default GPU stream. When passing an explicit stream to
+:class:`Timer`, create the measured operations inside the corresponding
+:func:`stream` context.
+
+Calling :meth:`Timer.elapsed_time` schedules the stop marker if necessary and
+blocks the CPU until it completes. Using :func:`async_eval` makes that the only
+synchronization point. If :func:`eval` is used instead, it already waits for the
+timed graph to finish before :meth:`Timer.elapsed_time` is called.
+
+To measure a compiled function, place the markers outside the compiled
+function:
+
+.. code-block:: python
+
+   compiled_matmul = mx.compile(lambda a, b: a @ b)
+   timer = mx.Timer()
+   x, y = timer.start(x, y)
+   z = compiled_matmul(x, y)
+   z = timer.stop(z)
+   elapsed = timer.elapsed_time()

--- a/mlx/CMakeLists.txt
+++ b/mlx/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(
           ${CMAKE_CURRENT_SOURCE_DIR}/random.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/scheduler.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/stream.cpp
+          ${CMAKE_CURRENT_SOURCE_DIR}/timer.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/transforms.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/utils.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/linalg.cpp

--- a/mlx/backend/cuda/CMakeLists.txt
+++ b/mlx/backend/cuda/CMakeLists.txt
@@ -57,6 +57,7 @@ target_sources(
           ${CMAKE_CURRENT_SOURCE_DIR}/softmax.cu
           ${CMAKE_CURRENT_SOURCE_DIR}/sort.cu
           ${CMAKE_CURRENT_SOURCE_DIR}/ternary.cu
+          ${CMAKE_CURRENT_SOURCE_DIR}/timer.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/utils.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/quantized/qmm/qmm.cu
           ${CMAKE_CURRENT_SOURCE_DIR}/quantized/qmm/qmm_naive.cu

--- a/mlx/backend/cuda/device.cpp
+++ b/mlx/backend/cuda/device.cpp
@@ -455,6 +455,19 @@ void CommandEncoder::add_graph_node(
   insert_graph_dependencies(GraphNode{node, subgraph_key});
 }
 
+void CommandEncoder::add_event_record_node(cudaEvent_t event) {
+  if (!use_cuda_graphs()) {
+    CHECK_CUDA_ERROR(cudaEventRecord(event, stream_));
+    return;
+  }
+
+  cudaGraphNode_t node;
+  CHECK_CUDA_ERROR(
+      cudaGraphAddEventRecordNode(&node, graph_, nullptr, 0, event));
+  insert_graph_dependencies(GraphNode{node, "R"});
+  is_graph_updatable_ = false;
+}
+
 bool CommandEncoder::needs_commit() {
   return (node_count_ > max_ops_per_graph_) ||
       ((bytes_in_graph_ >> 20) > max_mb_per_graph_);

--- a/mlx/backend/cuda/device.h
+++ b/mlx/backend/cuda/device.h
@@ -104,6 +104,7 @@ class CommandEncoder {
       cudaGraph_t child,
       const std::string& subgraph_key,
       bool is_updatable);
+  void add_event_record_node(cudaEvent_t event);
 
   void add_temporary(const array& arr) {
     temporaries_.push_back(arr.data_shared_ptr());

--- a/mlx/backend/cuda/event.cu
+++ b/mlx/backend/cuda/event.cu
@@ -103,6 +103,14 @@ void CudaEvent::record(cudaStream_t stream) {
   cudaEventRecord(event_, stream);
 }
 
+float CudaEvent::elapsed_time(const CudaEvent& end) {
+  end.event_.device.make_current();
+  CHECK_CUDA_ERROR(cudaEventSynchronize(end.event_));
+  float elapsed;
+  CHECK_CUDA_ERROR(cudaEventElapsedTime(&elapsed, event_, end.event_));
+  return elapsed;
+}
+
 bool CudaEvent::completed() const {
   // Note: cudaEventQuery can be safely called from any device.
   return cudaEventQuery(event_) == cudaSuccess;

--- a/mlx/backend/cuda/event.h
+++ b/mlx/backend/cuda/event.h
@@ -38,6 +38,11 @@ class CudaEvent {
   void wait();
   void wait(cudaStream_t stream);
   void record(cudaStream_t stream);
+  float elapsed_time(const CudaEvent& end);
+
+  cudaEvent_t handle() const {
+    return event_;
+  }
 
   // Return whether the recorded kernels have completed. Note that this method
   // returns true if record() has not been called.

--- a/mlx/backend/cuda/timer.cpp
+++ b/mlx/backend/cuda/timer.cpp
@@ -1,0 +1,85 @@
+// Copyright © 2026 Apple Inc.
+
+#include "mlx/timer.h"
+
+#include <stdexcept>
+
+#include "mlx/backend/cuda/device.h"
+#include "mlx/backend/cuda/event.h"
+
+namespace mlx::core {
+
+namespace {
+
+struct TimerImpl {
+  explicit TimerImpl(cu::Device& device)
+      : start(device, cudaEventBlockingSync),
+        end(device, cudaEventBlockingSync) {}
+
+  cu::CudaEvent start;
+  cu::CudaEvent end;
+  bool started{false};
+  bool stopped{false};
+};
+
+} // namespace
+
+Timer::Timer(Stream stream) : stream_(stream) {
+  if (stream.device != Device::gpu) {
+    throw std::invalid_argument("[Timer] GPU timing is not supported on CPU.");
+  }
+  impl_ = std::shared_ptr<void>(
+      new TimerImpl{cu::device(stream.device)},
+      [](void* ptr) { delete static_cast<TimerImpl*>(ptr); });
+}
+
+void Timer::start(
+    const std::vector<array>& inputs,
+    const std::vector<array>& outputs) {
+  auto& impl = *static_cast<TimerImpl*>(impl_.get());
+  if (impl.started) {
+    throw std::runtime_error("[Timer] The timer has already started.");
+  }
+
+  auto& encoder = cu::get_command_encoder(stream_);
+  for (const auto& input : inputs) {
+    encoder.set_input_array(input);
+  }
+  for (const auto& output : outputs) {
+    encoder.set_output_array(output);
+  }
+  encoder.add_event_record_node(impl.start.handle());
+  impl.started = true;
+}
+
+void Timer::stop(
+    const std::vector<array>& inputs,
+    const std::vector<array>& outputs) {
+  auto& impl = *static_cast<TimerImpl*>(impl_.get());
+  if (!impl.started) {
+    throw std::runtime_error("[Timer] The timer has not started.");
+  }
+  if (impl.stopped) {
+    throw std::runtime_error("[Timer] The timer has already stopped.");
+  }
+
+  auto& encoder = cu::get_command_encoder(stream_);
+  for (const auto& input : inputs) {
+    encoder.set_input_array(input);
+  }
+  for (const auto& output : outputs) {
+    encoder.set_output_array(output);
+  }
+  encoder.add_event_record_node(impl.end.handle());
+  impl.stopped = true;
+}
+
+double Timer::elapsed_time() {
+  auto& impl = *static_cast<TimerImpl*>(impl_.get());
+  if (!impl.stopped) {
+    throw std::runtime_error("[Timer] The timer has not completed.");
+  }
+  return impl.start.elapsed_time(impl.end);
+}
+
+} // namespace mlx::core

--- a/mlx/backend/metal/CMakeLists.txt
+++ b/mlx/backend/metal/CMakeLists.txt
@@ -146,6 +146,7 @@ target_sources(
           ${CMAKE_CURRENT_SOURCE_DIR}/sort.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/reduce.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/ternary.cpp
+          ${CMAKE_CURRENT_SOURCE_DIR}/timer.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/unary.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/resident.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/utils.cpp)

--- a/mlx/backend/metal/eval.cpp
+++ b/mlx/backend/metal/eval.cpp
@@ -44,6 +44,7 @@ void eval(array& arr) {
     debug_set_primitive_buffer_label(command_buffer, arr.primitive());
     arr.primitive().eval_gpu(arr.inputs(), outputs);
   }
+  command_buffer = encoder.get_command_buffer();
   std::unordered_set<std::shared_ptr<array::Data>> buffers;
   for (auto& in : arr.inputs()) {
     buffers.insert(in.data_shared_ptr());

--- a/mlx/backend/metal/timer.cpp
+++ b/mlx/backend/metal/timer.cpp
@@ -1,0 +1,91 @@
+// Copyright © 2026 Apple Inc.
+
+#include "mlx/timer.h"
+
+#include <stdexcept>
+
+#include "mlx/backend/metal/device.h"
+
+namespace mlx::core {
+
+namespace {
+
+struct TimerImpl {
+  ~TimerImpl() {
+    auto pool = metal::new_scoped_memory_pool();
+    start.reset();
+    end.reset();
+  }
+
+  NS::SharedPtr<MTL::CommandBuffer> start;
+  NS::SharedPtr<MTL::CommandBuffer> end;
+};
+
+void check_command_buffer(MTL::CommandBuffer* command_buffer) {
+  if (command_buffer->status() == MTL::CommandBufferStatusError) {
+    auto* error = command_buffer->error();
+    auto description = error ? error->localizedDescription()->utf8String()
+                             : "unknown Metal error";
+    throw std::runtime_error(
+        std::string("[Timer] Command buffer execution failed: ") + description +
+        ".");
+  }
+}
+
+} // namespace
+
+Timer::Timer(Stream stream) : stream_(stream) {
+  if (stream.device != Device::gpu) {
+    throw std::invalid_argument("[Timer] GPU timing is not supported on CPU.");
+  }
+  impl_ = std::shared_ptr<void>(
+      new TimerImpl{}, [](void* ptr) { delete static_cast<TimerImpl*>(ptr); });
+}
+
+void Timer::start(const std::vector<array>&, const std::vector<array>&) {
+  auto& impl = *static_cast<TimerImpl*>(impl_.get());
+  if (impl.start) {
+    throw std::runtime_error("[Timer] The timer has already started.");
+  }
+
+  auto& encoder = metal::get_command_encoder(stream_);
+  encoder.end_encoding();
+  encoder.commit();
+  impl.start = NS::RetainPtr(encoder.get_command_buffer());
+}
+
+void Timer::stop(const std::vector<array>&, const std::vector<array>&) {
+  auto& impl = *static_cast<TimerImpl*>(impl_.get());
+  if (!impl.start) {
+    throw std::runtime_error("[Timer] The timer has not started.");
+  }
+  if (impl.end) {
+    throw std::runtime_error("[Timer] The timer has already stopped.");
+  }
+
+  auto& encoder = metal::get_command_encoder(stream_);
+  impl.end = NS::RetainPtr(encoder.get_command_buffer());
+  encoder.end_encoding();
+  encoder.commit();
+}
+
+double Timer::elapsed_time() {
+  auto& impl = *static_cast<TimerImpl*>(impl_.get());
+  if (!impl.end) {
+    throw std::runtime_error("[Timer] The timer has not completed.");
+  }
+
+  auto pool = metal::new_scoped_memory_pool();
+  impl.end->waitUntilCompleted();
+  check_command_buffer(impl.start.get());
+  check_command_buffer(impl.end.get());
+
+  auto start = impl.start->GPUStartTime();
+  auto end = impl.end->GPUEndTime();
+  if (start == 0.0 || end == 0.0 || end < start) {
+    throw std::runtime_error("[Timer] Metal GPU timing is unavailable.");
+  }
+  return (end - start) * 1e3;
+}
+
+} // namespace mlx::core

--- a/mlx/backend/no_gpu/CMakeLists.txt
+++ b/mlx/backend/no_gpu/CMakeLists.txt
@@ -5,4 +5,5 @@ target_sources(
           ${CMAKE_CURRENT_SOURCE_DIR}/event.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/fence.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/eval.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/primitives.cpp)
+          ${CMAKE_CURRENT_SOURCE_DIR}/primitives.cpp
+          ${CMAKE_CURRENT_SOURCE_DIR}/timer.cpp)

--- a/mlx/backend/no_gpu/timer.cpp
+++ b/mlx/backend/no_gpu/timer.cpp
@@ -1,0 +1,25 @@
+// Copyright © 2026 Apple Inc.
+
+#include "mlx/timer.h"
+
+#include <stdexcept>
+
+namespace mlx::core {
+
+Timer::Timer(Stream stream) : stream_(stream) {
+  throw std::invalid_argument("[Timer] GPU timing requires a GPU backend.");
+}
+
+void Timer::start(const std::vector<array>&, const std::vector<array>&) {
+  throw std::runtime_error("[Timer] GPU timing requires a GPU backend.");
+}
+
+void Timer::stop(const std::vector<array>&, const std::vector<array>&) {
+  throw std::runtime_error("[Timer] GPU timing requires a GPU backend.");
+}
+
+double Timer::elapsed_time() {
+  throw std::runtime_error("[Timer] GPU timing requires a GPU backend.");
+}
+
+} // namespace mlx::core

--- a/mlx/mlx.h
+++ b/mlx/mlx.h
@@ -20,6 +20,7 @@
 #include "mlx/ops.h"
 #include "mlx/random.h"
 #include "mlx/stream.h"
+#include "mlx/timer.h"
 #include "mlx/transforms.h"
 #include "mlx/utils.h"
 #include "mlx/version.h"

--- a/mlx/timer.cpp
+++ b/mlx/timer.cpp
@@ -1,0 +1,91 @@
+// Copyright © 2026 Apple Inc.
+
+#include "mlx/timer.h"
+
+#include <algorithm>
+#include <stdexcept>
+
+#include "mlx/primitives.h"
+
+namespace mlx::core {
+
+namespace {
+
+enum class TimerMarkerType { start, stop };
+
+class TimerMarker : public Primitive {
+ public:
+  TimerMarker(Stream stream, Timer timer, TimerMarkerType type)
+      : Primitive(stream), timer_(std::move(timer)), type_(type) {}
+
+  void eval_cpu(const std::vector<array>&, std::vector<array>&) override {
+    throw std::invalid_argument("[Timer] GPU timing is not supported on CPU.");
+  }
+
+  void eval_gpu(const std::vector<array>& inputs, std::vector<array>& outputs)
+      override {
+    for (size_t i = 0; i < outputs.size(); ++i) {
+      outputs[i].copy_shared_buffer(inputs[i]);
+    }
+    if (type_ == TimerMarkerType::start) {
+      timer_.start(inputs, outputs);
+    } else {
+      timer_.stop(inputs, outputs);
+    }
+  }
+
+  const char* name() const override {
+    return type_ == TimerMarkerType::start ? "TimerStart" : "TimerStop";
+  }
+
+ private:
+  Timer timer_;
+  TimerMarkerType type_;
+};
+
+std::vector<array> timer_marker(
+    const std::vector<array>& inputs,
+    const Timer& timer,
+    TimerMarkerType type) {
+  if (inputs.empty()) {
+    throw std::invalid_argument(
+        "[Timer] Expected at least one array at each timing marker.");
+  }
+  if (std::any_of(inputs.begin(), inputs.end(), [](const array& input) {
+        return input.is_tracer();
+      })) {
+    throw std::invalid_argument(
+        "[Timer] Timers cannot be used inside graph transformations.");
+  }
+
+  std::vector<Shape> shapes;
+  std::vector<Dtype> dtypes;
+  shapes.reserve(inputs.size());
+  dtypes.reserve(inputs.size());
+  for (const auto& input : inputs) {
+    shapes.push_back(input.shape());
+    dtypes.push_back(input.dtype());
+  }
+
+  return array::make_arrays(
+      std::move(shapes),
+      dtypes,
+      std::make_shared<TimerMarker>(timer.stream(), timer, type),
+      inputs);
+}
+
+} // namespace
+
+std::vector<array> timer_start(
+    const std::vector<array>& inputs,
+    const Timer& timer) {
+  return timer_marker(inputs, timer, TimerMarkerType::start);
+}
+
+std::vector<array> timer_stop(
+    const std::vector<array>& inputs,
+    const Timer& timer) {
+  return timer_marker(inputs, timer, TimerMarkerType::stop);
+}
+
+} // namespace mlx::core

--- a/mlx/timer.h
+++ b/mlx/timer.h
@@ -1,0 +1,43 @@
+// Copyright © 2026 Apple Inc.
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "mlx/api.h"
+#include "mlx/array.h"
+#include "mlx/stream.h"
+
+namespace mlx::core {
+
+class MLX_API Timer {
+ public:
+  explicit Timer(Stream stream);
+
+  void start(
+      const std::vector<array>& inputs,
+      const std::vector<array>& outputs);
+  void stop(
+      const std::vector<array>& inputs,
+      const std::vector<array>& outputs);
+  double elapsed_time();
+
+  const Stream& stream() const {
+    return stream_;
+  }
+
+ private:
+  Stream stream_;
+  std::shared_ptr<void> impl_;
+};
+
+MLX_API std::vector<array> timer_start(
+    const std::vector<array>& inputs,
+    const Timer& timer);
+
+MLX_API std::vector<array> timer_stop(
+    const std::vector<array>& inputs,
+    const Timer& timer);
+
+} // namespace mlx::core

--- a/python/mlx/_stub_patterns.txt
+++ b/python/mlx/_stub_patterns.txt
@@ -1,15 +1,39 @@
 mlx.core.__prefix__:
   from typing import Any, Callable, Dict, List, Optional, Protocol, Sequence, Tuple, Union, ParamSpec, TypeVar
   import sys
-  if sys.version_info >= (3, 10):
-    from typing import TypeAlias
+  if sys.version_info >= (3, 11):
+    from typing import TypeAlias, TypeVarTuple, Unpack
   else:
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
+    from typing_extensions import TypeVarTuple, Unpack
   P = ParamSpec("P")
   R = TypeVar("R")
+  T = TypeVar("T")
+  U = TypeVar("U")
+  Ts = TypeVarTuple("Ts")
   class DLPackCompatible(Protocol):
     __dlpack__: Callable[..., Any]
     __dlpack_device__: Callable[..., Any]
+
+mlx.core.Timer.start:
+  @overload
+  def start(self, arg: T, /) -> T:
+    """Insert a start timing marker before one or more arrays."""
+
+  @overload
+  def start(
+    self, arg1: T, arg2: U, /, *args: Unpack[Ts]
+  ) -> tuple[T, U, Unpack[Ts]]: ...
+
+mlx.core.Timer.stop:
+  @overload
+  def stop(self, arg: T, /) -> T:
+    """Insert an end timing marker after one or more arrays."""
+
+  @overload
+  def stop(
+    self, arg1: T, arg2: U, /, *args: Unpack[Ts]
+  ) -> tuple[T, U, Unpack[Ts]]: ...
 
 mlx.core.__suffix__:
   from typing import Union

--- a/python/src/CMakeLists.txt
+++ b/python/src/CMakeLists.txt
@@ -22,6 +22,7 @@ nanobind_add_module(
   ${CMAKE_CURRENT_SOURCE_DIR}/mlx_func.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ops.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/stream.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/timer.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/transforms.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/random.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/linalg.cpp

--- a/python/src/mlx.cpp
+++ b/python/src/mlx.cpp
@@ -11,6 +11,7 @@ void init_mlx_func(nb::module_&);
 void init_array(nb::module_&);
 void init_device(nb::module_&);
 void init_stream(nb::module_&);
+void init_timer(nb::module_&);
 void init_metal(nb::module_&);
 void init_cuda(nb::module_&);
 void init_memory(nb::module_&);
@@ -34,6 +35,7 @@ NB_MODULE(core, m) {
   init_mlx_func(m);
   init_device(m);
   init_stream(m);
+  init_timer(m);
   init_array(m);
   init_metal(m);
   init_cuda(m);

--- a/python/src/timer.cpp
+++ b/python/src/timer.cpp
@@ -1,0 +1,150 @@
+// Copyright © 2026 Apple Inc.
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/variant.h>
+
+#include "mlx/timer.h"
+#include "mlx/transforms.h"
+#include "mlx/utils.h"
+#include "python/src/trees.h"
+
+namespace mx = mlx::core;
+namespace nb = nanobind;
+using namespace nb::literals;
+
+namespace {
+
+mx::Stream timer_stream(mx::StreamOrDevice stream) {
+  if (std::holds_alternative<std::monostate>(stream)) {
+    return mx::default_stream(mx::Device::gpu);
+  }
+  return mx::to_stream(stream);
+}
+
+class PyTimer {
+ public:
+  explicit PyTimer(mx::StreamOrDevice stream)
+      : timer_(timer_stream(std::move(stream))) {}
+
+  nb::object start(const nb::args& args) {
+    if (started_) {
+      throw std::runtime_error("[Timer.start] The timer has already started.");
+    }
+    auto outputs = marker(args, true);
+    started_ = true;
+    return outputs;
+  }
+
+  nb::object stop(const nb::args& args) {
+    if (!started_) {
+      throw std::runtime_error("[Timer.stop] The timer has not started.");
+    }
+    if (stopped_) {
+      throw std::runtime_error("[Timer.stop] The timer has already stopped.");
+    }
+    auto outputs = marker(args, false);
+    timed_outputs_ = tree_flatten(outputs);
+    stopped_ = true;
+    return outputs;
+  }
+
+  double elapsed_time() {
+    if (!stopped_) {
+      throw std::runtime_error(
+          "[Timer.elapsed_time] The timer has not stopped.");
+    }
+    mx::eval(timed_outputs_);
+    auto elapsed = timer_.elapsed_time();
+    timed_outputs_.clear();
+    return elapsed;
+  }
+
+  const mx::Stream& stream() const {
+    return timer_.stream();
+  }
+
+ private:
+  nb::object marker(const nb::args& args, bool start) {
+    if (args.empty()) {
+      throw std::invalid_argument(
+          start ? "[Timer.start] Expected at least one array."
+                : "[Timer.stop] Expected at least one array.");
+    }
+    auto inputs = tree_flatten(args);
+    auto outputs = start ? mx::timer_start(inputs, timer_)
+                         : mx::timer_stop(inputs, timer_);
+    if (args.size() == 1) {
+      return tree_unflatten(nb::borrow<nb::object>(args[0]), outputs);
+    }
+    return tree_unflatten(args, outputs);
+  }
+
+  mx::Timer timer_;
+  std::vector<mx::array> timed_outputs_;
+  bool started_{false};
+  bool stopped_{false};
+};
+
+} // namespace
+
+void init_timer(nb::module_& m) {
+  nb::class_<PyTimer>(m, "Timer", R"pbdoc(
+        Measure the GPU execution time of a lazy subgraph.
+
+        :meth:`start` and :meth:`stop` insert pass-through timing markers in
+        the graph. Operations which produce the inputs to :meth:`start` are
+        excluded from the measured interval.
+
+        Args:
+            stream (Stream or Device, optional): GPU stream on which to place
+                the timing markers. If ``None``, use the default GPU stream.
+                Default: ``None``.
+      )pbdoc")
+      .def(nb::init<mx::StreamOrDevice>(), "stream"_a = nb::none())
+      .def_prop_ro("stream", &PyTimer::stream)
+      .def(
+          "start",
+          &PyTimer::start,
+          nb::sig("def start(self, *args)"),
+          R"pbdoc(
+          Insert a start timing marker before one or more arrays.
+
+          The returned arrays share storage with the inputs. Operations that
+          consume them are ordered after the start marker.
+
+          Args:
+              *args: Arrays or array pytrees marking the start dependencies.
+
+          Returns:
+              A single array or pytree for one argument, otherwise a tuple.
+      )pbdoc")
+      .def(
+          "stop",
+          &PyTimer::stop,
+          nb::sig("def stop(self, *args)"),
+          R"pbdoc(
+          Insert an end timing marker after one or more arrays.
+
+          Evaluating the returned arrays schedules the measured operations and
+          the end marker.
+
+          Args:
+              *args: Arrays or array pytrees marking the end dependencies.
+
+          Returns:
+              A single array or pytree for one argument, otherwise a tuple.
+      )pbdoc")
+      .def(
+          "elapsed_time",
+          &PyTimer::elapsed_time,
+          nb::call_guard<nb::gil_scoped_release>(),
+          R"pbdoc(
+          Evaluate the timed subgraph and return its GPU time.
+
+          This method schedules the end marker if necessary, then blocks the
+          CPU until it completes.
+
+          Returns:
+              float: GPU elapsed time in milliseconds.
+      )pbdoc");
+}

--- a/python/tests/test_timer.py
+++ b/python/tests/test_timer.py
@@ -1,0 +1,84 @@
+# Copyright © 2026 Apple Inc.
+
+import unittest
+
+import mlx.core as mx
+import mlx_tests
+
+
+class TestTimer(mlx_tests.MLXTestCase):
+    def test_cpu_is_not_supported(self):
+        with self.assertRaises(ValueError):
+            mx.Timer(mx.cpu)
+
+    @unittest.skipUnless(mx.is_available(mx.gpu), "GPU is not available")
+    def test_interval(self):
+        x = mx.random.uniform(shape=(256, 256))
+        y = mx.random.uniform(shape=(256, 256))
+        mx.eval(x, y)
+
+        timer = mx.Timer()
+        x, y = timer.start(x, y)
+        out = (x @ y) * 2.0
+        out = timer.stop(out)
+
+        mx.async_eval(out)
+        elapsed = timer.elapsed_time()
+        self.assertGreater(elapsed, 0.0)
+        self.assertTrue(mx.allclose(out, (x @ y) * 2.0))
+        self.assertEqual(timer.elapsed_time(), elapsed)
+
+    @unittest.skipUnless(mx.is_available(mx.gpu), "GPU is not available")
+    def test_output_pytree(self):
+        x = mx.arange(8)
+        mx.eval(x)
+
+        timer = mx.Timer()
+        x = timer.start(x)
+        out = timer.stop({"a": x + 1, "b": x * 2})
+
+        self.assertGreater(timer.elapsed_time(), 0.0)
+        self.assertTrue(mx.array_equal(out["a"], x + 1))
+        self.assertTrue(mx.array_equal(out["b"], x * 2))
+
+    @unittest.skipUnless(mx.is_available(mx.gpu), "GPU is not available")
+    def test_stream(self):
+        stream = mx.new_stream(mx.gpu)
+        x = mx.arange(8)
+        mx.eval(x)
+
+        timer = mx.Timer(stream)
+        x = timer.start(x)
+        with mx.stream(stream):
+            out = x + 1
+        out = timer.stop(out)
+
+        self.assertEqual(timer.stream, stream)
+        self.assertGreater(timer.elapsed_time(), 0.0)
+        self.assertTrue(mx.array_equal(out, x + 1))
+
+    @unittest.skipUnless(mx.is_available(mx.gpu), "GPU is not available")
+    def test_invalid_usage(self):
+        timer = mx.Timer()
+        with self.assertRaises(RuntimeError):
+            timer.elapsed_time()
+        with self.assertRaises(ValueError):
+            timer.start()
+
+        x = mx.array(1.0)
+        with self.assertRaises(RuntimeError):
+            timer.stop(x)
+        x = timer.start(x)
+        with self.assertRaises(RuntimeError):
+            timer.start(x)
+        with self.assertRaises(ValueError):
+            timer.stop()
+        out = timer.stop(x + 1)
+        with self.assertRaises(RuntimeError):
+            timer.stop(out)
+        self.assertGreater(timer.elapsed_time(), 0.0)
+        self.assertEqual(out.item(), 2.0)
+
+
+if __name__ == "__main__":
+    mlx_tests.MLXTestRunner()


### PR DESCRIPTION
## Proposed changes

Add `mx.Timer`, a graph-based API for measuring GPU execution time between two points in a lazy graph. It uses Metal command-buffer timestamps and CUDA events, preserves pytree structures through pass-through markers, and synchronizes in `elapsed_time()` before returning milliseconds.

Add Python typing, tests, and usage documentation.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
