### PR TITLE
Remove redundant Metal bitwise dispatch

### DIFF
--- a/mlx/backend/metal/binary.cpp
+++ b/mlx/backend/metal/binary.cpp
@@ -235,7 +235,7 @@ BINARY_GPU(Power)
 BINARY_GPU(Subtract)
 
 void BitwiseBinary::eval_gpu(const std::vector<array>& inputs, array& out) {
-  return binary_op_gpu(inputs, out, name());
+  binary_op_gpu(inputs, out, name());
 }
 
 } // namespace mlx::core

--- a/mlx/backend/metal/binary.cpp
+++ b/mlx/backend/metal/binary.cpp
@@ -235,15 +235,7 @@ BINARY_GPU(Power)
 BINARY_GPU(Subtract)
 
 void BitwiseBinary::eval_gpu(const std::vector<array>& inputs, array& out) {
-  switch (op_) {
-    case BitwiseBinary::And:
-    case BitwiseBinary::Or:
-    case BitwiseBinary::Xor:
-    case BitwiseBinary::LeftShift:
-    case BitwiseBinary::RightShift:
-      binary_op_gpu(inputs, out, name());
-      break;
-  }
+  return binary_op_gpu(inputs, out, name());
 }
 
 } // namespace mlx::core

--- a/mlx/backend/metal/binary.cpp
+++ b/mlx/backend/metal/binary.cpp
@@ -237,17 +237,9 @@ BINARY_GPU(Subtract)
 void BitwiseBinary::eval_gpu(const std::vector<array>& inputs, array& out) {
   switch (op_) {
     case BitwiseBinary::And:
-      binary_op_gpu(inputs, out, name());
-      break;
     case BitwiseBinary::Or:
-      binary_op_gpu(inputs, out, name());
-      break;
     case BitwiseBinary::Xor:
-      binary_op_gpu(inputs, out, name());
-      break;
     case BitwiseBinary::LeftShift:
-      binary_op_gpu(inputs, out, name());
-      break;
     case BitwiseBinary::RightShift:
       binary_op_gpu(inputs, out, name());
       break;


### PR DESCRIPTION
## Summary

- remove the switch whose five Metal bitwise operations all take the same path
- call `binary_op_gpu` directly from `BitwiseBinary::eval_gpu`
- remove 16 net production lines

## Testing

- Release Metal build with C++20 and `-Werror`
- focused native GPU binary tests (4 cases, 122 assertions)
- focused Python bitwise tests (2 passed)
- native C++ suite excluding the exact-main beta-Accelerate linalg failures (248 cases, 3,407 assertions)
- full native suite matches the exact-main beta-Accelerate result (257/263 cases; the same 6 linalg failures)
- changed object shrinks by 16 bytes; unchanged defined global names and byte-identical Metal library
