### PR TITLE
Refactor CPU GatherAxis dtype dispatch

### DIFF
--- a/mlx/backend/cpu/indexing.cpp
+++ b/mlx/backend/cpu/indexing.cpp
@@ -281,50 +281,10 @@ void dispatch_gather_axis(
     const array& inds,
     array& out,
     const int axis) {
-  switch (out.dtype()) {
-    case bool_:
-      gather_axis<bool, IdxT>(src, inds, out, axis);
-      break;
-    case uint8:
-      gather_axis<uint8_t, IdxT>(src, inds, out, axis);
-      break;
-    case uint16:
-      gather_axis<uint16_t, IdxT>(src, inds, out, axis);
-      break;
-    case uint32:
-      gather_axis<uint32_t, IdxT>(src, inds, out, axis);
-      break;
-    case uint64:
-      gather_axis<uint64_t, IdxT>(src, inds, out, axis);
-      break;
-    case int8:
-      gather_axis<int8_t, IdxT>(src, inds, out, axis);
-      break;
-    case int16:
-      gather_axis<int16_t, IdxT>(src, inds, out, axis);
-      break;
-    case int32:
-      gather_axis<int32_t, IdxT>(src, inds, out, axis);
-      break;
-    case int64:
-      gather_axis<int64_t, IdxT>(src, inds, out, axis);
-      break;
-    case float16:
-      gather_axis<float16_t, IdxT>(src, inds, out, axis);
-      break;
-    case float32:
-      gather_axis<float, IdxT>(src, inds, out, axis);
-      break;
-    case float64:
-      gather_axis<double, IdxT>(src, inds, out, axis);
-      break;
-    case bfloat16:
-      gather_axis<bfloat16_t, IdxT>(src, inds, out, axis);
-      break;
-    case complex64:
-      gather_axis<complex64_t, IdxT>(src, inds, out, axis);
-      break;
-  }
+  dispatch_all_types(out.dtype(), [&](auto type_tag) {
+    using T = MLX_GET_TYPE(type_tag);
+    gather_axis<T, IdxT>(src, inds, out, axis);
+  });
 }
 
 void GatherAxis::eval_cpu(const std::vector<array>& inputs, array& out) {


### PR DESCRIPTION
## Summary

CPU GatherAxis repeats the same `gather_axis<T, IdxT>` call for each supported
payload dtype. Replace that payload switch with `dispatch_all_types`,
preserving all 14 existing payload instantiations.

The separate eight-way index dispatch and its unsupported-index diagnostic
remain unchanged. This moves the `take_along_axis` payload path onto the
existing common dispatcher without changing behavior.

## Testing

- Release CPU build with C++20 and warnings as errors
- All 14 payload dtypes across all 8 supported index dtypes
- Contiguous and strided source/index arrays, negative axes, signed negative
  indices, and empty dimensions
- #4105 changes `dispatch_gather`; this changes only `dispatch_gather_axis`.
  The patches apply cleanly in either order, and the combined tree passes
  Release/Werror and the 336-case matrix
- `python/tests/test_ops.py` on current main (150 passed)
- Native C++ suite (247/247 cases, 3,326/3,326 assertions)
- `pre-commit` and `git diff --check`
