### PR TITLE
Fix einsum not broadcasting batch dimensions in batched tensordot

### DIFF
--- a/mlx/einsum.cpp
+++ b/mlx/einsum.cpp
@@ -356,9 +356,7 @@ array batch_tensordot(
     std::vector<int> b_batch,
     std::vector<int> b_concat,
     StreamOrDevice s) {
-  // Broadcast contracting and batch dimensions. The batch dimensions have to
-  // be broadcast as well, otherwise out_shape below is taken from ``a`` alone
-  // and does not match the batch size matmul produces.
+  // Broadcast contracting and batch dimensions.
   {
     auto a_shape = a.shape();
     auto b_shape = b.shape();

--- a/mlx/einsum.cpp
+++ b/mlx/einsum.cpp
@@ -356,7 +356,9 @@ array batch_tensordot(
     std::vector<int> b_batch,
     std::vector<int> b_concat,
     StreamOrDevice s) {
-  // Broadcast contracting dimensions
+  // Broadcast contracting and batch dimensions. The batch dimensions have to
+  // be broadcast as well, otherwise out_shape below is taken from ``a`` alone
+  // and does not match the batch size matmul produces.
   {
     auto a_shape = a.shape();
     auto b_shape = b.shape();
@@ -364,6 +366,11 @@ array batch_tensordot(
       auto d = std::max(a.shape(a_contract[i]), b.shape(b_contract[i]));
       a_shape[a_contract[i]] = d;
       b_shape[b_contract[i]] = d;
+    }
+    for (int i = 0; i < a_batch.size(); ++i) {
+      auto d = std::max(a.shape(a_batch[i]), b.shape(b_batch[i]));
+      a_shape[a_batch[i]] = d;
+      b_shape[b_batch[i]] = d;
     }
     a = broadcast_to(a, a_shape, s);
     b = broadcast_to(b, b_shape, s);

--- a/python/tests/test_einsum.py
+++ b/python/tests/test_einsum.py
@@ -188,7 +188,6 @@ class TestEinsum(mlx_tests.MLXTestCase):
         a = mx.full((5, 1), 1.0)
         b = mx.full((8, 2), 1.0)
         a_mx = mx.einsum("ab,bc->c", a, b)
-        return
         a_np = np.einsum("ab,bc->c", a, b)
         self.assertTrue(np.array_equal(a_mx, a_np))
 
@@ -357,6 +356,40 @@ class TestEinsum(mlx_tests.MLXTestCase):
             inputs = inputs_for_case(test_case[0])
             with self.assertRaises(ValueError):
                 mx.einsum(test_case[1], *inputs)
+
+    def test_ellipses_broadcast(self):
+        # Size 1 batch dimensions covered by an ellipsis have to broadcast
+        # against the other operands, including when the smaller operand
+        # comes first.
+        shape_pairs = [
+            ((1, 3, 4), (2, 4, 5)),
+            ((2, 3, 4), (1, 4, 5)),
+            ((1, 1, 3, 4), (5, 2, 4, 5)),
+            ((5, 1, 3, 4), (1, 2, 4, 5)),
+        ]
+        for sa, sb in shape_pairs:
+            a = mx.random.uniform(shape=sa)
+            b = mx.random.uniform(shape=sb)
+            mx_out = mx.einsum("...ij,...jk->...ik", a, b)
+            np_out = np.einsum("...ij,...jk->...ik", np.array(a), np.array(b))
+            self.assertEqual(mx_out.shape, np_out.shape)
+            self.assertTrue(np.allclose(mx_out, np_out, rtol=1e-4, atol=1e-4))
+
+        for sa, sb in [((1, 4), (5, 4)), ((5, 4), (1, 4))]:
+            a = mx.random.uniform(shape=sa)
+            b = mx.random.uniform(shape=sb)
+            mx_out = mx.einsum("...i,...i->...", a, b)
+            np_out = np.einsum("...i,...i->...", np.array(a), np.array(b))
+            self.assertEqual(mx_out.shape, np_out.shape)
+            self.assertTrue(np.allclose(mx_out, np_out, rtol=1e-4, atol=1e-4))
+
+        # Same thing with explicit labels rather than an ellipsis
+        a = mx.random.uniform(shape=(1, 3, 4))
+        b = mx.random.uniform(shape=(2, 4, 5))
+        mx_out = mx.einsum("bij,bjk->bik", a, b)
+        np_out = np.einsum("bij,bjk->bik", np.array(a), np.array(b))
+        self.assertEqual(mx_out.shape, np_out.shape)
+        self.assertTrue(np.allclose(mx_out, np_out, rtol=1e-4, atol=1e-4))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #4124.

### Proposed changes

`batch_tensordot` broadcast the contracting dimensions of its two operands to a common size but left the batch dimensions alone, then built the output shape from the first operand only:

```cpp
for (auto ax : a_batch) {
  out_shape.push_back(a.shape(ax));
}
```

When the first operand had a size 1 batch dimension, `matmul` broadcast it against the second operand while `out_shape` kept the 1, so the final reshape got the wrong element count:

```python
mx.einsum("...ij,...jk->...ik", mx.zeros((1, 3, 4)), mx.zeros((2, 4, 5)))
# ValueError: [reshape] Cannot reshape array of size 30 into shape (1,3,5).
```

The reverse operand order worked, because the output shape was then taken from the larger operand. That asymmetry is why it went unnoticed. It is not specific to ellipses either, `"bij,bjk->bik"` with the same shapes fails identically.

The fix broadcasts the batch dimensions the same way the contracting dimensions already are, in the same block. `a_batch` and `b_batch` are parallel by construction (`b_batch` is built by looking up each `a_batch` label in `b`'s subscript), so they can be zipped exactly like `a_contract` / `b_contract`.

| operands | NumPy | before | after |
| --- | --- | --- | --- |
| `(1,3,4)`, `(2,4,5)` | `(2,3,5)` | error | `(2,3,5)` |
| `(2,3,4)`, `(1,4,5)` | `(2,3,5)` | `(2,3,5)` | `(2,3,5)` |
| `(1,4)`, `(5,4)` -> `...` | `(5,)` | error | `(5,)` |
| `(5,4)`, `(1,4)` -> `...` | `(5,)` | `(5,)` | `(5,)` |

### Tests

Added `test_ellipses_broadcast` to `python/tests/test_einsum.py` covering both operand orders, multiple leading batch dimensions, a reduced (`->...`) output, and the explicit-label spelling, each checked against NumPy for both shape and values.

I also removed an unconditional `return` in `test_broadcasting` that made the four lines after it dead code. To be clear about scope: those assertions pass on `main` as well, so that is an unrelated cleanup rather than something this fix enables. I checked before touching it. It was simply hiding coverage right next to the bug.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (not needed, no API change)
- [x] I have run `pre-commit run --all-files` to format my code and installed pre-commit prior to committing changes

Verified with a CPU-only build (`-DMLX_BUILD_METAL=OFF`): `test_einsum`, `test_ops`, `test_autograd`, `test_vmap`, `test_linalg`, `test_blas`, `test_nn`, `test_array` and `test_reduce` pass (464 tests).
