### PR TITLE
Build extensions with the interpreter running the build

### DIFF
--- a/python/mlx/extension.py
+++ b/python/mlx/extension.py
@@ -30,13 +30,14 @@ class CMakeBuild(build_ext):
         debug = int(os.environ.get("DEBUG", 0)) if self.debug is None else self.debug
         cfg = "Debug" if debug else "Release"
 
-        # Set Python_EXECUTABLE instead if you use PYBIND11_FINDPYTHON
-        # EXAMPLE_VERSION_INFO shows you how to pass a value into the C++ code
-        # from Python.
+        # Point CMake at the interpreter running the build. Otherwise
+        # find_package(Python) picks whichever interpreter it finds first,
+        # which is not the one nanobind and mlx are installed into.
         cmake_args = [
             f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}{os.sep}",
             f"-DCMAKE_BUILD_TYPE={cfg}",
             "-DBUILD_SHARED_LIBS=ON",
+            f"-DPython_EXECUTABLE={sys.executable}",
         ]
         build_args = []
         # Adding CMake arguments set as environment variable


### PR DESCRIPTION
## Proposed changes

`pip install -e .` in `examples/extensions` fails on any setup where the interpreter running the build is not the first Python CMake finds, which includes a plain virtualenv:

```
$ pip install -e .
/opt/homebrew/opt/python@3.12/bin/python3.12: No module named nanobind
CMake Error at CMakeLists.txt:21 (find_package):
  Could not find a package configuration file provided by "nanobind"
ERROR: Failed building editable for mlx_sample_extensions
```

`CMakeBuild.build_extension` never passes `Python_EXECUTABLE`, so the extension's `find_package(Python ...)` resolves independently of the build interpreter. The extension CMakeLists then shells out to that interpreter for the nanobind and MLX cmake dirs:

```cmake
execute_process(COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir ...)
execute_process(COMMAND "${Python_EXECUTABLE}" -m mlx --cmake-dir ...)
```

Both look in a Python that has neither package installed, even though `pip install -r requirements.txt` put them in the right one. The stale comment above `cmake_args` is a leftover from the pybind11 project template ("Set Python_EXECUTABLE instead if you use PYBIND11_FINDPYTHON"); the bindings moved to nanobind, which uses exactly the `find_package(Python ... Development.Module)` path that needs it.

Passing `sys.executable` fixes both the `pip install -e .` and the `python setup.py build_ext --inplace` routes from `examples/extensions/README.md`, since they share this command.

After the change, on the same virtualenv:

```
$ pip install -e .
Successfully installed mlx_sample_extensions-0.0.0
$ python test.py
c shape: (3, 4)
c dtype: mlx.core.float32
c_cpu correct: True
```

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

No test added since nothing in CI builds `examples/extensions` today, so there is no existing harness to hook into. Verified by hand instead: reverted the one line, rebuilt, got the error above; reapplied, rebuilt, `test.py` passes. CPU only build (`MLX_BUILD_METAL=OFF`), so the `c_gpu` line of `test.py` is the only part I could not run.

---

freshman contributor, i use Claude Code as a second pair of eyes. found this by trying to follow `examples/extensions/README.md` end to end in a fresh venv. one thing i chased and ruled out first: i had nanobind 2.4.0 installed while the repo builds against 2.13.0, which produces a different and unrelated failure. this one reproduces with the pinned version.
