### PR TITLE
Refactor CPU Matmul dtype dispatch

### DIFF
--- a/mlx/backend/cpu/matmul.cpp
+++ b/mlx/backend/cpu/matmul.cpp
@@ -7,6 +7,7 @@
 #include "mlx/backend/cpu/copy.h"
 #include "mlx/backend/cpu/encoder.h"
 #include "mlx/backend/cpu/gemm.h"
+#include "mlx/dtype_utils.h"
 #include "mlx/primitives.h"
 
 namespace mlx::core {
@@ -97,24 +98,11 @@ void matmul_general(
     return;
   }
 
-  if (out.dtype() == float32) {
-    matmul_dispatch<float>(
+  dispatch_inexact_types(out.dtype(), "[Matmul::eval_cpu]", [&](auto type_tag) {
+    using T = MLX_GET_TYPE(type_tag);
+    matmul_dispatch<T>(
         a, b, out, a_transposed, b_transposed, lda, ldb, alpha, beta, stream);
-  } else if (out.dtype() == float16) {
-    matmul_dispatch<float16_t>(
-        a, b, out, a_transposed, b_transposed, lda, ldb, alpha, beta, stream);
-  } else if (out.dtype() == bfloat16) {
-    matmul_dispatch<bfloat16_t>(
-        a, b, out, a_transposed, b_transposed, lda, ldb, alpha, beta, stream);
-  } else if (out.dtype() == float64) {
-    matmul_dispatch<double>(
-        a, b, out, a_transposed, b_transposed, lda, ldb, alpha, beta, stream);
-  } else if (out.dtype() == complex64) {
-    matmul_dispatch<complex64_t>(
-        a, b, out, a_transposed, b_transposed, lda, ldb, alpha, beta, stream);
-  } else {
-    throw std::runtime_error("[Matmul::eval_cpu] Invalid type.");
-  }
+  });
   cpu::get_command_encoder(stream).add_temporaries(std::move(temps));
 }
 


### PR DESCRIPTION
## Summary

CPU Matmul repeats the same `matmul_dispatch<T>` call for each supported
inexact dtype. Replace the branch chain with `dispatch_inexact_types`,
preserving the existing float16, bfloat16, float32, float64, and complex64
specializations.

The public Matmul and AddMM paths already validate and promote inputs to an
inexact dtype; `dispatch_inexact_types` remains the defensive backend
validation.

## Testing

- CPU Release build with C++20 and warnings as errors
- CPU Matmul coverage for all five current inexact dtypes
- `python/tests/test_blas.py`
- Native C++ tests
- Formatting and `git diff --check`
