### PR TITLE
Reject a negative max_norm in clip_grad_norm

### DIFF
--- a/python/mlx/optimizers/optimizers.py
+++ b/python/mlx/optimizers/optimizers.py
@@ -968,6 +968,9 @@ def clip_grad_norm(grads, max_norm):
         (dict, float): The possibly rescaled gradients and the original
         gradient norm.
     """
+    if max_norm < 0:
+        raise ValueError(f"max_norm should be >=0, {max_norm} was provided instead")
+
     norm_squared = tree_reduce(lambda acc, g: acc + g.square().sum(), grads, 0.0)
     total_norm = mx.sqrt(norm_squared)
     normalizer = mx.minimum(max_norm / (total_norm + 1e-6), 1.0)

--- a/python/tests/test_optimizers.py
+++ b/python/tests/test_optimizers.py
@@ -562,6 +562,9 @@ class TestSchedulers(mlx_tests.MLXTestCase):
             "Gradients were not scaled correctly during clipping.",
         )
 
+        with self.assertRaises(ValueError):
+            opt.clip_grad_norm(small_grads, -1.0)
+
     def test_init_from_state(self):
         class Model(nn.Module):
             def __init__(self):


### PR DESCRIPTION
## Proposed changes

`clip_grad_norm` accepts a negative `max_norm` and silently reverses every gradient:

```python
>>> grads = {"w": mx.array([0.1, 0.2])}
>>> opt.clip_grad_norm(grads, -1.0)[0]["w"]
array([-0.447212, -0.894423], dtype=float32)
```

The scale factor is `mx.minimum(max_norm / (total_norm + 1e-6), 1.0)`, which is negative whenever `max_norm` is, so the gradients get flipped rather than clipped. Feeding that to an optimizer ascends the loss instead of descending it, with nothing in the output to say so. The docstring promises the opposite: "It scales down the gradients proportionally if their norm is greater than `max_norm`."

This is reachable without a typo, since `max_norm` is often computed, for example a warmup style `max_norm = base * (1 - step / total)` that goes negative once `step` passes `total`.

Every other hyperparameter in this module is already range checked and raises, for instance `RMSprop epsilon should be >0, -1 was provided instead` at optimizers.py:614. Added the matching check:

```python
>>> opt.clip_grad_norm(grads, -1.0)
ValueError: max_norm should be >=0, -1.0 was provided instead
```

`max_norm=0` is left working and still returns zeroed gradients, since that is a coherent request and not a sign error.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

`test_optimizers.py` passes (25 tests, CPU only build); the new assertion fails on main.

---

freshman here, i work alongside Claude Code. found this while feeding out of range hyperparameters to each optimizer and comparing which ones complained. the rest of the module was solid, this was the one that took the bad value and quietly changed the answer.
