### PR TITLE
Allow saving empty arrays to npy and safetensors

### DIFF
--- a/mlx/io/load.cpp
+++ b/mlx/io/load.cpp
@@ -208,7 +208,11 @@ void save(std::shared_ptr<io::Writer> out_stream, array a) {
 
   out_stream->write(magic_ver_len.str().c_str(), magic_ver_len.str().length());
   out_stream->write(header.str().c_str(), header.str().length());
-  out_stream->write(a.data<char>(), a.nbytes());
+  // An empty array has no data to write, and asking for its pointer is not
+  // meaningful, so stop after the header.
+  if (a.nbytes() > 0) {
+    out_stream->write(a.data<char>(), a.nbytes());
+  }
 }
 
 /** Save array to file in .npy format */

--- a/mlx/io/load.cpp
+++ b/mlx/io/load.cpp
@@ -148,10 +148,6 @@ void save(std::shared_ptr<io::Writer> out_stream, array a) {
   a = contiguous(a, true);
   a.eval();
 
-  if (a.nbytes() == 0) {
-    throw std::invalid_argument("[save] cannot serialize an empty array");
-  }
-
   ////////////////////////////////////////////////////////
   // Check file
   if (!out_stream->good() || !out_stream->is_open()) {

--- a/mlx/io/safetensors.cpp
+++ b/mlx/io/safetensors.cpp
@@ -263,7 +263,11 @@ void save_safetensors(
   out_stream->write(reinterpret_cast<char*>(&header_len), 8);
   out_stream->write(header.c_str(), header_len);
   for (auto& [key, arr] : a) {
-    out_stream->write(arr.data<char>(), arr.nbytes());
+    // An empty tensor contributes a zero length span and has no data pointer
+    // worth asking for.
+    if (arr.nbytes() > 0) {
+      out_stream->write(arr.data<char>(), arr.nbytes());
+    }
   }
 }
 

--- a/mlx/io/safetensors.cpp
+++ b/mlx/io/safetensors.cpp
@@ -250,13 +250,6 @@ void save_safetensors(
 
   size_t offset = 0;
   for (auto& [key, arr] : a) {
-    if (arr.nbytes() == 0) {
-      std::ostringstream msg;
-      msg << "[save_safetensors] Cannot serialize an empty array ('" << key
-          << "')";
-      throw std::invalid_argument(msg.str());
-    }
-
     json child;
     child["dtype"] = dtype_to_safetensor_str(arr.dtype());
     child["shape"] = arr.shape();

--- a/python/tests/test_load.py
+++ b/python/tests/test_load.py
@@ -524,6 +524,34 @@ class TestLoad(mlx_tests.MLXTestCase):
 
         self.assertEqual(load_only, load_with_binary)
 
+    def test_save_and_load_empty(self):
+        for i, shape in enumerate([(0,), (0, 3), (3, 0), (2, 0, 4)]):
+            with self.subTest(shape=shape):
+                save_arr = mx.zeros(shape)
+
+                npy_file = os.path.join(self.test_dir, f"empty_{i}.npy")
+                mx.save(npy_file, save_arr)
+                self.assertEqual(mx.load(npy_file).shape, shape)
+                # numpy can read what we wrote
+                self.assertEqual(np.load(npy_file).shape, shape)
+
+                st_file = os.path.join(self.test_dir, f"empty_{i}.safetensors")
+                mx.save_safetensors(st_file, {"x": save_arr})
+                self.assertEqual(mx.load(st_file)["x"].shape, shape)
+
+        # An empty array alongside a normal one round trips both
+        npz_file = os.path.join(self.test_dir, "empty.npz")
+        mx.savez(npz_file, x=mx.zeros((0, 3)), y=mx.ones((2, 2)))
+        loaded = mx.load(npz_file)
+        self.assertEqual(loaded["x"].shape, (0, 3))
+        self.assertTrue(mx.array_equal(loaded["y"], mx.ones((2, 2))))
+
+        st_file = os.path.join(self.test_dir, "empty_mixed.safetensors")
+        mx.save_safetensors(st_file, {"x": mx.zeros((0, 3)), "y": mx.ones((2, 2))})
+        loaded = mx.load(st_file)
+        self.assertEqual(loaded["x"].shape, (0, 3))
+        self.assertTrue(mx.array_equal(loaded["y"], mx.ones((2, 2))))
+
 
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner()


### PR DESCRIPTION
## Proposed changes

mlx can read empty arrays but cannot write them:

```python
>>> mx.save("a.npy", mx.zeros((0, 3)))
ValueError: [save] cannot serialize an empty array
>>> mx.save_safetensors("a.safetensors", {"x": mx.zeros((0, 3))})
ValueError: [save_safetensors] Cannot serialize an empty array ('x')
```

The readers already handle them at every shape. numpy writes the same files, and `mx.load` reads them back correctly today:

```python
>>> np.save("a.npy", np.zeros((0, 3), dtype=np.float32))
>>> mx.load("a.npy").shape
(0, 3)
```

So an array that mlx is happy to load is one it refuses to have produced. That bites when a shape is data dependent, for example saving a batch of matched indices that happens to be empty for one input, since the whole checkpoint call fails rather than that one entry being empty.

Both guards are `nbytes() == 0` early throws that date to the initial commit with no comment. Removed them. The writers needed nothing else:

```python
>>> for s in [(0,), (0, 3), (3, 0), (2, 0, 4)]:
...     mx.save("a.npy", mx.zeros(s))
...     print(s, mx.load("a.npy").shape, np.load("a.npy").shape)
(0,) (0,) (0,)
(0, 3) (0, 3) (0, 3)
(3, 0) (3, 0) (3, 0)
(2, 0, 4) (2, 0, 4) (2, 0, 4)
```

For safetensors the header comes out well formed, with a zero length span, and the reference `safetensors` package reads the file mlx produced:

```
{'x': {'data_offsets': [16, 16], 'dtype': 'F32', 'shape': [0, 3]},
 'y': {'data_offsets': [0, 16],  'dtype': 'F32', 'shape': [2, 2]}}
```

Reading in the other direction works too: mlx loads an empty tensor written by `safetensors.numpy.save_file`.

`save_gguf` is untouched. It already writes empty weights and reads them back, and its separate guard on empty *metadata* arrays still throws, which is what `tests/load_tests.cpp:237` checks.

If these guards were deliberate rather than leftover, say so and I will close this. I could not find a reason for them in the code or history, and the asymmetry with both the readers and `save_gguf` is what made me think it was an oversight.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

CPU only build (`MLX_BUILD_METAL=OFF`) at 8d66629. `test_load.py`, `test_ops.py` and `test_array.py` pass; the new test raises `ValueError` on main. No existing test asserted either removed message.

---

freshman contributor, i use Claude Code alongside my own poking. i went looking for places where mlx and numpy disagree on zero-size input and this one stood out because the read path was already complete, so it was only the writer holding it back. the safetensors cross-check against the reference package was the part i most wanted to be sure of before sending this.
