### PR TITLE
Fix: mx.distributed.sum_scatter crashes on a scalar(0-d)

### DIFF
--- a/mlx/distributed/ops.cpp
+++ b/mlx/distributed/ops.cpp
@@ -165,11 +165,11 @@ array sum_scatter(
   if (group.size() == 1) {
     return x;
   }
-  if (x.shape()[0] % group.size() != 0) {
+  if (x.ndim() == 0 || x.shape()[0] % group.size() != 0) {
     std::ostringstream msg;
     msg << "[sum_scatter] Invalid shape=" << x.shape()
         << " for a group of size " << group.size()
-        << ". The first dimension (axis 0) must be divisible by the group size.";
+        << ". The first dimension (axis 0) must be divisible by the group size and input mst have at least one.";
     throw std::invalid_argument(msg.str());
   }
 


### PR DESCRIPTION
## Proposed changes

Fix #4070 

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
