### PR TITLE
Fix fence tracking for donated dynamic slice offsets

### DIFF
--- a/mlx/backend/metal/slicing.cpp
+++ b/mlx/backend/metal/slicing.cpp
@@ -58,8 +58,8 @@ array compute_dynamic_offset(
     offset.copy_shared_buffer(indices);
   } else {
     offset.set_data(allocator::malloc(offset.itemsize()));
+    compute_encoder.add_temporary(offset);
   }
-  compute_encoder.add_temporary(offset);
 
   auto dtype = indices.dtype();
   std::string lib_name = "compute_dynamic_offset_" + type_to_name(dtype);

--- a/tests/gpu_tests.cpp
+++ b/tests/gpu_tests.cpp
@@ -6,6 +6,7 @@
 #include <future>
 
 #include "doctest/doctest.h"
+#include "mlx/backend/gpu/slicing.h"
 #include "mlx/mlx.h"
 
 using namespace mlx::core;
@@ -478,6 +479,25 @@ TEST_CASE("test gpu validation") {
   eval(argmax(x));
 
   eval(scatter_max(array(1), {}, array(2), std::vector<int>{}));
+}
+
+TEST_CASE("test donated dynamic offset is not a temporary") {
+  if (!metal::is_available()) {
+    return;
+  }
+
+  auto stream = default_stream(Device::gpu);
+  auto indices = array({1, 1});
+  REQUIRE(indices.is_donatable());
+
+  auto offset = compute_dynamic_offset(indices, Strides{4, 1}, {0, 1}, stream);
+  REQUIRE_EQ(offset.buffer().ptr(), indices.buffer().ptr());
+
+  indices = array(0);
+  CHECK(offset.is_donatable());
+
+  synchronize(stream);
+  CHECK_EQ(offset.data<int64_t>()[0], 5);
 }
 
 TEST_CASE("test gpu int32 shape overflow errors") {

--- a/tests/gpu_tests.cpp
+++ b/tests/gpu_tests.cpp
@@ -481,33 +481,29 @@ TEST_CASE("test gpu validation") {
 }
 
 TEST_CASE("test dynamic slice update waits for its start") {
-  if (!metal::is_available()) {
-    return;
-  }
-
   // Regression for #3880: a donated array-valued start could be read
   // stale when a command-buffer boundary lands between its producer
   // and the dynamic slice. The boundary occurs when the buffer's op
   // or memory limits split the graph (or with MLX_MAX_OPS_PER_BUFFER
   // set low); without a split the checks still assert the correct
   // update position.
-  auto source = ones({2, 1 << 26}, int32, Device::gpu);
-  auto target = zeros({4, 4}, int32, Device::gpu);
-  auto update = full({1, 1}, 7, int32, Device::gpu);
+  auto source = ones({2, 1 << 26}, int32);
+  auto target = zeros({4, 4}, int32);
+  auto update = full({1, 1}, 7, int32);
   eval(source, target, update);
 
   {
-    auto recycled = zeros({2}, int32, Device::gpu);
+    auto recycled = zeros({2}, int32);
     eval(recycled);
   }
 
   auto out = [&] {
-    auto start = max(source, 1, false, Device::gpu);
-    return slice_update(target, update, start, {0, 1}, Device::gpu);
+    auto start = max(source, 1, false);
+    return slice_update(target, update, start, {0, 1});
   }();
 
-  CHECK_EQ(slice(out, {1, 1}, {2, 2}, Device::gpu).item<int>(), 7);
-  CHECK_EQ(slice(out, {0, 0}, {1, 1}, Device::gpu).item<int>(), 0);
+  CHECK_EQ(slice(out, {1, 1}, {2, 2}).item<int>(), 7);
+  CHECK_EQ(slice(out, {0, 0}, {1, 1}).item<int>(), 0);
 }
 
 TEST_CASE("test gpu int32 shape overflow errors") {

--- a/tests/gpu_tests.cpp
+++ b/tests/gpu_tests.cpp
@@ -6,7 +6,6 @@
 #include <future>
 
 #include "doctest/doctest.h"
-#include "mlx/backend/gpu/slicing.h"
 #include "mlx/mlx.h"
 
 using namespace mlx::core;
@@ -481,23 +480,34 @@ TEST_CASE("test gpu validation") {
   eval(scatter_max(array(1), {}, array(2), std::vector<int>{}));
 }
 
-TEST_CASE("test donated dynamic offset is not a temporary") {
+TEST_CASE("test dynamic slice update waits for its start") {
   if (!metal::is_available()) {
     return;
   }
 
-  auto stream = default_stream(Device::gpu);
-  auto indices = array({1, 1});
-  REQUIRE(indices.is_donatable());
+  // Regression for #3880: a donated array-valued start could be read
+  // stale when a command-buffer boundary lands between its producer
+  // and the dynamic slice. The boundary occurs when the buffer's op
+  // or memory limits split the graph (or with MLX_MAX_OPS_PER_BUFFER
+  // set low); without a split the checks still assert the correct
+  // update position.
+  auto source = ones({2, 1 << 26}, int32, Device::gpu);
+  auto target = zeros({4, 4}, int32, Device::gpu);
+  auto update = full({1, 1}, 7, int32, Device::gpu);
+  eval(source, target, update);
 
-  auto offset = compute_dynamic_offset(indices, Strides{4, 1}, {0, 1}, stream);
-  REQUIRE_EQ(offset.buffer().ptr(), indices.buffer().ptr());
+  {
+    auto recycled = zeros({2}, int32, Device::gpu);
+    eval(recycled);
+  }
 
-  indices = array(0);
-  CHECK(offset.is_donatable());
+  auto out = [&] {
+    auto start = max(source, 1, false, Device::gpu);
+    return slice_update(target, update, start, {0, 1}, Device::gpu);
+  }();
 
-  synchronize(stream);
-  CHECK_EQ(offset.data<int64_t>()[0], 5);
+  CHECK_EQ(slice(out, {1, 1}, {2, 2}, Device::gpu).item<int>(), 7);
+  CHECK_EQ(slice(out, {0, 0}, {1, 1}, Device::gpu).item<int>(), 0);
 }
 
 TEST_CASE("test gpu int32 shape overflow errors") {


### PR DESCRIPTION
## Proposed changes

Fixes #3880.

Metal's `compute_dynamic_offset` can donate the dynamic-start input buffer to
its one-element offset output. The donated alias is currently registered as
an encoder temporary. During `CommandEncoder::end_encoding()`, temporary
cleanup removes that shared pointer from the input and output dependency sets
before producer fences are resolved, so a dynamic slice can use a stale start
after an encoder boundary.

Register the offset as a temporary only when its storage was newly allocated.
The donated path remains enabled, and the primitive input retains the shared
storage through command-buffer completion. This matches the CPU path and the
temporary-lifetime pattern fixed for vector SDPA in #3121.

Per review, the committed regression is now the public `slice_update`
reproducer from #3880 (no internal APIs).

Testing, on an M3 Pro (36 GB, macOS 26.2), base
8c28c385f86d17e1da427bf8d81afe084ee17c35:

- Committed regression: on pristine `main` it fails 10/10 fresh processes
  with default buffer limits (the 512 MB reduction crosses the per-buffer
  memory limit, so the command-buffer boundary lands between the start's
  producer and the slice) and 10/10 with `MLX_MAX_OPS_PER_BUFFER=0`; with
  the fix, 0/20 in both modes.
- Public `slice` reproduction from #3880, fresh processes with
  `MLX_MAX_OPS_PER_BUFFER=0`: pristine 20/20 wrong; fixed 0/50 wrong.
- Same reproductions under `METAL_DEVICE_WRAPPER_TYPE=1`
  `METAL_DEBUG_ERROR_MODE=0`: pristine 20/20 wrong; fixed 0/20 wrong.
- Full C++ suite on Metal: 264 test cases, all passing, plain and under the
  Metal validation wrapper.
- Full Python suite: 810 tests, OK (46 skipped).
- `pre-commit run --all-files`: passing.

## Checklist

- [x] I have read the
      [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md)
      document
- [x] I have run `pre-commit run --all-files` to format my code / installed
      pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature
      works
- [ ] I have updated the necessary documentation (if needed — no public API
      change)
