### PR TITLE
Fix intermittent crashes at thread and interpreter teardown

### DIFF
--- a/mlx/backend/cuda/cublas_utils.cpp
+++ b/mlx/backend/cuda/cublas_utils.cpp
@@ -45,8 +45,10 @@ auto& cublas_handles_cache() {
   struct CublasHandles {
     ~CublasHandles() {
       if (handle) {
-        CHECK_CUBLAS_ERROR(cublasLtDestroy(handle));
-        CHECK_CUBLAS_ERROR(cublasLtMatmulPreferenceDestroy(pref));
+        // Unchecked: destroy can fail once the library is unloading, and
+        // throwing from this thread_local destructor would call std::terminate.
+        cublasLtDestroy(handle);
+        cublasLtMatmulPreferenceDestroy(pref);
       }
     }
     cublasLtHandle_t handle{nullptr};

--- a/mlx/backend/cuda/cuda_utils.h
+++ b/mlx/backend/cuda/cuda_utils.h
@@ -30,7 +30,13 @@ class CudaHandle {
     if (cudaPeekAtLastError() != cudaSuccess) {
       return;
     }
-    reset();
+    // Not reset(): the check above only catches an already-pending error, so
+    // Destroy can still return cudaErrorCudartUnloading at teardown, which
+    // CHECK_CUDA_ERROR would throw out of this destructor.
+    if (handle_ != nullptr) {
+      Destroy(handle_);
+      handle_ = nullptr;
+    }
   }
 
   CudaHandle(const CudaHandle&) = delete;

--- a/mlx/backend/cuda/cudnn_utils.cpp
+++ b/mlx/backend/cuda/cudnn_utils.cpp
@@ -52,7 +52,8 @@ auto& cudnn_handles_cache() {
   struct CudnnHandle {
     ~CudnnHandle() {
       if (handle) {
-        CHECK_CUDNN_ERROR(cudnnDestroy(handle));
+        // Unchecked, as in CublasHandles: cudnnDestroy can fail at teardown.
+        cudnnDestroy(handle);
       }
     }
     cudnnHandle_t handle{nullptr};

--- a/mlx/backend/cuda/device.cpp
+++ b/mlx/backend/cuda/device.cpp
@@ -213,7 +213,12 @@ CommandEncoder::CommandEncoder(Device& d)
 }
 
 CommandEncoder::~CommandEncoder() {
-  synchronize();
+  // Runs from __call_tls_dtors(), where synchronize() can fail and
+  // CHECK_CUDA_ERROR would throw out of a noexcept destructor.
+  try {
+    synchronize();
+  } catch (...) {
+  }
   worker_->stop();
 }
 

--- a/python/src/CMakeLists.txt
+++ b/python/src/CMakeLists.txt
@@ -14,6 +14,7 @@ nanobind_add_module(
   ${CMAKE_CURRENT_SOURCE_DIR}/export.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/fast.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/fft.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/gil.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/indexing.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/load.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/metal.cpp

--- a/python/src/gil.cpp
+++ b/python/src/gil.cpp
@@ -1,0 +1,54 @@
+// Copyright © 2026 Apple Inc.
+
+#include "python/src/gil.h"
+
+#include <mutex>
+#include <vector>
+
+namespace {
+
+struct DeferredReleases {
+  std::mutex mtx;
+  // Raw PyObject* because dropping a reference needs the GIL, which the
+  // queueing thread does not hold. Whatever is still queued at exit is leaked.
+  std::vector<PyObject*> refs;
+};
+
+DeferredReleases& deferred() {
+  // Leak - see Scheduler singleton comment in scheduler.cpp. Threads exiting
+  // late can queue here after static destruction would have run.
+  static DeferredReleases* deferred_ = new DeferredReleases;
+  return *deferred_;
+}
+
+} // namespace
+
+bool py_is_finalizing() {
+#if PY_VERSION_HEX >= 0x030D0000
+  return Py_IsFinalizing();
+#else
+  return _Py_IsFinalizing();
+#endif
+}
+
+void defer_release(nb::object&& obj) {
+  PyObject* ptr = obj.release().ptr();
+  if (ptr == nullptr) {
+    return;
+  }
+  auto& d = deferred();
+  std::lock_guard<std::mutex> lk(d.mtx);
+  d.refs.push_back(ptr);
+}
+
+void drain_deferred_releases() {
+  auto& d = deferred();
+  std::vector<PyObject*> pending;
+  {
+    std::lock_guard<std::mutex> lk(d.mtx);
+    pending.swap(d.refs);
+  }
+  for (PyObject* ptr : pending) {
+    Py_DECREF(ptr);
+  }
+}

--- a/python/src/gil.h
+++ b/python/src/gil.h
@@ -1,0 +1,18 @@
+// Copyright © 2026 Apple Inc.
+
+#pragma once
+
+#include <nanobind/nanobind.h>
+
+namespace nb = nanobind;
+
+// True once CPython has begun finalizing. Py_IsInitialized() is not a
+// substitute; it stays true for most of finalization.
+bool py_is_finalizing();
+
+// Queue a strong reference to drop later, for references a thread_local
+// destructor cannot drop itself. Safe to call without the GIL.
+void defer_release(nb::object&& obj);
+
+// Drop everything queued. The caller must hold the GIL.
+void drain_deferred_releases();

--- a/python/src/random.cpp
+++ b/python/src/random.cpp
@@ -9,6 +9,7 @@
 
 #include "mlx/ops.h"
 #include "mlx/random.h"
+#include "python/src/gil.h"
 #include "python/src/random.h"
 #include "python/src/small_vector.h"
 #include "python/src/utils.h"
@@ -20,10 +21,12 @@ using namespace nb::literals;
 class PyKeySequence {
  public:
   ~PyKeySequence() {
-    if (state_.has_value()) {
-      nb::gil_scoped_acquire gil;
-      state_.reset();
+    if (!state_.has_value()) {
+      return;
     }
+    // Runs from __call_tls_dtors(), where taking the GIL can be fatal (gil.h).
+    defer_release(std::move(*state_));
+    state_.reset();
   }
 
   void reset() {
@@ -41,6 +44,8 @@ class PyKeySequence {
   }
 
   nb::list& state() {
+    // GIL is held here: drain what exiting threads parked.
+    drain_deferred_releases();
     if (!state_) {
       static auto time_seed = []() {
         auto now = std::chrono::system_clock::now();

--- a/python/src/transforms.cpp
+++ b/python/src/transforms.cpp
@@ -19,6 +19,7 @@
 #include "mlx/transforms.h"
 #include "mlx/transforms_impl.h"
 #include "mlx/utils.h"
+#include "python/src/gil.h"
 #include "python/src/mlx_func.h"
 #include "python/src/small_vector.h"
 #include "python/src/trees.h"
@@ -411,10 +412,15 @@ void ensure_compile_cache_cleanup() {
   // before python interpreter exits.
   struct ThreadCleanup {
     ~ThreadCleanup() {
-      if (!mx::detail::compile_cache_empty()) {
-        nb::gil_scoped_acquire gil;
-        mx::detail::compile_clear_cache();
+      if (mx::detail::compile_cache_empty()) {
+        return;
       }
+      // No GIL from a thread_local destructor (gil.h); the atexit hook below
+      // still clears with it held.
+      if (py_is_finalizing()) {
+        return;
+      }
+      mx::detail::compile_clear_cache();
     }
   };
   static thread_local auto clear_cache = []() {
@@ -438,6 +444,12 @@ struct PyCompiledFun {
 
     AttachedData(nb::object output_structure_, int num_outputs_)
         : output_structure(output_structure_), num_outputs(num_outputs_) {}
+
+    ~AttachedData() {
+      // Owned by the thread_local compile cache, so this can run without the
+      // GIL (gil.h); DECREF-ing there can race Python's GC.
+      defer_release(std::move(output_structure));
+    }
   };
 
   PyCompiledFun(
@@ -465,6 +477,8 @@ struct PyCompiledFun {
 
   nb::object call_impl(const nb::args& args, const nb::kwargs& kwargs) {
     ensure_compile_cache_cleanup();
+    // GIL is held here: drain what exiting threads parked.
+    drain_deferred_releases();
 
     // Flat array inputs
     std::vector<mx::array> inputs;

--- a/python/tests/test_teardown.py
+++ b/python/tests/test_teardown.py
@@ -1,0 +1,107 @@
+# Copyright © 2026 Apple Inc.
+
+"""Regression tests for crashes at thread and interpreter teardown.
+
+These cannot be written as ordinary assertions: the failure mode is the process dying
+(std::terminate, or SIGSEGV) during `__call_tls_dtors()`, so there is nothing left to
+assert on. Each case therefore runs a small program in a subprocess and checks that it
+exits cleanly.
+
+The faults are intermittent on Linux, though reliable on Windows, so a single clean run
+is not evidence of a fix. Each case therefore repeats.
+"""
+
+import subprocess
+import sys
+import unittest
+
+import mlx_tests
+
+# Two worker threads, each running a compiled function whose captured state includes
+# mx.random.state, on a CPU stream. This is the shape that made PyKeySequence and the
+# compile cache's ThreadCleanup destructors acquire the GIL from a thread_local
+# destructor -- which CPython answers, when another thread is finalizing, by calling
+# PyThread_exit_thread(). The forced unwind then crosses a noexcept destructor.
+GIL_IN_TLS_DTOR = """
+import threading
+from functools import partial
+import mlx.core as mx
+
+def make_fn():
+    @partial(mx.compile, inputs=mx.random.state, outputs=mx.random.state)
+    def f():
+        return mx.random.uniform(shape=(10, 10))
+
+    return f
+
+
+fns = [make_fn() for _ in range(2)]
+
+def worker(f):
+    with mx.stream(mx.cpu):
+        a = f()
+        b = f()
+        mx.eval(a, b)
+
+for f in fns:
+    t = threading.Thread(target=worker, args=(f,))
+    t.start()
+    t.join()
+"""
+
+# Sequential worker threads doing GPU work with a compiled function returning a tuple.
+# This is what exposed the throwing CUDA destructors (~CommandEncoder calling
+# synchronize(), ~CublasHandles, ~CudnnHandle): the *first* thread's teardown killed the
+# process as join() returned. It also covers dropping a Python reference (the compiled
+# function's output structure) from a thread_local destructor without the GIL.
+THREADED_COMPILE_TEARDOWN = """
+import gc
+import threading
+import mlx.core as mx
+
+@mx.compile
+def fun(x):
+    return x + 1.0, x + 1.0
+
+def worker():
+    x = mx.array([1.0])
+    y, z = fun(x)
+    mx.eval(y, z)
+    assert y.item() == 2.0 and z.item() == 2.0
+
+for _ in range(3):
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join()
+    gc.collect()
+"""
+
+
+class TestTeardown(mlx_tests.MLXTestCase):
+    def _run_repeatedly(self, program, runs=8):
+        failures = []
+        for i in range(runs):
+            p = subprocess.run(
+                [sys.executable, "-c", program],
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+            if p.returncode != 0:
+                failures.append((i, p.returncode, p.stderr[-2000:]))
+        if failures:
+            i, rc, err = failures[0]
+            self.fail(
+                f"{len(failures)}/{runs} runs died at teardown; "
+                f"first was run {i} with exit {rc}:\n{err}"
+            )
+
+    def test_gil_not_acquired_from_thread_local_destructor(self):
+        self._run_repeatedly(GIL_IN_TLS_DTOR)
+
+    def test_threaded_compile_teardown(self):
+        self._run_repeatedly(THREADED_COMPILE_TEARDOWN)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Proposed changes

MLX sometimes dies at thread or process teardown with "terminate called without an active exception" or SIGSEGV, on Linux/Windows.  The general pattern: a destructor reachable from __call_tls_dtors() must not acquire the GIL, nor throw, nor drop a Python reference.

Acquiring the GIL is fatal because take_gil() answers a request from a non-finalizing thread, while another thread finalizes, by calling PyThread_exit_thread(); the forced unwind then crosses the noexcept destructor frame.

Throwing is equally fatal: CUDA destructors ran CHECK_*_ERROR on teardown calls that legitimately fail -- every Windows run with two threads died.

Adds python/tests/test_teardown.py. The failure kills the process, so the cases run in subprocesses and repeat; both fail without this change.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
