### PR TITLE
Fix stream API documentation grammar

### DIFF
--- a/python/src/stream.cpp
+++ b/python/src/stream.cpp
@@ -126,7 +126,7 @@ void init_stream(nb::module_& m) {
         Unlike :func:`new_stream` which can only work on the thread of creation,
         streams created by this API can be passed to and evaluated anywhere, but
         note that currently all nodes in a graph must be evaluated in sequence
-        and it is user's responsibilty to ensure there is no race condition.
+        and it is the user's responsibility to ensure there is no race condition.
       )pbdoc");
   m.def(
       "new_thread_local_stream",


### PR DESCRIPTION
## Summary

Correct the grammar and spelling in the public `new_thread_unsafe_stream` Python docstring.

The sentence now says that it is the user's responsibility to ensure there is no race condition. Runtime stream behavior is unchanged.

## Testing

- Release build with Metal and Python bindings using C++20 and warnings as errors
- Direct import of the candidate extension and exact public docstring check
- Unsafe-stream array evaluation smoke test
- Python-extension artifact and exported-symbol check
- Fully paginated open-PR overlap and collision scan
- `clang-format` and `git diff --check`