### PR TITLE
Refactor CPU DivMod dtype dispatch

### DIFF
--- a/mlx/backend/cpu/binary.cpp
+++ b/mlx/backend/cpu/binary.cpp
@@ -3,12 +3,14 @@
 #include <cassert>
 #include <cmath>
 #include <sstream>
+#include <type_traits>
 
 #include "mlx/allocator.h"
 #include "mlx/backend/cpu/binary.h"
 #include "mlx/backend/cpu/binary_ops.h"
 #include "mlx/backend/cpu/binary_two.h"
 #include "mlx/backend/cpu/encoder.h"
+#include "mlx/dtype_utils.h"
 #include "mlx/primitives.h"
 #include "mlx/utils.h"
 
@@ -51,51 +53,16 @@ void DivMod::eval_cpu(
       return std::make_pair(std::trunc(x / y), std::fmod(x, y));
     };
 
-    switch (out_a.dtype()) {
-      case bool_:
-        binary_op<bool>(a, b, out_a, out_b, integral_op, bopt);
-        break;
-      case uint8:
-        binary_op<uint8_t>(a, b, out_a, out_b, integral_op, bopt);
-        break;
-      case uint16:
-        binary_op<uint16_t>(a, b, out_a, out_b, integral_op, bopt);
-        break;
-      case uint32:
-        binary_op<uint32_t>(a, b, out_a, out_b, integral_op, bopt);
-        break;
-      case uint64:
-        binary_op<uint64_t>(a, b, out_a, out_b, integral_op, bopt);
-        break;
-      case int8:
-        binary_op<int8_t>(a, b, out_a, out_b, integral_op, bopt);
-        break;
-      case int16:
-        binary_op<int16_t>(a, b, out_a, out_b, integral_op, bopt);
-        break;
-      case int32:
-        binary_op<int32_t>(a, b, out_a, out_b, integral_op, bopt);
-        break;
-      case int64:
-        binary_op<int64_t>(a, b, out_a, out_b, integral_op, bopt);
-        break;
-      case float16:
-        binary_op<float16_t>(a, b, out_a, out_b, float_op, bopt);
-        break;
-      case float32:
-        binary_op<float>(a, b, out_a, out_b, float_op, bopt);
-        break;
-      case float64:
-        binary_op<double>(a, b, out_a, out_b, float_op, bopt);
-        break;
-      case bfloat16:
-        binary_op<bfloat16_t>(a, b, out_a, out_b, float_op, bopt);
-        break;
-      case complex64:
-        // Should never get here
+    dispatch_all_types(out_a.dtype(), [&](auto type_tag) {
+      using T = MLX_GET_TYPE(type_tag);
+      if constexpr (std::is_same_v<T, complex64_t>) {
         throw std::runtime_error("[DivMod] Complex type not supported");
-        break;
-    }
+      } else if constexpr (std::is_integral_v<T>) {
+        binary_op<T>(a, b, out_a, out_b, integral_op, bopt);
+      } else {
+        binary_op<T>(a, b, out_a, out_b, float_op, bopt);
+      }
+    });
   });
 }
 


### PR DESCRIPTION
Replace the repeated dtype switch in the CPU DivMod implementation with the common dispatcher. Compile-time branches preserve the existing integral, floating-point, and complex-type behavior.

### Testing

- CPU Release build with C++20 and warnings as errors
- Python `divmod` coverage across all 13 real dtypes and complex rejection
- `python/tests/test_ops.py` (149/149)
- Serial native C++ suite (246/246 cases, 3272/3272 assertions)
- `pre-commit` formatting checks