### PR TITLE
Handle zero-size inputs in eig and qr on the CPU

### DIFF
--- a/mlx/backend/cpu/eig.cpp
+++ b/mlx/backend/cpu/eig.cpp
@@ -241,6 +241,15 @@ void Eig::eval_cpu(
 
   values.set_data(allocator::malloc(values.nbytes()));
 
+  // Nothing to decompose for n = 0; LAPACK rejects lda = 0. The input is
+  // square, so both outputs are empty and there is nothing to write.
+  if (a.shape(-1) == 0) {
+    if (compute_eigenvectors_) {
+      vectors.set_data(allocator::malloc(vectors.nbytes()));
+    }
+    return;
+  }
+
   if (compute_eigenvectors_) {
     // Set the strides and flags so the eigenvectors
     // are in the columns of the output

--- a/mlx/backend/cpu/eig.cpp
+++ b/mlx/backend/cpu/eig.cpp
@@ -228,6 +228,19 @@ void Eig::eval_cpu(
   const auto& a = inputs[0];
   auto& values = outputs[0];
 
+  values.set_data(allocator::malloc(values.nbytes()));
+
+  // Nothing to decompose for n = 0; LAPACK rejects lda = 0. The input is
+  // square, so both outputs are empty and there is nothing to write. Return
+  // before the copy below, since the temporary it produces is only kept alive
+  // by the add_temporary in eig_impl.
+  if (a.shape(-1) == 0) {
+    if (compute_eigenvectors_) {
+      outputs[1].set_data(allocator::malloc(outputs[1].nbytes()));
+    }
+    return;
+  }
+
   auto vectors = compute_eigenvectors_
       ? outputs[1]
       : array(a.shape(), complex64, nullptr, {});
@@ -238,17 +251,6 @@ void Eig::eval_cpu(
       a_copy,
       a.flags().row_contiguous ? CopyType::Vector : CopyType::General,
       stream());
-
-  values.set_data(allocator::malloc(values.nbytes()));
-
-  // Nothing to decompose for n = 0; LAPACK rejects lda = 0. The input is
-  // square, so both outputs are empty and there is nothing to write.
-  if (a.shape(-1) == 0) {
-    if (compute_eigenvectors_) {
-      vectors.set_data(allocator::malloc(vectors.nbytes()));
-    }
-    return;
-  }
 
   if (compute_eigenvectors_) {
     // Set the strides and flags so the eigenvectors

--- a/mlx/backend/cpu/eig.cpp
+++ b/mlx/backend/cpu/eig.cpp
@@ -230,10 +230,7 @@ void Eig::eval_cpu(
 
   values.set_data(allocator::malloc(values.nbytes()));
 
-  // Nothing to decompose for n = 0; LAPACK rejects lda = 0. The input is
-  // square, so both outputs are empty and there is nothing to write. Return
-  // before the copy below, since the temporary it produces is only kept alive
-  // by the add_temporary in eig_impl.
+  // Nothing to decompose for n = 0; LAPACK rejects lda = 0.
   if (a.shape(-1) == 0) {
     if (compute_eigenvectors_) {
       outputs[1].set_data(allocator::malloc(outputs[1].nbytes()));

--- a/mlx/backend/cpu/eigh.cpp
+++ b/mlx/backend/cpu/eigh.cpp
@@ -194,8 +194,7 @@ void Eigh::eval_cpu(
 
   values.set_data(allocator::malloc(values.nbytes()));
 
-  // Nothing to decompose for n = 0; LAPACK rejects lda = 0. The input is
-  // square, so both outputs are empty and there is nothing to write.
+  // Nothing to decompose for n = 0; LAPACK rejects lda = 0.
   if (a.shape(-1) == 0) {
     if (compute_eigenvectors_) {
       outputs[1].set_data(allocator::malloc(outputs[1].nbytes()));

--- a/mlx/backend/cpu/qrf.cpp
+++ b/mlx/backend/cpu/qrf.cpp
@@ -12,6 +12,16 @@ template <typename T>
 void qrf_impl(const array& a, array& q, array& r, Stream stream) {
   const int M = a.shape(-2);
   const int N = a.shape(-1);
+
+  // Nothing to factorize when either dimension is zero; LAPACK rejects
+  // lda = 0. Both outputs carry min(M, N) as one of their dimensions, so
+  // both are empty and there is nothing to write.
+  if (M == 0 || N == 0) {
+    q.set_data(allocator::malloc(q.nbytes()));
+    r.set_data(allocator::malloc(r.nbytes()));
+    return;
+  }
+
   const int lda = M;
   size_t num_matrices = a.size() / (M * N);
 

--- a/mlx/backend/cpu/qrf.cpp
+++ b/mlx/backend/cpu/qrf.cpp
@@ -13,9 +13,7 @@ void qrf_impl(const array& a, array& q, array& r, Stream stream) {
   const int M = a.shape(-2);
   const int N = a.shape(-1);
 
-  // Nothing to factorize when either dimension is zero; LAPACK rejects
-  // lda = 0. Both outputs carry min(M, N) as one of their dimensions, so
-  // both are empty and there is nothing to write.
+  // Nothing to factorize when either dimension is zero; LAPACK rejects lda = 0.
   if (M == 0 || N == 0) {
     q.set_data(allocator::malloc(q.nbytes()));
     r.set_data(allocator::malloc(r.nbytes()));

--- a/python/tests/test_linalg.py
+++ b/python/tests/test_linalg.py
@@ -154,6 +154,16 @@ class TestLinalg(mlx_tests.MLXTestCase):
                 mx.allclose(out, mx.eye(min(A.shape)), rtol=1e-4, atol=1e-6)
             )
 
+        # Zero-size inputs. Both factors carry min(M, N) as a dimension, so
+        # both are empty whichever dimension is zero.
+        for shape in [(0, 0), (3, 0, 0), (0, 4, 4), (5, 0), (0, 5)]:
+            A_np = np.zeros(shape, dtype=np.float32)
+            Q, R = mx.linalg.qr(mx.array(A_np), stream=mx.cpu)
+            mx.eval(Q, R)
+            Q_np, R_np = np.linalg.qr(A_np)
+            self.assertEqual(Q.shape, Q_np.shape)
+            self.assertEqual(R.shape, R_np.shape)
+
     def test_svd_decomposition(self):
         A = mx.array([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]], dtype=mx.float32)
         U, S, Vt = mx.linalg.svd(A, compute_uv=True, stream=mx.cpu)
@@ -451,6 +461,19 @@ class TestLinalg(mlx_tests.MLXTestCase):
             )
             self.assertEqual(eig_vals_c64.dtype, mx.complex64)
             self.assertEqual(eig_vecs_c64.dtype, mx.complex64)
+
+        # Zero-size inputs. The input is square, so both outputs are empty.
+        for shape in [(0, 0), (3, 0, 0), (0, 4, 4)]:
+            A_np = np.zeros(shape, dtype=np.float32)
+            eig_vals, eig_vecs = mx.linalg.eig(mx.array(A_np), stream=mx.cpu)
+            mx.eval(eig_vals, eig_vecs)
+            vals_np, vecs_np = np.linalg.eig(A_np)
+            self.assertEqual(eig_vals.shape, vals_np.shape)
+            self.assertEqual(eig_vecs.shape, vecs_np.shape)
+
+            vals_only = mx.linalg.eigvals(mx.array(A_np), stream=mx.cpu)
+            mx.eval(vals_only)
+            self.assertEqual(vals_only.shape, vals_np.shape)
 
         # Test error cases
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Proposed changes

#4033 and #3834 fixed zero-size inputs for `cholesky`, `eigh` and `svd`. `eig` and `qr` have the same hole and were not covered by either.

`eig` aborts the process:

```python
>>> mx.eval(mx.linalg.eig(mx.zeros((0, 0)), stream=mx.cpu))
** On entry to SGEEV , parameter number  5 had an illegal value
libc++abi: terminating due to uncaught exception of type std::runtime_error:
[Eig::eval_cpu] Eigenvalue decomposition failed with error code -5
abort
```

`qr` returns the right shapes but still calls LAPACK with a zero leading dimension, so it prints on every call:

```python
>>> q, r = mx.linalg.qr(mx.zeros((0, 0)), stream=mx.cpu); mx.eval(q, r)
** On entry to SGEQRF, parameter number  4 had an illegal value
** On entry to SORGQR, parameter number  5 had an illegal value
```

Both come from the same place the earlier two did. `num_matrices` is `a.size() / (M * N)`, which divides by zero when a dimension is zero, and the workspace query runs before the loop either way, so LAPACK gets `lda = 0`. numpy returns empty results for all of these.

Guards added in the same spirit as the merged ones:

- `eig.cpp`, after `values.set_data`. The input is square, so `n = 0` means both outputs are empty and there is nothing to write. No identity fill is needed here, unlike `svd`.
- `qrf.cpp`, before `num_matrices` is computed, so the zero division never happens. `q` is `(..., M, k)` and `r` is `(..., k, N)` with `k = min(M, N)`, so if either dimension is zero then `k` is zero and both outputs are empty whichever one it was.

Shapes now match numpy for `(0, 0)`, `(3, 0, 0)`, `(0, 4, 4)`, and for `qr` also `(5, 0)` and `(0, 5)`.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

Worth being precise about the two tests, since they are not equally strong. The `eig` one aborts the interpreter on main, so it fails there in the loudest possible way. The `qr` one passes on main, because the shapes were already correct and the only visible symptom was the LAPACK output above; it is a regression guard for the new early return rather than proof of the old break. Say the word if you would rather I drop it.

CPU only build (`MLX_BUILD_METAL=OFF`) at f599c020, `test_linalg.py` 18 tests OK, and non-empty `eig` and `qr` verified unchanged against their existing reconstruction checks.

---

freshman contributor, i lean on Claude Code while digging. i had actually built a version of this a day earlier that also touched cholesky, eigh and svd, then found #4033 and #3834 already open and threw it away rather than compete. this is only the part those two left behind.
