### PR TITLE
Refactor CPU Arange dtype dispatch

### DIFF
--- a/mlx/backend/cpu/primitives.cpp
+++ b/mlx/backend/cpu/primitives.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <numeric>
 #include <sstream>
+#include <type_traits>
 
 #include "mlx/allocator.h"
 #include "mlx/backend/common/slicing.h"
@@ -13,6 +14,7 @@
 #include "mlx/backend/cpu/copy.h"
 #include "mlx/backend/cpu/encoder.h"
 #include "mlx/backend/cpu/threefry.h"
+#include "mlx/dtype_utils.h"
 #include "mlx/primitives.h"
 #include "mlx/utils.h"
 
@@ -125,50 +127,14 @@ void Transpose::eval_cpu(const std::vector<array>& inputs, array& out) {
 void Arange::eval_cpu(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 0);
   out.set_data(allocator::malloc(out.nbytes()));
-  switch (out.dtype()) {
-    case bool_:
+  dispatch_all_types(out.dtype(), [&](auto type_tag) {
+    using T = MLX_GET_TYPE(type_tag);
+    if constexpr (std::is_same_v<T, bool>) {
       throw std::runtime_error("Bool type unsupported for arange.");
-      break;
-    case uint8:
-      arange<uint8_t>(start_, start_ + step_, out, out.size(), stream());
-      break;
-    case uint16:
-      arange<uint16_t>(start_, start_ + step_, out, out.size(), stream());
-      break;
-    case uint32:
-      arange<uint32_t>(start_, start_ + step_, out, out.size(), stream());
-      break;
-    case uint64:
-      arange<uint64_t>(start_, start_ + step_, out, out.size(), stream());
-      break;
-    case int8:
-      arange<int8_t>(start_, start_ + step_, out, out.size(), stream());
-      break;
-    case int16:
-      arange<int16_t>(start_, start_ + step_, out, out.size(), stream());
-      break;
-    case int32:
-      arange<int32_t>(start_, start_ + step_, out, out.size(), stream());
-      break;
-    case int64:
-      arange<int64_t>(start_, start_ + step_, out, out.size(), stream());
-      break;
-    case float16:
-      arange<float16_t>(start_, start_ + step_, out, out.size(), stream());
-      break;
-    case float32:
-      arange<float>(start_, start_ + step_, out, out.size(), stream());
-      break;
-    case float64:
-      arange<double>(start_, start_ + step_, out, out.size(), stream());
-      break;
-    case bfloat16:
-      arange<bfloat16_t>(start_, start_ + step_, out, out.size(), stream());
-      break;
-    case complex64:
-      arange<complex64_t>(start_, start_ + step_, out, out.size(), stream());
-      break;
-  }
+    } else {
+      arange<T>(start_, start_ + step_, out, out.size(), stream());
+    }
+  });
 }
 
 void AsType::eval_cpu(const std::vector<array>& inputs, array& out) {


### PR DESCRIPTION
CPU Arange has the same exhaustive dtype mapping cleaned up in #4064–#4066. Replace the switch with `dispatch_all_types`, preserving the explicit bool rejection and the existing `arange<T>` specializations for all supported dtypes.

### Testing

- CPU Release build with C++20 and warnings as errors
- Python Arange tests and all 13 supported output dtypes
- Serial native C++ suite (246/246 cases, 3272/3272 assertions)
- `pre-commit` formatting checks