### PR TITLE
Deduplicate custom Metal kernel size validation

### DIFF
--- a/mlx/backend/common/metal_kernel.cpp
+++ b/mlx/backend/common/metal_kernel.cpp
@@ -283,27 +283,18 @@ CustomKernelFunction metal_kernel(
              std::optional<float> init_value = std::nullopt,
              bool verbose = false,
              StreamOrDevice s_ = {}) {
-    if (inputs.size() != input_names.size()) {
+    auto check_size = [](size_t actual, size_t expected, const char* name) {
+      if (actual == expected) {
+        return;
+      }
       std::ostringstream msg;
-      msg << "[metal_kernel] Expected `inputs` to have size "
-          << input_names.size() << " but got size " << inputs.size() << "."
-          << std::endl;
+      msg << "[metal_kernel] Expected `" << name << "` to have size "
+          << expected << " but got size " << actual << "." << std::endl;
       throw std::invalid_argument(msg.str());
-    }
-    if (output_shapes.size() != output_names.size()) {
-      std::ostringstream msg;
-      msg << "[metal_kernel] Expected `output_shapes` to have size "
-          << output_names.size() << " but got size " << output_shapes.size()
-          << "." << std::endl;
-      throw std::invalid_argument(msg.str());
-    }
-    if (output_dtypes.size() != output_names.size()) {
-      std::ostringstream msg;
-      msg << "[metal_kernel] Expected `output_dtypes` to have size "
-          << output_names.size() << " but got size " << output_dtypes.size()
-          << "." << std::endl;
-      throw std::invalid_argument(msg.str());
-    }
+    };
+    check_size(inputs.size(), input_names.size(), "inputs");
+    check_size(output_shapes.size(), output_names.size(), "output_shapes");
+    check_size(output_dtypes.size(), output_names.size(), "output_dtypes");
 
     auto s = resolve_metal_kernel_stream(s_);
 


### PR DESCRIPTION
## Summary

- share the three identical custom Metal-kernel size checks through a local helper
- preserve validation order and exact diagnostics, including the trailing newline
- remove 9 net production lines

## Testing

- Release Metal build with C++20 and `-Werror`
- exact baseline/candidate parity for all three size diagnostics
- focused custom-kernel Python tests (9 passed)
- native C++ suite excluding the exact-main beta-Accelerate linalg failures (248 cases, 3,407 assertions)
- byte-identical Metal library and unchanged defined global names; changed object is 104 bytes smaller
