### PR TITLE
Fix hardcoding pow2=10 in get_block_dims_common.

### DIFF
--- a/mlx/backend/common/utils.cpp
+++ b/mlx/backend/common/utils.cpp
@@ -124,21 +124,21 @@ Dims get_block_dims_common(int dim0, int dim1, int dim2, int pow2 /* = 10 */) {
       pows[0]++;
       sum++;
     }
-    if (sum == 10) {
+    if (sum >= pow2) {
       break;
     }
     if (dim1 >= (1 << (pows[1] + 1))) {
       pows[1]++;
       sum++;
     }
-    if (sum == 10) {
+    if (sum >= pow2) {
       break;
     }
     if (dim2 >= (1 << (pows[2] + 1))) {
       pows[2]++;
       sum++;
     }
-    if (sum == presum || sum == pow2) {
+    if (sum == presum || sum >= pow2) {
       break;
     }
   }


### PR DESCRIPTION
## Proposed changes
Fix [4062](https://github.com/ml-explore/mlx/issues/4062)
Fix hardcoding pow2=10 process logic to a more reasonable and robust way.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
