### PR TITLE
Deduplicate Metal scan encoder setup

### DIFF
--- a/mlx/backend/metal/scan.cpp
+++ b/mlx/backend/metal/scan.cpp
@@ -59,14 +59,14 @@ void scan_gpu_inplace(
   auto kernel =
       get_scan_kernel(d, kname, reverse, inclusive, reduce_type_str, in, out);
 
-  if (contiguous) {
-    auto& compute_encoder = metal::get_command_encoder(s);
-    compute_encoder.set_compute_pipeline_state(kernel);
-    compute_encoder.set_input_array(in, 0);
-    compute_encoder.set_output_array(out, 1);
-    size_t size = in.shape(axis);
-    compute_encoder.set_bytes(size, 2);
+  auto& compute_encoder = metal::get_command_encoder(s);
+  compute_encoder.set_compute_pipeline_state(kernel);
+  compute_encoder.set_input_array(in, 0);
+  compute_encoder.set_output_array(out, 1);
+  size_t size = in.shape(axis);
+  compute_encoder.set_bytes(size, 2);
 
+  if (contiguous) {
     // Compute the thread grid
     int n_reads = (in.itemsize() <= 4) ? 4 : 2;
     constexpr int simd_size = 32;
@@ -89,15 +89,9 @@ void scan_gpu_inplace(
     MTL::Size group_dims(thread_group_size, 1, 1);
     compute_encoder.dispatch_threads(grid_dims, group_dims);
   } else {
-    auto& compute_encoder = metal::get_command_encoder(s);
-    compute_encoder.set_compute_pipeline_state(kernel);
-    compute_encoder.set_input_array(in, 0);
-    compute_encoder.set_output_array(out, 1);
-    size_t size = in.shape(axis);
     size_t stride = in.strides()[axis];
     int bn = 32;
     size_t stride_blocks = (stride + bn - 1) / bn;
-    compute_encoder.set_bytes(size, 2);
     compute_encoder.set_bytes(stride, 3);
     compute_encoder.set_bytes(stride_blocks, 4);
 


### PR DESCRIPTION
## Summary

Hoist the command encoder, pipeline, input/output bindings, and scan-size binding shared by the contiguous and strided Metal scan paths.

The branch-specific stride bindings and thread-grid calculations remain unchanged. This removes six net production lines without changing scan kernels or dispatch.

## Testing

- Release Metal build and Python bindings with C++20 and warnings as errors
- Native Metal scan operation test (12/12 assertions)
- Native Metal scan gradient test (20/20 assertions)
- Python scan, logcumsumexp, and NaN cummax/cummin tests
- Baseline-matched full native suite
- Object-size and global-symbol comparison
- Fully paginated open-PR overlap and collision scan
- `clang-format` and `git diff --check`