### PR TITLE
Fix hadamard_transform on the GPU for n = m with no power-of-2 factor

### DIFF
--- a/mlx/backend/metal/hadamard.cpp
+++ b/mlx/backend/metal/hadamard.cpp
@@ -69,9 +69,7 @@ void hadamard_mn_contiguous(
   int n = n1 * n2;
   int read_width_n1 = n1 == 2 ? 2 : 4;
   int read_width_n2 = n2 == 2 ? 2 : 4;
-  // n == 1 (m in (12, 20, 28) with no power-of-2 factor) leaves the m stage as
-  // the only transform, and it strides by n / read_width_m, so the read width
-  // cannot exceed n.
+  // The m stage strides by n / read_width_m, so cap the read width at n.
   int read_width_m = (n == 1) ? 1 : ((n == 2 || m == 28) ? 2 : 4);
   int max_radix_1 = std::min(n1, 16);
   int max_radix_2 = std::min(n2, 16);
@@ -158,8 +156,7 @@ void hadamard_mn_contiguous(
   if (m > 1) {
     auto kernel = d.get_kernel("m" + kname, lib);
     compute_encoder.set_compute_pipeline_state(kernel);
-    // n = 1 means neither power-of-2 stage ran, so x has not been copied into y
-    // yet and the only transform is this one; read straight from x.
+    // With n == 1 no earlier stage copied x into y, so read from x.
     compute_encoder.set_input_array(n > 1 ? y : x, 0);
     compute_encoder.set_output_array(y, 1);
     compute_encoder.set_bytes(scale_m, 2);

--- a/mlx/backend/metal/hadamard.cpp
+++ b/mlx/backend/metal/hadamard.cpp
@@ -69,7 +69,10 @@ void hadamard_mn_contiguous(
   int n = n1 * n2;
   int read_width_n1 = n1 == 2 ? 2 : 4;
   int read_width_n2 = n2 == 2 ? 2 : 4;
-  int read_width_m = (n == 2 || m == 28) ? 2 : 4;
+  // n == 1 (m in (12, 20, 28) with no power-of-2 factor) leaves the m stage as
+  // the only transform, and it strides by n / read_width_m, so the read width
+  // cannot exceed n.
+  int read_width_m = (n == 1) ? 1 : ((n == 2 || m == 28) ? 2 : 4);
   int max_radix_1 = std::min(n1, 16);
   int max_radix_2 = std::min(n2, 16);
   float scale_n1 = 1.0;
@@ -97,17 +100,16 @@ void hadamard_mn_contiguous(
   auto lib = d.get_library(kname, [&]() {
     std::string kernel;
     concatenate(
-        kernel,
-        metal::utils(),
-        gen_hadamard_codelet(m),
-        metal::hadamard(),
-        get_template_definition(
-            "n2" + kname,
-            "hadamard_n",
-            get_type_string(x.dtype()),
-            n2,
-            max_radix_2,
-            read_width_n2));
+        kernel, metal::utils(), gen_hadamard_codelet(m), metal::hadamard());
+    if (n2 > 1) {
+      kernel += get_template_definition(
+          "n2" + kname,
+          "hadamard_n",
+          get_type_string(x.dtype()),
+          n2,
+          max_radix_2,
+          read_width_n2);
+    }
     if (n1 > 1) {
       kernel += get_template_definition(
           "n1" + kname,
@@ -143,18 +145,22 @@ void hadamard_mn_contiguous(
 
   // Launch the transform for n2
   auto& compute_encoder = metal::get_command_encoder(s);
-  auto kernel = d.get_kernel("n2" + kname, lib);
-  compute_encoder.set_compute_pipeline_state(kernel);
-  compute_encoder.set_input_array(n1 > 1 ? y : x, 0);
-  compute_encoder.set_output_array(y, 1);
-  compute_encoder.set_bytes(scale_n2, 2);
-  compute_encoder.dispatch_threads(grid_dims_n2, group_dims_n2);
+  if (n2 > 1) {
+    auto kernel = d.get_kernel("n2" + kname, lib);
+    compute_encoder.set_compute_pipeline_state(kernel);
+    compute_encoder.set_input_array(n1 > 1 ? y : x, 0);
+    compute_encoder.set_output_array(y, 1);
+    compute_encoder.set_bytes(scale_n2, 2);
+    compute_encoder.dispatch_threads(grid_dims_n2, group_dims_n2);
+  }
 
   // Launch the strided transform for m
   if (m > 1) {
     auto kernel = d.get_kernel("m" + kname, lib);
     compute_encoder.set_compute_pipeline_state(kernel);
-    compute_encoder.set_input_array(y, 0);
+    // n = 1 means neither power-of-2 stage ran, so x has not been copied into y
+    // yet and the only transform is this one; read straight from x.
+    compute_encoder.set_input_array(n > 1 ? y : x, 0);
     compute_encoder.set_output_array(y, 1);
     compute_encoder.set_bytes(scale_m, 2);
     compute_encoder.dispatch_threads(grid_dims_m, group_dims_m);

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -3482,14 +3482,8 @@ class TestOps(mlx_tests.MLXTestCase):
                     )
 
     def test_hadamard_m_only(self):
-        # n = m * 2^0 for m in (12, 20, 28): the power-of-2 factor is exactly 1,
-        # so only the m stage has work to do. test_hadamard sweeps k from 1, so
-        # these sizes were never exercised and used to fail to build the Metal
-        # library (num_steps = logN / logR with logR = 0).
+        # n = m * 2^0, so only the m stage runs. test_hadamard sweeps k from 1.
         for m in (12, 20, 28):
-            # a batch dimension matters here: the m stage strides by
-            # n / read_width_m, which silently dispatched zero threads (all-zero
-            # output) for n = 1 until read_width_m was capped at n
             for shape in ((m,), (4, m), (3, 5, m)):
                 for scale in (None, 0.25):
                     with self.subTest(m=m, shape=shape, scale=scale):
@@ -3504,8 +3498,7 @@ class TestOps(mlx_tests.MLXTestCase):
                         mx.eval(y_cpu, y_gpu)
                         self.assertEqual(y_gpu.shape, x.shape)
                         self.assertLess(mx.abs(y_cpu - y_gpu).max().item(), 1e-5)
-                        # a non-donatable input takes the malloc'd-output path,
-                        # where the m stage must read x, not the untouched output
+                        # non-donatable input: the malloc'd-output path
                         y_nd = mx.hadamard_transform(x + 0.0, stream=mx.gpu, **kwargs)
                         mx.eval(y_nd)
                         self.assertLess(mx.abs(y_cpu - y_nd).max().item(), 1e-5)

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -3481,6 +3481,35 @@ class TestOps(mlx_tests.MLXTestCase):
                         y_bf16.astype(mx.float16), y, atol=atol * 2
                     )
 
+    def test_hadamard_m_only(self):
+        # n = m * 2^0 for m in (12, 20, 28): the power-of-2 factor is exactly 1,
+        # so only the m stage has work to do. test_hadamard sweeps k from 1, so
+        # these sizes were never exercised and used to fail to build the Metal
+        # library (num_steps = logN / logR with logR = 0).
+        for m in (12, 20, 28):
+            # a batch dimension matters here: the m stage strides by
+            # n / read_width_m, which silently dispatched zero threads (all-zero
+            # output) for n = 1 until read_width_m was capped at n
+            for shape in ((m,), (4, m), (3, 5, m)):
+                for scale in (None, 0.25):
+                    with self.subTest(m=m, shape=shape, scale=scale):
+                        x = mx.array(
+                            np.random.RandomState(3)
+                            .normal(size=shape)
+                            .astype(np.float32)
+                        )
+                        kwargs = {} if scale is None else {"scale": scale}
+                        y_cpu = mx.hadamard_transform(x, stream=mx.cpu, **kwargs)
+                        y_gpu = mx.hadamard_transform(x, stream=mx.gpu, **kwargs)
+                        mx.eval(y_cpu, y_gpu)
+                        self.assertEqual(y_gpu.shape, x.shape)
+                        self.assertLess(mx.abs(y_cpu - y_gpu).max().item(), 1e-5)
+                        # a non-donatable input takes the malloc'd-output path,
+                        # where the m stage must read x, not the untouched output
+                        y_nd = mx.hadamard_transform(x + 0.0, stream=mx.gpu, **kwargs)
+                        mx.eval(y_nd)
+                        self.assertLess(mx.abs(y_cpu - y_nd).max().item(), 1e-5)
+
     def test_hadamard_grad_vmap(self):
         np.random.seed(4)
 

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -3481,27 +3481,32 @@ class TestOps(mlx_tests.MLXTestCase):
                         y_bf16.astype(mx.float16), y, atol=atol * 2
                     )
 
+    @unittest.skipIf(not mx.metal.is_available(), "Metal only")
     def test_hadamard_m_only(self):
+        if mx.default_device() == mx.cpu:
+            self.skipTest("requires GPU")
+
         # n = m * 2^0, so only the m stage runs. test_hadamard sweeps k from 1.
-        for m in (12, 20, 28):
+        tests = product(
+            (12, 20, 28),  # m
+            (None, 0.25),  # scale
+        )
+        for m, scale in tests:
             for shape in ((m,), (4, m), (3, 5, m)):
-                for scale in (None, 0.25):
-                    with self.subTest(m=m, shape=shape, scale=scale):
-                        x = mx.array(
-                            np.random.RandomState(3)
-                            .normal(size=shape)
-                            .astype(np.float32)
-                        )
-                        kwargs = {} if scale is None else {"scale": scale}
-                        y_cpu = mx.hadamard_transform(x, stream=mx.cpu, **kwargs)
-                        y_gpu = mx.hadamard_transform(x, stream=mx.gpu, **kwargs)
-                        mx.eval(y_cpu, y_gpu)
-                        self.assertEqual(y_gpu.shape, x.shape)
-                        self.assertLess(mx.abs(y_cpu - y_gpu).max().item(), 1e-5)
-                        # non-donatable input: the malloc'd-output path
-                        y_nd = mx.hadamard_transform(x + 0.0, stream=mx.gpu, **kwargs)
-                        mx.eval(y_nd)
-                        self.assertLess(mx.abs(y_cpu - y_nd).max().item(), 1e-5)
+                with self.subTest(m=m, shape=shape, scale=scale):
+                    x = mx.array(
+                        np.random.RandomState(3).normal(size=shape).astype(np.float32)
+                    )
+                    kwargs = {} if scale is None else {"scale": scale}
+                    y_cpu = mx.hadamard_transform(x, stream=mx.cpu, **kwargs)
+                    y_gpu = mx.hadamard_transform(x, stream=mx.gpu, **kwargs)
+                    mx.eval(y_cpu, y_gpu)
+                    self.assertEqual(y_gpu.shape, x.shape)
+                    self.assertLess(mx.abs(y_cpu - y_gpu).max().item(), 1e-5)
+                    # non-donatable input: the malloc'd-output path
+                    y_nd = mx.hadamard_transform(x + 0.0, stream=mx.gpu, **kwargs)
+                    mx.eval(y_nd)
+                    self.assertLess(mx.abs(y_cpu - y_nd).max().item(), 1e-5)
 
     def test_hadamard_grad_vmap(self):
         np.random.seed(4)


### PR DESCRIPTION
Fixes #4049.

## Summary

`hadamard_transform` is documented for `n = m*2^k` with `m in (1, 12, 20, 28)`, but on Metal the three sizes where the power-of-2 factor is exactly 1 (`n = 12, 20, 28`) failed to build the Metal library:

```
hadamard.h:44:19: error: constexpr variable 'num_steps' must be initialized by a constant expression
note: division by zero
  constexpr short num_steps = logN / logR;
```

`decompose_hadamard` returns `(n=1, m)` for those sizes, so the n2 stage is instantiated with `N=1`, giving `logR = ctz(max_radix_2) = ctz(1) = 0` and a `0/0`. The n1 and m stages are already guarded by `> 1`; n2 was not.

## Changes

**Emit and launch the n2 stage only when `n2 > 1`.** When `n2 == 1` the stage is the identity and carries no scale: `scale_n2` is `scale` only when `m == 1`, and `n == 1 && m == 1` returns before the primitive is created (`ops.cpp:530`), so `n2 == 1` inside the backend always implies `m > 1` and `scale_n2 == 1.0`. The skipped stage was also what copied `x` into `y`, so the m stage now reads `x` directly when `n == 1`; that matters on the non-donatable path, where `y` is freshly allocated and otherwise never written.

**Cap `read_width_m` at `n`.** The m kernel strides by `n / read_width`, so with `n = 1` and `read_width = 4` the group width was `1/4 == 0` and **zero threads were dispatched**, leaving the output untouched. Fixing only the build error surfaces this as a silent all-zero result for any batched input, so both changes are needed.

## Verification

Built with Metal on an **M2 Pro (Mac mini, macOS 26.5.2)** and compared against the CPU backend. Bit-exact, `max |gpu - cpu| = 0`, for `m in (12, 20, 28)` across shapes `(m,)`, `(4, m)`, `(3, 5, m)`, with and without an explicit `scale`, on both the donatable and freshly-allocated output paths. Sizes with `k >= 1` (24, 40, 48, 56, 80, 112, ...) are unchanged and still bit-exact.

`pytest python/tests/test_ops.py python/tests/test_autograd.py python/tests/test_vmap.py`: 227 passed. The one failure, `test_unstack`, is unrelated and pre-existing here (`np.unstack` needs numpy >= 2.1, this env has 1.26.4); it fails identically without this patch. `clang-format` 21.1.8 and `black` clean.

## Why it was not caught

`test_hadamard` builds its cases from `range(1, 14)`, so `k` starts at 1 and `n = m*2^0` was never tested; `m = 12` and `m = 20` do not appear in its `[1, 28]` list at all. The new `test_hadamard_m_only` pins all three sizes, and includes a batch dimension deliberately: the 1-D case alone still passes with the zero-thread dispatch when the input happens to be donated, so a 1-D-only test would not have caught the second half of this.

## Risks

Low, and confined to `n == 1`. For every other size the emitted kernels, launch order, grid dimensions and `read_width_m` are byte-identical to before, so `k >= 1` paths cannot change behavior. The one judgement call is reading from `x` in the m stage when `n == 1`; it is guarded on `n > 1 ? y : x` rather than changing the general path, so the multi-stage cases keep chaining through `y` exactly as they did.

## Pre-merge / post-merge

None. No API or build changes.
