### PR TITLE
Bound winograd conv2d working set by tiling the batch

### DIFF
--- a/mlx/backend/metal/conv.cpp
+++ b/mlx/backend/metal/conv.cpp
@@ -1,10 +1,7 @@
 // Copyright © 2023-2024 Apple Inc.
 #include <algorithm>
 #include <cassert>
-#include <cerrno>
-#include <cstdlib>
 #include <numeric>
-#include <stdexcept>
 
 #include "mlx/backend/gpu/copy.h"
 #include "mlx/backend/gpu/slicing.h"
@@ -15,7 +12,6 @@
 #include "mlx/backend/metal/kernels/steel/conv/params.h"
 #include "mlx/backend/metal/matmul.h"
 #include "mlx/backend/metal/utils.h"
-#include "mlx/memory.h"
 #include "mlx/primitives.h"
 #include "mlx/utils.h"
 
@@ -53,10 +49,9 @@ inline int max_unfold_rows(metal::Device& d, size_t row_bytes, int total_rows) {
 }
 
 // Winograd's scratch is a multiple of the input, all referenced by one
-// command buffer; past the GPU's working set limit the kernels silently
-// produce zeros. Run the batch in tiles to bound it. Returns the batch
-// elements per tile, or 0 if not even one fits (the caller must then pick a
-// path that needs no scratch).
+// command buffer, which fails past the GPU's working set limit. Run the
+// batch in tiles to bound it. Returns the batch elements per tile, or 0 if
+// not even one fits.
 inline int winograd_batch_step(
     metal::Device& d,
     const array& in,
@@ -64,17 +59,18 @@ inline int winograd_batch_step(
   int total_n = conv_params.N;
 
   size_t itemsize = in.itemsize();
-  int padded_h =
-      6 * ((conv_params.iS[0] + 2 * conv_params.pad[0] - 2 + 5) / 6) + 2;
-  int padded_w =
-      6 * ((conv_params.iS[1] + 2 * conv_params.pad[1] - 2 + 5) / 6) + 2;
+  int64_t padded_h = static_cast<int64_t>(conv_params.iS[0]) +
+      2 * static_cast<int64_t>(conv_params.pad[0]);
+  int64_t padded_w = static_cast<int64_t>(conv_params.iS[1]) +
+      2 * static_cast<int64_t>(conv_params.pad[1]);
+  padded_h = 6 * ((padded_h - 2 + 5) / 6) + 2;
+  padded_w = 6 * ((padded_w - 2 + 5) / 6) + 2;
   int tiles_per_n =
       ((conv_params.oS[0] + 5) / 6) * ((conv_params.oS[1] + 5) / 6);
 
   // The padded input and both gemm workspaces scale with the tile; the
-  // transformed filter does not. That is all of the scratch: the batched gemm
-  // allocates nothing here (split-k needs a batch size of one, winograd always
-  // runs 8 * 8, and its operands are contiguous so it never copies one).
+  // transformed filter does not. That is all of the scratch: the batched
+  // gemm allocates nothing here.
   size_t filt_bytes =
       static_cast<size_t>(8 * 8) * conv_params.C * conv_params.O * itemsize;
   size_t bytes_per_n =
@@ -83,40 +79,30 @@ inline int winograd_batch_step(
           (conv_params.C + conv_params.O) * itemsize;
 
   size_t working_set = d.mtl_device()->recommendedMaxWorkingSetSize();
-  // Test hook: pretend the GPU can only keep this many bytes resident, so the
-  // budget arithmetic below can be exercised at sizes that fit in CI.
-  if (auto env_ws = env::get_var("MLX_CONV_WINOGRAD_WORKING_SET", "");
-      !env_ws.empty()) {
-    // A silent parse failure would read as a budget of zero and quietly swap
-    // the kernel, so reject anything but a plain decimal count.
-    errno = 0;
-    unsigned long long parsed = std::strtoull(env_ws.c_str(), nullptr, 10);
-    if (env_ws.find_first_not_of("0123456789") != std::string::npos ||
-        errno == ERANGE) {
-      throw std::invalid_argument(
-          "[conv] MLX_CONV_WINOGRAD_WORKING_SET must be a plain decimal byte "
-          "count, but got '" +
-          env_ws + "'.");
-    }
-    working_set = parsed;
+  // Lets tests shrink the working set to exercise tiling at small sizes.
+  if (int env_ws = env::get_var("MLX_CONV_WINOGRAD_WORKING_SET", 0);
+      env_ws > 0) {
+    working_set = env_ws;
   }
-  // Results went wrong at ~99% of the working set, so hold a quarter of it
-  // back: this process cannot see the GPU memory other processes hold, nor
-  // the allocator's cache of freed-but-unreturned buffers.
+  // Hold a quarter back for what is not charged below: GPU memory held by
+  // other processes and allocations unrelated to the conv.
   size_t limit = working_set / 4 * 3;
 
-  // Deliberately over-counts: only buffers this command buffer binds matter,
-  // but charging all live allocations only errs toward a smaller tile. The
-  // input, weights and output are already allocated and inside this figure,
-  // so only winograd's scratch is left to make room for.
-  size_t used = get_active_memory() + filt_bytes;
+  // The conv's own input and output stay resident alongside the scratch.
+  size_t io_bytes =
+      (static_cast<size_t>(total_n) * conv_params.iS[0] * conv_params.iS[1] *
+           conv_params.C +
+       static_cast<size_t>(total_n) * conv_params.oS[0] * conv_params.oS[1] *
+           conv_params.O) *
+      itemsize;
+  size_t used = io_bytes + filt_bytes;
   size_t budget = limit > used ? limit - used : 0;
 
   auto max_n = static_cast<int64_t>(budget / bytes_per_n);
   int safe_n = static_cast<int>(std::min<int64_t>(max_n, total_n));
 
-  // Force a smaller tile (tests, or to bound the scratch space further). It
-  // caps the tile the budget allows, so it can only ever shrink the tile.
+  // Force a smaller tile, capped by the budget (tests, or to bound the
+  // scratch space further).
   if (int forced = env::get_var("MLX_CONV_WINOGRAD_TILE_BATCH", 0);
       forced > 0) {
     return std::min(forced, safe_n);
@@ -990,10 +976,14 @@ void winograd_conv_2D_gpu(
   int O_c = conv_params.O;
   int C_c = conv_params.C;
 
-  int padded_h =
-      6 * ((conv_params.iS[0] + 2 * conv_params.pad[0] - 2 + 5) / 6) + 2;
-  int padded_w =
-      6 * ((conv_params.iS[1] + 2 * conv_params.pad[1] - 2 + 5) / 6) + 2;
+  // Round the padded spatial dims up to the winograd tile in int64 so the
+  // rounding cannot overflow int32 just below the limit.
+  int64_t pad_h = static_cast<int64_t>(conv_params.iS[0]) +
+      2 * static_cast<int64_t>(conv_params.pad[0]);
+  int64_t pad_w = static_cast<int64_t>(conv_params.iS[1]) +
+      2 * static_cast<int64_t>(conv_params.pad[1]);
+  int padded_h = safe_cast(6 * ((pad_h - 2 + 5) / 6) + 2, "conv");
+  int padded_w = safe_cast(6 * ((pad_w - 2 + 5) / 6) + 2, "conv");
 
   int N_tiles_h = (conv_params.oS[0] + 5) / 6;
   int N_tiles_w = (conv_params.oS[1] + 5) / 6;

--- a/mlx/backend/metal/conv.cpp
+++ b/mlx/backend/metal/conv.cpp
@@ -1,7 +1,10 @@
 // Copyright © 2023-2024 Apple Inc.
 #include <algorithm>
 #include <cassert>
+#include <cerrno>
+#include <cstdlib>
 #include <numeric>
+#include <stdexcept>
 
 #include "mlx/backend/gpu/copy.h"
 #include "mlx/backend/gpu/slicing.h"
@@ -12,6 +15,7 @@
 #include "mlx/backend/metal/kernels/steel/conv/params.h"
 #include "mlx/backend/metal/matmul.h"
 #include "mlx/backend/metal/utils.h"
+#include "mlx/memory.h"
 #include "mlx/primitives.h"
 #include "mlx/utils.h"
 
@@ -46,6 +50,86 @@ inline int max_unfold_rows(metal::Device& d, size_t row_bytes, int total_rows) {
     throw std::runtime_error(msg.str());
   }
   return static_cast<int>(std::min(max_rows, static_cast<size_t>(total_rows)));
+}
+
+// Winograd's scratch is a multiple of the input, all referenced by one
+// command buffer; past the GPU's working set limit the kernels silently
+// produce zeros. Run the batch in tiles to bound it. Returns the batch
+// elements per tile, or 0 if not even one fits (the caller must then pick a
+// path that needs no scratch).
+inline int winograd_batch_step(
+    metal::Device& d,
+    const array& in,
+    const MLXConvParams<2>& conv_params) {
+  int total_n = conv_params.N;
+
+  size_t itemsize = in.itemsize();
+  int padded_h =
+      6 * ((conv_params.iS[0] + 2 * conv_params.pad[0] - 2 + 5) / 6) + 2;
+  int padded_w =
+      6 * ((conv_params.iS[1] + 2 * conv_params.pad[1] - 2 + 5) / 6) + 2;
+  int tiles_per_n =
+      ((conv_params.oS[0] + 5) / 6) * ((conv_params.oS[1] + 5) / 6);
+
+  // The padded input and both gemm workspaces scale with the tile; the
+  // transformed filter does not. That is all of the scratch: the batched gemm
+  // allocates nothing here (split-k needs a batch size of one, winograd always
+  // runs 8 * 8, and its operands are contiguous so it never copies one).
+  size_t filt_bytes =
+      static_cast<size_t>(8 * 8) * conv_params.C * conv_params.O * itemsize;
+  size_t bytes_per_n =
+      static_cast<size_t>(padded_h) * padded_w * conv_params.C * itemsize +
+      static_cast<size_t>(8 * 8) * tiles_per_n *
+          (conv_params.C + conv_params.O) * itemsize;
+
+  size_t working_set = d.mtl_device()->recommendedMaxWorkingSetSize();
+  // Test hook: pretend the GPU can only keep this many bytes resident, so the
+  // budget arithmetic below can be exercised at sizes that fit in CI.
+  if (auto env_ws = env::get_var("MLX_CONV_WINOGRAD_WORKING_SET", "");
+      !env_ws.empty()) {
+    // A silent parse failure would read as a budget of zero and quietly swap
+    // the kernel, so reject anything but a plain decimal count.
+    errno = 0;
+    unsigned long long parsed = std::strtoull(env_ws.c_str(), nullptr, 10);
+    if (env_ws.find_first_not_of("0123456789") != std::string::npos ||
+        errno == ERANGE) {
+      throw std::invalid_argument(
+          "[conv] MLX_CONV_WINOGRAD_WORKING_SET must be a plain decimal byte "
+          "count, but got '" +
+          env_ws + "'.");
+    }
+    working_set = parsed;
+  }
+  // Results went wrong at ~99% of the working set, so hold a quarter of it
+  // back: this process cannot see the GPU memory other processes hold, nor
+  // the allocator's cache of freed-but-unreturned buffers.
+  size_t limit = working_set / 4 * 3;
+
+  // Deliberately over-counts: only buffers this command buffer binds matter,
+  // but charging all live allocations only errs toward a smaller tile. The
+  // input, weights and output are already allocated and inside this figure,
+  // so only winograd's scratch is left to make room for.
+  size_t used = get_active_memory() + filt_bytes;
+  size_t budget = limit > used ? limit - used : 0;
+
+  auto max_n = static_cast<int64_t>(budget / bytes_per_n);
+  int safe_n = static_cast<int>(std::min<int64_t>(max_n, total_n));
+
+  // Force a smaller tile (tests, or to bound the scratch space further). It
+  // caps the tile the budget allows, so it can only ever shrink the tile.
+  if (int forced = env::get_var("MLX_CONV_WINOGRAD_TILE_BATCH", 0);
+      forced > 0) {
+    return std::min(forced, safe_n);
+  }
+  // When the budget forces tiling, each tile must carry enough gemm rows to
+  // amortize its fixed cost (dispatches plus the input and output
+  // transforms); below that the implicit gemm fallback is much faster.
+  constexpr int min_rows_per_tile = 32;
+  if (safe_n < total_n &&
+      static_cast<int64_t>(safe_n) * tiles_per_n < min_rows_per_tile) {
+    return 0;
+  }
+  return safe_n;
 }
 
 template <int N>
@@ -901,80 +985,19 @@ void winograd_conv_2D_gpu(
     const array& wt,
     array& out,
     const MLXConvParams<2>& conv_params,
-    std::vector<array>& copies_w) {
-  // Round the padded spatial dims up to the Winograd tile in int64 so the
-  // rounding cannot overflow int32 just below the limit.
-  int64_t pad_h = static_cast<int64_t>(conv_params.iS[0]) +
-      2 * static_cast<int64_t>(conv_params.pad[0]);
-  int64_t pad_w = static_cast<int64_t>(conv_params.iS[1]) +
-      2 * static_cast<int64_t>(conv_params.pad[1]);
-  pad_h = 6 * ((pad_h - 2 + 5) / 6) + 2;
-  pad_w = 6 * ((pad_w - 2 + 5) / 6) + 2;
-  Shape padded_shape = {
-      conv_params.N,
-      safe_cast(pad_h, "conv"),
-      safe_cast(pad_w, "conv"),
-      conv_params.C};
-
-  array in_padded(std::move(padded_shape), in.dtype(), nullptr, {});
-
-  // Fill with zeros
-  array zero_arr = array(0, in.dtype());
-  fill_gpu(zero_arr, in_padded, s);
-  copies_w.push_back(zero_arr);
-
-  // Pick input slice from padded
-  size_t data_offset = conv_params.pad[0] * in_padded.strides()[1] +
-      conv_params.pad[1] * in_padded.strides()[2];
-  array in_padded_slice(in.shape(), in_padded.dtype(), nullptr, {});
-  in_padded_slice.copy_shared_buffer(
-      in_padded,
-      in_padded.strides(),
-      in_padded.flags(),
-      in_padded_slice.size(),
-      data_offset);
-
-  // Copy input values into the slice
-  copy_gpu_inplace(in, in_padded_slice, CopyType::GeneralGeneral, s);
-
-  copies_w.push_back(in_padded_slice);
-  copies_w.push_back(in_padded);
-
-  MLXConvParams<2> conv_params_updated{
-      /* const int  N = */ static_cast<int>(in_padded.shape(0)),
-      /* const int  C = */ static_cast<int>(in_padded.shape(3)),
-      /* const int  O = */ static_cast<int>(wt.shape(0)),
-      /* const int iS[NDIM] = */
-      {static_cast<int>(in_padded.shape(1)),
-       static_cast<int>(in_padded.shape(2))},
-      /* const int wS[NDIM] = */
-      {static_cast<int>(wt.shape(1)), static_cast<int>(wt.shape(2))},
-      /* const int oS[NDIM] = */
-      {static_cast<int>(out.shape(1)), static_cast<int>(out.shape(2))},
-      /* const int str[NDIM] = */ {1, 1},
-      /* const int pad[NDIM] = */ {0, 0},
-      /* const int kdil[NDIM] = */ {1, 1},
-      /* const int idil[NDIM] = */ {1, 1},
-      /* const size_t in_strides[NDIM + 2] = */
-      {in_padded.strides()[0],
-       in_padded.strides()[1],
-       in_padded.strides()[2],
-       in_padded.strides()[3]},
-      /* const size_t wt_strides[NDIM + 2] = */
-      {wt.strides()[0], wt.strides()[1], wt.strides()[2], wt.strides()[3]},
-      /* const size_t out_strides[NDIM + 2] = */
-      {out.strides()[0], out.strides()[1], out.strides()[2], out.strides()[3]},
-      /* const int groups = */ 1,
-      /* const bool flip = */ false,
-  };
-
+    std::vector<array>& copies_w,
+    int n_step) {
   int O_c = conv_params.O;
   int C_c = conv_params.C;
 
-  int N_tiles_n = conv_params.N;
+  int padded_h =
+      6 * ((conv_params.iS[0] + 2 * conv_params.pad[0] - 2 + 5) / 6) + 2;
+  int padded_w =
+      6 * ((conv_params.iS[1] + 2 * conv_params.pad[1] - 2 + 5) / 6) + 2;
+
   int N_tiles_h = (conv_params.oS[0] + 5) / 6;
   int N_tiles_w = (conv_params.oS[1] + 5) / 6;
-  int N_tiles = N_tiles_n * N_tiles_h * N_tiles_w;
+  int tiles_per_n = N_tiles_h * N_tiles_w;
 
   // Do filter transform
   Shape filt_wg_shape = {8 * 8, conv_params.C, conv_params.O};
@@ -1008,88 +1031,192 @@ void winograd_conv_2D_gpu(
     compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
   }
 
-  // Do input transform
-  Shape inp_wg_shape = {8 * 8, N_tiles, conv_params.C};
-  array inp_wg(std::move(inp_wg_shape), in.dtype(), nullptr, {});
+  // Scratch space, reused by every batch tile. in_padded's buffer is
+  // allocated by fill_gpu below.
+  array in_padded({n_step, padded_h, padded_w, C_c}, in.dtype(), nullptr, {});
+  copies_w.push_back(in_padded);
+
+  array inp_wg({8 * 8, n_step * tiles_per_n, C_c}, in.dtype(), nullptr, {});
   inp_wg.set_data(allocator::malloc(inp_wg.nbytes()));
   copies_w.push_back(inp_wg);
-  {
-    int bc = 32;
-    int wm = 2;
-    int wn = 2;
-    std::string kname;
-    kname.reserve(32);
-    concatenate(
-        kname,
-        "winograd_conv_2d_input_transform_",
-        type_to_name(out),
-        "_bc",
-        bc);
-    auto& compute_encoder = metal::get_command_encoder(s);
-    auto kernel = d.get_kernel(kname);
-    compute_encoder.set_compute_pipeline_state(kernel);
 
-    compute_encoder.set_input_array(in_padded, 0);
-    compute_encoder.set_output_array(inp_wg, 1);
-
-    compute_encoder.set_bytes(conv_params_updated, 2);
-
-    MTL::Size group_dims = MTL::Size(32, wn, wm);
-    MTL::Size grid_dims = MTL::Size(N_tiles_w, N_tiles_h, N_tiles_n);
-
-    compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
-  }
-
-  // Do batched gemm
-  Shape out_wg_shape = {8 * 8, N_tiles, conv_params.O};
-  array out_wg(std::move(out_wg_shape), in.dtype(), nullptr, {});
+  array out_wg({8 * 8, n_step * tiles_per_n, O_c}, in.dtype(), nullptr, {});
   out_wg.set_data(allocator::malloc(out_wg.nbytes()));
   copies_w.push_back(out_wg);
-  {
-    std::vector<array> empty_copies;
-    steel_matmul(
-        s,
-        d,
-        /*a = */ inp_wg,
-        /*b = */ filt_wg,
-        /*c = */ out_wg,
-        /*M = */ N_tiles,
-        /*N = */ conv_params.O,
-        /*K = */ conv_params.C,
-        /*batch_size_out = */ 8 * 8,
-        /*a_cols = */ conv_params.C,
-        /*b_cols = */ conv_params.O,
-        /*a_transposed = */ false,
-        /*b_transposed = */ false,
-        /*copies = */ empty_copies);
-  }
 
-  // Do output transform
-  {
-    int bc = 32;
-    int wm = 2;
-    int wn = 2;
-    std::string kname;
-    kname.reserve(32);
-    concatenate(
-        kname,
-        "winograd_conv_2d_output_transform_",
-        type_to_name(out),
-        "_bo",
-        bc);
-    auto& compute_encoder = metal::get_command_encoder(s);
-    auto kernel = d.get_kernel(kname);
-    compute_encoder.set_compute_pipeline_state(kernel);
+  // Every tile overwrites the same interior window, so the padding only has to
+  // be zeroed once.
+  array zero_arr = array(0, in.dtype());
+  fill_gpu(zero_arr, in_padded, s);
+  copies_w.push_back(zero_arr);
 
-    compute_encoder.set_input_array(out_wg, 0);
-    compute_encoder.set_output_array(out, 1);
+  int64_t pad_offset = conv_params.pad[0] * in_padded.strides()[1] +
+      conv_params.pad[1] * in_padded.strides()[2];
 
-    compute_encoder.set_bytes(conv_params_updated, 2);
+  for (int n_offset = 0; n_offset < conv_params.N; n_offset += n_step) {
+    int tile_n = std::min(n_step, conv_params.N - n_offset);
+    int N_tiles = tile_n * tiles_per_n;
 
-    MTL::Size group_dims = MTL::Size(32, wn, wm);
-    MTL::Size grid_dims = MTL::Size(N_tiles_w, N_tiles_h, N_tiles_n);
+    // Copy this tile's inputs into the interior of the padded scratch buffer
+    array in_tile(
+        {tile_n, conv_params.iS[0], conv_params.iS[1], C_c},
+        in.dtype(),
+        nullptr,
+        {});
+    in_tile.copy_shared_buffer(
+        in,
+        in.strides(),
+        in.flags(),
+        in_tile.size(),
+        n_offset * in.strides()[0]);
 
-    compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+    array in_padded_slice(in_tile.shape(), in_padded.dtype(), nullptr, {});
+    in_padded_slice.copy_shared_buffer(
+        in_padded,
+        in_padded.strides(),
+        in_padded.flags(),
+        in_padded_slice.size(),
+        pad_offset);
+
+    copy_gpu_inplace(in_tile, in_padded_slice, CopyType::GeneralGeneral, s);
+    copies_w.push_back(in_padded_slice);
+
+    // The tile writes into its own batch window of the output. Views of the
+    // input and the output must not be registered as temporaries: temporaries
+    // are dropped from the encoder's cross-encoder fence bookkeeping, which
+    // would let a later kernel read the output before this one has written it.
+    array out_tile(
+        {tile_n, conv_params.oS[0], conv_params.oS[1], O_c},
+        out.dtype(),
+        nullptr,
+        {});
+    out_tile.copy_shared_buffer(
+        out,
+        out.strides(),
+        out.flags(),
+        out_tile.size(),
+        n_offset * out.strides()[0]);
+
+    MLXConvParams<2> conv_params_updated{
+        /* const int  N = */ tile_n,
+        /* const int  C = */ C_c,
+        /* const int  O = */ O_c,
+        /* const int iS[NDIM] = */ {padded_h, padded_w},
+        /* const int wS[NDIM] = */
+        {static_cast<int>(wt.shape(1)), static_cast<int>(wt.shape(2))},
+        /* const int oS[NDIM] = */
+        {static_cast<int>(out.shape(1)), static_cast<int>(out.shape(2))},
+        /* const int str[NDIM] = */ {1, 1},
+        /* const int pad[NDIM] = */ {0, 0},
+        /* const int kdil[NDIM] = */ {1, 1},
+        /* const int idil[NDIM] = */ {1, 1},
+        /* const size_t in_strides[NDIM + 2] = */
+        {in_padded.strides()[0],
+         in_padded.strides()[1],
+         in_padded.strides()[2],
+         in_padded.strides()[3]},
+        /* const size_t wt_strides[NDIM + 2] = */
+        {wt.strides()[0], wt.strides()[1], wt.strides()[2], wt.strides()[3]},
+        /* const size_t out_strides[NDIM + 2] = */
+        {out.strides()[0],
+         out.strides()[1],
+         out.strides()[2],
+         out.strides()[3]},
+        /* const int groups = */ 1,
+        /* const bool flip = */ false,
+    };
+
+    // Do input transform. The transforms lay their result out as
+    // (8 x 8 x N_tiles x channels), so a short tile writes a compacted prefix
+    // of the scratch buffer and the gemm reads it back the same way.
+    {
+      int bc = 32;
+      int wm = 2;
+      int wn = 2;
+      std::string kname;
+      kname.reserve(32);
+      concatenate(
+          kname,
+          "winograd_conv_2d_input_transform_",
+          type_to_name(out),
+          "_bc",
+          bc);
+      auto& compute_encoder = metal::get_command_encoder(s);
+      auto kernel = d.get_kernel(kname);
+      compute_encoder.set_compute_pipeline_state(kernel);
+
+      compute_encoder.set_input_array(in_padded, 0);
+      compute_encoder.set_output_array(inp_wg, 1);
+
+      compute_encoder.set_bytes(conv_params_updated, 2);
+
+      MTL::Size group_dims = MTL::Size(32, wn, wm);
+      MTL::Size grid_dims = MTL::Size(N_tiles_w, N_tiles_h, tile_n);
+
+      compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+    }
+
+    // Do batched gemm
+    {
+      array inp_wg_tile({8 * 8, N_tiles, C_c}, inp_wg.dtype(), nullptr, {});
+      inp_wg_tile.copy_shared_buffer(
+          inp_wg,
+          {static_cast<int64_t>(N_tiles) * C_c, C_c, 1},
+          inp_wg.flags(),
+          inp_wg_tile.size());
+
+      array out_wg_tile({8 * 8, N_tiles, O_c}, out_wg.dtype(), nullptr, {});
+      out_wg_tile.copy_shared_buffer(
+          out_wg,
+          {static_cast<int64_t>(N_tiles) * O_c, O_c, 1},
+          out_wg.flags(),
+          out_wg_tile.size());
+
+      std::vector<array> empty_copies;
+      steel_matmul(
+          s,
+          d,
+          /*a = */ inp_wg_tile,
+          /*b = */ filt_wg,
+          /*c = */ out_wg_tile,
+          /*M = */ N_tiles,
+          /*N = */ O_c,
+          /*K = */ C_c,
+          /*batch_size_out = */ 8 * 8,
+          /*a_cols = */ C_c,
+          /*b_cols = */ O_c,
+          /*a_transposed = */ false,
+          /*b_transposed = */ false,
+          /*copies = */ empty_copies);
+    }
+
+    // Do output transform
+    {
+      int bc = 32;
+      int wm = 2;
+      int wn = 2;
+      std::string kname;
+      kname.reserve(32);
+      concatenate(
+          kname,
+          "winograd_conv_2d_output_transform_",
+          type_to_name(out),
+          "_bo",
+          bc);
+      auto& compute_encoder = metal::get_command_encoder(s);
+      auto kernel = d.get_kernel(kname);
+      compute_encoder.set_compute_pipeline_state(kernel);
+
+      compute_encoder.set_input_array(out_wg, 0);
+      compute_encoder.set_output_array(out_tile, 1);
+
+      compute_encoder.set_bytes(conv_params_updated, 2);
+
+      MTL::Size group_dims = MTL::Size(32, wn, wm);
+      MTL::Size grid_dims = MTL::Size(N_tiles_w, N_tiles_h, tile_n);
+
+      compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+    }
   }
 }
 
@@ -1233,7 +1360,12 @@ void dispatch_conv_2D_gpu(
       conv_params.wS[0] == 3 && conv_params.wS[1] == 3 &&
       conv_params.C % 32 == 0 && conv_params.O % 32 == 0 && inp_large &&
       channels_large) {
-    return winograd_conv_2D_gpu(s, d, in, wt, out, conv_params, copies);
+    // Falls through to the scratch-free implicit gemm when winograd's scratch
+    // does not fit in the working set.
+    if (int n_step = winograd_batch_step(d, in, conv_params); n_step > 0) {
+      return winograd_conv_2D_gpu(
+          s, d, in, wt, out, conv_params, copies, n_step);
+    }
   }
 
   // Whether the specialized implicit gemm kernel can take the channels as-is.

--- a/mlx/backend/metal/conv.cpp
+++ b/mlx/backend/metal/conv.cpp
@@ -48,10 +48,17 @@ inline int max_unfold_rows(metal::Device& d, size_t row_bytes, int total_rows) {
   return static_cast<int>(std::min(max_rows, static_cast<size_t>(total_rows)));
 }
 
-// Winograd's scratch is a multiple of the input, all referenced by one
-// command buffer, which fails past the GPU's working set limit. Run the
-// batch in tiles to bound it. Returns the batch elements per tile, or 0 if
-// not even one fits.
+inline auto winograd_padded_size(const MLXConvParams<2>& conv_params) {
+  int64_t pad_h = static_cast<int64_t>(conv_params.iS[0]) +
+      2 * static_cast<int64_t>(conv_params.pad[0]);
+  int64_t pad_w = static_cast<int64_t>(conv_params.iS[1]) +
+      2 * static_cast<int64_t>(conv_params.pad[1]);
+  int padded_h = safe_cast(6 * ceildiv(pad_h - 2, 6) + 2, "conv");
+  int padded_w = safe_cast(6 * ceildiv(pad_w - 2, 6) + 2, "conv");
+  return std::make_tuple(padded_h, padded_w);
+}
+
+// Return how many rows to compute per each step.
 inline int winograd_batch_step(
     metal::Device& d,
     const array& in,
@@ -59,60 +66,45 @@ inline int winograd_batch_step(
   int total_n = conv_params.N;
 
   size_t itemsize = in.itemsize();
-  int64_t padded_h = static_cast<int64_t>(conv_params.iS[0]) +
-      2 * static_cast<int64_t>(conv_params.pad[0]);
-  int64_t padded_w = static_cast<int64_t>(conv_params.iS[1]) +
-      2 * static_cast<int64_t>(conv_params.pad[1]);
-  padded_h = 6 * ((padded_h - 2 + 5) / 6) + 2;
-  padded_w = 6 * ((padded_w - 2 + 5) / 6) + 2;
+  auto [padded_h, padded_w] = winograd_padded_size(conv_params);
   int tiles_per_n =
-      ((conv_params.oS[0] + 5) / 6) * ((conv_params.oS[1] + 5) / 6);
+      ceildiv(conv_params.oS[0], 6) * ceildiv(conv_params.oS[1], 6);
 
-  // The padded input and both gemm workspaces scale with the tile; the
-  // transformed filter does not. That is all of the scratch: the batched
-  // gemm allocates nothing here.
-  size_t filt_bytes =
-      static_cast<size_t>(8 * 8) * conv_params.C * conv_params.O * itemsize;
-  size_t bytes_per_n =
-      static_cast<size_t>(padded_h) * padded_w * conv_params.C * itemsize +
-      static_cast<size_t>(8 * 8) * tiles_per_n *
-          (conv_params.C + conv_params.O) * itemsize;
-
+  // Limit of maximum memory can be used for the step.
   size_t working_set = d.mtl_device()->recommendedMaxWorkingSetSize();
-  // Lets tests shrink the working set to exercise tiling at small sizes.
   if (int env_ws = env::get_var("MLX_CONV_WINOGRAD_WORKING_SET", 0);
       env_ws > 0) {
     working_set = env_ws;
   }
-  // Hold a quarter back for what is not charged below: GPU memory held by
-  // other processes and allocations unrelated to the conv.
   size_t limit = working_set / 4 * 3;
 
-  // The conv's own input and output stay resident alongside the scratch.
-  size_t io_bytes =
+  // Memory used by inputs.
+  size_t filt_bytes =
+      static_cast<size_t>(8 * 8) * conv_params.C * conv_params.O * itemsize;
+  size_t io_bytes = itemsize *
       (static_cast<size_t>(total_n) * conv_params.iS[0] * conv_params.iS[1] *
            conv_params.C +
        static_cast<size_t>(total_n) * conv_params.oS[0] * conv_params.oS[1] *
-           conv_params.O) *
-      itemsize;
+           conv_params.O);
   size_t used = io_bytes + filt_bytes;
   size_t budget = limit > used ? limit - used : 0;
 
+  // How many rows to use per step to avoid running over limit.
+  size_t bytes_per_n =
+      static_cast<size_t>(padded_h) * padded_w * conv_params.C * itemsize +
+      static_cast<size_t>(8 * 8) * tiles_per_n *
+          (conv_params.C + conv_params.O) * itemsize;
   auto max_n = static_cast<int64_t>(budget / bytes_per_n);
   int safe_n = static_cast<int>(std::min<int64_t>(max_n, total_n));
-
-  // Force a smaller tile, capped by the budget (tests, or to bound the
-  // scratch space further).
   if (int forced = env::get_var("MLX_CONV_WINOGRAD_TILE_BATCH", 0);
       forced > 0) {
     return std::min(forced, safe_n);
   }
+
   // When the budget forces tiling, each tile must carry enough gemm rows to
-  // amortize its fixed cost (dispatches plus the input and output
-  // transforms); below that the implicit gemm fallback is much faster.
+  // amortize fixed cost, below that the implicit gemm fallback is much faster.
   constexpr int min_rows_per_tile = 32;
-  if (safe_n < total_n &&
-      static_cast<int64_t>(safe_n) * tiles_per_n < min_rows_per_tile) {
+  if ((safe_n < total_n) && (safe_n * tiles_per_n < min_rows_per_tile)) {
     return 0;
   }
   return safe_n;
@@ -975,21 +967,13 @@ void winograd_conv_2D_gpu(
     int n_step) {
   int O_c = conv_params.O;
   int C_c = conv_params.C;
+  auto [padded_h, padded_w] = winograd_padded_size(conv_params);
 
-  // Round the padded spatial dims up to the winograd tile in int64 so the
-  // rounding cannot overflow int32 just below the limit.
-  int64_t pad_h = static_cast<int64_t>(conv_params.iS[0]) +
-      2 * static_cast<int64_t>(conv_params.pad[0]);
-  int64_t pad_w = static_cast<int64_t>(conv_params.iS[1]) +
-      2 * static_cast<int64_t>(conv_params.pad[1]);
-  int padded_h = safe_cast(6 * ((pad_h - 2 + 5) / 6) + 2, "conv");
-  int padded_w = safe_cast(6 * ((pad_w - 2 + 5) / 6) + 2, "conv");
-
-  int N_tiles_h = (conv_params.oS[0] + 5) / 6;
-  int N_tiles_w = (conv_params.oS[1] + 5) / 6;
+  int N_tiles_h = ceildiv(conv_params.oS[0], 6);
+  int N_tiles_w = ceildiv(conv_params.oS[1], 6);
   int tiles_per_n = N_tiles_h * N_tiles_w;
 
-  // Do filter transform
+  // Do filter transform.
   Shape filt_wg_shape = {8 * 8, conv_params.C, conv_params.O};
   array filt_wg(std::move(filt_wg_shape), wt.dtype(), nullptr, {});
   filt_wg.set_data(allocator::malloc(filt_wg.nbytes()));
@@ -1021,11 +1005,7 @@ void winograd_conv_2D_gpu(
     compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
   }
 
-  // Scratch space, reused by every batch tile. in_padded's buffer is
-  // allocated by fill_gpu below.
-  array in_padded({n_step, padded_h, padded_w, C_c}, in.dtype(), nullptr, {});
-  copies_w.push_back(in_padded);
-
+  // Scratch space reused by every batch tile.
   array inp_wg({8 * 8, n_step * tiles_per_n, C_c}, in.dtype(), nullptr, {});
   inp_wg.set_data(allocator::malloc(inp_wg.nbytes()));
   copies_w.push_back(inp_wg);
@@ -1034,20 +1014,24 @@ void winograd_conv_2D_gpu(
   out_wg.set_data(allocator::malloc(out_wg.nbytes()));
   copies_w.push_back(out_wg);
 
-  // Every tile overwrites the same interior window, so the padding only has to
-  // be zeroed once.
+  array in_padded({n_step, padded_h, padded_w, C_c}, in.dtype(), nullptr, {});
+  copies_w.push_back(in_padded);
+
+  // Fill padding with zeros.
   array zero_arr = array(0, in.dtype());
   fill_gpu(zero_arr, in_padded, s);
   copies_w.push_back(zero_arr);
 
-  int64_t pad_offset = conv_params.pad[0] * in_padded.strides()[1] +
-      conv_params.pad[1] * in_padded.strides()[2];
+  int64_t pad_offset =
+      static_cast<int64_t>(conv_params.pad[0]) * in_padded.strides()[1] +
+      static_cast<int64_t>(conv_params.pad[1]) * in_padded.strides()[2];
 
+  // Loop over all rows.
   for (int n_offset = 0; n_offset < conv_params.N; n_offset += n_step) {
     int tile_n = std::min(n_step, conv_params.N - n_offset);
     int N_tiles = tile_n * tiles_per_n;
 
-    // Copy this tile's inputs into the interior of the padded scratch buffer
+    // Views for current step.
     array in_tile(
         {tile_n, conv_params.iS[0], conv_params.iS[1], C_c},
         in.dtype(),
@@ -1060,21 +1044,6 @@ void winograd_conv_2D_gpu(
         in_tile.size(),
         n_offset * in.strides()[0]);
 
-    array in_padded_slice(in_tile.shape(), in_padded.dtype(), nullptr, {});
-    in_padded_slice.copy_shared_buffer(
-        in_padded,
-        in_padded.strides(),
-        in_padded.flags(),
-        in_padded_slice.size(),
-        pad_offset);
-
-    copy_gpu_inplace(in_tile, in_padded_slice, CopyType::GeneralGeneral, s);
-    copies_w.push_back(in_padded_slice);
-
-    // The tile writes into its own batch window of the output. Views of the
-    // input and the output must not be registered as temporaries: temporaries
-    // are dropped from the encoder's cross-encoder fence bookkeeping, which
-    // would let a later kernel read the output before this one has written it.
     array out_tile(
         {tile_n, conv_params.oS[0], conv_params.oS[1], O_c},
         out.dtype(),
@@ -1086,6 +1055,18 @@ void winograd_conv_2D_gpu(
         out.flags(),
         out_tile.size(),
         n_offset * out.strides()[0]);
+
+    array in_padded_slice(in_tile.shape(), in_padded.dtype(), nullptr, {});
+    in_padded_slice.copy_shared_buffer(
+        in_padded,
+        in_padded.strides(),
+        in_padded.flags(),
+        in_padded_slice.size(),
+        pad_offset);
+
+    // Copy input values into the slice.
+    copy_gpu_inplace(in_tile, in_padded_slice, CopyType::GeneralGeneral, s);
+    copies_w.push_back(in_padded_slice);
 
     MLXConvParams<2> conv_params_updated{
         /* const int  N = */ tile_n,
@@ -1116,9 +1097,7 @@ void winograd_conv_2D_gpu(
         /* const bool flip = */ false,
     };
 
-    // Do input transform. The transforms lay their result out as
-    // (8 x 8 x N_tiles x channels), so a short tile writes a compacted prefix
-    // of the scratch buffer and the gemm reads it back the same way.
+    // Do input transform, result layout is (8 x 8 x N_tiles x channels).
     {
       int bc = 32;
       int wm = 2;
@@ -1146,7 +1125,7 @@ void winograd_conv_2D_gpu(
       compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
     }
 
-    // Do batched gemm
+    // Do batched gemm.
     {
       array inp_wg_tile({8 * 8, N_tiles, C_c}, inp_wg.dtype(), nullptr, {});
       inp_wg_tile.copy_shared_buffer(
@@ -1180,7 +1159,7 @@ void winograd_conv_2D_gpu(
           /*copies = */ empty_copies);
     }
 
-    // Do output transform
+    // Do output transform.
     {
       int bc = 32;
       int wm = 2;
@@ -1350,8 +1329,7 @@ void dispatch_conv_2D_gpu(
       conv_params.wS[0] == 3 && conv_params.wS[1] == 3 &&
       conv_params.C % 32 == 0 && conv_params.O % 32 == 0 && inp_large &&
       channels_large) {
-    // Falls through to the scratch-free implicit gemm when winograd's scratch
-    // does not fit in the working set.
+    // Only use winograd conv when having enough memory.
     if (int n_step = winograd_batch_step(d, in, conv_params); n_step > 0) {
       return winograd_conv_2D_gpu(
           s, d, in, wt, out, conv_params, copies, n_step);

--- a/python/tests/test_conv.py
+++ b/python/tests/test_conv.py
@@ -1217,9 +1217,9 @@ class TestConv(mlx_tests.MLXTestCase):
 
     @unittest.skipIf(not mx.metal.is_available(), "requires Metal")
     def test_conv2d_winograd_batch_tiling(self):
-        # Winograd's scratch outgrows the GPU working set at large batch and
-        # silently produces zeros (issue #3979). Real repros need tens of GB,
-        # so shrink the budget the selector is handed instead.
+        # Winograd's scratch used to outgrow the GPU working set at large
+        # batch and silently produce zeros (issue #3979). Real repros need
+        # tens of GB, so shrink the budget the selector is handed instead.
         tile_key = "MLX_CONV_WINOGRAD_TILE_BATCH"
         ws_key = "MLX_CONV_WINOGRAD_WORKING_SET"
         prev = {k: os.environ.get(k) for k in (tile_key, ws_key)}
@@ -1233,25 +1233,18 @@ class TestConv(mlx_tests.MLXTestCase):
         )
 
         def run(x, w, **env):
-            # Returns the result plus the bytes the conv itself allocated.
             for k in (tile_key, ws_key):
                 os.environ.pop(k, None)
             os.environ.update(env)
-            # Get the previous run's temporaries off the books first.
-            mx.synchronize()
-            mx.reset_peak_memory()
-            base = mx.get_active_memory()
             y = mx.conv2d(x, w, padding=1)
             mx.eval(y)
-            mx.synchronize()
-            return np.array(y), mx.get_peak_memory() - base
+            return np.array(y)
 
         try:
             for in_shape, wt_shape in cases:
                 np.random.seed(0)
                 x = mx.array(np.random.normal(size=in_shape).astype(np.float32))
-                # Small weights keep the output near unit scale so the
-                # tolerance stays tight.
+                # Small weights keep the output near unit scale.
                 w = mx.array(
                     (np.random.normal(size=wt_shape) * 0.05).astype(np.float32)
                 )
@@ -1259,17 +1252,19 @@ class TestConv(mlx_tests.MLXTestCase):
                 mx.eval(x, w, b)
                 cpu_ref = np.array(mx.conv2d(x, w, padding=1, stream=mx.cpu))
 
-                untiled, untiled_bytes = run(x, w)
+                untiled = run(x, w)
                 self.assertGreater(np.abs(untiled).max(), 0)
                 self.assertTrue(np.allclose(untiled, cpu_ref, atol=1e-3))
 
+                # Tiled winograd keeps the same per-element reduction order,
+                # so it is bit-identical to untiled; the implicit gemm
+                # fallback never is. Exact equality pins each run to its path.
                 # 3 divides none of the batches, so it also covers a short
                 # final tile.
                 for tile in (1, 3):
                     with self.subTest(in_shape=in_shape, tile=tile):
-                        tiled, tiled_bytes = run(x, w, **{tile_key: str(tile)})
-                        self.assertTrue(np.allclose(untiled, tiled, atol=1e-4))
-                        self.assertLess(tiled_bytes, untiled_bytes)
+                        tiled = run(x, w, **{tile_key: str(tile)})
+                        self.assertTrue(np.array_equal(untiled, tiled))
 
                         # A consumer op checks the output is fenced across
                         # command encoders.
@@ -1289,38 +1284,24 @@ class TestConv(mlx_tests.MLXTestCase):
                     pH * pW * C * 4
                     + 64 * ((iH + 5) // 6) * ((iW + 5) // 6) * (C + O) * 4
                 )
-                # Winograd allocates at least the output plus the transformed
-                # filter, the implicit gemm only the output; bracketing the
-                # allocation pins each run to the intended path.
-                winograd_floor = n * iH * iW * O * 4 + 64 * C * O * 4
-                used = mx.get_active_memory() + winograd_floor
+                used = (n * iH * iW * (C + O) + 64 * C * O) * 4
                 with self.subTest(in_shape=in_shape, budget="tiled"):
-                    # Half an element of headroom: allocator rounding makes
-                    # the mirror undershoot.
                     budget = str(int((used + 5 * per_n // 2) / 0.75))
-                    tiled, tiled_bytes = run(x, w, **{ws_key: budget})
-                    self.assertTrue(np.allclose(untiled, tiled, atol=1e-4))
-                    self.assertGreater(tiled_bytes, winograd_floor)
-                    self.assertLess(tiled_bytes, untiled_bytes)
+                    tiled = run(x, w, **{ws_key: budget})
+                    self.assertTrue(np.array_equal(untiled, tiled))
 
-                # Too small for even one batch element: must fall back to the
-                # implicit gemm.
+                # Too small for even one batch element: must fall back.
                 with self.subTest(in_shape=in_shape, budget="infeasible"):
-                    fallback, fallback_bytes = run(x, w, **{ws_key: "1"})
-                    self.assertGreater(np.abs(fallback).max(), 0)
+                    fallback = run(x, w, **{ws_key: "1"})
+                    self.assertFalse(np.array_equal(untiled, fallback))
                     self.assertTrue(np.allclose(fallback, cpu_ref, atol=1e-3))
-                    self.assertLess(fallback_bytes, winograd_floor)
 
                 # A forced tile is capped by the budget, so this must still
                 # fall back.
                 with self.subTest(in_shape=in_shape, budget="forced+infeasible"):
-                    capped, capped_bytes = run(x, w, **{ws_key: "1", tile_key: "1"})
+                    capped = run(x, w, **{ws_key: "1", tile_key: "1"})
+                    self.assertFalse(np.array_equal(untiled, capped))
                     self.assertTrue(np.allclose(capped, cpu_ref, atol=1e-3))
-                    self.assertLess(capped_bytes, winograd_floor)
-
-            with self.subTest(budget="malformed"):
-                with self.assertRaises(ValueError):
-                    run(x, w, **{ws_key: "not-a-number"})
         finally:
             for k, v in prev.items():
                 if v is None:
@@ -1346,19 +1327,14 @@ class TestConv(mlx_tests.MLXTestCase):
         pH = 6 * ((iH + 2 - 2 + 5) // 6) + 2
         pW = 6 * ((iW + 2 - 2 + 5) // 6) + 2
         per_n = pH * pW * C * 4 + 64 * ((iH + 5) // 6) * ((iW + 5) // 6) * (C + O) * 4
-        winograd_floor = n * iH * iW * O * 4 + 64 * C * O * 4
+        used = (n * iH * iW * (C + O) + 64 * C * O) * 4
         try:
-            mx.synchronize()
-            mx.reset_peak_memory()
-            used = mx.get_active_memory() + winograd_floor
+            wino_ref = np.array(mx.conv2d(x, w, padding=1))
             os.environ[ws_key] = str(int((used + 2 * per_n) / 0.75))
-            base = mx.get_active_memory()
-            y = mx.conv2d(x, w, padding=1)
-            mx.eval(y)
-            mx.synchronize()
-            self.assertGreater(np.abs(np.array(y)).max(), 0)
-            self.assertTrue(np.allclose(np.array(y), cpu_ref, atol=1e-3))
-            self.assertLess(mx.get_peak_memory() - base, winograd_floor)
+            y = np.array(mx.conv2d(x, w, padding=1))
+            # Differing from winograd's bits proves the fallback ran.
+            self.assertFalse(np.array_equal(wino_ref, y))
+            self.assertTrue(np.allclose(y, cpu_ref, atol=1e-3))
         finally:
             os.environ.pop(ws_key, None)
             for k, v in prev.items():

--- a/python/tests/test_conv.py
+++ b/python/tests/test_conv.py
@@ -1307,38 +1307,6 @@ class TestConv(mlx_tests.MLXTestCase):
                 else:
                     os.environ[k] = v
 
-    def test_conv2d_winograd_tile_work_floor(self):
-        # A spatially tiny conv reaches winograd on batch size alone, but its
-        # tiles carry almost no gemm work, so a small budget must fall back to
-        # the implicit gemm rather than tile.
-        tile_key = "MLX_CONV_WINOGRAD_TILE_BATCH"
-        ws_key = "MLX_CONV_WINOGRAD_WORKING_SET"
-        prev = {k: os.environ.pop(k, None) for k in (tile_key, ws_key)}
-        in_shape, wt_shape = (256, 4, 4, 64), (192, 3, 3, 64)
-        np.random.seed(0)
-        x = mx.array(np.random.normal(size=in_shape).astype(np.float32))
-        w = mx.array((np.random.normal(size=wt_shape) * 0.05).astype(np.float32))
-        mx.eval(x, w)
-        cpu_ref = np.array(mx.conv2d(x, w, padding=1, stream=mx.cpu))
-        n, iH, iW, C = in_shape
-        O = wt_shape[0]
-        pH = 6 * ((iH + 2 - 2 + 5) // 6) + 2
-        pW = 6 * ((iW + 2 - 2 + 5) // 6) + 2
-        per_n = pH * pW * C * 4 + 64 * ((iH + 5) // 6) * ((iW + 5) // 6) * (C + O) * 4
-        used = (n * iH * iW * (C + O) + 64 * C * O) * 4
-        try:
-            wino_ref = np.array(mx.conv2d(x, w, padding=1))
-            os.environ[ws_key] = str(int((used + 2 * per_n) / 0.75))
-            y = np.array(mx.conv2d(x, w, padding=1))
-            # Differing from winograd's bits proves the fallback ran.
-            self.assertFalse(np.array_equal(wino_ref, y))
-            self.assertTrue(np.allclose(y, cpu_ref, atol=1e-3))
-        finally:
-            os.environ.pop(ws_key, None)
-            for k, v in prev.items():
-                if v is not None:
-                    os.environ[k] = v
-
     def test_conv2d_large_filter_small_channels(self):
         x = mx.random.normal(shape=(1, 181, 181, 1))
         w = mx.random.normal(shape=(1, 182, 182, 1))

--- a/python/tests/test_conv.py
+++ b/python/tests/test_conv.py
@@ -1215,6 +1215,156 @@ class TestConv(mlx_tests.MLXTestCase):
         y_hat = mx.conv_transpose2d(x, w)
         self.assertTrue(mx.allclose(y, y_hat))
 
+    @unittest.skipIf(not mx.metal.is_available(), "requires Metal")
+    def test_conv2d_winograd_batch_tiling(self):
+        # Winograd's scratch outgrows the GPU working set at large batch and
+        # silently produces zeros (issue #3979). Real repros need tens of GB,
+        # so shrink the budget the selector is handed instead.
+        tile_key = "MLX_CONV_WINOGRAD_TILE_BATCH"
+        ws_key = "MLX_CONV_WINOGRAD_WORKING_SET"
+        prev = {k: os.environ.get(k) for k in (tile_key, ws_key)}
+
+        # Winograd needs 3x3 stride-1, channels in multiples of 32,
+        # C + O >= 256 and N * iH * iW >= 4096.
+        cases = (
+            ((8, 48, 48, 64), (192, 3, 3, 64)),
+            ((5, 52, 44, 128), (128, 3, 3, 128)),
+            ((4, 48, 48, 192), (96, 3, 3, 192)),
+        )
+
+        def run(x, w, **env):
+            # Returns the result plus the bytes the conv itself allocated.
+            for k in (tile_key, ws_key):
+                os.environ.pop(k, None)
+            os.environ.update(env)
+            # Get the previous run's temporaries off the books first.
+            mx.synchronize()
+            mx.reset_peak_memory()
+            base = mx.get_active_memory()
+            y = mx.conv2d(x, w, padding=1)
+            mx.eval(y)
+            mx.synchronize()
+            return np.array(y), mx.get_peak_memory() - base
+
+        try:
+            for in_shape, wt_shape in cases:
+                np.random.seed(0)
+                x = mx.array(np.random.normal(size=in_shape).astype(np.float32))
+                # Small weights keep the output near unit scale so the
+                # tolerance stays tight.
+                w = mx.array(
+                    (np.random.normal(size=wt_shape) * 0.05).astype(np.float32)
+                )
+                b = mx.zeros((wt_shape[0],))
+                mx.eval(x, w, b)
+                cpu_ref = np.array(mx.conv2d(x, w, padding=1, stream=mx.cpu))
+
+                untiled, untiled_bytes = run(x, w)
+                self.assertGreater(np.abs(untiled).max(), 0)
+                self.assertTrue(np.allclose(untiled, cpu_ref, atol=1e-3))
+
+                # 3 divides none of the batches, so it also covers a short
+                # final tile.
+                for tile in (1, 3):
+                    with self.subTest(in_shape=in_shape, tile=tile):
+                        tiled, tiled_bytes = run(x, w, **{tile_key: str(tile)})
+                        self.assertTrue(np.allclose(untiled, tiled, atol=1e-4))
+                        self.assertLess(tiled_bytes, untiled_bytes)
+
+                        # A consumer op checks the output is fenced across
+                        # command encoders.
+                        os.environ[tile_key] = str(tile)
+                        fused = mx.conv2d(x, w, padding=1) + b
+                        mx.eval(fused)
+                        self.assertTrue(np.allclose(untiled, fused, atol=1e-4))
+                        os.environ.pop(tile_key, None)
+
+                # Budget for ~2 batch elements so the selector itself must
+                # tile; mirrors the winograd_batch_step arithmetic.
+                n, iH, iW, C = in_shape
+                O = wt_shape[0]
+                pH = 6 * ((iH + 2 - 2 + 5) // 6) + 2
+                pW = 6 * ((iW + 2 - 2 + 5) // 6) + 2
+                per_n = (
+                    pH * pW * C * 4
+                    + 64 * ((iH + 5) // 6) * ((iW + 5) // 6) * (C + O) * 4
+                )
+                # Winograd allocates at least the output plus the transformed
+                # filter, the implicit gemm only the output; bracketing the
+                # allocation pins each run to the intended path.
+                winograd_floor = n * iH * iW * O * 4 + 64 * C * O * 4
+                used = mx.get_active_memory() + winograd_floor
+                with self.subTest(in_shape=in_shape, budget="tiled"):
+                    # Half an element of headroom: allocator rounding makes
+                    # the mirror undershoot.
+                    budget = str(int((used + 5 * per_n // 2) / 0.75))
+                    tiled, tiled_bytes = run(x, w, **{ws_key: budget})
+                    self.assertTrue(np.allclose(untiled, tiled, atol=1e-4))
+                    self.assertGreater(tiled_bytes, winograd_floor)
+                    self.assertLess(tiled_bytes, untiled_bytes)
+
+                # Too small for even one batch element: must fall back to the
+                # implicit gemm.
+                with self.subTest(in_shape=in_shape, budget="infeasible"):
+                    fallback, fallback_bytes = run(x, w, **{ws_key: "1"})
+                    self.assertGreater(np.abs(fallback).max(), 0)
+                    self.assertTrue(np.allclose(fallback, cpu_ref, atol=1e-3))
+                    self.assertLess(fallback_bytes, winograd_floor)
+
+                # A forced tile is capped by the budget, so this must still
+                # fall back.
+                with self.subTest(in_shape=in_shape, budget="forced+infeasible"):
+                    capped, capped_bytes = run(x, w, **{ws_key: "1", tile_key: "1"})
+                    self.assertTrue(np.allclose(capped, cpu_ref, atol=1e-3))
+                    self.assertLess(capped_bytes, winograd_floor)
+
+            with self.subTest(budget="malformed"):
+                with self.assertRaises(ValueError):
+                    run(x, w, **{ws_key: "not-a-number"})
+        finally:
+            for k, v in prev.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+
+    def test_conv2d_winograd_tile_work_floor(self):
+        # A spatially tiny conv reaches winograd on batch size alone, but its
+        # tiles carry almost no gemm work, so a small budget must fall back to
+        # the implicit gemm rather than tile.
+        tile_key = "MLX_CONV_WINOGRAD_TILE_BATCH"
+        ws_key = "MLX_CONV_WINOGRAD_WORKING_SET"
+        prev = {k: os.environ.pop(k, None) for k in (tile_key, ws_key)}
+        in_shape, wt_shape = (256, 4, 4, 64), (192, 3, 3, 64)
+        np.random.seed(0)
+        x = mx.array(np.random.normal(size=in_shape).astype(np.float32))
+        w = mx.array((np.random.normal(size=wt_shape) * 0.05).astype(np.float32))
+        mx.eval(x, w)
+        cpu_ref = np.array(mx.conv2d(x, w, padding=1, stream=mx.cpu))
+        n, iH, iW, C = in_shape
+        O = wt_shape[0]
+        pH = 6 * ((iH + 2 - 2 + 5) // 6) + 2
+        pW = 6 * ((iW + 2 - 2 + 5) // 6) + 2
+        per_n = pH * pW * C * 4 + 64 * ((iH + 5) // 6) * ((iW + 5) // 6) * (C + O) * 4
+        winograd_floor = n * iH * iW * O * 4 + 64 * C * O * 4
+        try:
+            mx.synchronize()
+            mx.reset_peak_memory()
+            used = mx.get_active_memory() + winograd_floor
+            os.environ[ws_key] = str(int((used + 2 * per_n) / 0.75))
+            base = mx.get_active_memory()
+            y = mx.conv2d(x, w, padding=1)
+            mx.eval(y)
+            mx.synchronize()
+            self.assertGreater(np.abs(np.array(y)).max(), 0)
+            self.assertTrue(np.allclose(np.array(y), cpu_ref, atol=1e-3))
+            self.assertLess(mx.get_peak_memory() - base, winograd_floor)
+        finally:
+            os.environ.pop(ws_key, None)
+            for k, v in prev.items():
+                if v is not None:
+                    os.environ[k] = v
+
     def test_conv2d_large_filter_small_channels(self):
         x = mx.random.normal(shape=(1, 181, 181, 1))
         w = mx.random.normal(shape=(1, 182, 182, 1))

--- a/python/tests/test_conv.py
+++ b/python/tests/test_conv.py
@@ -1217,9 +1217,7 @@ class TestConv(mlx_tests.MLXTestCase):
 
     @unittest.skipIf(not mx.metal.is_available(), "requires Metal")
     def test_conv2d_winograd_batch_tiling(self):
-        # Winograd's scratch used to outgrow the GPU working set at large
-        # batch and silently produce zeros (issue #3979). Real repros need
-        # tens of GB, so shrink the budget the selector is handed instead.
+        # Use envs to test tiling without allocating large buffers.
         tile_key = "MLX_CONV_WINOGRAD_TILE_BATCH"
         ws_key = "MLX_CONV_WINOGRAD_WORKING_SET"
         prev = {k: os.environ.get(k) for k in (tile_key, ws_key)}
@@ -1232,7 +1230,7 @@ class TestConv(mlx_tests.MLXTestCase):
             ((4, 48, 48, 192), (96, 3, 3, 192)),
         )
 
-        def run(x, w, **env):
+        def run(x, w, env={}):
             for k in (tile_key, ws_key):
                 os.environ.pop(k, None)
             os.environ.update(env)
@@ -1263,7 +1261,7 @@ class TestConv(mlx_tests.MLXTestCase):
                 # final tile.
                 for tile in (1, 3):
                     with self.subTest(in_shape=in_shape, tile=tile):
-                        tiled = run(x, w, **{tile_key: str(tile)})
+                        tiled = run(x, w, {tile_key: str(tile)})
                         self.assertTrue(np.array_equal(untiled, tiled))
 
                         # A consumer op checks the output is fenced across
@@ -1287,19 +1285,19 @@ class TestConv(mlx_tests.MLXTestCase):
                 used = (n * iH * iW * (C + O) + 64 * C * O) * 4
                 with self.subTest(in_shape=in_shape, budget="tiled"):
                     budget = str(int((used + 5 * per_n // 2) / 0.75))
-                    tiled = run(x, w, **{ws_key: budget})
+                    tiled = run(x, w, {ws_key: budget})
                     self.assertTrue(np.array_equal(untiled, tiled))
 
                 # Too small for even one batch element: must fall back.
                 with self.subTest(in_shape=in_shape, budget="infeasible"):
-                    fallback = run(x, w, **{ws_key: "1"})
+                    fallback = run(x, w, {ws_key: "1"})
                     self.assertFalse(np.array_equal(untiled, fallback))
                     self.assertTrue(np.allclose(fallback, cpu_ref, atol=1e-3))
 
                 # A forced tile is capped by the budget, so this must still
                 # fall back.
                 with self.subTest(in_shape=in_shape, budget="forced+infeasible"):
-                    capped = run(x, w, **{ws_key: "1", tile_key: "1"})
+                    capped = run(x, w, {ws_key: "1", tile_key: "1"})
                     self.assertFalse(np.array_equal(untiled, capped))
                     self.assertTrue(np.allclose(capped, cpu_ref, atol=1e-3))
         finally:


### PR DESCRIPTION
Addresses the conv2d manifestation of #3979 — the conv-side guard, not a fix for the general silent-error mechanism.

## Problem

`conv2d` on Metal silently returns all zeros for large batched inputs. The Winograd path keeps the padded input and both GEMM workspaces alive at once (~3.7x the input for the reported shapes), all referenced by one command buffer; once that working set exceeds `recommendedMaxWorkingSetSize` the driver fails the command buffer. As [@jasonge27's instrumentation](https://github.com/ml-explore/mlx/issues/3979#issuecomment-5231678147) shows, Metal reports the OOM but errors from mid-eval commits are dropped, so nothing surfaces. Winograd's selection criteria (`C % 32 == 0 && O % 32 == 0 && C + O >= 256`) explain the channel dependence in the report. That dropped-error mechanism is general and needs a separate, complementary fix in the eval machinery; this PR avoids the OOM for conv2d, which also bounds its peak memory.

## Fix

Run the batch in tiles sized from the available working set, reusing one set of scratch buffers across tiles — mirroring the row tiling in `explicit_gemm_conv_ND_gpu`. The budget is 3/4 of `recommendedMaxWorkingSetSize` minus the conv's own tensors (input, output, and transformed filter), making the tile choice a deterministic function of the conv and the device. Measured failures start at ~99% of the reported limit; the quarter held back is headroom for what is not charged — GPU memory held by other processes and allocations unrelated to the conv.

When the whole batch fits, the common case, the emitted work is unchanged. It falls back to the scratch-free implicit GEMM when not even one batch element fits, or when tiles would carry too few GEMM rows to amortize their fixed cost (small tiles can be far slower than the fallback).

## Testing

The real threshold needs tens of GB, so tests shrink the budget instead:

- `MLX_CONV_WINOGRAD_WORKING_SET` injects the byte budget: covers automatic tiling and both fallbacks.
- `MLX_CONV_WINOGRAD_TILE_BATCH` forces a tile size (capped by the budget): covers uniform tiles, a short final tile, and a consumer op reading the tiled output in the same eval.

Tiling keeps the per-element reduction order, so tiled Winograd is bit-identical to untiled while the implicit GEMM fallback never is — the tests use exact equality to pin each run to its intended path, with no memory measurements.

At real sizes on a 96 GB M2 Max: the issue's repro passes (previously all-zero at batch 80 on this machine; the reporter hit it at batch 40 on 48 GB), tiled vs untiled outputs are bit-identical at ~50 GB scale, CPU cross-checks agree, and the batch-80 repro peaks at 58 GB where untiled Winograd would need ~84 GB. On the reported fp32 shape (40x512x512, 192 -> 96 channels) Winograd runs ~1.7x faster than implicit GEMM (310 ms vs 536 ms), while a spatially tiny conv (256x4x4, 64 -> 192) cut into one-element Winograd tiles is ~40x slower than implicit GEMM — the two sides of the tile-versus-fallback trade-off. Mid-size Winograd shapes select a single tile and show no regression.
