### PR TITLE
Refactor CPU SegmentedMM dtype dispatch

### DIFF
--- a/mlx/backend/cpu/masked_mm.cpp
+++ b/mlx/backend/cpu/masked_mm.cpp
@@ -8,6 +8,7 @@
 #include "mlx/backend/cpu/encoder.h"
 #include "mlx/backend/cpu/gemm.h"
 #include "mlx/backend/cpu/lapack.h"
+#include "mlx/dtype_utils.h"
 #include "mlx/primitives.h"
 
 namespace mlx::core {
@@ -525,83 +526,26 @@ void SegmentedMM::eval_cpu(const std::vector<array>& inputs, array& out) {
                     b_transposed = b_transposed,
                     lda = lda,
                     ldb = ldb]() {
-    switch (a.dtype()) {
-      case float64:
-        segmented_mm<double>(
-            a.data<double>(),
-            b.data<double>(),
-            segments.data<uint32_t>(),
-            static_cast<double*>(out_ptr),
-            a_transposed,
-            b_transposed,
-            lda,
-            ldb,
-            a.shape(),
-            a.strides(),
-            b.shape(),
-            b.strides(),
-            segments.size() / 2,
-            segments.shape(),
-            segments.strides());
-        break;
-      case float32:
-        segmented_mm<float>(
-            a.data<float>(),
-            b.data<float>(),
-            segments.data<uint32_t>(),
-            static_cast<float*>(out_ptr),
-            a_transposed,
-            b_transposed,
-            lda,
-            ldb,
-            a.shape(),
-            a.strides(),
-            b.shape(),
-            b.strides(),
-            segments.size() / 2,
-            segments.shape(),
-            segments.strides());
-        break;
-      case float16:
-        segmented_mm<float16_t>(
-            a.data<float16_t>(),
-            b.data<float16_t>(),
-            segments.data<uint32_t>(),
-            static_cast<float16_t*>(out_ptr),
-            a_transposed,
-            b_transposed,
-            lda,
-            ldb,
-            a.shape(),
-            a.strides(),
-            b.shape(),
-            b.strides(),
-            segments.size() / 2,
-            segments.shape(),
-            segments.strides());
-        break;
-      case bfloat16:
-        segmented_mm<bfloat16_t>(
-            a.data<bfloat16_t>(),
-            b.data<bfloat16_t>(),
-            segments.data<uint32_t>(),
-            static_cast<bfloat16_t*>(out_ptr),
-            a_transposed,
-            b_transposed,
-            lda,
-            ldb,
-            a.shape(),
-            a.strides(),
-            b.shape(),
-            b.strides(),
-            segments.size() / 2,
-            segments.shape(),
-            segments.strides());
-        break;
-      default:
-        throw std::invalid_argument(
-            "Segmented mm supports only real float types.");
-    }
+    dispatch_float_types(
+        a.dtype(), "[SegmentedMM::eval_cpu]", [&](auto type_tag) {
+          using T = MLX_GET_TYPE(type_tag);
+          segmented_mm<T>(
+              a.data<T>(),
+              b.data<T>(),
+              segments.data<uint32_t>(),
+              static_cast<T*>(out_ptr),
+              a_transposed,
+              b_transposed,
+              lda,
+              ldb,
+              a.shape(),
+              a.strides(),
+              b.shape(),
+              b.strides(),
+              segments.size() / 2,
+              segments.shape(),
+              segments.strides());
+        });
   });
 }
 


### PR DESCRIPTION
CPU SegmentedMM repeats the same operation for each floating-point dtype. Replace the switch with `dispatch_float_types`, preserving the four existing `segmented_mm<T>` specializations and their call arguments.

The public operation already validates and promotes inputs to a real floating dtype; `dispatch_float_types` remains the defensive backend validation.

### Testing

- CPU Release build with C++20 and warnings as errors
- Python BLAS suite (28 tests, 3 expected skips)
- All four supported floating dtypes and invalid-dtype controls compared with current `main`
- Serial native C++ suite (246/246 cases, 3272/3272 assertions)
- `pre-commit` formatting checks