### PR TITLE
Group equivalent Metal integer reduction cases

### DIFF
--- a/mlx/backend/metal/reduce.cpp
+++ b/mlx/backend/metal/reduce.cpp
@@ -249,21 +249,16 @@ std::pair<Dtype, Dtype> remap_reduce_types(
     if (issubdtype(in.dtype(), integer)) {
       switch (in.dtype()) {
         case uint8:
-          return {uint8, uint32};
         case uint16:
-          return {uint16, uint32};
-        case uint32:
-          return {uint32, uint32};
-        case uint64:
-          return {uint64, uint64};
+          return {in.dtype(), uint32};
         case int8:
-          return {int8, int32};
         case int16:
-          return {int16, int32};
+          return {in.dtype(), int32};
+        case uint32:
+        case uint64:
         case int32:
-          return {int32, int32};
         case int64:
-          return {int64, int64};
+          return {in.dtype(), in.dtype()};
         default:
           throw std::runtime_error("Unsupported integer type");
       }


### PR DESCRIPTION
## Summary

- group equivalent Metal integer sum/product accumulator mappings
- return the input dtype directly for the four identity mappings
- retain the existing default diagnostic while removing 5 net production lines

## Testing

- Release Metal build with C++20 and `-Werror`
- 96-case GPU parity against exact main across all eight integer dtypes, sum/product, axes, and `keepdims`
- full Python reduce tests (12 passed)
- native C++ suite excluding the exact-main beta-Accelerate linalg failures (248 cases, 3,407 assertions)
- byte-identical Metal library and unchanged defined global names; changed object is 408 bytes smaller
