### PR TITLE
Refactor generic CPU binary dtype dispatch

### DIFF
--- a/mlx/backend/cpu/binary.h
+++ b/mlx/backend/cpu/binary.h
@@ -6,6 +6,7 @@
 #include "mlx/array.h"
 #include "mlx/backend/common/binary.h"
 #include "mlx/backend/common/utils.h"
+#include "mlx/dtype_utils.h"
 
 #include "mlx/backend/cpu/encoder.h"
 #include "mlx/backend/cpu/simd/simd.h"
@@ -309,50 +310,10 @@ void binary_op_cpu(
                     b = array::unsafe_weak_copy(b),
                     out = array::unsafe_weak_copy(out),
                     bopt]() mutable {
-    switch (out.dtype()) {
-      case bool_:
-        binary_op<bool, Op>(a, b, out, bopt);
-        break;
-      case uint8:
-        binary_op<uint8_t, Op>(a, b, out, bopt);
-        break;
-      case uint16:
-        binary_op<uint16_t, Op>(a, b, out, bopt);
-        break;
-      case uint32:
-        binary_op<uint32_t, Op>(a, b, out, bopt);
-        break;
-      case uint64:
-        binary_op<uint64_t, Op>(a, b, out, bopt);
-        break;
-      case int8:
-        binary_op<int8_t, Op>(a, b, out, bopt);
-        break;
-      case int16:
-        binary_op<int16_t, Op>(a, b, out, bopt);
-        break;
-      case int32:
-        binary_op<int32_t, Op>(a, b, out, bopt);
-        break;
-      case int64:
-        binary_op<int64_t, Op>(a, b, out, bopt);
-        break;
-      case float16:
-        binary_op<float16_t, Op>(a, b, out, bopt);
-        break;
-      case float32:
-        binary_op<float, Op>(a, b, out, bopt);
-        break;
-      case float64:
-        binary_op<double, Op>(a, b, out, bopt);
-        break;
-      case bfloat16:
-        binary_op<bfloat16_t, Op>(a, b, out, bopt);
-        break;
-      case complex64:
-        binary_op<complex64_t, Op>(a, b, out, bopt);
-        break;
-    }
+    dispatch_all_types(out.dtype(), [&](auto type_tag) {
+      using T = MLX_GET_TYPE(type_tag);
+      binary_op<T, Op>(a, b, out, bopt);
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

CPU `binary_op_cpu` repeats the same `binary_op<T, Op>` call for each of the
14 current dtypes. Replace the output-type switch with `dispatch_all_types`,
preserving all existing type instantiations.

The restricted comparison, inexact, and integer dispatchers remain unchanged.
Include `mlx/dtype_utils.h` directly for the common dispatcher.

## Testing

- CPU Release build with C++20 and warnings as errors
- Baseline/candidate parity for 10 binary operation families across all 14
  dtypes and six scalar, vector, strided, and broadcast layouts (840/840 cases)
- `python/tests/test_ops.py` (149/149)
- Full CPU Python discovery (810 tests, 75 skipped; no failures)
- Native C++ suite (247/247 cases, 3,326/3,326 assertions)
- `pre-commit` and `git diff --check`
