### PR TITLE
Fix second order gradients for sort, partition, topk and cummax/cummin

### DIFF
--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -3390,7 +3390,10 @@ std::vector<array> Partition::vjp(
     const std::vector<array>& cotangents,
     const std::vector<int>& argnums,
     const std::vector<array>&) {
-  auto sort_idx = argpartition(primals[0], kth_, axis_, stream());
+  // The permutation is locally constant in the input, so cut the gradient
+  // there to keep higher order derivatives working.
+  auto sort_idx =
+      stop_gradient(argpartition(primals[0], kth_, axis_, stream()), stream());
   return {put_along_axis(
       zeros_like(primals[0], stream()),
       sort_idx,
@@ -3405,7 +3408,8 @@ std::vector<array> Partition::jvp(
     const std::vector<int>& argnums) {
   assert(primals.size() == 1);
   assert(tangents.size() == 1);
-  auto sort_idx = argpartition(primals[0], kth_, axis_, stream());
+  auto sort_idx =
+      stop_gradient(argpartition(primals[0], kth_, axis_, stream()), stream());
   auto out = take_along_axis(tangents[0], sort_idx, axis_, stream());
   return {out};
 }
@@ -4390,10 +4394,14 @@ std::vector<array> Scan::vjp(
         iota,
         array(reverse_ ? n : -1, int32),
         s);
-    auto owner = astype(
-        reverse_ ? cummin(masked, axis_, /* reverse = */ true, true, s)
-                 : cummax(masked, axis_, /* reverse = */ false, true, s),
-        uint32,
+    // The owner indices are locally constant in the input, so cut the
+    // gradient there to keep higher order derivatives working.
+    auto owner = stop_gradient(
+        astype(
+            reverse_ ? cummin(masked, axis_, /* reverse = */ true, true, s)
+                     : cummax(masked, axis_, /* reverse = */ false, true, s),
+            uint32,
+            s),
         s);
 
     if (!inclusive_) {
@@ -5432,7 +5440,9 @@ std::vector<array> Sort::vjp(
   // Sort applies a permutation to the input, so the cotangents must be
   // scattered back to the original positions (the transpose of the
   // permutation), not gathered forward as in the jvp.
-  auto sort_idx = argsort(primals[0], axis_, stream());
+  // The permutation is locally constant in the input, so cut the gradient
+  // there to keep higher order derivatives working.
+  auto sort_idx = stop_gradient(argsort(primals[0], axis_, stream()), stream());
   return {put_along_axis(
       zeros_like(primals[0], stream()),
       sort_idx,
@@ -5447,7 +5457,7 @@ std::vector<array> Sort::jvp(
     const std::vector<int>& argnums) {
   assert(primals.size() == 1);
   assert(tangents.size() == 1);
-  auto sort_idx = argsort(primals[0], axis_, stream());
+  auto sort_idx = stop_gradient(argsort(primals[0], axis_, stream()), stream());
   auto out = take_along_axis(tangents[0], sort_idx, axis_, stream());
   return {out};
 }

--- a/python/tests/test_autograd.py
+++ b/python/tests/test_autograd.py
@@ -1491,6 +1491,50 @@ class TestAutograd(mlx_tests.MLXTestCase):
         _, (jvp,) = mx.jvp(mx.abs, [x], [t])
         self.assertTrue(mx.allclose(jvp, mx.sign(x) * t))
 
+    def test_second_order_permutation_ops(self):
+        # The permutation these ops apply is locally constant in the input, so
+        # the indices must not carry a gradient. Otherwise differentiating the
+        # vjp a second time fails with "Cannot calculate VJP with respect to
+        # indices".
+        def hvp(f, x, v):
+            return mx.grad(lambda a: mx.sum(mx.grad(f)(a) * v))(x)
+
+        def numerical_hvp(f, x, v, eps=1e-3):
+            # The values below are well separated, so the permutation does not
+            # change over this step and the difference is exact enough.
+            return (mx.grad(f)(x + eps * v) - mx.grad(f)(x - eps * v)) / (2 * eps)
+
+        x = mx.array([3.0, 1.0, 2.0, 5.0])
+        v = mx.array([1.0, -2.0, 0.5, 1.5])
+
+        for fn in (
+            lambda a: mx.sort(a),
+            lambda a: mx.partition(a, 2),
+            lambda a: mx.topk(a, 2),
+            lambda a: mx.cummax(a, axis=0),
+            lambda a: mx.cummin(a, axis=0),
+            lambda a: mx.cummax(a, axis=0, reverse=True),
+            lambda a: mx.cummax(a, axis=0, inclusive=False),
+            lambda a: mx.cummin(a, axis=0, reverse=True, inclusive=False),
+        ):
+            f = lambda a: mx.sum(fn(a) ** 2)
+            self.assertTrue(
+                mx.allclose(hvp(f, x, v), numerical_hvp(f, x, v), atol=1e-3)
+            )
+
+        # A non-trailing axis
+        y = mx.array([[3.0, 1.0], [2.0, 5.0]])
+        w = mx.array([[1.0, -2.0], [0.5, 1.5]])
+        for fn in (
+            lambda a: mx.sort(a, axis=0),
+            lambda a: mx.partition(a, 1, axis=0),
+            lambda a: mx.cummax(a, axis=0),
+        ):
+            f = lambda a: mx.sum(fn(a) ** 2)
+            self.assertTrue(
+                mx.allclose(hvp(f, y, w), numerical_hvp(f, y, w), atol=1e-3)
+            )
+
 
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner()


### PR DESCRIPTION
Fixes #4114.

### Proposed changes

`Sort::vjp` / `Sort::jvp`, `Partition::vjp` / `Partition::jvp` and the `Max` / `Min` branch of `Scan::vjp` build an index array from the primal and feed it to a gather/scatter:

```cpp
auto sort_idx = argsort(primals[0], axis_, stream());
return {put_along_axis(
    zeros_like(primals[0], stream()), sort_idx, cotangents[0], axis_, stream())};
```

When those rules are themselves differentiated, `primals[0]` is a tracer, so the index array becomes part of the graph and the engine tries to compute a VJP with respect to the indices argument of `ScatterAxis` / `GatherAxis`. That is explicitly unsupported, so any second order derivative through these ops failed with

```
[scatter_axis] Cannot calculate VJP with respect to indices.
Use stop_gradient on indices to stop gradients from being computed.
```

even though the first derivative was fine.

The permutation these ops apply is locally constant in the input, so the indices carry no gradient. This wraps them in `stop_gradient`, which is what the error message itself recommends.

Before, on `main`, with `x = [3, 1, 2, 5]` and `hvp(f, x) = grad(lambda a: sum(grad(f)(a)))(x)`:

```
sort       -> ValueError: [scatter_axis] Cannot calculate VJP with respect to indices.
partition  -> ValueError: ...
topk       -> ValueError: ...
cummax     -> ValueError: ...
max        -> array([0, 0, 0, 2])          (already worked)
```

After:

```
sort       -> array([2, 2, 2, 2])
partition  -> array([2, 2, 2, 2])
topk       -> array([2, 0, 0, 2])
cummax     -> array([6, 0, 0, 2])
cummin     -> array([2, 6, 0, 0])
max        -> array([0, 0, 0, 2])          (unchanged)
```

### Tests

Added `test_second_order_permutation_ops` to `python/tests/test_autograd.py`, covering `sort`, `partition`, `topk`, `cummax`, `cummin`, the `reverse` and `inclusive` scan variants, and a non-trailing axis.

Rather than hardcoding expected Hessian values, the test compares the analytic HVP against a central-difference of the first gradient. The inputs are well separated so the permutation does not change across the finite-difference step. (I originally hand-computed the constants and got `cummax` wrong, so the self-checking form seemed safer.)

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (not needed, no API change)
- [x] I have run `pre-commit run --all-files` to format my code and installed pre-commit prior to committing changes

Verified with a CPU-only build (`-DMLX_BUILD_METAL=OFF`); `test_autograd`, `test_ops` and `test_vmap` pass.
