### PR TITLE
Deduplicate scalar-vector output allocation

### DIFF
--- a/mlx/backend/common/binary.h
+++ b/mlx/backend/common/binary.h
@@ -47,27 +47,21 @@ inline void set_binary_op_output_data(
       out.set_data(mallocfn(out.itemsize()), 1, a.strides(), a.flags());
       break;
     case BinaryOpType::ScalarVector:
-      if (b_donatable) {
-        out.copy_shared_buffer(b);
+    case BinaryOpType::VectorScalar: {
+      const auto& x = bopt == BinaryOpType::ScalarVector ? b : a;
+      bool x_donatable =
+          bopt == BinaryOpType::ScalarVector ? b_donatable : a_donatable;
+      if (x_donatable) {
+        out.copy_shared_buffer(x);
       } else {
         out.set_data(
-            mallocfn(b.data_size() * out.itemsize()),
-            b.data_size(),
-            b.strides(),
-            b.flags());
+            mallocfn(x.data_size() * out.itemsize()),
+            x.data_size(),
+            x.strides(),
+            x.flags());
       }
       break;
-    case BinaryOpType::VectorScalar:
-      if (a_donatable) {
-        out.copy_shared_buffer(a);
-      } else {
-        out.set_data(
-            mallocfn(a.data_size() * out.itemsize()),
-            a.data_size(),
-            a.strides(),
-            a.flags());
-      }
-      break;
+    }
     case BinaryOpType::VectorVector:
       if (a_donatable) {
         out.copy_shared_buffer(a);


### PR DESCRIPTION
## Summary

- share the identical scalar-vector and vector-scalar output-allocation path
- select the corresponding vector operand and its already-computed donation flag
- remove 6 net production lines without changing allocation or donation behavior

## Testing

- Release Metal build with C++20 and `-Werror`
- 80-case scalar/vector GPU parity against exact main across four dtypes and five binary operations
- focused Python binary tests (3 passed)
- native C++ suite excluding the exact-main beta-Accelerate linalg failures (248 cases, 3,407 assertions)
- byte-identical Metal library and unchanged defined global names; `libmlx.a` is 1,920 bytes smaller
