### PR TITLE
Fix Eigh CPU dtype error message

### DIFF
--- a/mlx/backend/cpu/eigh.cpp
+++ b/mlx/backend/cpu/eigh.cpp
@@ -244,7 +244,7 @@ void Eigh::eval_cpu(
       break;
     default:
       throw std::runtime_error(
-          "[Eigh::eval_cpu] only supports float32 or float64.");
+          "[Eigh::eval_cpu] only supports float32, float64, or complex64.");
   }
 }
 


### PR DESCRIPTION
## Summary

Update the CPU `Eigh` unsupported-dtype error to include `complex64`, which
already has a dispatch case immediately above it.

## Testing

- Release CPU-only build with C++20
- Exact `eigh.cpp` Release translation-unit replay with warnings as errors
- Direct unsupported-dtype diagnostic check
- Focused native Eigh test (1/1 case, 9/9 assertions)
- Full native C++ suite (247/247 cases, 3,326/3,326 assertions)
- Global object and library symbol lists unchanged
- `clang-format` and `git diff --check`
