### PR TITLE
Enable complex64 scatter addition on GPU

### DIFF
--- a/mlx/backend/metal/indexing.cpp
+++ b/mlx/backend/metal/indexing.cpp
@@ -230,7 +230,8 @@ void Gather::eval_gpu(const std::vector<array>& inputs, array& out) {
 }
 
 void Scatter::eval_gpu(const std::vector<array>& inputs, array& out) {
-  if (size_of(out.dtype()) == 8) {
+  if (size_of(out.dtype()) == 8 &&
+      !(out.dtype() == complex64 && reduce_type_ == Scatter::Sum)) {
     std::ostringstream msg;
     msg << "[Scatter::eval_gpu] Does not support " << out.dtype();
     throw std::invalid_argument(msg.str());

--- a/mlx/backend/metal/kernels/reduction/ops.h
+++ b/mlx/backend/metal/kernels/reduction/ops.h
@@ -133,6 +133,15 @@ struct Sum {
     mlx_atomic_fetch_add_explicit(out, val, offset);
   }
 
+  void atomic_update(
+      device mlx_atomic<complex64_t>* out,
+      complex64_t val,
+      size_t offset = 0) thread {
+    auto out_lanes = reinterpret_cast<device mlx_atomic<float>*>(out);
+    mlx_atomic_fetch_add_explicit(out_lanes, val.real, 2 * offset);
+    mlx_atomic_fetch_add_explicit(out_lanes, val.imag, 2 * offset + 1);
+  }
+
   // Operator
   U operator()(U a, U b) thread {
     return a + b;

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -3794,7 +3794,8 @@ array scatter(
   }
 
   // TODO, remove when scatter supports 64-bit outputs
-  if (to_stream(s).device == Device::gpu && size_of(a.dtype()) == 8) {
+  if (to_stream(s).device == Device::gpu && size_of(a.dtype()) == 8 &&
+      !(a.dtype() == complex64 && mode == Scatter::Sum)) {
     std::ostringstream msg;
     msg << "[scatter] GPU scatter does not yet support " << a.dtype()
         << " for the input or updates.";

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -1548,6 +1548,37 @@ class TestArray(mlx_tests.MLXTestCase):
         a = a.at[1:3, :, 0].minimum(update)
         self.assertEqualArray(a[1:3, :, 0], mx.minimum(a[1:3, :, 0], update))
 
+    @unittest.skipIf(not mx.is_available(mx.gpu), "No GPU available")
+    def test_array_at_complex_add_gpu(self):
+        n = 4096
+        base = [1 + 10j, 2 + 20j, 3 + 30j, 4 + 40j]
+
+        with mx.stream(mx.gpu):
+            a = mx.array(base, dtype=mx.complex64)
+            update_indices = mx.full((n,), 3, dtype=mx.int32)
+            updates = mx.full((n,), 1 + 3j, dtype=mx.complex64)
+            out = a.at[update_indices].add(updates)
+            mx.eval(out)
+
+            indices = mx.array([1, 1, 3])
+            x = mx.array([1 + 0j, 3 + 4j, 6 + 8j, 5 + 12j], dtype=mx.complex64)
+
+            def loss(z):
+                return mx.square(mx.abs(z[indices])).sum()
+
+            _, gradient = mx.value_and_grad(loss)(x)
+            mx.eval(gradient)
+
+        expected = base.copy()
+        expected[-1] += n * (1 + 3j)
+        self.assertEqual(out.tolist(), expected)
+        np.testing.assert_allclose(
+            np.array(gradient),
+            np.array([0, 12 + 16j, 0, 10 + 24j], dtype=np.complex64),
+            rtol=0,
+            atol=1e-5,
+        )
+
     def test_array_at_slice_update_extensive(self):
         # Test with transposed inputs
         a = mx.zeros((4, 5))


### PR DESCRIPTION
## Summary

Enable the existing GPU scatter-add path for `complex64`. This supports
`.at[...].add(...)` and complex gather backward, addressing the additive case
reported in #1214.

Complex addition is componentwise. On Metal, `Scatter::Sum` accumulates the
real and imaginary FP32 lanes independently with native atomics. The shared
eight-byte GPU restriction is relaxed only for the existing `Scatter::Sum`
mode with `complex64`.

CUDA already has a CAS-based complex atomic-add implementation, so the same
guard change makes that path reachable. Assignment, product, min/max, other
eight-byte dtypes, and `ScatterAxis` remain unchanged.

## Testing

Coverage includes:

- 4,096 colliding `complex64` GPU updates
- Complex gather `value_and_grad`
- Python array tests on CPU and Metal
- Native scatter tests on CPU and Metal
- The focused regression with Metal API validation enabled