### PR TITLE
Fix Cholesky crash when empty matrix (#4032)

### DIFF
--- a/mlx/linalg.cpp
+++ b/mlx/linalg.cpp
@@ -344,6 +344,11 @@ array cholesky(
         "[linalg::cholesky] Cholesky decomposition is only defined for square "
         "matrices.");
   }
+
+  if (a.shape(-1) == 0 || a.shape(-2) == 0) {
+    return zeros(a.shape(), a.dtype(), s);
+  }
+
   return array(
       a.shape(),
       a.dtype(),

--- a/python/tests/test_linalg.py
+++ b/python/tests/test_linalg.py
@@ -276,6 +276,18 @@ class TestLinalg(mlx_tests.MLXTestCase):
         for M, L in zip(AB, Ls):
             self.assertTrue(mx.allclose(L @ L.T, M, rtol=1e-5, atol=1e-7))
 
+        # Single empty matrix
+        a = mx.zeros((0, 0), stream=mx.cpu)
+        r = mx.linalg.cholesky(a, stream=mx.cpu)
+        self.assertEqual(r.shape, (0, 0))
+        mx.eval(r)
+
+        # Batched empty matrices
+        a_batch = mx.zeros((3, 0, 0), stream=mx.cpu)
+        r_batch = mx.linalg.cholesky(a_batch, stream=mx.cpu)
+        self.assertEqual(r_batch.shape, (3, 0, 0))
+        mx.eval(r_batch)
+
     def test_pseudo_inverse(self):
         A = mx.array([[1, 2, 3], [6, -5, 4], [-9, 8, 7]], dtype=mx.float32)
         A_plus = mx.linalg.pinv(A, stream=mx.cpu)


### PR DESCRIPTION
## Proposed changes

[4032](https://github.com/ml-explore/mlx/issues/4032)
This issue is caused by unhandled empty matrix check before calling cholesky_impl.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
