### PR TITLE
fix: make Device and Stream operator< a strict weak ordering

### DIFF
--- a/mlx/device.h
+++ b/mlx/device.h
@@ -27,7 +27,10 @@ struct MLX_API Device {
   // TODO: Use default three-way comparison when it gets supported in XCode.
   bool operator==(const Device&) const = default;
   bool operator<(const Device& rhs) const {
-    return type < rhs.type || index < rhs.index;
+    if (type != rhs.type) {
+      return type < rhs.type;
+    }
+    return index < rhs.index;
   }
 };
 

--- a/mlx/stream.h
+++ b/mlx/stream.h
@@ -17,7 +17,10 @@ struct MLX_API Stream {
   // TODO: Use default three-way comparison when it gets supported in XCode.
   bool operator==(const Stream&) const = default;
   bool operator<(const Stream& rhs) const {
-    return device < rhs.device || index < rhs.index;
+    if (device != rhs.device) {
+      return device < rhs.device;
+    }
+    return index < rhs.index;
   }
 };
 

--- a/python/tests/test_device.py
+++ b/python/tests/test_device.py
@@ -146,5 +146,52 @@ class TestDeviceInfo(mlx_tests.MLXTestCase):
         self.assertIn("device_name", info)
 
 
+class TestStrictWeakOrdering(mlx_tests.MLXTestCase):
+    """Regression tests for issue #4083: Device/Stream operator< strict weak ordering.
+
+    The C++ operator< is not directly exposed in Python, so we verify the fix
+    by exercising std::set<Stream> in eval_impl which is the real-world crash path.
+    """
+
+    @unittest.skipIf(not mx.is_available(mx.gpu), "GPU is not available")
+    def test_eval_multi_device_streams(self):
+        """eval() with ops on both CPU and GPU streams must not crash.
+
+        This exercises std::set<Stream> in eval_impl which would abort
+        under libc++ hardening mode with the old non-SWO comparator.
+        """
+        gpu_stream = mx.new_stream(mx.gpu)
+        cpu_stream = mx.new_stream(mx.cpu)
+
+        mx.set_default_stream(gpu_stream)
+        a = mx.array([1.0, 2.0, 3.0])
+        b = mx.array([4.0, 5.0, 6.0])
+
+        mx.set_default_stream(cpu_stream)
+        c = mx.array([7.0, 8.0, 9.0])
+
+        # This path uses std::set<Stream> internally — would crash before the fix
+        mx.eval(a, b, c)
+        self.assertEqual(a.tolist(), [1.0, 2.0, 3.0])
+        self.assertEqual(c.tolist(), [7.0, 8.0, 9.0])
+
+    @unittest.skipIf(not mx.is_available(mx.gpu), "GPU is not available")
+    def test_eval_many_streams_repeated(self):
+        """Repeated eval() with interleaved CPU/GPU streams (regression test)."""
+        for _ in range(50):
+            gpu_stream = mx.new_stream(mx.gpu)
+            cpu_stream = mx.new_stream(mx.cpu)
+
+            mx.set_default_stream(gpu_stream)
+            a = mx.array([1.0]) + mx.array([2.0])
+
+            mx.set_default_stream(cpu_stream)
+            b = mx.array([3.0]) + mx.array([4.0])
+
+            mx.eval(a, b)
+            self.assertEqual(a.tolist(), [3.0])
+            self.assertEqual(b.tolist(), [7.0])
+
+
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner()


### PR DESCRIPTION
Fix `Device::operator<` and `Stream::operator<` to implement a proper strict weak ordering by replacing `||` with lexicographic comparison.

Both operators used `||` to combine field comparisons, which means `a < b` and `b < a` can both be true when the first field differs and the second field differs in the opposite direction. This violates the strict weak ordering contract required by `std::set` — which is what `eval_impl()` in `mlx/transforms.cpp` relies on for its `std::set<Stream>`. On libc++ with hardening enabled (Xcode 26+ SDK), this triggers a runtime assertion and crashes during cross-device `eval()` calls.

## Changes

- **`mlx/mlx/device.h`** — replaced `type < rhs.type || index < rhs.index` with lexicographic comparison (compare `type` first, then `index`)
- **`mlx/mlx/stream.h`** — replaced `device < rhs.device || index < rhs.index` with lexicographic comparison (compare `device` first, then `index`)
- **`python/tests/test_device.py`** — added regression tests that exercise the `std::set<Stream>` code path via `eval()` across CPU and GPU streams

## Testing

- `test_eval_multi_device_streams` — verifies `eval()` with ops on both CPU and GPU streams doesn't crash
- `test_eval_many_streams_repeated` — 50 iterations of interleaved cross-device eval to catch ordering regressions
- Full test suite passes (678 tests), all pre-commit hooks pass

Fixes #4083.
