### PR TITLE
Validate pooling kernel size, stride and padding

### DIFF
--- a/python/mlx/nn/layers/pooling.py
+++ b/python/mlx/nn/layers/pooling.py
@@ -85,6 +85,19 @@ class _Pool(Module):
     def __init__(self, pooling_function, kernel_size, stride, padding, padding_value):
         super().__init__()
 
+        class_name = type(self).__name__
+        for name, values in (("kernel_size", kernel_size), ("stride", stride)):
+            if any(v <= 0 for v in values):
+                raise ValueError(
+                    f"[{class_name}] '{name}' must be positive but got "
+                    f"{tuple(values)}."
+                )
+        if any(p[0] < 0 for p in padding):
+            raise ValueError(
+                f"[{class_name}] 'padding' must be non-negative but got "
+                f"{tuple(p[0] for p in padding)}."
+            )
+
         self._pooling_function = pooling_function
         self._kernel_size = kernel_size
         self._stride = stride


### PR DESCRIPTION
## Proposed changes

The pooling layers do not check their window arguments, so a bad value surfaces as a raw Python error from the middle of the sliding window helper:

```python
>>> nn.MaxPool1d(2, stride=0)(mx.ones((1, 4, 2)))
ZeroDivisionError: integer division or modulo by zero
>>> nn.MaxPool1d(0)(mx.ones((1, 4, 2)))
ZeroDivisionError: integer modulo by zero
```

Both come from `_sliding_windows`, which divides by the stride and takes `size % window`:

```python
size % window == 0 ...
(size - window) // stride + 1
```

A negative kernel is worse, because nothing raises at all and the layer returns an array with a negative dimension:

```python
>>> nn.MaxPool1d(-2)(mx.ones((1, 4, 2))).shape
(1, -2, 2)
```

Negative padding is also accepted and quietly ignored. The convolution layers already reject the same mistakes with a clear message, for example `[conv] Stride sizes must be positive. Got strides (0).`, so this is pooling being the odd one out.

The check goes in `_Pool.__init__`, which is the one place `MaxPool1d/2d/3d` and `AvgPool1d/2d/3d` all pass through after their arguments have been normalized to lists, so all six get it from a single spot:

```python
>>> nn.MaxPool2d(2, stride=0)
ValueError: [MaxPool2d] 'stride' must be positive but got (0, 0).
>>> nn.AvgPool3d(-2)
ValueError: [AvgPool3d] 'kernel_size' must be positive but got (-2, -2, -2).
>>> nn.MaxPool1d(2, padding=-1)
ValueError: [MaxPool1d] 'padding' must be non-negative but got (-1,).
```

The message follows the shape the pooling layers already use for their argument errors, `[{class_name}] '{name}' ...`.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

No test, since this is an argument check and the last time I added one for a fix this size the reviewer asked me to drop it. Happy to add one if you would rather have it.

Checked by hand across all six pooling classes for `kernel_size` and `stride` of 0 and negative and for negative padding, and confirmed valid pooling is untouched: int and tuple arguments, padding, the `_extra_repr` output, and `test_nn.py` (72 tests) all still pass. Python only, no rebuild needed.

---

freshman contributor, i work through these with Claude Code. found it while feeding out of range arguments to layers and comparing what a user actually sees against what the conv layers say for the identical mistake. the negative kernel case was the one that bothered me most, since it returns an array rather than complaining.
