### PR TITLE
Refactor inexact CPU unary dtype dispatch

### DIFF
--- a/mlx/backend/cpu/unary.h
+++ b/mlx/backend/cpu/unary.h
@@ -106,27 +106,9 @@ void unary_fp(const array& a, array& out, Op op, Stream stream) {
   encoder.dispatch([a = array::unsafe_weak_copy(a),
                     out = array::unsafe_weak_copy(out),
                     op = op]() mutable {
-    switch (out.dtype()) {
-      case bfloat16:
-        unary_op<bfloat16_t>(a, out, op);
-        break;
-      case float16:
-        unary_op<float16_t>(a, out, op);
-        break;
-      case float32:
-        unary_op<float>(a, out, op);
-        break;
-      case float64:
-        unary_op<double>(a, out, op);
-        break;
-      case complex64:
-        unary_op<complex64_t>(a, out, op);
-        break;
-      default:
-        std::ostringstream err;
-        err << "[unary_fp] Does not support " << out.dtype();
-        throw std::runtime_error(err.str());
-    }
+    dispatch_inexact_types(out.dtype(), "[unary_fp]", [&](auto type_tag) {
+      unary_op<MLX_GET_TYPE(type_tag)>(a, out, op);
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

Replace `unary_fp`'s explicit five-dtype switch with
`dispatch_inexact_types`.

This preserves the existing `float16`, `bfloat16`, `float32`, `float64`, and
`complex64` mappings while making the helper's accepted set follow the common
inexact dtype category. Public non-inexact inputs are promoted or bypassed
before this helper; an invalid internal call receives the common dispatcher's
more specific `invalid_argument` diagnostic.

#4106 has now merged with the same patch that was reviewed. On current main,
this is a single +3/-21 `unary_fp` hunk.

## Testing

- Release CPU-only build with C++20 and warnings as errors
- All public-reachable `unary_fp` operation and dtype combinations with
  contiguous and noncontiguous inputs (236 baseline-matched cases)
- Public bool and integer promotion/bypass matrix (432 baseline-matched cases)
- `python/tests/test_ops.py` on current main (150/150)
- Native C++ suite (247/247 cases, 3,326/3,326 assertions)
- `pre-commit` and `git diff --check`
