### PR TITLE
Fix `mx.maximum` / `mx.minimum` / `mx.max` / `mx.min` handle signed zeros (`+0.0` vs `-0.0`) incorrectly

### DIFF
--- a/mlx/backend/cpu/simd/base_simd.h
+++ b/mlx/backend/cpu/simd/base_simd.h
@@ -235,7 +235,11 @@ Simd<T, 1> maximum(Simd<T, 1> a_, Simd<T, 1> b_) {
       return a;
     }
   }
-  return (a > b) ? a : b;
+  if constexpr (std::is_floating_point_v<T>) {
+    return (a > b || (a == b && !std::signbit(a))) ? a : b;
+  } else {
+    return (a > b) ? a : b;
+  }
 }
 
 template <typename T>
@@ -247,7 +251,11 @@ Simd<T, 1> minimum(Simd<T, 1> a_, Simd<T, 1> b_) {
       return a;
     }
   }
-  return (a < b) ? a : b;
+  if constexpr (std::is_floating_point_v<T>) {
+    return (a < b || (a == b && std::signbit(a))) ? a : b;
+  } else {
+    return (a < b) ? a : b;
+  }
 }
 
 template <typename T>

--- a/mlx/backend/metal/kernels/binary_ops.h
+++ b/mlx/backend/metal/kernels/binary_ops.h
@@ -163,7 +163,7 @@ struct Maximum {
     if (metal::isnan(x)) {
       return x;
     }
-    return x > y ? x : y;
+    return (x > y || (x == y && !metal::signbit(x))) ? x : y;
   }
 
   template <>
@@ -186,7 +186,7 @@ struct Minimum {
     if (metal::isnan(x)) {
       return x;
     }
-    return x < y ? x : y;
+    return (x < y || (x == y && metal::signbit(x))) ? x : y;
   }
 
   template <>

--- a/mlx/backend/metal/kernels/reduction/ops.h
+++ b/mlx/backend/metal/kernels/reduction/ops.h
@@ -200,7 +200,7 @@ struct Min {
     if (metal::isnan(a) || metal::isnan(b)) {
       return static_cast<T>(NAN);
     } else {
-      return a < b ? a : b;
+      return (a < b || a == b && metal::signbit(a)) ? a : b;
     }
   }
 
@@ -260,7 +260,7 @@ struct Max {
     if (metal::isnan(a) || metal::isnan(b)) {
       return static_cast<T>(NAN);
     } else {
-      return a > b ? a : b;
+      return (a > b || (a == b && !metal::signbit(a))) ? a : b;
     }
   }
 

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -532,6 +532,21 @@ class TestOps(mlx_tests.MLXTestCase):
         self.assertTrue(math.isnan(mx.maximum(a, b).item()))
         self.assertTrue(math.isnan(mx.maximum(b, a).item()))
 
+    def test_maximum_minimum_signed_zero(self):
+        for dt in (mx.float32, mx.float16, mx.bfloat16):
+            pz = mx.array(0.0, dtype=dt)
+            nz = mx.array(-0.0, dtype=dt)
+
+            self.assertEqual(math.copysign(1.0, mx.maximum(pz, nz).item()), 1.0)
+            self.assertEqual(math.copysign(1.0, mx.maximum(nz, pz).item()), 1.0)
+            self.assertEqual(math.copysign(1.0, mx.minimum(pz, nz).item()), -1.0)
+            self.assertEqual(math.copysign(1.0, mx.minimum(nz, pz).item()), -1.0)
+
+            # Reductions: max of mixed signed zeros is +0, min is -0.
+            x = mx.array(np.array([-0.0, 0.0, -0.0], dtype=np.float32), dtype=dt)
+            self.assertEqual(math.copysign(1.0, mx.max(x).item()), 1.0)
+            self.assertEqual(math.copysign(1.0, mx.min(x).item()), -1.0)
+
     def test_floor(self):
         x = mx.array([-22.03, 19.98, -27, 9, 0.0, -np.inf, np.inf])
         expected = [-23, 19, -27, 9, 0, -np.inf, np.inf]


### PR DESCRIPTION
## Proposed changes

Fix #4063 

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
