### PR TITLE
Deduplicate slow CPU convolution dtype dispatch

### DIFF
--- a/mlx/backend/cpu/conv.cpp
+++ b/mlx/backend/cpu/conv.cpp
@@ -6,6 +6,7 @@
 #include "mlx/backend/cpu/copy.h"
 #include "mlx/backend/cpu/encoder.h"
 #include "mlx/backend/cpu/lapack.h"
+#include "mlx/dtype_utils.h"
 #include "mlx/primitives.h"
 #include "mlx/utils.h"
 
@@ -670,6 +671,24 @@ void slow_conv_3D(
   });
 }
 
+template <typename F>
+void dispatch_slow_conv_type(Dtype dtype, F&& f) {
+  switch (dtype) {
+    case float32:
+      f(type_identity<float>{});
+      break;
+    case float16:
+      f(type_identity<float16_t>{});
+      break;
+    case bfloat16:
+      f(type_identity<bfloat16_t>{});
+      break;
+    default:
+      throw std::invalid_argument(
+          "[Convolution::eval] got unsupported data type.");
+  }
+}
+
 void dispatch_slow_conv_1D(
     const array& in,
     const array& wt,
@@ -681,8 +700,8 @@ void dispatch_slow_conv_1D(
     const std::vector<int>& in_dilation,
     bool flip,
     Stream stream) {
-  if (in.dtype() == float32) {
-    return slow_conv_1D<float>(
+  dispatch_slow_conv_type(in.dtype(), [&](auto type_tag) {
+    slow_conv_1D<MLX_GET_TYPE(type_tag)>(
         in,
         wt,
         out,
@@ -693,34 +712,7 @@ void dispatch_slow_conv_1D(
         in_dilation,
         flip,
         stream);
-  } else if (in.dtype() == float16) {
-    return slow_conv_1D<float16_t>(
-        in,
-        wt,
-        out,
-        padding_lo,
-        padding_hi,
-        wt_strides,
-        wt_dilation,
-        in_dilation,
-        flip,
-        stream);
-  } else if (in.dtype() == bfloat16) {
-    return slow_conv_1D<bfloat16_t>(
-        in,
-        wt,
-        out,
-        padding_lo,
-        padding_hi,
-        wt_strides,
-        wt_dilation,
-        in_dilation,
-        flip,
-        stream);
-  } else {
-    throw std::invalid_argument(
-        "[Convolution::eval] got unsupported data type.");
-  }
+  });
 }
 
 void dispatch_slow_conv_2D(
@@ -734,8 +726,8 @@ void dispatch_slow_conv_2D(
     const std::vector<int>& in_dilation,
     bool flip,
     Stream stream) {
-  if (in.dtype() == float32) {
-    return slow_conv_2D<float>(
+  dispatch_slow_conv_type(in.dtype(), [&](auto type_tag) {
+    slow_conv_2D<MLX_GET_TYPE(type_tag)>(
         in,
         wt,
         out,
@@ -746,34 +738,7 @@ void dispatch_slow_conv_2D(
         in_dilation,
         flip,
         stream);
-  } else if (in.dtype() == float16) {
-    return slow_conv_2D<float16_t>(
-        in,
-        wt,
-        out,
-        padding_lo,
-        padding_hi,
-        wt_strides,
-        wt_dilation,
-        in_dilation,
-        flip,
-        stream);
-  } else if (in.dtype() == bfloat16) {
-    return slow_conv_2D<bfloat16_t>(
-        in,
-        wt,
-        out,
-        padding_lo,
-        padding_hi,
-        wt_strides,
-        wt_dilation,
-        in_dilation,
-        flip,
-        stream);
-  } else {
-    throw std::invalid_argument(
-        "[Convolution::eval] got unsupported data type.");
-  }
+  });
 }
 
 void dispatch_slow_conv_3D(
@@ -787,8 +752,8 @@ void dispatch_slow_conv_3D(
     const std::vector<int>& in_dilation,
     bool flip,
     Stream stream) {
-  if (in.dtype() == float32) {
-    return slow_conv_3D<float>(
+  dispatch_slow_conv_type(in.dtype(), [&](auto type_tag) {
+    slow_conv_3D<MLX_GET_TYPE(type_tag)>(
         in,
         wt,
         out,
@@ -799,34 +764,7 @@ void dispatch_slow_conv_3D(
         in_dilation,
         flip,
         stream);
-  } else if (in.dtype() == float16) {
-    return slow_conv_3D<float16_t>(
-        in,
-        wt,
-        out,
-        padding_lo,
-        padding_hi,
-        wt_strides,
-        wt_dilation,
-        in_dilation,
-        flip,
-        stream);
-  } else if (in.dtype() == bfloat16) {
-    return slow_conv_3D<bfloat16_t>(
-        in,
-        wt,
-        out,
-        padding_lo,
-        padding_hi,
-        wt_strides,
-        wt_dilation,
-        in_dilation,
-        flip,
-        stream);
-  } else {
-    throw std::invalid_argument(
-        "[Convolution::eval] got unsupported data type.");
-  }
+  });
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/mlx/backend/cpu/conv.cpp
+++ b/mlx/backend/cpu/conv.cpp
@@ -6,7 +6,6 @@
 #include "mlx/backend/cpu/copy.h"
 #include "mlx/backend/cpu/encoder.h"
 #include "mlx/backend/cpu/lapack.h"
-#include "mlx/dtype_utils.h"
 #include "mlx/primitives.h"
 #include "mlx/utils.h"
 
@@ -675,13 +674,13 @@ template <typename F>
 void dispatch_slow_conv_type(Dtype dtype, F&& f) {
   switch (dtype) {
     case float32:
-      f(type_identity<float>{});
+      f.template operator()<float>();
       break;
     case float16:
-      f(type_identity<float16_t>{});
+      f.template operator()<float16_t>();
       break;
     case bfloat16:
-      f(type_identity<bfloat16_t>{});
+      f.template operator()<bfloat16_t>();
       break;
     default:
       throw std::invalid_argument(
@@ -700,8 +699,8 @@ void dispatch_slow_conv_1D(
     const std::vector<int>& in_dilation,
     bool flip,
     Stream stream) {
-  dispatch_slow_conv_type(in.dtype(), [&](auto type_tag) {
-    slow_conv_1D<MLX_GET_TYPE(type_tag)>(
+  dispatch_slow_conv_type(in.dtype(), [&]<typename T>() {
+    slow_conv_1D<T>(
         in,
         wt,
         out,
@@ -726,8 +725,8 @@ void dispatch_slow_conv_2D(
     const std::vector<int>& in_dilation,
     bool flip,
     Stream stream) {
-  dispatch_slow_conv_type(in.dtype(), [&](auto type_tag) {
-    slow_conv_2D<MLX_GET_TYPE(type_tag)>(
+  dispatch_slow_conv_type(in.dtype(), [&]<typename T>() {
+    slow_conv_2D<T>(
         in,
         wt,
         out,
@@ -752,8 +751,8 @@ void dispatch_slow_conv_3D(
     const std::vector<int>& in_dilation,
     bool flip,
     Stream stream) {
-  dispatch_slow_conv_type(in.dtype(), [&](auto type_tag) {
-    slow_conv_3D<MLX_GET_TYPE(type_tag)>(
+  dispatch_slow_conv_type(in.dtype(), [&]<typename T>() {
+    slow_conv_3D<T>(
         in,
         wt,
         out,


### PR DESCRIPTION
## Summary

The 1D, 2D, and 3D slow CPU convolution paths repeat the same
`float32`/`float16`/`bfloat16` routing. Move that mapping into one file-local,
positive dispatcher using C++20 templated callables.

Unsupported and future dtypes still fail closed with the existing diagnostic,
and no unsupported slow-convolution templates are instantiated. This removes
63 net lines without changing kernels, route selection, or public behavior.

## Testing

- Release CPU-only build with C++20 and warnings as errors
- Byte-identical PR-base parity for 900 supported cases: 1D/2D/3D, all
  three supported dtypes, four forced slow routes per dimension, and every
  pairing of five input and five weight layouts
- Exact unsupported-type diagnostics for `float64`, `int32`, `complex64`, and
  `bool`
- CPU convolution tests (9 passed, 9 skipped, 16 subtests passed; skips require
  Torch, which was unavailable in the validation environment)
- Native C++ suite (247/247 cases, 3,326/3,326 assertions)
- External symbol-name lists unchanged; convolution object, archive, and linked
  text sections shrink
- `pre-commit` and `git diff --check`
