### PR TITLE
Enable complex64 take_along_axis backward on Metal

### DIFF
--- a/mlx/backend/metal/indexing.cpp
+++ b/mlx/backend/metal/indexing.cpp
@@ -520,7 +520,8 @@ void GatherAxis::eval_gpu(const std::vector<array>& inputs, array& out) {
 }
 
 void ScatterAxis::eval_gpu(const std::vector<array>& inputs, array& out) {
-  if (size_of(out.dtype()) == 8) {
+  if (size_of(out.dtype()) == 8 &&
+      !(out.dtype() == complex64 && reduce_type_ == ScatterAxis::Sum)) {
     std::ostringstream msg;
     msg << "[ScatterAxis::eval_gpu] Does not support " << out.dtype();
     throw std::invalid_argument(msg.str());

--- a/python/tests/test_autograd.py
+++ b/python/tests/test_autograd.py
@@ -519,24 +519,22 @@ class TestAutograd(mlx_tests.MLXTestCase):
         grad = mx.grad(scatter_axis_fun)(mx.ones((3, 3)))
         self.assertTrue(mx.array_equal(grad, mx.ones((3, 3))))
 
-    @unittest.skipIf(not mx.metal.is_available(), "Metal is not available")
-    def test_take_along_axis_complex_vjp_metal(self):
-        with mx.stream(mx.gpu):
-            x = mx.zeros((4,), dtype=mx.complex64)
-            indices = mx.array([3, 3], dtype=mx.int32)
-            cotangent = mx.array([1 + 2j, 3 + 4j], dtype=mx.complex64)
-            _, (gradient,) = mx.vjp(
-                lambda z: mx.take_along_axis(z, indices, axis=0),
-                [x],
-                [cotangent],
-            )
-            mx.eval(gradient)
-            self.assertEqualArray(
-                gradient,
-                mx.array([0j, 0j, 0j, 4 + 6j], dtype=mx.complex64),
-                atol=0,
-                rtol=0,
-            )
+    def test_take_along_axis_complex_vjp(self):
+        x = mx.zeros((4,), dtype=mx.complex64)
+        indices = mx.array([3, 3], dtype=mx.int32)
+        cotangent = mx.array([1 + 2j, 3 + 4j], dtype=mx.complex64)
+        _, (gradient,) = mx.vjp(
+            lambda z: mx.take_along_axis(z, indices, axis=0),
+            [x],
+            [cotangent],
+        )
+        mx.eval(gradient)
+        self.assertEqualArray(
+            gradient,
+            mx.array([0j, 0j, 0j, 4 + 6j], dtype=mx.complex64),
+            atol=0,
+            rtol=0,
+        )
 
     def test_scatter_add_vjp(self):
         def fun(src, updates):

--- a/python/tests/test_autograd.py
+++ b/python/tests/test_autograd.py
@@ -519,6 +519,25 @@ class TestAutograd(mlx_tests.MLXTestCase):
         grad = mx.grad(scatter_axis_fun)(mx.ones((3, 3)))
         self.assertTrue(mx.array_equal(grad, mx.ones((3, 3))))
 
+    @unittest.skipIf(not mx.metal.is_available(), "Metal is not available")
+    def test_take_along_axis_complex_vjp_metal(self):
+        with mx.stream(mx.gpu):
+            x = mx.zeros((4,), dtype=mx.complex64)
+            indices = mx.array([3, 3], dtype=mx.int32)
+            cotangent = mx.array([1 + 2j, 3 + 4j], dtype=mx.complex64)
+            _, (gradient,) = mx.vjp(
+                lambda z: mx.take_along_axis(z, indices, axis=0),
+                [x],
+                [cotangent],
+            )
+            mx.eval(gradient)
+            self.assertEqualArray(
+                gradient,
+                mx.array([0j, 0j, 0j, 4 + 6j], dtype=mx.complex64),
+                atol=0,
+                rtol=0,
+            )
+
     def test_scatter_add_vjp(self):
         def fun(src, updates):
             x = src.at[mx.array([1, 3])].add(updates)


### PR DESCRIPTION
## Summary

Enable the existing Metal `ScatterAxis::Sum` path for `complex64`. This supports `take_along_axis` backward when duplicate indices require additive accumulation.

The eight-byte restriction is relaxed only for `complex64` in sum mode, reusing the componentwise atomic addition merged in #4078. Assignment and other eight-byte outputs remain unchanged. CUDA already supports this path; there is no public API or Metal-kernel change.

## Testing

- Complex `take_along_axis` VJP with duplicate indices under Metal API validation
- Full autograd module on CPU and Metal: 52 passed, 1 environment-dependent Torch test skipped on each
- Existing `take_along_axis` and `put_along_axis` controls on CPU and Metal
- Inherited #4078 complex scatter-add regression and unsupported assignment guard
- Release C++20 warnings-as-errors build, all eight JIT layout/location compile-link variants, and formatting checks