### PR TITLE
Fix set_printoptions example

### DIFF
--- a/python/src/print.cpp
+++ b/python/src/print.cpp
@@ -44,7 +44,7 @@ void init_print(nb::module_& m) {
 
         Example:
             >>> print(x)  # Uses default precision
-            >>> mx.set_printoptions(precision=3):
+            >>> mx.set_printoptions(precision=3)
             >>> print(x)  # Uses precision of 3
             >>> print(x)  # Uses precision of 3 (again)
 


### PR DESCRIPTION
## Summary

Remove the stray colon from the `set_printoptions` REPL example so the shown
call is valid Python.

## Testing

- Release Metal build with C++20 and warnings as errors
- Focused Python print test (1/1)
- Native C++ suite (263/263 cases, 3,581/3,581 assertions)
- `clang-format` and `git diff --check`
