### PR TITLE
Return an empty result from pinv for zero-size inputs

### DIFF
--- a/mlx/linalg.cpp
+++ b/mlx/linalg.cpp
@@ -362,6 +362,15 @@ array pinv(const array& a, StreamOrDevice s /* = {} */) {
     throw std::invalid_argument(msg.str());
   }
 
+  // The cutoff below reduces over the singular values, which cannot run on an
+  // empty array. Nothing needs computing anyway, and the result is the shape
+  // of the transposed input, like numpy.
+  if (a.size() == 0) {
+    auto out_shape = a.shape();
+    std::swap(out_shape[a.ndim() - 1], out_shape[a.ndim() - 2]);
+    return zeros(std::move(out_shape), a.dtype(), s);
+  }
+
   int m = a.shape(-2);
   int n = a.shape(-1);
   int k = std::min(m, n);

--- a/python/tests/test_linalg.py
+++ b/python/tests/test_linalg.py
@@ -310,6 +310,13 @@ class TestLinalg(mlx_tests.MLXTestCase):
         A_plus = mx.linalg.pinv(A, stream=mx.cpu)
         self.assertTrue(mx.allclose(A @ A_plus @ A, A))
 
+        # Zero-size inputs. The result takes the shape of the transposed input.
+        for shape in [(0, 0), (0, 3), (3, 0), (0, 2, 2), (2, 0, 0), (0, 4, 3)]:
+            A_np = np.zeros(shape, dtype=np.float32)
+            A_plus = mx.linalg.pinv(mx.array(A_np), stream=mx.cpu)
+            mx.eval(A_plus)
+            self.assertEqual(A_plus.shape, np.linalg.pinv(A_np).shape)
+
     def test_cholesky_inv(self):
         mx.random.seed(7)
 


### PR DESCRIPTION
## Proposed changes

`mx.linalg.pinv` fails on any zero-size input:

```python
>>> mx.linalg.pinv(mx.zeros((0, 0)), stream=mx.cpu)
ValueError: [max] Cannot max reduce zero size array.
```

The cutoff for small singular values reduces over them:

```cpp
auto cutoff = multiply(array(rcond, a.dtype()), max(S, -1, true, s), s);
```

`max` rejects a zero-size array, so this trips before anything meaningful happens. It is not limited to a zero trailing dimension. `(0, 2, 2)` fails too, because `S` is `(0, 2)` and `max` refuses the whole array even though the reduced axis is not the empty one. numpy returns an empty result for all of these.

Added an early return, since there is nothing to decompose and the answer is fully determined by the shape:

```python
>>> [mx.linalg.pinv(mx.zeros(s), stream=mx.cpu).shape
...  for s in [(0, 0), (0, 3), (3, 0), (0, 2, 2), (2, 0, 0), (0, 4, 3)]]
[(0, 0), (3, 0), (0, 3), (0, 2, 2), (2, 0, 0), (0, 3, 4)]
```

Those match `np.linalg.pinv` on the same shapes. The guard keys on `a.size() == 0` rather than a zero trailing dimension so the `(0, 2, 2)` case is covered.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

CPU only build (`MLX_BUILD_METAL=OFF`) at f599c020. `test_linalg.py` 18 tests OK, and the new shape assertions all raise `ValueError` on main. Existing non-empty behaviour verified unchanged, including the singular matrix case already in `test_pseudo_inverse` and a batched rectangular input checked against numpy.

---

freshman, i use Claude Code as a sounding board. found this by running every `mx.linalg` entry point on a `(0, 0)` input and comparing against numpy. the `(0, 2, 2)` case is the one that surprised me: i expected the empty trailing dimension to be the trigger and it was not, so the guard checks total size instead.
