### PR TITLE
Validate axes in flatten instead of silently clamping them

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -507,29 +507,15 @@ array flatten(
     int start_axis,
     int end_axis /* = -1 */,
     StreamOrDevice s /* = {} */) {
-  auto ndim = static_cast<int>(a.ndim());
-  auto start_ax = start_axis + (start_axis < 0 ? ndim : 0);
-  auto end_ax = end_axis + (end_axis < 0 ? ndim : 0);
-  start_ax = std::max(0, start_ax);
-  end_ax = std::min(ndim - 1, end_ax);
   if (a.ndim() == 0) {
     return reshape(a, {1}, s);
   }
+  auto ndim = static_cast<int>(a.ndim());
+  auto start_ax = normalize_axis_index(start_axis, ndim, "[flatten] ");
+  auto end_ax = normalize_axis_index(end_axis, ndim, "[flatten] ");
   if (end_ax < start_ax) {
     throw std::invalid_argument(
         "[flatten] start_axis must be less than or equal to end_axis");
-  }
-  if (start_ax >= ndim) {
-    std::ostringstream msg;
-    msg << "[flatten] Invalid start_axis " << start_axis << " for array with "
-        << ndim << " dimensions.";
-    throw std::invalid_argument(msg.str());
-  }
-  if (end_ax < 0) {
-    std::ostringstream msg;
-    msg << "[flatten] Invalid end_axis " << end_axis << " for array with "
-        << ndim << " dimensions.";
-    throw std::invalid_argument(msg.str());
   }
   if (start_ax == end_ax) {
     return a;
@@ -2285,7 +2271,7 @@ array median(
 
   // Move all the median axes to the back and flatten
   auto flat_a =
-      flatten(transpose(a, transpose_axes, s), flat_start, a.ndim(), s);
+      flatten(transpose(a, transpose_axes, s), flat_start, a.ndim() - 1, s);
   int flat_size = flat_a.shape(-1);
   if (flat_size == 0) {
     throw std::invalid_argument(

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -2647,6 +2647,23 @@ class TestOps(mlx_tests.MLXTestCase):
         self.assertEqual(x.flatten(start_axis=1).shape, (2, 3 * 4))
         self.assertEqual(x.flatten(end_axis=1).shape, (2 * 3, 4))
 
+        # Valid negative axes
+        self.assertEqual(mx.flatten(x, start_axis=-2).shape, (2, 3 * 4))
+        self.assertEqual(mx.flatten(x, end_axis=-2).shape, (2 * 3, 4))
+
+        # Scalars are flattened to a single element array
+        self.assertEqual(mx.flatten(mx.array(1.0)).shape, (1,))
+
+        # Out of bounds axes are rejected rather than silently clamped
+        for ax in [3, 4, 100, -4, -5, -100]:
+            with self.assertRaises(ValueError):
+                mx.flatten(x, start_axis=ax)
+            with self.assertRaises(ValueError):
+                mx.flatten(x, end_axis=ax)
+
+        with self.assertRaises(ValueError):
+            mx.flatten(x, start_axis=2, end_axis=1)
+
     def test_clip(self):
         a = np.array([1, 4, 3, 8, 5], np.int32)
         expected = np.clip(a, 2, 6)


### PR DESCRIPTION
Fixes #4121.

### Proposed changes

`flatten` normalized its axes and then clamped them into range:

```cpp
start_ax = std::max(0, start_ax);
end_ax = std::min(ndim - 1, end_ax);
```

so out of bounds axes were silently accepted. On a 3-D array `mx.flatten(x, -100, -1)` returned a fully flattened `(24,)` array.

The clamping also made the two specific error branches below it dead code: anything out of range was folded into the `end_ax < start_ax` comparison first, so callers always got `start_axis must be less than or equal to end_axis` even when the real problem was an invalid axis, and the `Invalid start_axis` / `Invalid end_axis` messages could never be produced.

This replaces the hand-rolled normalize-then-clamp with `normalize_axis_index`, which validates and normalizes in one step and is already used for this purpose by `squeeze`, `expand_dims`, `flip`, `concatenate`, `stack` and `repeat`. The two unreachable branches go away with it, so the net change removes more than it adds.

Two details worth calling out for review:

- The `ndim == 0` early return moves **above** the validation, so `mx.flatten` still turns a scalar into a single element array rather than failing on `normalize_axis_index(0, 0)`.
- `median` was relying on the clamping. It called `flatten(..., flat_start, a.ndim(), s)` with `a.ndim()`, one past the last valid axis, and depended on it being clamped to `ndim - 1`. It now passes the last axis explicitly. This was the only caller in the tree that depended on the clamping; I checked the rest (`ops.cpp`, `linalg.cpp`, `fast.cpp`, `primitives.cpp`) and they all pass in-range axes.

Before:

```python
x = mx.arange(24).reshape(2, 3, 4)
mx.flatten(x, -4, -1).shape     # (24,)
mx.flatten(x, -100, -1).shape   # (24,)
mx.flatten(x, 100, -1)          # "start_axis must be less than or equal to end_axis"
```

After:

```python
mx.flatten(x, -4, -1)     # ValueError: [flatten] Axis -4 is out of bounds for array with 3 dimensions.
mx.flatten(x, -100, -1)   # ValueError: [flatten] Axis -100 is out of bounds for array with 3 dimensions.
mx.flatten(x, 100, -1)    # ValueError: [flatten] Axis 100 is out of bounds for array with 3 dimensions.
```

Valid behaviour is unchanged, including negative axes, scalars and `median`.

This is a behaviour change for input that was previously accepted, so it is worth a deliberate call on whether rejecting is preferred over clamping. I went with rejecting because it matches every other axis taking op in MLX and matches NumPy, which raises `AxisError`.

### Tests

Extended `test_flatten` in `python/tests/test_ops.py` to cover valid negative axes, scalars, `start_axis > end_axis`, and out of bounds values in both directions for both arguments.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (not needed, no API change)
- [x] I have run `pre-commit run --all-files` to format my code and installed pre-commit prior to committing changes

Verified with a CPU-only build (`-DMLX_BUILD_METAL=OFF`): `test_ops`, `test_autograd`, `test_vmap`, `test_linalg`, `test_fast`, `test_nn`, `test_array` and `test_reduce` pass (452 tests).
