### PR TITLE
Refactor CPU Softmax dtype dispatch

### DIFF
--- a/mlx/backend/cpu/softmax.cpp
+++ b/mlx/backend/cpu/softmax.cpp
@@ -6,6 +6,7 @@
 #include "mlx/backend/cpu/copy.h"
 #include "mlx/backend/cpu/encoder.h"
 #include "mlx/backend/cpu/simd/simd.h"
+#include "mlx/dtype_utils.h"
 #include "mlx/primitives.h"
 #include "mlx/types/limits.h"
 
@@ -139,32 +140,23 @@ void Softmax::eval_cpu(const std::vector<array>& inputs, array& out) {
 
   auto in = set_output(inputs[0]);
 
-  switch (in.dtype()) {
-    case float32:
-      softmax<float, float>(in, out, stream());
-      break;
-    case float16:
+  dispatch_all_types(in.dtype(), [&](auto type_tag) {
+    using T = MLX_GET_TYPE(type_tag);
+    if constexpr (
+        std::is_same_v<T, float16_t> || std::is_same_v<T, bfloat16_t>) {
       if (precise_) {
-        softmax<float16_t, float>(in, out, stream());
+        softmax<T, float>(in, out, stream());
       } else {
-        softmax<float16_t, float16_t>(in, out, stream());
+        softmax<T, T>(in, out, stream());
       }
-      break;
-    case bfloat16:
-      if (precise_) {
-        softmax<bfloat16_t, float>(in, out, stream());
-      } else {
-        softmax<bfloat16_t, bfloat16_t>(in, out, stream());
-      }
-      break;
-    case float64:
-      softmax<double, double>(in, out, stream());
-      break;
-    default:
+    } else if constexpr (
+        std::is_same_v<T, float> || std::is_same_v<T, double>) {
+      softmax<T, T>(in, out, stream());
+    } else {
       throw std::runtime_error(
           "[softmax] Only defined for floating point types.");
-      break;
-  }
+    }
+  });
 }
 
 } // namespace mlx::core


### PR DESCRIPTION
## Summary

Replace CPU `Softmax`'s explicit dtype switch with `dispatch_all_types`.
The compile-time branches preserve the existing accumulator policy: float16
and bfloat16 use float accumulation in precise mode and their native types
otherwise, while float32 and float64 keep native accumulation. Other types
retain the existing unsupported-type error.

This removes eight net lines from one function.

## Testing

- Release CPU-only build with C++20 and warnings as errors
- Baseline/candidate raw-byte parity across float16, bfloat16, float32, and
  float64, with precise mode both enabled and disabled (32 cases; transcripts
  byte-identical)
- Python operations suite (150/150 tests)
- Native C++ suite (247/247 cases, 3,326/3,326 assertions)
- Global object symbols preserved
- Composition check with the older same-file #3019: both patch orders have
  only the adjacent include insertion to resolve; retaining both includes
  produces identical source in either order, the combined Release library
  builds, and the focused reduction/softmax suite passes
- `clang-format` and `git diff --check`
