### PR TITLE
Reuse Stockham twiddles in large batched Bluestein FFTs

### DIFF
--- a/mlx/backend/metal/fft.cpp
+++ b/mlx/backend/metal/fft.cpp
@@ -320,8 +320,10 @@ std::tuple<array, array, array> compute_raders_constants(
 }
 
 // Bluestein
-std::pair<array, array>
-compute_bluestein_constants(int n, int bluestein_n, int radix_twiddle_size) {
+std::pair<array, array> compute_bluestein_constants(
+    int n,
+    int bluestein_n,
+    int radix_twiddle_size = 0) {
   // We need to calculate the Bluestein twiddle factors
   // in double precision for the overall numerical stability
   // of Bluestein's FFT algorithm to be acceptable.
@@ -365,10 +367,6 @@ compute_bluestein_constants(int n, int bluestein_n, int radix_twiddle_size) {
       /* data_out= */ w_q_ptr,
       /* scale= */ 1.0f);
   return std::make_tuple(w_k, w_q);
-}
-
-std::pair<array, array> compute_bluestein_constants(int n, int bluestein_n) {
-  return compute_bluestein_constants(n, bluestein_n, 0);
 }
 
 void multi_upload_bluestein_fft(

--- a/mlx/backend/metal/fft.cpp
+++ b/mlx/backend/metal/fft.cpp
@@ -2,6 +2,7 @@
 #include <cassert>
 #include <complex>
 #include <map>
+#include <numbers>
 #include <numeric>
 #include <set>
 #include <sstream>
@@ -27,6 +28,9 @@ using MTLFC = std::tuple<const void*, MTL::DataType, NS::UInteger>;
 #define MIN_THREADGROUP_MEM_SIZE 256
 // For strided reads/writes, coalesce at least this many complex64s
 #define MIN_COALESCE_WIDTH 4
+// Precomputed radix twiddles pay off for the largest batched fused plan.
+constexpr int BLUESTEIN_TWIDDLE_TABLE_FFT_SIZE = 4096;
+constexpr int MIN_BLUESTEIN_TWIDDLE_TABLE_BATCH = 1024;
 
 inline const std::vector<int> supported_radices() {
   // Ordered by preference in decomposition.
@@ -316,7 +320,10 @@ std::tuple<array, array, array> compute_raders_constants(
 }
 
 // Bluestein
-std::pair<array, array> compute_bluestein_constants(int n, int bluestein_n) {
+std::pair<array, array> compute_bluestein_constants(
+    int n,
+    int bluestein_n,
+    const std::vector<int>& stockham) {
   // We need to calculate the Bluestein twiddle factors
   // in double precision for the overall numerical stability
   // of Bluestein's FFT algorithm to be acceptable.
@@ -343,7 +350,33 @@ std::pair<array, array> compute_bluestein_constants(int n, int bluestein_n) {
   w_k.set_data(allocator::malloc(w_k.nbytes()));
   std::copy(w_k_vec.begin(), w_k_vec.end(), w_k.data<complex64_t>());
 
-  array w_q({bluestein_n}, complex64, nullptr, {});
+  std::vector<complex64_t> radix_twiddles;
+  int p = 1;
+  auto radices = supported_radices();
+  for (int i = static_cast<int>(stockham.size()) - 1; i >= 0; i--) {
+    int radix = radices[i];
+    for (int step = 0; step < stockham[i]; step++) {
+      if (p > 1) {
+        for (int k = 0; k < p; k++) {
+          double theta =
+              -2.0 * std::numbers::pi * static_cast<double>(k) / (radix * p);
+          radix_twiddles.emplace_back(
+              static_cast<float>(std::cos(theta)),
+              static_cast<float>(std::sin(theta)));
+        }
+      }
+      p *= radix;
+    }
+  }
+  if (!stockham.empty()) {
+    assert(p == bluestein_n);
+  }
+
+  array w_q(
+      {bluestein_n + static_cast<int>(radix_twiddles.size())},
+      complex64,
+      nullptr,
+      {});
   w_q.set_data(allocator::malloc(w_q.nbytes()));
   auto w_q_ptr =
       reinterpret_cast<std::complex<float>*>(w_q.data<complex64_t>());
@@ -359,7 +392,15 @@ std::pair<array, array> compute_bluestein_constants(int n, int bluestein_n) {
       /* data_in= */ w_q_vec.data(),
       /* data_out= */ w_q_ptr,
       /* scale= */ 1.0f);
+  std::copy(
+      radix_twiddles.begin(),
+      radix_twiddles.end(),
+      w_q.data<complex64_t>() + bluestein_n);
   return std::make_tuple(w_k, w_q);
+}
+
+std::pair<array, array> compute_bluestein_constants(int n, int bluestein_n) {
+  return compute_bluestein_constants(n, bluestein_n, {});
 }
 
 void multi_upload_bluestein_fft(
@@ -649,6 +690,12 @@ void fft_op(
     size = out.size();
   }
   int total_batch_size = size / n;
+  bool use_bluestein_twiddle_table = !real &&
+      plan.bluestein_n == BLUESTEIN_TWIDDLE_TABLE_FFT_SIZE &&
+      total_batch_size >= MIN_BLUESTEIN_TWIDDLE_TABLE_BATCH;
+  if (plan.bluestein_n > 0 && !real) {
+    func_consts.push_back(make_bool(&use_bluestein_twiddle_table, 22));
+  }
   int threads_per_fft = (fft_size + elems_per_thread - 1) / elems_per_thread;
 
   // We batch among threadgroups for improved efficiency when n is small
@@ -702,6 +749,9 @@ void fft_op(
     std::string base_name = kname.str();
     // We use a specialized kernel for each FFT size
     kname << "_n" << fft_size << "_inv_" << inverse;
+    if (use_bluestein_twiddle_table) {
+      kname << "_precomputed";
+    }
     std::string hash_name = kname.str();
     auto template_def = func_name == "four_step_fft" ? get_template_definition(
                                                            base_name,
@@ -726,7 +776,9 @@ void fft_op(
 
     if (plan.bluestein_n > 0) {
       // Precomputed twiddle factors for Bluestein's
-      auto [w_k, w_q] = compute_bluestein_constants(n, plan.bluestein_n);
+      auto [w_k, w_q] = use_bluestein_twiddle_table
+          ? compute_bluestein_constants(n, plan.bluestein_n, plan.stockham)
+          : compute_bluestein_constants(n, plan.bluestein_n);
       copies.push_back(w_q);
       copies.push_back(w_k);
 

--- a/mlx/backend/metal/fft.cpp
+++ b/mlx/backend/metal/fft.cpp
@@ -2,7 +2,6 @@
 #include <cassert>
 #include <complex>
 #include <map>
-#include <numbers>
 #include <numeric>
 #include <set>
 #include <sstream>
@@ -30,6 +29,7 @@ using MTLFC = std::tuple<const void*, MTL::DataType, NS::UInteger>;
 #define MIN_COALESCE_WIDTH 4
 // Precomputed radix twiddles pay off for the largest batched fused plan.
 constexpr int BLUESTEIN_TWIDDLE_TABLE_FFT_SIZE = 4096;
+constexpr int BLUESTEIN_TWIDDLE_TABLE_SIZE = 584;
 constexpr int MIN_BLUESTEIN_TWIDDLE_TABLE_BATCH = 1024;
 
 inline const std::vector<int> supported_radices() {
@@ -320,10 +320,8 @@ std::tuple<array, array, array> compute_raders_constants(
 }
 
 // Bluestein
-std::pair<array, array> compute_bluestein_constants(
-    int n,
-    int bluestein_n,
-    const std::vector<int>& stockham) {
+std::pair<array, array>
+compute_bluestein_constants(int n, int bluestein_n, int radix_twiddle_size) {
   // We need to calculate the Bluestein twiddle factors
   // in double precision for the overall numerical stability
   // of Bluestein's FFT algorithm to be acceptable.
@@ -350,33 +348,7 @@ std::pair<array, array> compute_bluestein_constants(
   w_k.set_data(allocator::malloc(w_k.nbytes()));
   std::copy(w_k_vec.begin(), w_k_vec.end(), w_k.data<complex64_t>());
 
-  std::vector<complex64_t> radix_twiddles;
-  int p = 1;
-  auto radices = supported_radices();
-  for (int i = static_cast<int>(stockham.size()) - 1; i >= 0; i--) {
-    int radix = radices[i];
-    for (int step = 0; step < stockham[i]; step++) {
-      if (p > 1) {
-        for (int k = 0; k < p; k++) {
-          double theta =
-              -2.0 * std::numbers::pi * static_cast<double>(k) / (radix * p);
-          radix_twiddles.emplace_back(
-              static_cast<float>(std::cos(theta)),
-              static_cast<float>(std::sin(theta)));
-        }
-      }
-      p *= radix;
-    }
-  }
-  if (!stockham.empty()) {
-    assert(p == bluestein_n);
-  }
-
-  array w_q(
-      {bluestein_n + static_cast<int>(radix_twiddles.size())},
-      complex64,
-      nullptr,
-      {});
+  array w_q({bluestein_n + radix_twiddle_size}, complex64, nullptr, {});
   w_q.set_data(allocator::malloc(w_q.nbytes()));
   auto w_q_ptr =
       reinterpret_cast<std::complex<float>*>(w_q.data<complex64_t>());
@@ -392,15 +364,11 @@ std::pair<array, array> compute_bluestein_constants(
       /* data_in= */ w_q_vec.data(),
       /* data_out= */ w_q_ptr,
       /* scale= */ 1.0f);
-  std::copy(
-      radix_twiddles.begin(),
-      radix_twiddles.end(),
-      w_q.data<complex64_t>() + bluestein_n);
   return std::make_tuple(w_k, w_q);
 }
 
 std::pair<array, array> compute_bluestein_constants(int n, int bluestein_n) {
-  return compute_bluestein_constants(n, bluestein_n, {});
+  return compute_bluestein_constants(n, bluestein_n, 0);
 }
 
 void multi_upload_bluestein_fft(
@@ -690,8 +658,11 @@ void fft_op(
     size = out.size();
   }
   int total_batch_size = size / n;
+  static const std::vector<int> bluestein_twiddle_table_plan = {
+      0, 0, 4, 0, 0, 0, 0, 0, 0};
   bool use_bluestein_twiddle_table = !real &&
       plan.bluestein_n == BLUESTEIN_TWIDDLE_TABLE_FFT_SIZE &&
+      plan.stockham == bluestein_twiddle_table_plan &&
       total_batch_size >= MIN_BLUESTEIN_TWIDDLE_TABLE_BATCH;
   if (plan.bluestein_n > 0 && !real) {
     func_consts.push_back(make_bool(&use_bluestein_twiddle_table, 22));
@@ -770,17 +741,34 @@ void fft_op(
     auto kernel =
         get_fft_kernel(d, base_name, hash_name, func_consts, template_def);
 
-    compute_encoder.set_compute_pipeline_state(kernel);
-    compute_encoder.set_input_array(in_contiguous, 0);
-    compute_encoder.set_output_array(out, 1);
-
     if (plan.bluestein_n > 0) {
       // Precomputed twiddle factors for Bluestein's
       auto [w_k, w_q] = use_bluestein_twiddle_table
-          ? compute_bluestein_constants(n, plan.bluestein_n, plan.stockham)
+          ? compute_bluestein_constants(
+                n, plan.bluestein_n, BLUESTEIN_TWIDDLE_TABLE_SIZE)
           : compute_bluestein_constants(n, plan.bluestein_n);
       copies.push_back(w_q);
       copies.push_back(w_k);
+
+      if (use_bluestein_twiddle_table) {
+        auto twiddle_kernel =
+            get_fft_twiddle_kernel(d, base_name, template_def);
+        compute_encoder.set_compute_pipeline_state(twiddle_kernel);
+        compute_encoder.set_output_array(
+            w_q,
+            0,
+            plan.bluestein_n * static_cast<int64_t>(sizeof(complex64_t)));
+        auto twiddle_group_size = std::min(
+            static_cast<NS::UInteger>(BLUESTEIN_TWIDDLE_TABLE_SIZE),
+            twiddle_kernel->maxTotalThreadsPerThreadgroup());
+        compute_encoder.dispatch_threads(
+            MTL::Size(BLUESTEIN_TWIDDLE_TABLE_SIZE, 1, 1),
+            MTL::Size(twiddle_group_size, 1, 1));
+      }
+
+      compute_encoder.set_compute_pipeline_state(kernel);
+      compute_encoder.set_input_array(in_contiguous, 0);
+      compute_encoder.set_output_array(out, 1);
 
       compute_encoder.set_input_array(w_q, 2); // w_q
       compute_encoder.set_input_array(w_k, 3); // w_k
@@ -788,6 +776,10 @@ void fft_op(
       compute_encoder.set_bytes(plan.bluestein_n, 5);
       compute_encoder.set_bytes(total_batch_size, 6);
     } else if (plan.rader_n > 1) {
+      compute_encoder.set_compute_pipeline_state(kernel);
+      compute_encoder.set_input_array(in_contiguous, 0);
+      compute_encoder.set_output_array(out, 1);
+
       auto [b_q, g_q, g_minus_q] = compute_raders_constants(plan.rader_n, s);
       copies.push_back(b_q);
       copies.push_back(g_q);
@@ -800,10 +792,18 @@ void fft_op(
       compute_encoder.set_bytes(total_batch_size, 6);
       compute_encoder.set_bytes(plan.rader_n, 7);
     } else if (four_step_params.required) {
+      compute_encoder.set_compute_pipeline_state(kernel);
+      compute_encoder.set_input_array(in_contiguous, 0);
+      compute_encoder.set_output_array(out, 1);
+
       compute_encoder.set_bytes(four_step_params.n1, 2);
       compute_encoder.set_bytes(four_step_params.n2, 3);
       compute_encoder.set_bytes(total_batch_size, 4);
     } else {
+      compute_encoder.set_compute_pipeline_state(kernel);
+      compute_encoder.set_input_array(in_contiguous, 0);
+      compute_encoder.set_output_array(out, 1);
+
       compute_encoder.set_bytes(n, 2);
       compute_encoder.set_bytes(total_batch_size, 3);
     }

--- a/mlx/backend/metal/jit_kernels.cpp
+++ b/mlx/backend/metal/jit_kernels.cpp
@@ -989,6 +989,18 @@ MTL::ComputePipelineState* get_fft_kernel(
   return d.get_kernel(kernel_name, lib, hash_name, func_consts);
 }
 
+MTL::ComputePipelineState* get_fft_twiddle_kernel(
+    metal::Device& d,
+    const std::string& library_name,
+    const std::string& template_def) {
+  auto lib = d.get_library(library_name, [&]() {
+    std::ostringstream kernel_source;
+    kernel_source << metal::fft() << template_def;
+    return kernel_source.str();
+  });
+  return d.get_kernel("generate_bluestein_twiddles", lib);
+}
+
 MTL::ComputePipelineState* get_quantized_kernel(
     metal::Device& d,
     const std::string& kernel_name,

--- a/mlx/backend/metal/kernels.h
+++ b/mlx/backend/metal/kernels.h
@@ -290,6 +290,11 @@ MTL::ComputePipelineState* get_fft_kernel(
     const metal::MTLFCList& func_consts,
     const std::string& template_def);
 
+MTL::ComputePipelineState* get_fft_twiddle_kernel(
+    metal::Device& d,
+    const std::string& library_name,
+    const std::string& template_def);
+
 MTL::ComputePipelineState* get_quantized_kernel(
     metal::Device& d,
     const std::string& kernel_name,

--- a/mlx/backend/metal/kernels/fft.h
+++ b/mlx/backend/metal/kernels/fft.h
@@ -215,14 +215,14 @@ METAL_FUNC void radix_n_steps(
       buf,                                                   \
       twiddles);
 
-template <typename T, bool rader, bool use_twiddle_table>
+template <typename T, bool rader = false, bool use_twiddle_table = false>
 METAL_FUNC void perform_fft(
     int fft_idx,
     thread int* p,
     int m,
     int n,
     threadgroup vec<T, 2>* buf,
-    const device vec<T, 2>* twiddles) {
+    const device vec<T, 2>* twiddles = nullptr) {
   vec<T, 2> inputs[MAX_RADIX];
   short indices[MAX_OUTPUT_SIZE];
   vec<T, 2> values[MAX_OUTPUT_SIZE];
@@ -237,16 +237,6 @@ METAL_FUNC void perform_fft(
   RADIX_STEP(8, radix8, rader ? rader_8_steps_ : radix_8_steps_);
   RADIX_STEP(11, radix11, rader ? rader_11_steps_ : radix_11_steps_);
   RADIX_STEP(13, radix13, rader ? rader_13_steps_ : radix_13_steps_);
-}
-
-template <typename T, bool rader = false>
-METAL_FUNC void perform_fft(
-    int fft_idx,
-    thread int* p,
-    int m,
-    int n,
-    threadgroup vec<T, 2>* buf) {
-  perform_fft<T, rader, false>(fft_idx, p, m, n, buf, nullptr);
 }
 
 // Each FFT is computed entirely in shared GPU memory.

--- a/mlx/backend/metal/kernels/fft.h
+++ b/mlx/backend/metal/kernels/fft.h
@@ -47,6 +47,27 @@ STEEL_CONST int rader_3_steps_ [[function_constant(20)]];
 STEEL_CONST int rader_2_steps_ [[function_constant(21)]];
 STEEL_CONST bool use_bluestein_twiddle_table_ [[function_constant(22)]];
 
+// Generate the compact radix-8 Stockham twiddle table used by the fused
+// 4096-point Bluestein convolution. The first p=1 stage needs no twiddles;
+// the remaining stages contribute 8, 64, and 512 entries.
+[[kernel]] void generate_bluestein_twiddles(
+    device float2* twiddles [[buffer(0)]],
+    uint index [[thread_position_in_grid]]) {
+  uint p;
+  uint k;
+  if (index < 8) {
+    p = 8;
+    k = index;
+  } else if (index < 72) {
+    p = 64;
+    k = index - 8;
+  } else {
+    p = 512;
+    k = index - 72;
+  }
+  twiddles[index] = get_twiddle<float>(k, 8 * p);
+}
+
 // See "radix.h" for radix codelets.
 template <typename T>
 using RadixFunc = void (*)(thread vec<T, 2>*, thread vec<T, 2>*);

--- a/mlx/backend/metal/kernels/fft.h
+++ b/mlx/backend/metal/kernels/fft.h
@@ -45,19 +45,26 @@ STEEL_CONST int rader_5_steps_ [[function_constant(18)]];
 STEEL_CONST int rader_4_steps_ [[function_constant(19)]];
 STEEL_CONST int rader_3_steps_ [[function_constant(20)]];
 STEEL_CONST int rader_2_steps_ [[function_constant(21)]];
+STEEL_CONST bool use_bluestein_twiddle_table_ [[function_constant(22)]];
 
 // See "radix.h" for radix codelets.
 template <typename T>
 using RadixFunc = void (*)(thread vec<T, 2>*, thread vec<T, 2>*);
 
 // Perform a single radix n butterfly with appropriate twiddles
-template <typename T, int radix, RadixFunc<T> radix_func>
+template <
+    typename T,
+    bool use_twiddle_table,
+    int radix,
+    RadixFunc<T> radix_func>
 METAL_FUNC void radix_butterfly(
     int i,
     int p,
+    int twiddle_offset,
     thread vec<T, 2>* x,
     thread short* indices,
-    thread vec<T, 2>* y) {
+    thread vec<T, 2>* y,
+    const device vec<T, 2>* twiddles) {
   // i: the index in the overall DFT that we're processing.
   // p: the size of the DFTs we're merging at this step.
   // m: how many threads are working on this DFT.
@@ -76,7 +83,12 @@ METAL_FUNC void radix_butterfly(
 
   // Apply twiddles
   if (p > 1) {
-    vec<T, 2> twiddle_1 = get_twiddle<T>(k, radix * p);
+    vec<T, 2> twiddle_1;
+    if constexpr (use_twiddle_table) {
+      twiddle_1 = twiddles[twiddle_offset + k];
+    } else {
+      twiddle_1 = get_twiddle<T>(k, radix * p);
+    }
     vec<T, 2> twiddle = twiddle_1;
     x[1] = complex_mul<T>(x[1], twiddle);
 
@@ -97,17 +109,23 @@ METAL_FUNC void radix_butterfly(
 
 // Perform all the radix steps required for a
 // particular radix size n.
-template <typename T, int radix, RadixFunc<T> radix_func>
+template <
+    typename T,
+    bool use_twiddle_table,
+    int radix,
+    RadixFunc<T> radix_func>
 METAL_FUNC void radix_n_steps(
     int i,
     thread int* p,
+    thread int* twiddle_offset,
     int m,
     int n,
     int num_steps,
     thread vec<T, 2>* inputs,
     thread short* indices,
     thread vec<T, 2>* values,
-    threadgroup vec<T, 2>* buf) {
+    threadgroup vec<T, 2>* buf,
+    const device vec<T, 2>* twiddles) {
   int m_r = n / radix;
   // When combining different sized radices, we have to do
   // multiple butterflies in a single thread.
@@ -127,8 +145,14 @@ METAL_FUNC void radix_n_steps(
         for (int r = 0; r < radix; r++) {
           inputs[r] = buf[index + r * m_r];
         }
-        radix_butterfly<T, radix, radix_func>(
-            index, *p, inputs, indices + t * radix, values + t * radix);
+        radix_butterfly<T, use_twiddle_table, radix, radix_func>(
+            index,
+            *p,
+            *twiddle_offset,
+            inputs,
+            indices + t * radix,
+            values + t * radix,
+            twiddles);
       }
     }
 
@@ -147,24 +171,41 @@ METAL_FUNC void radix_n_steps(
 
     // Wait until all threads have written back to threadgroup mem
     threadgroup_barrier(mem_flags::mem_threadgroup);
+    if constexpr (use_twiddle_table) {
+      if (*p > 1) {
+        *twiddle_offset += *p;
+      }
+    }
     *p *= radix;
   }
 }
 
-#define RADIX_STEP(radix, radix_func, num_steps) \
-  radix_n_steps<T, radix, radix_func<T>>(        \
-      fft_idx, p, m, n, num_steps, inputs, indices, values, buf);
+#define RADIX_STEP(radix, radix_func, num_steps)             \
+  radix_n_steps<T, use_twiddle_table, radix, radix_func<T>>( \
+      fft_idx,                                               \
+      p,                                                     \
+      &twiddle_offset,                                       \
+      m,                                                     \
+      n,                                                     \
+      num_steps,                                             \
+      inputs,                                                \
+      indices,                                               \
+      values,                                                \
+      buf,                                                   \
+      twiddles);
 
-template <typename T, bool rader = false>
+template <typename T, bool rader, bool use_twiddle_table>
 METAL_FUNC void perform_fft(
     int fft_idx,
     thread int* p,
     int m,
     int n,
-    threadgroup vec<T, 2>* buf) {
+    threadgroup vec<T, 2>* buf,
+    const device vec<T, 2>* twiddles) {
   vec<T, 2> inputs[MAX_RADIX];
   short indices[MAX_OUTPUT_SIZE];
   vec<T, 2> values[MAX_OUTPUT_SIZE];
+  int twiddle_offset = 0;
 
   RADIX_STEP(2, radix2, rader ? rader_2_steps_ : radix_2_steps_);
   RADIX_STEP(3, radix3, rader ? rader_3_steps_ : radix_3_steps_);
@@ -175,6 +216,16 @@ METAL_FUNC void perform_fft(
   RADIX_STEP(8, radix8, rader ? rader_8_steps_ : radix_8_steps_);
   RADIX_STEP(11, radix11, rader ? rader_11_steps_ : radix_11_steps_);
   RADIX_STEP(13, radix13, rader ? rader_13_steps_ : radix_13_steps_);
+}
+
+template <typename T, bool rader = false>
+METAL_FUNC void perform_fft(
+    int fft_idx,
+    thread int* p,
+    int m,
+    int n,
+    threadgroup vec<T, 2>* buf) {
+  perform_fft<T, rader, false>(fft_idx, p, m, n, buf, nullptr);
 }
 
 // Each FFT is computed entirely in shared GPU memory.
@@ -437,9 +488,20 @@ template <int tg_mem_size, typename in_T, typename out_T>
   int m = grid.z; // Threads per DFT
   int tg_idx = elem.y * n; // Index of this DFT in threadgroup
   threadgroup vec<scalar_T, 2>* buf = &shared_in[tg_idx];
+  const device vec<scalar_T, 2>* twiddles = w_q + n;
 
   // fft
-  perform_fft<scalar_T>(fft_idx, &p, m, n, buf);
+  if constexpr (
+      tg_mem_size == 4096 && metal::is_same_v<in_T, float2> &&
+      metal::is_same_v<out_T, float2>) {
+    if (use_bluestein_twiddle_table_) {
+      perform_fft<scalar_T, false, true>(fft_idx, &p, m, n, buf, twiddles);
+    } else {
+      perform_fft<scalar_T>(fft_idx, &p, m, n, buf);
+    }
+  } else {
+    perform_fft<scalar_T>(fft_idx, &p, m, n, buf);
+  }
 
   vec<scalar_T, 2> convolution_factor = {1.0f, -1.0f};
   if constexpr (!metal::is_same_v<scalar_T, float>) {
@@ -458,7 +520,17 @@ template <int tg_mem_size, typename in_T, typename out_T>
 
   // ifft
   p = 1;
-  perform_fft<scalar_T>(fft_idx, &p, m, n, buf);
+  if constexpr (
+      tg_mem_size == 4096 && metal::is_same_v<in_T, float2> &&
+      metal::is_same_v<out_T, float2>) {
+    if (use_bluestein_twiddle_table_) {
+      perform_fft<scalar_T, false, true>(fft_idx, &p, m, n, buf, twiddles);
+    } else {
+      perform_fft<scalar_T>(fft_idx, &p, m, n, buf);
+    }
+  } else {
+    perform_fft<scalar_T>(fft_idx, &p, m, n, buf);
+  }
 
   read_writer.write_padded(length, w_k);
 }

--- a/mlx/backend/metal/nojit_kernels.cpp
+++ b/mlx/backend/metal/nojit_kernels.cpp
@@ -345,6 +345,13 @@ MTL::ComputePipelineState* get_fft_kernel(
   return d.get_kernel(kernel_name, hash_name, func_consts);
 }
 
+MTL::ComputePipelineState* get_fft_twiddle_kernel(
+    metal::Device& d,
+    const std::string&,
+    const std::string&) {
+  return d.get_kernel("generate_bluestein_twiddles");
+}
+
 MTL::ComputePipelineState* get_quantized_kernel(
     metal::Device& d,
     const std::string& kernel_name,

--- a/python/tests/test_fft.py
+++ b/python/tests/test_fft.py
@@ -168,6 +168,26 @@ class TestFFT(mlx_tests.MLXTestCase):
                 atol = 1e-4 if num < 1025 else 1e-3
                 self._run_ffts((batch_size, num), atol=atol)
 
+    @unittest.skipIf(not mx.metal.is_available(), "Metal is not available")
+    def test_batched_bluestein_twiddle_table(self):
+        batch, n = 1024, 1031
+
+        with mx.stream(mx.gpu):
+            impulse = (mx.arange(n) == 1).astype(mx.complex64)
+            expected_fft = mx.fft.fft(impulse)
+            expected_ifft = mx.fft.ifft(impulse)
+            signal = mx.broadcast_to(impulse, (batch, n))
+            output_fft = mx.fft.fft(signal)
+            output_ifft = mx.fft.ifft(signal)
+            mx.eval(expected_fft, expected_ifft, output_fft, output_ifft)
+
+        self.assertTrue(
+            mx.allclose(output_fft, expected_fft[None], atol=1e-3, rtol=1e-4)
+        )
+        self.assertTrue(
+            mx.allclose(output_ifft, expected_ifft[None], atol=1e-4, rtol=1e-4)
+        )
+
     @unittest.skip("Too slow for CI but useful for local testing.")
     def test_fft_exhaustive(self):
         nums = range(2, 4097)

--- a/python/tests/test_fft.py
+++ b/python/tests/test_fft.py
@@ -170,23 +170,26 @@ class TestFFT(mlx_tests.MLXTestCase):
 
     @unittest.skipIf(not mx.metal.is_available(), "Metal is not available")
     def test_batched_bluestein_twiddle_table(self):
-        batch, n = 1024, 1031
+        for batch, n in ((1023, 1031), (1024, 1031), (1024, 1531)):
+            with self.subTest(batch=batch, n=n), mx.stream(mx.gpu):
+                index = mx.arange(n, dtype=mx.float32)
+                base = mx.cos(index * 0.017) + 0.25 * mx.sin(index * 0.031)
+                base = base + 1j * (
+                    mx.sin(index * 0.023) - 0.125 * mx.cos(index * 0.047)
+                )
+                scale_index = mx.arange(batch, dtype=mx.float32)
+                scales = (0.75 + 0.25 * mx.cos(scale_index * 0.013)) * (
+                    mx.cos(scale_index * 0.019) + 1j * mx.sin(scale_index * 0.019)
+                )
+                signal = scales[:, None] * base[None, :]
 
-        with mx.stream(mx.gpu):
-            impulse = (mx.arange(n) == 1).astype(mx.complex64)
-            expected_fft = mx.fft.fft(impulse)
-            expected_ifft = mx.fft.ifft(impulse)
-            signal = mx.broadcast_to(impulse, (batch, n))
-            output_fft = mx.fft.fft(signal)
-            output_ifft = mx.fft.ifft(signal)
-            mx.eval(expected_fft, expected_ifft, output_fft, output_ifft)
-
-        self.assertTrue(
-            mx.allclose(output_fft, expected_fft[None], atol=1e-3, rtol=1e-4)
-        )
-        self.assertTrue(
-            mx.allclose(output_ifft, expected_ifft[None], atol=1e-4, rtol=1e-4)
-        )
+                for transform, atol in ((mx.fft.fft, 1e-3), (mx.fft.ifft, 1e-4)):
+                    expected = scales[:, None] * transform(base)[None, :]
+                    output = transform(signal)
+                    mx.eval(expected, output)
+                    self.assertTrue(
+                        mx.allclose(output, expected, atol=atol, rtol=1e-4).item()
+                    )
 
     @unittest.skip("Too slow for CI but useful for local testing.")
     def test_fft_exhaustive(self):


### PR DESCRIPTION
## Proposed changes

Fused Bluestein FFTs run the same Stockham plan twice and currently recompute its radix twiddles in each pass. For complex64 transforms using the 4096-point internal plan with total batch at least 1024, this change dispatches one private Metal kernel to generate a 584-value twiddle table, then reuses it in both internal transforms. Smaller batches, other plans, and real transforms retain dynamic twiddles. There are no public API changes.

## Results

The implementation was benchmarked against `main` at `bb6d960f` on an Apple M5 Max using static Metal. Across 20 selected end-to-end `fft` and `ifft` cells, the median of the per-cell candidate/main ratios was `1.03856x` (3.856%). Each full-matrix cell used six balanced fresh-process rounds, 10 warmups, and nine samples of 30 transforms. Fresh 12- or 24-round targeted reruns placed every initially noisy candidate/main 95% lower bound above 1.0. The targeted 2047-point, batch-2048 cases remained near-neutral at `1.0056x` forward and `1.0028x` inverse. An unchanged 4096-point Stockham control measured `0.9984x`, with a 95% interval of `[0.9817, 1.0186]`.

All 48 deterministic accuracy comparisons passed. Relative to the benchmark baseline, the selected path adds 16,384 bytes of measured peak allocation, 38,432 bytes to `mlx.metallib`, 4,080 bytes to `libmlx.a`, and one private Metal kernel entry point.

## Validation

- Resealed on exact current `main` at `7729d587`
- Static and JIT Metal builds passed with warnings treated as errors
- Static FFT module: 16 passed, 2 expected skips
- JIT FFT module: 16 passed, 2 expected skips
- In both build-directory native runs, the candidate reproduced the same six failing linalg cases and 17 failed assertions as the exact-main baseline; there were no candidate-only failures
- Pre-commit on all six changed files and diff check passed

## Checklist

- [x] I have read the contributing guide
- [x] I have run pre-commit on all changed files
- [x] I have added tests for the selected and threshold-control paths
- [x] Documentation is not needed because there is no public API change
