### PR TITLE
Fix vmap of partition/argpartition dropping the kth argument

### DIFF
--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -616,7 +616,7 @@ std::pair<std::vector<array>, std::vector<int>> ArgPartition::vmap(
   assert(axes.size() == 1);
 
   int axis_left = axes[0] >= 0 && axes[0] <= axis_;
-  return {{argpartition(inputs[0], axis_ + axis_left, stream())}, axes};
+  return {{argpartition(inputs[0], kth_, axis_ + axis_left, stream())}, axes};
 }
 
 std::vector<array> ArgPartition::vjp(
@@ -3417,7 +3417,7 @@ std::pair<std::vector<array>, std::vector<int>> Partition::vmap(
   assert(axes.size() == 1);
 
   int axis_left = axes[0] >= 0 && axes[0] <= axis_;
-  return {{partition(inputs[0], axis_ + axis_left, stream())}, axes};
+  return {{partition(inputs[0], kth_, axis_ + axis_left, stream())}, axes};
 }
 
 bool Partition::is_equivalent(const Primitive& other) const {

--- a/python/tests/test_vmap.py
+++ b/python/tests/test_vmap.py
@@ -252,6 +252,85 @@ class TestVmap(mlx_tests.MLXTestCase):
         expected = mx.array([2, 1])
         self.assertTrue(mx.array_equal(out, expected))
 
+    def _unstack(self, x, axis):
+        return [s.squeeze(axis) for s in mx.split(x, x.shape[axis], axis=axis)]
+
+    def test_vmap_partition(self):
+        # Distinct values so each lane has a single valid kth element
+        a = mx.random.permutation(2 * 3 * 4).reshape(2, 3, 4).astype(mx.float32)
+
+        for in_axis in (0, 1, 2):
+            slices = self._unstack(a, in_axis)
+            # Axis of the batched output that the inner axis maps onto
+            out_axes_map = [d for d in range(a.ndim) if d != in_axis]
+            for axis in (0, 1, -1):
+                oaxis = out_axes_map[axis if axis >= 0 else axis + 2]
+                for kth in range(slices[0].shape[axis]):
+                    expected = mx.stack(
+                        [mx.partition(x, kth, axis=axis) for x in slices],
+                        axis=in_axis,
+                    )
+                    pivot = mx.take(expected, mx.array([kth]), axis=oaxis)
+
+                    out = mx.vmap(
+                        lambda x: mx.partition(x, kth, axis=axis),
+                        in_axes=in_axis,
+                        out_axes=in_axis,
+                    )(a)
+                    self.assertEqual(out.shape, expected.shape)
+                    # partition only pins the kth element; the two sides are
+                    # an arbitrary permutation, so compare against the sorted
+                    # input rather than element-wise.
+                    self.assertTrue(
+                        mx.array_equal(mx.sort(out, axis=oaxis), mx.sort(a, axis=oaxis))
+                    )
+                    self.assertTrue(
+                        mx.array_equal(mx.take(out, mx.array([kth]), axis=oaxis), pivot)
+                    )
+
+                    idx = mx.vmap(
+                        lambda x: mx.argpartition(x, kth, axis=axis),
+                        in_axes=in_axis,
+                        out_axes=in_axis,
+                    )(a)
+                    self.assertEqual(idx.shape, expected.shape)
+                    gathered = mx.take_along_axis(a, idx, axis=oaxis)
+                    self.assertTrue(
+                        mx.array_equal(
+                            mx.sort(gathered, axis=oaxis), mx.sort(a, axis=oaxis)
+                        )
+                    )
+                    self.assertTrue(
+                        mx.array_equal(
+                            mx.take(gathered, mx.array([kth]), axis=oaxis), pivot
+                        )
+                    )
+
+    def test_vmap_topk(self):
+        a = mx.random.permutation(2 * 3 * 4).reshape(2, 3, 4).astype(mx.float32)
+
+        for in_axis in (0, 1, 2):
+            slices = self._unstack(a, in_axis)
+            out_axes_map = [d for d in range(a.ndim) if d != in_axis]
+            for axis in (0, 1, -1):
+                oaxis = out_axes_map[axis if axis >= 0 else axis + 2]
+                for k in range(1, slices[0].shape[axis] + 1):
+                    out = mx.vmap(
+                        lambda x: mx.topk(x, k, axis=axis),
+                        in_axes=in_axis,
+                        out_axes=in_axis,
+                    )(a)
+                    expected = mx.stack(
+                        [mx.topk(x, k, axis=axis) for x in slices], axis=in_axis
+                    )
+                    self.assertEqual(out.shape, expected.shape)
+                    # topk does not promise an order within the k elements
+                    self.assertTrue(
+                        mx.array_equal(
+                            mx.sort(out, axis=oaxis), mx.sort(expected, axis=oaxis)
+                        )
+                    )
+
     def test_vmap_mean(self):
         a = mx.arange(8).reshape(2, 4)
         out = mx.vmap(mx.mean)(a)


### PR DESCRIPTION
Fixes #4113.

### Proposed changes

`Partition::vmap` and `ArgPartition::vmap` called the two-argument overload

```cpp
partition(inputs[0], axis_ + axis_left, stream())
```

which is the one that partitions the **flattened** array, with `axis_ + axis_left` bound to `kth`. `kth_` was dropped entirely, so under `vmap` these ops returned a 1-D array partitioned around the wrong element. `Sort::vmap` immediately below is correct only because `sort` has no `kth` parameter.

`topk` is built on `partition`, so it inherited the bug and failed outright once the traced `slice` was applied to the flattened result.

Passing `kth_` explicitly selects the `(a, kth, axis, stream)` overload.

Before, on `main`:

```
vmap(partition)    -> (24,)   expected (2, 3, 4)
vmap(argpartition) -> (24,)   expected (2, 3, 4)
vmap(topk)         -> ValueError: [slice] Invalid number of indices or strides
                                 for array with dimension 1.
vmap(topk, in_axes=1) -> IndexError: SmallVector out of range.
```

After:

```
vmap(partition)    -> (2, 3, 4), kth element matches the loop reference
vmap(argpartition) -> (2, 3, 4)
vmap(topk)         -> (2, 3, 2)
vmap(topk, in_axes=1) -> (2, 3, 2)
```

### Tests

Added `test_vmap_partition` and `test_vmap_topk` to `python/tests/test_vmap.py`; there was previously no `vmap` coverage for these ops. They sweep every `in_axes`, inner `axis` and every valid `kth` / `k`, comparing against the equivalent loop.

Because `partition` only pins the `kth` element and leaves the two sides in an arbitrary order, the tests compare the sorted result against the sorted input and check the `kth` element against the reference, rather than asserting element-wise equality that the API does not promise. `argpartition` is checked by gathering with the returned indices.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (not needed, no API change)
- [x] I have run `pre-commit run --all-files` to format my code and installed pre-commit prior to committing changes

Verified with a CPU-only build (`-DMLX_BUILD_METAL=OFF`); `test_vmap`, `test_ops` and `test_autograd` pass.
