### PR TITLE
Refactor CPU equal_nan dtype dispatch

### DIFF
--- a/mlx/backend/cpu/binary.cpp
+++ b/mlx/backend/cpu/binary.cpp
@@ -96,26 +96,11 @@ void Equal::eval_cpu(const std::vector<array>& inputs, array& out) {
                       b = array::unsafe_weak_copy(b),
                       out = array::unsafe_weak_copy(out),
                       bopt]() mutable {
-      switch (a.dtype()) {
-        case float16:
-          binary_op<float16_t, bool, detail::NaNEqual>(a, b, out, bopt);
-          break;
-        case float32:
-          binary_op<float, bool, detail::NaNEqual>(a, b, out, bopt);
-          break;
-        case float64:
-          binary_op<double, bool, detail::NaNEqual>(a, b, out, bopt);
-          break;
-        case bfloat16:
-          binary_op<bfloat16_t, bool, detail::NaNEqual>(a, b, out, bopt);
-          break;
-        case complex64:
-          binary_op<complex64_t, bool, detail::NaNEqual>(a, b, out, bopt);
-          break;
-        default:
-          throw std::runtime_error(
-              "[NanEqual::eval_cpu] Only for floating point types.");
-      }
+      dispatch_inexact_types(
+          a.dtype(), "[NanEqual::eval_cpu]", [&](auto type_tag) {
+            using T = MLX_GET_TYPE(type_tag);
+            binary_op<T, bool, detail::NaNEqual>(a, b, out, bopt);
+          });
     });
   } else {
     comparison_op_cpu(a, b, out, detail::Equal(), stream());


### PR DESCRIPTION
CPU `Equal::eval_cpu` repeats the same `NaNEqual` operation for each inexact dtype. Replace the switch with `dispatch_inexact_types`, preserving the five existing specializations.

The public `array_equal` operation enables this path only for an inexact promoted dtype; `dispatch_inexact_types` remains the defensive backend validation.

### Testing

- CPU Release build with C++20 and warnings as errors
- `array_equal` coverage across all 14 current dtypes, including NaN, complex, mixed-promotion, and shape controls
- `python/tests/test_ops.py` (149/149)
- Serial native C++ suite (247/247 cases, 3326/3326 assertions)
- `pre-commit` formatting checks