### PR TITLE
Refactor CPU Select dtype dispatch

### DIFF
--- a/mlx/backend/cpu/select.cpp
+++ b/mlx/backend/cpu/select.cpp
@@ -4,6 +4,7 @@
 
 #include "mlx/backend/cpu/binary_ops.h"
 #include "mlx/backend/cpu/ternary.h"
+#include "mlx/dtype_utils.h"
 #include "mlx/primitives.h"
 
 namespace mlx::core {
@@ -32,53 +33,10 @@ void select_op(
                     out = array::unsafe_weak_copy(out),
                     op,
                     topt]() mutable {
-    switch (out.dtype()) {
-      case bool_:
-        ternary_op<bool, bool, bool, bool>(a, b, c, out, op, topt);
-        break;
-      case uint8:
-        ternary_op<bool, uint8_t, uint8_t, uint8_t>(a, b, c, out, op, topt);
-        break;
-      case uint16:
-        ternary_op<bool, uint16_t, uint16_t, uint16_t>(a, b, c, out, op, topt);
-        break;
-      case uint32:
-        ternary_op<bool, uint32_t, uint32_t, uint32_t>(a, b, c, out, op, topt);
-        break;
-      case uint64:
-        ternary_op<bool, uint64_t, uint64_t, uint64_t>(a, b, c, out, op, topt);
-        break;
-      case int8:
-        ternary_op<bool, int8_t, int8_t, int8_t>(a, b, c, out, op, topt);
-        break;
-      case int16:
-        ternary_op<bool, int16_t, int16_t, int16_t>(a, b, c, out, op, topt);
-        break;
-      case int32:
-        ternary_op<bool, int32_t, int32_t, int32_t>(a, b, c, out, op, topt);
-        break;
-      case int64:
-        ternary_op<bool, int64_t, int64_t, int64_t>(a, b, c, out, op, topt);
-        break;
-      case float16:
-        ternary_op<bool, float16_t, float16_t, float16_t>(
-            a, b, c, out, op, topt);
-        break;
-      case float32:
-        ternary_op<bool, float, float, float>(a, b, c, out, op, topt);
-        break;
-      case float64:
-        ternary_op<bool, double, double, double>(a, b, c, out, op, topt);
-        break;
-      case bfloat16:
-        ternary_op<bool, bfloat16_t, bfloat16_t, bfloat16_t>(
-            a, b, c, out, op, topt);
-        break;
-      case complex64:
-        ternary_op<bool, complex64_t, complex64_t, complex64_t>(
-            a, b, c, out, op, topt);
-        break;
-    }
+    dispatch_all_types(out.dtype(), [&](auto type_tag) {
+      using T = MLX_GET_TYPE(type_tag);
+      ternary_op<bool, T, T, T>(a, b, c, out, op, topt);
+    });
   });
 }
 


### PR DESCRIPTION
CPU Select has the same exhaustive dtype mapping cleaned up in #4064. Replace the switch with `dispatch_all_types`, preserving the supported dtypes, ternary specializations, and behavior.

### Testing

- CPU Release build and serial native C++ test suite
- Native and Python `where` tests, including float64
- All 14 current dtypes with scalar, broadcast, and non-contiguous conditions
- `pre-commit` formatting checks