### PR TITLE
Refactor CPU Copy destination dtype dispatch

### DIFF
--- a/mlx/backend/cpu/copy.cpp
+++ b/mlx/backend/cpu/copy.cpp
@@ -7,6 +7,7 @@
 #include "mlx/backend/cpu/copy.h"
 #include "mlx/backend/cpu/encoder.h"
 #include "mlx/backend/cpu/simd/simd.h"
+#include "mlx/dtype_utils.h"
 
 namespace mlx::core {
 
@@ -196,50 +197,10 @@ void copy(const array& src, array& dst, CopyType ctype, Args&&... args) {
 
 template <typename SrcT, typename... Args>
 void copy(const array& src, array& dst, CopyType ctype, Args&&... args) {
-  switch (dst.dtype()) {
-    case bool_:
-      copy<SrcT, bool>(src, dst, ctype, std::forward<Args>(args)...);
-      break;
-    case uint8:
-      copy<SrcT, uint8_t>(src, dst, ctype, std::forward<Args>(args)...);
-      break;
-    case uint16:
-      copy<SrcT, uint16_t>(src, dst, ctype, std::forward<Args>(args)...);
-      break;
-    case uint32:
-      copy<SrcT, uint32_t>(src, dst, ctype, std::forward<Args>(args)...);
-      break;
-    case uint64:
-      copy<SrcT, uint64_t>(src, dst, ctype, std::forward<Args>(args)...);
-      break;
-    case int8:
-      copy<SrcT, int8_t>(src, dst, ctype, std::forward<Args>(args)...);
-      break;
-    case int16:
-      copy<SrcT, int16_t>(src, dst, ctype, std::forward<Args>(args)...);
-      break;
-    case int32:
-      copy<SrcT, int32_t>(src, dst, ctype, std::forward<Args>(args)...);
-      break;
-    case int64:
-      copy<SrcT, int64_t>(src, dst, ctype, std::forward<Args>(args)...);
-      break;
-    case float16:
-      copy<SrcT, float16_t>(src, dst, ctype, std::forward<Args>(args)...);
-      break;
-    case float32:
-      copy<SrcT, float>(src, dst, ctype, std::forward<Args>(args)...);
-      break;
-    case float64:
-      copy<SrcT, double>(src, dst, ctype, std::forward<Args>(args)...);
-      break;
-    case bfloat16:
-      copy<SrcT, bfloat16_t>(src, dst, ctype, std::forward<Args>(args)...);
-      break;
-    case complex64:
-      copy<SrcT, complex64_t>(src, dst, ctype, std::forward<Args>(args)...);
-      break;
-  }
+  dispatch_all_types(dst.dtype(), [&](auto type_tag) {
+    using DstT = MLX_GET_TYPE(type_tag);
+    copy<SrcT, DstT>(src, dst, ctype, std::forward<Args>(args)...);
+  });
 }
 
 template <typename... Args>


### PR DESCRIPTION
## Summary

CPU Copy repeats the same `copy<SrcT, DstT>` call for each of the 14 current
destination dtypes. Replace that switch with `dispatch_all_types`, preserving
the existing source-dtype switch and all four `CopyType` implementations.

This removes a duplicated dtype list while keeping the destination set in the
common dispatcher. In the paired Release build, `copy.cpp.o` decreased by 112
bytes; `libmlx.dylib` was size-neutral, and the Python extension was
byte-identical.

## Testing

- CPU-only Release build with C++20 and warnings as errors
- All 196 source/destination dtype pairs for Scalar, Vector, and General, plus
  28 GeneralGeneral cases spanning every source and destination dtype
- `python/tests/test_ops.py` (149 tests)
- `python/tests/test_array.py` (98 tests, 20 skipped)
- Native C++ suite (247 test cases, 3,326 assertions)
- Formatting and `git diff --check`
