### PR TITLE
Fix Device and Stream lexicographic ordering

### DIFF
--- a/mlx/device.h
+++ b/mlx/device.h
@@ -5,6 +5,7 @@
 #include "mlx/api.h"
 
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <variant>
 
@@ -27,7 +28,7 @@ struct MLX_API Device {
   // TODO: Use default three-way comparison when it gets supported in XCode.
   bool operator==(const Device&) const = default;
   bool operator<(const Device& rhs) const {
-    return type < rhs.type || index < rhs.index;
+    return std::tie(type, index) < std::tie(rhs.type, rhs.index);
   }
 };
 

--- a/mlx/stream.h
+++ b/mlx/stream.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <tuple>
 #include <vector>
 
 #include "mlx/api.h"
@@ -17,7 +18,7 @@ struct MLX_API Stream {
   // TODO: Use default three-way comparison when it gets supported in XCode.
   bool operator==(const Stream&) const = default;
   bool operator<(const Stream& rhs) const {
-    return device < rhs.device || index < rhs.index;
+    return std::tie(device, index) < std::tie(rhs.device, rhs.index);
   }
 };
 

--- a/tests/device_tests.cpp
+++ b/tests/device_tests.cpp
@@ -2,11 +2,56 @@
 
 #include "doctest/doctest.h"
 
+#include <algorithm>
+#include <array>
 #include <cstdlib>
+#include <set>
 
 #include "mlx/mlx.h"
 
 using namespace mlx::core;
+
+template <typename T, size_t N>
+void check_strict_weak_ordering(const std::array<T, N>& ordered_values) {
+  for (const auto& value : ordered_values) {
+    CHECK_FALSE(value < value);
+  }
+
+  for (const auto& lhs : ordered_values) {
+    for (const auto& rhs : ordered_values) {
+      if (lhs < rhs) {
+        CHECK_FALSE(rhs < lhs);
+      }
+      for (const auto& other : ordered_values) {
+        if (lhs < rhs && rhs < other) {
+          CHECK(lhs < other);
+        }
+      }
+    }
+  }
+
+  std::set<T> values(ordered_values.begin(), ordered_values.end());
+  REQUIRE_EQ(values.size(), ordered_values.size());
+  CHECK(std::equal(values.begin(), values.end(), ordered_values.begin()));
+}
+
+TEST_CASE("test device and stream ordering") {
+  const std::array devices{
+      Device(Device::cpu, 0),
+      Device(Device::cpu, 3),
+      Device(Device::gpu, 0),
+      Device(Device::gpu, 1),
+      Device(Device::gpu, 2)};
+  check_strict_weak_ordering(devices);
+
+  const std::array streams{
+      Stream(0, Device::cpu),
+      Stream(3, Device::cpu),
+      Stream(0, Device::gpu),
+      Stream(1, Device::gpu),
+      Stream(2, Device::gpu)};
+  check_strict_weak_ordering(streams);
+}
 
 TEST_CASE("test device placement") {
   auto device = default_device();


### PR DESCRIPTION
## Proposed changes

Fixes #4083.

This makes `Device` and `Stream` comparisons lexicographic, so they satisfy strict weak ordering when the first and second fields sort in opposite directions.

I also added regression coverage for asymmetry, transitivity, and `std::set` ordering for both types.

## Testing

- `pre-commit run --files mlx/device.h mlx/stream.h tests/device_tests.cpp`
- `cmake -S . -B build -DMLX_BUILD_METAL=OFF -DMLX_BUILD_EXAMPLES=OFF -DMLX_BUILD_PYTHON_BINDINGS=OFF`
- `cmake --build build --target tests -j 8`
- `ctest --test-dir build --output-on-failure -j 1` (248/248 passed)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
