### PR TITLE
Deduplicate CUBLAS compute type cases

### DIFF
--- a/mlx/backend/cuda/gemms/cublas_gemm.cpp
+++ b/mlx/backend/cuda/gemms/cublas_gemm.cpp
@@ -15,17 +15,14 @@ namespace {
 cublasComputeType_t dtype_to_compute_type(Dtype dtype) {
   switch (dtype) {
     case float16:
-      return CUBLAS_COMPUTE_32F;
     case bfloat16:
       return CUBLAS_COMPUTE_32F;
     case float32:
+    case complex64:
       return mlx::core::env::enable_tf32() ? CUBLAS_COMPUTE_32F_FAST_TF32
                                            : CUBLAS_COMPUTE_32F;
     case float64:
       return CUBLAS_COMPUTE_64F;
-    case complex64:
-      return mlx::core::env::enable_tf32() ? CUBLAS_COMPUTE_32F_FAST_TF32
-                                           : CUBLAS_COMPUTE_32F;
     default:
       throw std::runtime_error(
           fmt::format(


### PR DESCRIPTION
## Summary

Group the CUBLAS dtype cases that select identical compute types.

Float16 and bfloat16 still use 32-bit compute. Float32 and complex64 still
share the existing TF32 policy, while float64 and unsupported dtypes retain
their original paths. This removes three redundant production lines.

## Testing

- Strict C++20 host-side compilation with warnings as errors
- Exhaustive mapping parity for all five supported dtypes with TF32 enabled
  and disabled, plus exact unsupported-dtype diagnostics
- Baseline/candidate mapping objects are byte-identical
- Fully paginated open-PR file scan (no same-file owners)
- `clang-format` and `git diff --check`
