### PR TITLE
Fix safetensors dtype error formatting

### DIFF
--- a/mlx/io/safetensors.cpp
+++ b/mlx/io/safetensors.cpp
@@ -102,7 +102,7 @@ Dtype dtype_from_safetensor_str(std::string_view str) {
     return uint8;
   } else {
     std::ostringstream msg;
-    msg << "[safetensor] unsupported dtype" << str;
+    msg << "[safetensor] unsupported dtype " << str;
     throw std::runtime_error(msg.str());
   }
 }


### PR DESCRIPTION
## Summary

Restore the separator between `dtype` and the invalid dtype token in the
safetensors load error. The `ostringstream` conversion in #3364 accidentally
removed the existing space, producing messages such as `unsupported dtypeBAD`.

## Testing

- Release CPU-only build and Python bindings with C++20 and warnings as errors
- Direct baseline/candidate diagnostic check
- Public malformed-safetensors load check
- Python load suite (14/14 tests)
- Native safetensors suite (2/2 cases, 17/17 assertions)
- Full native C++ suite (247/247 cases, 3,326/3,326 assertions)
- Executable text and global object/library symbol lists unchanged
- Same-file composition with experimental #2300: this parser patch applies
  cleanly to its head and does not change its existing current-main conflict
  in `save_safetensors`
- `clang-format` and `git diff --check`
