### PR TITLE
[CUDA] Avoid copying transposed inputs in row reductions

### DIFF
--- a/mlx/backend/cuda/reduce.cu
+++ b/mlx/backend/cuda/reduce.cu
@@ -52,7 +52,13 @@ void Reduce::eval_gpu(const std::vector<array>& inputs, array& out) {
       broadcasted = in.strides(i) == 0;
     }
   }
-  if (plan.type == GeneralReduce || broadcasted || !in.flags().contiguous) {
+  // GeneralContiguousReduce computes offsets for the non-reduction axes. With
+  // enough output rows to occupy the GPU, reduce transposed inputs directly
+  // instead of allocating an O(in.size()) contiguous temporary.
+  const bool reduce_transposed =
+      plan.type == GeneralContiguousReduce && out.size() >= 1024;
+  const bool copy_noncontiguous = !in.flags().contiguous && !reduce_transposed;
+  if (plan.type == GeneralReduce || broadcasted || copy_noncontiguous) {
     array in_copy = contiguous_copy_gpu(in, s);
     encoder.add_temporary(in_copy);
     in = in_copy;

--- a/tests/gpu_tests.cpp
+++ b/tests/gpu_tests.cpp
@@ -202,6 +202,9 @@ TEST_CASE("test gpu reduce with axes") {
     auto a = reshape(arange(8 * 256 * 1024, int32), {8, 256, 1024});
     a = slice(a, {0, 0, 0}, {8, 256, 1024}, {1, 2, 1});
     a = transpose(a, {0, 2, 1});
+    eval(a);
+    CHECK(!a.flags().contiguous);
+    CHECK_EQ(a.strides(1), 1);
     auto out_gpu = sum(a, 1, false, Device::gpu);
     auto out_cpu = sum(a, 1, false, Device::cpu);
     CHECK(array_equal(out_gpu, out_cpu, Device::cpu).item<bool>());

--- a/tests/gpu_tests.cpp
+++ b/tests/gpu_tests.cpp
@@ -195,6 +195,16 @@ TEST_CASE("test gpu reduce with axes") {
       CHECK(array_equal(out_gpu, out_cpu, Device::cpu).item<bool>());
     }
   }
+
+  // A transposed input with a contiguous reduction axis can be reduced
+  // directly without materialising a contiguous copy of the full input.
+  {
+    auto a = reshape(arange(8 * 128 * 1024, int32), {8, 128, 1024});
+    a = transpose(a, {0, 2, 1});
+    auto out_gpu = sum(a, 1, false, Device::gpu);
+    auto out_cpu = sum(a, 1, false, Device::cpu);
+    CHECK(array_equal(out_gpu, out_cpu, Device::cpu).item<bool>());
+  }
 }
 
 TEST_CASE("test gpu binary ops") {

--- a/tests/gpu_tests.cpp
+++ b/tests/gpu_tests.cpp
@@ -199,7 +199,8 @@ TEST_CASE("test gpu reduce with axes") {
   // A transposed input with a contiguous reduction axis can be reduced
   // directly without materialising a contiguous copy of the full input.
   {
-    auto a = reshape(arange(8 * 128 * 1024, int32), {8, 128, 1024});
+    auto a = reshape(arange(8 * 256 * 1024, int32), {8, 256, 1024});
+    a = slice(a, {0, 0, 0}, {8, 256, 1024}, {1, 2, 1});
     a = transpose(a, {0, 2, 1});
     auto out_gpu = sum(a, 1, false, Device::gpu);
     auto out_cpu = sum(a, 1, false, Device::cpu);


### PR DESCRIPTION
## Proposed changes

CUDA reductions currently materialise every non-contiguous input as a contiguous temporary, even when `GeneralContiguousReduce` can compute the non-reduction-axis offsets directly.

This change uses the direct row-reduction path for `GeneralContiguousReduce` inputs when the output contains at least 1,024 elements. General reductions, broadcasted inputs, and smaller outputs retain the existing copy path. This removes one full-input allocation, copy, and kernel launch for sufficiently parallel transposed reductions.

A C++ test checks exact CPU/GPU equivalence for the transposed layout handled by the new path.

### Validation

- CUDA C++ suite: 262 test cases and 3,412 assertions passed.
- Focused CUDA reduction test: 1 test case and 11 assertions passed.
- Python reduction suite: 10 tests passed.
- `pre-commit run --all-files` passed.
- `git diff --check` passed.

The broader Python CUDA suite did not complete because CUDA 13 runtime JIT compilation could not locate `cute/tensor.hpp`. This header-discovery problem is tracked by #3995; the dedicated reduction suite and complete C++ CUDA suite passed.

Apple Silicon wasn't tested here.

### Performance

Environment:

- NVIDIA GeForce RTX 4070 Laptop GPU, compute capability 8.9
- Debian under WSL2, kernel 5.15.167.4
- CUDA 13.2.86
- GCC 14.2.0
- CMake 3.31.6
- Release build
- Baseline `8d666298652fdac2e7727ecdcf507b1d199bba16`

The benchmark interleaved the previous copy-plus-reduce path with the direct path in one warmed process. It used 1,000 warm-up evaluations per path, followed by 15 alternating rounds of 500 evaluations. Reported values are medians of the per-round means.

| Transposed input | Input size | Copy + reduce | Direct reduce | Change |
|---|---:|---:|---:|---:|
| `16x4096x64`, axis 1 | 16 MiB | 0.171558 ms | 0.038077 ms | 77.81% faster |
| `32x2048x128`, axis 1 | 32 MiB | 0.424505 ms | 0.048314 ms | 88.62% faster |
| `16x8192x128`, axis 1 | 64 MiB | 0.860658 ms | 0.307498 ms | 64.27% faster |
| `32x8192x128`, axis 1 | 128 MiB | 1.765737 ms | 0.611335 ms | 65.38% faster |

No eligible measured case regressed. Outputs below the 1,024-element threshold retain the existing path. No API or documentation changes are required.

## Checklist

Put an x in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)