### PR TITLE
Fix segfault on negative out of bounds axes in take_along_axis/put_along_axis

### DIFF
--- a/mlx/linalg.cpp
+++ b/mlx/linalg.cpp
@@ -440,12 +440,8 @@ array cross(
     int axis /* = -1 */,
     StreamOrDevice s /* = {} */) {
   auto check_ax = [axis](const array& arr) {
-    if (axis >= static_cast<int>(arr.ndim()) || axis + arr.ndim() < 0) {
-      std::ostringstream msg;
-      msg << "[linalg::cross] axis " << axis << " invalid for array with "
-          << arr.ndim() << " dimensions.";
-      throw std::invalid_argument(msg.str());
-    }
+    // Normalizes and validates the axis, including negative out of bounds ones
+    normalize_axis_index(axis, arr.ndim(), "[linalg::cross] ");
     if (arr.shape(axis) < 2 || arr.shape(axis) > 3) {
       throw std::invalid_argument(
           "[linalg::cross] The specified axis must have size 2 or 3.");

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -3616,12 +3616,8 @@ array take_along_axis(
     const array& indices,
     int axis,
     StreamOrDevice s /* = {} */) {
-  if (axis + a.ndim() < 0 || axis >= static_cast<int>(a.ndim())) {
-    std::ostringstream msg;
-    msg << "[take_along_axis] Received invalid axis for array with " << a.ndim()
-        << " dimensions.";
-    throw std::invalid_argument(msg.str());
-  }
+  // Normalizes and validates the axis, including negative out of bounds ones
+  axis = normalize_axis_index(axis, a.ndim(), "[take_along_axis] ");
 
   if (indices.ndim() != a.ndim()) {
     std::ostringstream msg;
@@ -3629,9 +3625,6 @@ array take_along_axis(
         << " does not match array of dimension " << a.ndim() << ".";
     throw std::invalid_argument(msg.str());
   }
-
-  // Allow negative axis
-  axis = axis < 0 ? a.ndim() + axis : axis;
 
   // Broadcast indices and input ignoring the take axis
   auto inputs =
@@ -3654,12 +3647,8 @@ array scatter_axis(
     StreamOrDevice s) {
   std::string prefix =
       (mode == ScatterAxis::None) ? "[put_along_axis]" : "[scatter_add_axis]";
-  if (axis + a.ndim() < 0 || axis >= static_cast<int>(a.ndim())) {
-    std::ostringstream msg;
-    msg << prefix << " Received invalid axis for array with " << a.ndim()
-        << " dimensions.";
-    throw std::invalid_argument(msg.str());
-  }
+  // Normalizes and validates the axis, including negative out of bounds ones
+  axis = normalize_axis_index(axis, a.ndim(), prefix + " ");
 
   if (indices.ndim() != a.ndim()) {
     std::ostringstream msg;
@@ -3683,9 +3672,6 @@ array scatter_axis(
 
   auto inputs = broadcast_arrays({indices, upd}, s);
   inputs.insert(inputs.begin(), a);
-
-  // Allow negative axis
-  axis = axis < 0 ? a.ndim() + axis : axis;
 
   // Broadcast src, indices, values while ignoring the take axis
   inputs = broadcast_arrays(inputs, {axis - int(a.ndim())}, s);

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -1399,6 +1399,32 @@ class TestOps(mlx_tests.MLXTestCase):
             out_mlx = mx.take_along_axis(a_mlx, mx.reshape(idx_mlx, shape), axis=ax)
             self.assertTrue(np.array_equal(out_np, np.array(out_mlx)))
 
+    def test_along_axis_invalid_axis(self):
+        # Negative out of bounds axes used to slip past the bounds check
+        # (unsigned arithmetic made it dead code) and either raise an internal
+        # error or segfault. See also expand_dims in test_expand_dims.
+        a = mx.arange(24).reshape(2, 3, 4)
+        idx = mx.zeros(a.shape, dtype=mx.int32)
+        values = mx.ones(a.shape, dtype=a.dtype)
+
+        for ax in [3, 4, 100, -4, -5, -100]:
+            with self.assertRaises(ValueError):
+                mx.take_along_axis(a, idx, axis=ax)
+            with self.assertRaises(ValueError):
+                mx.put_along_axis(a, idx, values, axis=ax)
+
+        # Valid negative axes still work
+        for ax in [-1, -2, -3]:
+            self.assertEqual(mx.take_along_axis(a, idx, axis=ax).shape, a.shape)
+            self.assertEqual(mx.put_along_axis(a, idx, values, axis=ax).shape, a.shape)
+
+    def test_cross_invalid_axis(self):
+        a = mx.array([1.0, 2.0, 3.0])
+        b = mx.array([4.0, 5.0, 6.0])
+        for ax in [1, 2, -2, -50]:
+            with self.assertRaises(ValueError):
+                mx.linalg.cross(a, b, axis=ax)
+
     def test_put_along_axis(self):
         for ax in [None, 0, 1, 2]:
             a_np = np.arange(16).reshape(2, 2, 4).astype(np.int32)


### PR DESCRIPTION
Fixes #4115.

### Proposed changes

The bounds check in `take_along_axis`, `scatter_axis` (which backs `put_along_axis` and `scatter_add_axis`) and `linalg::cross` was dead code:

```cpp
if (axis + a.ndim() < 0 || axis >= static_cast<int>(a.ndim()))
```

`array::ndim()` returns `size_t`, so `axis + a.ndim()` is evaluated in unsigned arithmetic and is never negative. Only the positive half of the check, which casts to `int`, actually ran.

A negative out of bounds axis therefore passed validation and reached `broadcast_arrays` as `axis - int(a.ndim())`. For small magnitudes that surfaced as an internal `IndexError: SmallVector out of range`; for larger ones it overwrote the stack and segfaulted inside `broadcast_shapes`:

```
Exception Type:  EXC_BAD_ACCESS (SIGSEGV)
Exception Subtype: KERN_INVALID_ADDRESS at 0x6d7ad7656d7ad74d

0  libmlx.dylib  mlx::core::broadcast_shapes(SmallVector<int, 10ul> const&, SmallVector<int, 10ul> const&) + 348
1  libmlx.dylib  mlx::core::BroadcastAxes::output_shape(...) + 576
2  libmlx.dylib  mlx::core::broadcast_arrays(...) + 196
3  libmlx.dylib  mlx::core::take_along_axis(...) + 348
```

This switches all three call sites to `normalize_axis_index`, which does the comparison in `int` and is already used for exactly this purpose elsewhere in `ops.cpp` (`squeeze`, `expand_dims`, `flip`, `concatenate`, `stack`, `repeat`, ...). Since it also normalizes, the later manual "allow negative axis" adjustments become redundant and are removed.

#4021 fixed this same pattern, but only in `squeeze` and `expand_dims`. It did
not touch these three call sites, which still carry the original expression. On
current `main` (which already includes #4021):

| call | on `main` today |
| --- | --- |
| `mx.expand_dims(x, -9)` | `ValueError: [expand_dims] Axis -9 is out of bounds ...` (fixed by #4021) |
| `mx.squeeze(x, -9)` | `ValueError: [squeeze] Axis -9 is out of bounds ...` (fixed by #4021) |
| `mx.take_along_axis(x, i, axis=-4)` | `IndexError: SmallVector out of range.` |
| `mx.put_along_axis(x, i, v, axis=-4)` | `IndexError: SmallVector out of range.` |
| `mx.linalg.cross(a, b, axis=-4)` | `IndexError: SmallVector out of range.` |

So this is a follow-up to #4021 covering the remaining call sites, not a
duplicate of it.

Before, on `main`:

```
take_along_axis(x, i, axis=3)     ValueError: [take_along_axis] Received invalid axis ...
take_along_axis(x, i, axis=-4)    IndexError: SmallVector out of range.
take_along_axis(x, i, axis=-100)  Segmentation fault
put_along_axis(x, i, v, axis=-4)  IndexError: SmallVector out of range.
linalg.cross(a, b, axis=-4)       IndexError: SmallVector out of range.
```

After, all of them raise the same clean error, e.g.

```
ValueError: [take_along_axis] Axis -100 is out of bounds for array with 3 dimensions.
```

Valid negative axes (`-1`, `-2`, `-3`) continue to work unchanged.

Note this slightly changes the wording of the existing error message for the positive out of bounds case, from "Received invalid axis for array with N dimensions" to `normalize_axis_index`'s "Axis A is out of bounds for array with N dimensions", which also has the benefit of naming the offending axis. No tests depended on the old wording.

### Tests

Added `test_along_axis_invalid_axis` and `test_cross_invalid_axis` to `python/tests/test_ops.py`, covering positive and negative out of bounds axes for `take_along_axis`, `put_along_axis` and `linalg.cross`, plus an assertion that valid negative axes still work. The deep-negative values are excluded from the test bodies only in the sense that they are asserted to raise; they crash on unpatched builds, which is the point.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (not needed, no API change)
- [x] I have run `pre-commit run --all-files` to format my code and installed pre-commit prior to committing changes

Verified with a CPU-only build (`-DMLX_BUILD_METAL=OFF`); `test_ops`, `test_linalg`, `test_autograd` and `test_vmap` pass. I also confirmed the new tests fail on an unpatched build.
