### PR TITLE
Fix random distribution dtype error messages

### DIFF
--- a/mlx/random.cpp
+++ b/mlx/random.cpp
@@ -187,8 +187,7 @@ array normal(
     return complex_normal(shape, loc, scale, key, s);
   } else if (!issubdtype(dtype, floating)) {
     throw std::invalid_argument(
-        "[normal] Can only generate uniform numbers with "
-        "floating point type.");
+        "[normal] Only floating point and complex64 types are supported.");
   }
 
   auto stream = to_stream(s);
@@ -459,8 +458,7 @@ array laplace(
     StreamOrDevice s /* = {} */) {
   if (!issubdtype(dtype, floating)) {
     throw std::invalid_argument(
-        "[laplace] Can only generate uniform numbers with real"
-        "floating point type.");
+        "[laplace] Only real floating point types are supported.");
   }
 
   auto stream = to_stream(s);


### PR DESCRIPTION
## Summary

Correct copy-pasted `uniform` wording in the `normal` and `laplace`
invalid-dtype errors. The messages now describe each function's existing
support set, including `normal`'s `complex64` path.

## Testing

- Release CPU-only build and Python bindings with C++20 and warnings as errors
- Direct baseline/candidate checks of both invalid-dtype diagnostics
- Accepted-dtype checks for all five `normal` and four `laplace` routes
- Python random suite (14/14 tests)
- Native random and Laplace suites (9/9 cases, 139/139 assertions)
- Full native C++ suite (247/247 cases, 3,326/3,326 assertions)
- Executable text and global object/library symbol lists unchanged
- `clang-format` and `git diff --check`
