### PR TITLE
Fix no-GPU synchronize error formatting

### DIFF
--- a/mlx/backend/no_gpu/eval.cpp
+++ b/mlx/backend/no_gpu/eval.cpp
@@ -28,7 +28,7 @@ void finalize(Stream) {
 }
 
 void synchronize(Stream) {
-  throw std::runtime_error("[gpu::synchronize]  GPU backend is not available");
+  throw std::runtime_error("[gpu::synchronize] GPU backend is not available");
 }
 
 void clear_streams() {}


### PR DESCRIPTION
## Summary

Remove the duplicated space in the no-GPU `synchronize` error so its formatting
matches the adjacent `eval` and `finalize` errors.

## Testing

- Release CPU-only build and Python bindings with C++20 and warnings as errors
- Direct baseline/candidate no-GPU synchronize diagnostic check
- Python device suite (10 tests, 2 GPU-only skips)
- Full native C++ suite (247/247 cases, 3,326/3,326 assertions)
- Object/archive sizes and global symbol lists unchanged
- `clang-format` and `git diff --check`
