### PR TITLE
Fix and enable non-transposed NAX qmm

### DIFF
--- a/mlx/backend/metal/kernels/quantized_nax.h
+++ b/mlx/backend/metal/kernels/quantized_nax.h
@@ -1145,7 +1145,6 @@ METAL_FUNC void qmm_n_nax_tgp_impl(
   // load_safe/store_safe handle, as they already do for the transposed
   // kernel. N needs no equivalent: the dispatch guard keeps N % BN == 0.
   const short sgp_sm = min(int(SM), M - (y_row + tm));
-  const bool is_unaligned_sm = (sgp_sm != SM);
 
   const short ldb_tgp = BN_padded;
 
@@ -1159,50 +1158,48 @@ METAL_FUNC void qmm_n_nax_tgp_impl(
 
   x += tm * K;
 
-  dispatch_bool(!is_unaligned_sm, [&](auto kAlignedM) {
-    for (int k = 0; k < K; k += BK) {
-      threadgroup_barrier(mem_flags::mem_threadgroup);
-      loader_w.load_unsafe();
-      threadgroup_barrier(mem_flags::mem_threadgroup);
-
-      STEEL_PRAGMA_NO_UNROLL
-      for (int kk1 = 0; kk1 < BK; kk1 += SK) {
-        NAXTile<T, TM, TK> Atile;
-        NAXTile<T, TK, TN> Btile;
-
-        volatile int compiler_barrier;
-
-        if constexpr (kAlignedM.value) {
-          Atile.load(x + kk1, K);
-        } else {
-          Atile.load_safe(x + kk1, K, short2(SK, sgp_sm));
-        }
-
-        Btile.template load<T, BN_padded, 1>(Ws + tn + kk1 * ldb_tgp);
-
-        tile_matmad_nax(
-            Dtile,
-            Atile,
-            metal::bool_constant<transpose_a>{},
-            Btile,
-            metal::bool_constant<transpose_b>{});
-
-        (void)compiler_barrier;
-      }
-
-      x += BK;
-      loader_w.next();
-    }
-
-    // Store results to device memory
+  for (int k = 0; k < K; k += BK) {
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    loader_w.load_unsafe();
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
-    if constexpr (kAlignedM.value) {
-      Dtile.store(y + tm * N + tn, N);
-    } else {
-      Dtile.store_safe(y + tm * N + tn, N, short2(SN, sgp_sm));
+    STEEL_PRAGMA_NO_UNROLL
+    for (int kk1 = 0; kk1 < BK; kk1 += SK) {
+      NAXTile<T, TM, TK> Atile;
+      NAXTile<T, TK, TN> Btile;
+
+      volatile int compiler_barrier;
+
+      if (sgp_sm == SM) {
+        Atile.load(x + kk1, K);
+      } else {
+        Atile.load_safe(x + kk1, K, short2(SK, sgp_sm));
+      }
+
+      Btile.template load<T, BN_padded, 1>(Ws + tn + kk1 * ldb_tgp);
+
+      tile_matmad_nax(
+          Dtile,
+          Atile,
+          metal::bool_constant<transpose_a>{},
+          Btile,
+          metal::bool_constant<transpose_b>{});
+
+      (void)compiler_barrier;
     }
-  });
+
+    x += BK;
+    loader_w.next();
+  }
+
+  // Store results to device memory
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  if (sgp_sm == SM) {
+    Dtile.store(y + tm * N + tn, N);
+  } else {
+    Dtile.store_safe(y + tm * N + tn, N, short2(SN, sgp_sm));
+  }
 }
 
 template <

--- a/mlx/backend/metal/kernels/quantized_nax.h
+++ b/mlx/backend/metal/kernels/quantized_nax.h
@@ -1140,10 +1140,6 @@ METAL_FUNC void qmm_n_nax_tgp_impl(
   const short tm = SM * (simd_gid / WN);
   const short tn = SN * (simd_gid % WN);
 
-  // Rows of this simdgroup's SM-row slice that actually exist. This can go
-  // <= 0 when a whole simdgroup sits past the end of the matrix, which
-  // load_safe/store_safe handle, as they already do for the transposed
-  // kernel. N needs no equivalent: the dispatch guard keeps N % BN == 0.
   const short sgp_sm = min(int(SM), M - (y_row + tm));
 
   const short ldb_tgp = BN_padded;

--- a/mlx/backend/metal/kernels/quantized_nax.h
+++ b/mlx/backend/metal/kernels/quantized_nax.h
@@ -1094,7 +1094,6 @@ METAL_FUNC void qmm_n_nax_tgp_impl(
     uint simd_gid [[simdgroup_index_in_threadgroup]],
     uint simd_lid [[thread_index_in_simdgroup]]) {
   (void)lid;
-  (void)M;
 
   static_assert(BK >= SIMD_SIZE, "BK should be larger than SIMD_SIZE");
   static_assert(BK % SIMD_SIZE == 0, "BK should be divisible by SIMD_SIZE");
@@ -1115,23 +1114,20 @@ METAL_FUNC void qmm_n_nax_tgp_impl(
       bits>;
 
   // Set the block
-  const int K_w = K * bytes_per_pack / pack_factor;
-  const int K_g = K / group_size;
   const int y_row = tid.y * BM;
   const int y_col = tid.x * BN;
 
   auto wl = (const device uint8_t*)w;
 
+  // Here w is [K, N]: packed and group-quantized along N, with row stride N.
   x += y_row * static_cast<int64_t>(K);
-  wl += y_col * K_w;
-  scales += y_col * K_g;
-  biases += y_col * K_g;
+  wl += y_col * bytes_per_pack / pack_factor;
+  scales += y_col / group_size;
+  biases += y_col / group_size;
   y += y_row * static_cast<int64_t>(N) + y_col;
 
-  // Make the x loader and mma operation
-  // const short num_els = min(BM, M - y_row);
-  // const short num_outs = min(BN, N - y_col);
-  loader_w_t loader_w(wl, scales, biases, K, Ws, simd_gid, simd_lid);
+  // Make the weight loader
+  loader_w_t loader_w(wl, scales, biases, N, Ws, simd_gid, simd_lid);
 
   constexpr short SM = BM / WM;
   constexpr short SN = BN / WN;
@@ -1143,6 +1139,13 @@ METAL_FUNC void qmm_n_nax_tgp_impl(
 
   const short tm = SM * (simd_gid / WN);
   const short tn = SN * (simd_gid % WN);
+
+  // Rows of this simdgroup's SM-row slice that actually exist. This can go
+  // <= 0 when a whole simdgroup sits past the end of the matrix, which
+  // load_safe/store_safe handle, as they already do for the transposed
+  // kernel. N needs no equivalent: the dispatch guard keeps N % BN == 0.
+  const short sgp_sm = min(int(SM), M - (y_row + tm));
+  const bool is_unaligned_sm = (sgp_sm != SM);
 
   const short ldb_tgp = BN_padded;
 
@@ -1156,39 +1159,50 @@ METAL_FUNC void qmm_n_nax_tgp_impl(
 
   x += tm * K;
 
-  for (int k = 0; k < K; k += BK) {
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-    loader_w.load_unsafe();
-    threadgroup_barrier(mem_flags::mem_threadgroup);
+  dispatch_bool(!is_unaligned_sm, [&](auto kAlignedM) {
+    for (int k = 0; k < K; k += BK) {
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      loader_w.load_unsafe();
+      threadgroup_barrier(mem_flags::mem_threadgroup);
 
-    STEEL_PRAGMA_NO_UNROLL
-    for (int kk1 = 0; kk1 < BK; kk1 += SK) {
-      NAXTile<T, TM, TK> Atile;
-      NAXTile<T, TK, TN> Btile;
+      STEEL_PRAGMA_NO_UNROLL
+      for (int kk1 = 0; kk1 < BK; kk1 += SK) {
+        NAXTile<T, TM, TK> Atile;
+        NAXTile<T, TK, TN> Btile;
 
-      volatile int compiler_barrier;
+        volatile int compiler_barrier;
 
-      Atile.load(x + kk1, K);
-      Btile.template load<T, BN_padded, 1>(Ws + tn + kk1 * ldb_tgp);
+        if constexpr (kAlignedM.value) {
+          Atile.load(x + kk1, K);
+        } else {
+          Atile.load_safe(x + kk1, K, short2(SK, sgp_sm));
+        }
 
-      tile_matmad_nax(
-          Dtile,
-          Atile,
-          metal::bool_constant<transpose_a>{},
-          Btile,
-          metal::bool_constant<transpose_b>{});
+        Btile.template load<T, BN_padded, 1>(Ws + tn + kk1 * ldb_tgp);
 
-      (void)compiler_barrier;
+        tile_matmad_nax(
+            Dtile,
+            Atile,
+            metal::bool_constant<transpose_a>{},
+            Btile,
+            metal::bool_constant<transpose_b>{});
+
+        (void)compiler_barrier;
+      }
+
+      x += BK;
+      loader_w.next();
     }
 
-    x += BK;
-    loader_w.next();
-  }
+    // Store results to device memory
+    threadgroup_barrier(mem_flags::mem_threadgroup);
 
-  // Store results to device memory
-  threadgroup_barrier(mem_flags::mem_threadgroup);
-
-  Dtile.store(y + tm * N + tn, N);
+    if constexpr (kAlignedM.value) {
+      Dtile.store(y + tm * N + tn, N);
+    } else {
+      Dtile.store_safe(y + tm * N + tn, N, short2(SN, sgp_sm));
+    }
+  });
 }
 
 template <

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -1011,8 +1011,12 @@ void qmm(
     metal::Device& d,
     const Stream& s,
     const std::string& mode) {
-  if (metal::is_nax_available() && transpose && (K % 64 == 0) &&
-      (env::enable_tf32() || x.dtype() != float32)) {
+  // The non-transposed kernel loads a BK x BN tile of w = [K, N] without
+  // clamping in N, so it additionally requires N % 64 == 0. Affine
+  // quantization with group_size >= 64 satisfies that structurally, since
+  // the groups run along N.
+  if (metal::is_nax_available() && (transpose || (N % 64 == 0)) &&
+      (K % 64 == 0) && (env::enable_tf32() || x.dtype() != float32)) {
     return qmm_nax(
         /* const array& x = */ x,
         /* const array& w = */ w,

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -1011,10 +1011,7 @@ void qmm(
     metal::Device& d,
     const Stream& s,
     const std::string& mode) {
-  // The non-transposed kernel loads a BK x BN tile of w = [K, N] without
-  // clamping in N, so it additionally requires N % 64 == 0. Affine
-  // quantization with group_size >= 64 satisfies that structurally, since
-  // the groups run along N.
+  // The non-transposed kernel requires N % 64 == 0.
   if (metal::is_nax_available() && (transpose || (N % 64 == 0)) &&
       (K % 64 == 0) && (env::enable_tf32() || x.dtype() != float32)) {
     return qmm_nax(

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -353,6 +353,53 @@ class TestQuantized(mlx_tests.MLXTestCase):
                 tol = 1e-3 if dtype == mx.float32 else 1.5e-3
                 self.assertLess((y_q - y_hat).abs().max(), tol)
 
+    def test_qmm_non_transposed(self):
+        # The non-transposed matmul (w is [K, N]) is reachable mainly from the
+        # vjp of a quantized linear layer, so it gets much less coverage than
+        # the transposed one. Sweep it over transformer-sized K/N and over M
+        # values that leave a partial M-tile.
+        key = mx.random.key(0)
+        k1, k2 = mx.random.split(key)
+        dtype = mx.float16 if (mx.default_device() == mx.gpu) else mx.float32
+        tol = 1e-3 if dtype == mx.float32 else 1.5e-3
+
+        def check(M, K, N, group_size, bits, batch=()):
+            x = mx.random.normal(shape=(*batch, M, K), key=k1) / K**0.5
+            w = mx.random.normal(shape=(K, N), key=k2) / K**0.5
+            x = x.astype(dtype)
+            w = w.astype(dtype)
+            w_q, scales, biases = mx.quantize(w, group_size, bits)
+            w_hat = mx.dequantize(w_q, scales, biases, group_size, bits)
+            y_q = mx.quantized_matmul(x, w_q, scales, biases, False, group_size, bits)
+            y_hat = x @ w_hat
+            self.assertEqual(y_q.shape, y_hat.shape)
+            self.assertLess((y_q - y_hat).abs().max(), tol)
+
+        # M sweep. 33..63 is the interesting range: a whole simdgroup of the
+        # threadgroup's M-tile falls past the end of the matrix.
+        for M in [1, 2, 31, 32, 33, 63, 64, 65, 96, 97, 100, 127, 128, 129]:
+            for group_size, bits in [(64, 4), (128, 4), (64, 8)]:
+                with self.subTest(M=M, group_size=group_size, bits=bits):
+                    check(M, 512, 1024, group_size, bits)
+
+        # Transformer-sized K/N, aligned and unaligned M.
+        for K, N in [(2048, 2048), (512, 2048), (2048, 512), (11008, 2048)]:
+            for M in [100, 256]:
+                with self.subTest(shape=(M, K, N)):
+                    check(M, K, N, 64, 4)
+
+        # Batched x, unaligned M.
+        for batch in [(2,), (2, 3)]:
+            for M in [33, 250]:
+                with self.subTest(batch=batch, M=M):
+                    check(M, 512, 1024, 64, 4, batch=batch)
+
+        # M > 2**15 with a partial M-tile, so the per-simdgroup row count is a
+        # distance that does not fit in an int16. Same failure mode as the one
+        # test_qmm_large_dims covers for the transposed kernel.
+        with self.subTest(shape=(33000, 128, 64)):
+            check(33000, 128, 64, 64, 4)
+
     def test_qmm_vjp(self):
         key = mx.random.key(0)
         k1, k2 = mx.random.split(key)


### PR DESCRIPTION
## What this does
`qmm()` only lets NAX through when `transpose == true`, so `affine_qmm_n_nax` is compiled but never actually run and is currently unreachable. It has two separate problems, both of which this PR fixes, and then enables the path to be reachable.

### FIX: Weight addressing uses the transposed layout
`qmm_n_nax_tgp_impl` uses the same `QuantizedBlockLoader` instantiation as the
generic `qmm_n_impl` in `kernels/quantized.h`:

```cpp
QuantizedBlockLoader<T, BK, BN, BN_padded, 0, WM * WN * SIMD_SIZE, group_size, bits>
```

but set the pointers up for `w = [N, K]` rather than `[K, N]`:

|                | `qmm_n_impl` (correct)                       | `qmm_n_nax_tgp_impl` (before) |
| -------------- | -------------------------------------------- | ----------------------------- |
| weight offset  | `wl += y_col * bytes_per_pack / pack_factor`  | `wl += y_col * K_w`           |
| scales offset  | `scales += y_col / group_size`                | `scales += y_col * K_g`       |
| biases offset  | `biases += y_col / group_size`                | `biases += y_col * K_g`       |
| leading dim    | `loader_w(..., N, ...)`                       | `loader_w(..., K, ...)`       |
| implied layout | `w = [K, N]`, grouped along N                 | `w = [N, K]`, grouped along K |

This fix makes those four lines match `qmm_n_impl`. `affine_gather_qmm_n_nax` shares the impl, so this fixes that too.

### FIX: No partial M tile handling
This same function had `(void)M;`, its bounds line commented out, and called `Atile.load` / `Dtile.store` unconditionally. `qmm_nax()` sizes the grid with `(M + bm - 1) / bm`, so partial M tiles are dispatched and any `M % 64 != 0`
read `x` and wrote `y` out of bounds.

Fixed by porting what `qmm_t_nax_tgp_impl` already does: `sgp_sm` plus a `dispatch_bool` picking `load_safe`/`store_safe`. That split is compile time, so the aligned path keeps the original unguarded loads and costs nothing, and only one branch is instantiated per call so the `x += BK` walk isn't duplicated. `sgp_sm` is `min(int(SM), M - (y_row + tm))` rather than truncating the distance to `short`, matching the int16 fix already made for the transposed kernel.

### FIX: The dispatch guard
```cpp
if (metal::is_nax_available() && (transpose || (N % 64 == 0)) &&
    (K % 64 == 0) && ...
```
The non-transposed weight tile is `BK x BN` over `w = [K, N]` and the loader isn't clamped in N, so it also needs `N % 64 == 0`. Affine quantization with `group_size >= 64` gives that structurally, since the groups run along N. This only rejects `group_size == 32` with N not a multiple of 64, which falls back to the generic kernel like before.

Scope: this patches `qmm()` only. `gather_qmm()` stays gated on `transpose`.

## Tests
`test_qmm_non_transposed` in `python/tests/test_quantized.py`:

* transformer sized `K`/`N`: (2048, 2048), (512, 2048), (2048, 512), (11008, 2048)
* `M` aligned and unaligned: 1, 2, 31, 32, 33, 63, 64, 65, 96, 97, 100, 127, 128, 129, 250, 256. The 33 to 63 range is where a whole simdgroup of the M tile lands past the end of the matrix
* batched `x`, 3D and 4D, with unaligned M
* `M = 33000` with a partial M tile, for the int16 distance case
* `group_size` 64 and 128, bits 4 and 8

Tolerances and the `1/sqrt(K)` operand scaling follow the existing `test_qmm`. Worth noting the existing `test_qmm` already covers `transpose=False` at M in {8, 32, 33, 64} with N, K in {128, 256}.

## Validation
I don't have M5 hardware. All NAX validation was on an iPhone 17 Pro (A19 Pro), iOS 26.5.2, through the Swift bindings, against a dequantized reference: 52 shape/M/batch cases covering every unaligned M above plus batched. Before the fix, relative error ran 1.5 to 7826, with an output norm of 427,429 against an expected 24,009 at K=N=2048, M=500. After, it's bit exact against the reference on that device.

On the M3 I have, `is_nax_available()` is false, so the full `test_quantized.py` suite passes there only through the generic path. That confirms no regression on the fallback, not the NAX path. The kernel itself does compile (`quantized_nax.air` builds clean).

## Performance
Same iPhone 17, but this time running LoRA fine tuning on SmolLM3-3B 4-bit (group_size 64, r=8, batch 1). 

One full training run with 405 examples and 1215 iterations. It took 2.9 hours before the fix and 1.5 after the fix (~1.93x speedup). Final loss 0.8829 with the fix against 0.8813 without, a 0.18% difference, and the two loss traces correlate at 0.9999 across 1210 steps.
<img width="2076" height="876" alt="naxab_e2e_2026-08-07" src="https://github.com/user-attachments/assets/775ea7ed-a495-4a8b-a87e-2d0f23dd0d63" />

A paired per op benchmark on fixed synthetic shapes puts the backward phase at 1.65 to 2.13x and the whole iteration around 1.55x.
<img width="1850" height="768" alt="naxab_speedup_2026-08-06" src="https://github.com/user-attachments/assets/be5dacae-6106-41ec-993c-87dc3086d71b" />

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
