### PR TITLE
Clarify export output type diagnostic

### DIFF
--- a/python/src/export.cpp
+++ b/python/src/export.cpp
@@ -124,8 +124,8 @@ auto wrap_export_function(nb::callable fun) {
           outputs_.push_back(nb::cast<mx::array>(outputs));
         } else if (!nb::try_cast(outputs, outputs_)) {
           throw std::invalid_argument(
-              "[export_function] Outputs can be either a single array "
-              "a tuple or list of arrays.");
+              "[export_function] Outputs can be either a single array, "
+              "a tuple, or a list of arrays.");
         }
         return outputs_;
       };


### PR DESCRIPTION
## Summary

Correct the malformed `export_function` output-type diagnostic so it clearly
lists a single array, a tuple, or a list of arrays.

The accepted output types and exception path are unchanged.

## Testing

- Release Metal build with C++20 and warnings as errors
- Focused malformed-output diagnostic test (1/1)
- Native C++ suite (263/263 cases, 3,581/3,581 assertions)
- `clang-format` and `git diff --check`
