### PR TITLE
Deduplicate distributed all-reduce construction

### DIFF
--- a/mlx/distributed/ops.cpp
+++ b/mlx/distributed/ops.cpp
@@ -12,7 +12,13 @@ namespace mlx::core::distributed {
 
 namespace {
 
-Group to_group(std::optional<Group> group);
+Group to_group(std::optional<Group> group) {
+  if (group.has_value()) {
+    return group.value();
+  } else {
+    return distributed::init();
+  }
+}
 
 array all_reduce(
     const array& x,
@@ -29,14 +35,6 @@ array all_reduce(
       x.dtype(),
       std::make_shared<AllReduce>(stream, group, reduce_type),
       {x});
-}
-
-Group to_group(std::optional<Group> group) {
-  if (group.has_value()) {
-    return group.value();
-  } else {
-    return distributed::init();
-  }
 }
 
 } // namespace

--- a/mlx/distributed/ops.cpp
+++ b/mlx/distributed/ops.cpp
@@ -12,6 +12,25 @@ namespace mlx::core::distributed {
 
 namespace {
 
+Group to_group(std::optional<Group> group);
+
+array all_reduce(
+    const array& x,
+    const std::optional<Group>& group_,
+    StreamOrDevice s,
+    AllReduce::ReduceType reduce_type) {
+  auto group = to_group(group_);
+  if (group.size() == 1) {
+    return x;
+  }
+  auto stream = detail::communication_stream(group, s);
+  return array(
+      x.shape(),
+      x.dtype(),
+      std::make_shared<AllReduce>(stream, group, reduce_type),
+      {x});
+}
+
 Group to_group(std::optional<Group> group) {
   if (group.has_value()) {
     return group.value();
@@ -26,54 +45,21 @@ array all_sum(
     const array& x,
     std::optional<Group> group_ /* = std::nullopt */,
     StreamOrDevice s /* = {} */) {
-  auto group = to_group(group_);
-
-  if (group.size() == 1) {
-    return x;
-  }
-  auto stream = detail::communication_stream(group, s);
-
-  return array(
-      x.shape(),
-      x.dtype(),
-      std::make_shared<AllReduce>(stream, group, AllReduce::Sum),
-      {x});
+  return all_reduce(x, group_, s, AllReduce::Sum);
 }
 
 array all_max(
     const array& x,
     std::optional<Group> group_ /* = std::nullopt */,
     StreamOrDevice s /* = {} */) {
-  auto group = to_group(group_);
-
-  if (group.size() == 1) {
-    return x;
-  }
-  auto stream = detail::communication_stream(group, s);
-
-  return array(
-      x.shape(),
-      x.dtype(),
-      std::make_shared<AllReduce>(stream, group, AllReduce::Max),
-      {x});
+  return all_reduce(x, group_, s, AllReduce::Max);
 }
 
 array all_min(
     const array& x,
     std::optional<Group> group_ /* = std::nullopt */,
     StreamOrDevice s /* = {} */) {
-  auto group = to_group(group_);
-
-  if (group.size() == 1) {
-    return x;
-  }
-  auto stream = detail::communication_stream(group, s);
-
-  return array(
-      x.shape(),
-      x.dtype(),
-      std::make_shared<AllReduce>(stream, group, AllReduce::Min),
-      {x});
+  return all_reduce(x, group_, s, AllReduce::Min);
 }
 
 array all_gather(


### PR DESCRIPTION
## Summary

Factor the identical construction shared by distributed `all_sum`, `all_max`,
and `all_min` into a local helper.

The helper is defined immediately below `to_group`, without a forward
declaration.

The three public wrappers still select their corresponding `AllReduce`
operation. Optional-group handling, the singleton fast path, communication
stream selection, output shape, and output dtype are unchanged. This removes
16 net lines and reduces the Release object and static library by 3,896 bytes.

## Testing

- Release CPU-only build with C++20 and warnings as errors
- Eight-rank Ring distributed suite on both baseline and candidate (13/13
  tests per rank), including 120 all-reduce cases per rank across ten dtypes,
  four shapes, and sum/max/min
- Native C++ suite (247/247 cases, 3,326/3,326 assertions)
- Exact artifact and global-symbol comparison
- Same-file review of older #3158 and #3164: the candidate adds no conflict to
  their independently conflicting current-main merges, and `ops.cpp` merges
  cleanly in both cases
- `clang-format` and `git diff --check`
