### PR TITLE
Fix wired limit documentation grammar

### DIFF
--- a/python/src/memory.cpp
+++ b/python/src/memory.cpp
@@ -97,8 +97,8 @@ void init_memory(nb::module_& m) {
       The wired limit is the total size in bytes of memory that will be kept
       resident. The default value is ``0``.
 
-      Setting a wired limit larger than system wired limit is an error. You can
-      increase the system wired limit with:
+      Setting a wired limit larger than the system wired limit is an error.
+      You can increase the system wired limit with:
 
       .. code-block::
 


### PR DESCRIPTION
## Summary

Fix a missing article in the public wired-memory-limit documentation and
reflow the surrounding sentence.

## Testing

- Release Metal build with C++20 and warnings as errors
- Focused Python memory tests (3/3)
- Native C++ suite (263/263 cases, 3,581/3,581 assertions)
- `clang-format` and `git diff --check`
