### PR TITLE
Use common dispatch for compiled constants

### DIFF
--- a/mlx/backend/common/compiled.cpp
+++ b/mlx/backend/common/compiled.cpp
@@ -8,9 +8,7 @@
 namespace mlx::core {
 
 void print_constant(std::ostream& os, const array& x) {
-  bool printed = false;
   dispatch_all_types(x.dtype(), [&](auto type_tag) {
-    printed = true;
     using T = MLX_GET_TYPE(type_tag);
     if constexpr (std::is_same_v<T, bool>) {
       os << std::boolalpha << x.item<bool>();
@@ -28,9 +26,6 @@ void print_constant(std::ostream& os, const array& x) {
       throw std::runtime_error("Unsupported constant type");
     }
   });
-  if (!printed) {
-    throw std::runtime_error("Unsupported constant type");
-  }
 }
 
 std::string get_type_string(Dtype d) {

--- a/mlx/backend/common/compiled.cpp
+++ b/mlx/backend/common/compiled.cpp
@@ -2,45 +2,34 @@
 
 #include "mlx/backend/common/compiled.h"
 #include "mlx/backend/common/utils.h"
+#include "mlx/dtype_utils.h"
 #include "mlx/utils.h"
 
 namespace mlx::core {
 
 void print_constant(std::ostream& os, const array& x) {
-  switch (x.dtype()) {
-    case float32:
-      return print_float_constant<float>(os, x);
-    case float16:
-      return print_float_constant<float16_t>(os, x);
-    case bfloat16:
-      return print_float_constant<bfloat16_t>(os, x);
-    case float64:
-      return print_float_constant<double>(os, x);
-    case complex64:
-      return print_complex_constant<complex64_t>(os, x);
-    case int8:
-      os << static_cast<int32_t>(x.item<int8_t>());
-      return;
-    case int16:
-      return print_int_constant<int16_t>(os, x);
-    case int32:
-      return print_int_constant<int32_t>(os, x);
-    case int64:
-      return print_int_constant<int64_t>(os, x);
-    case uint8:
-      os << static_cast<uint32_t>(x.item<uint8_t>());
-      return;
-    case uint16:
-      return print_int_constant<uint16_t>(os, x);
-    case uint32:
-      return print_int_constant<uint32_t>(os, x);
-    case uint64:
-      return print_int_constant<uint64_t>(os, x);
-    case bool_:
+  bool printed = false;
+  dispatch_all_types(x.dtype(), [&](auto type_tag) {
+    printed = true;
+    using T = MLX_GET_TYPE(type_tag);
+    if constexpr (std::is_same_v<T, bool>) {
       os << std::boolalpha << x.item<bool>();
-      return;
-    default:
+    } else if constexpr (std::is_same_v<T, int8_t>) {
+      os << static_cast<int32_t>(x.item<int8_t>());
+    } else if constexpr (std::is_same_v<T, uint8_t>) {
+      os << static_cast<uint32_t>(x.item<uint8_t>());
+    } else if constexpr (is_complex<T>) {
+      print_complex_constant<T>(os, x);
+    } else if constexpr (is_floating_point_v<T>) {
+      print_float_constant<T>(os, x);
+    } else if constexpr (std::is_integral_v<T>) {
+      print_int_constant<T>(os, x);
+    } else {
       throw std::runtime_error("Unsupported constant type");
+    }
+  });
+  if (!printed) {
+    throw std::runtime_error("Unsupported constant type");
   }
 }
 


### PR DESCRIPTION
## Summary

Replace `print_constant`'s exhaustive dtype switch with `dispatch_all_types`.
Compile-time capability branches retain the existing bool, byte-integer,
integer, floating, and complex formatting paths for every current dtype.

This removes sixteen net lines from one function.

## Testing

- Release CPU-only build with C++20 and warnings as errors
- Exact `compiled.cpp` Release translation-unit replay with warnings as errors;
  the replay matched the stored 41,120-byte object with a 14,836-byte text
  section
- Baseline/candidate generated-text parity for all 14 current dtypes, including
  the int8 and uint8 numeric formatting paths
- Native compile/JIT suite (24/24 cases, 117/117 assertions)
- Full native C++ suite (247/247 cases, 3,326/3,326 assertions)
- Release object and static library each shrink by 512 bytes; defined global
  object and library symbol-name lists are unchanged, while the now-unused
  `std::runtime_error(char const*)` import is removed
- Same-file overlap check against experimental #2300: it changes
  `compiled_check_contiguity` and its call in
  `compiled_collapse_contiguous_dims`, not `print_constant`; this change adds
  no new conflict to #2300's existing current-main conflict
- `clang-format` and `git diff --check`
