### PR TITLE
Refactor CPU Scatter dtype dispatch

### DIFF
--- a/mlx/backend/cpu/indexing.cpp
+++ b/mlx/backend/cpu/indexing.cpp
@@ -430,50 +430,10 @@ void Scatter::eval_cpu(const std::vector<array>& inputs, array& out) {
                     updates = array::unsafe_weak_copy(updates),
                     inds = std::move(inds),
                     out = array::unsafe_weak_copy(out)]() mutable {
-    switch (out.dtype()) {
-      case bool_:
-        dispatch_scatter<bool>(out, inds, updates, axes_, reduce_type_);
-        break;
-      case uint8:
-        dispatch_scatter<uint8_t>(out, inds, updates, axes_, reduce_type_);
-        break;
-      case uint16:
-        dispatch_scatter<uint16_t>(out, inds, updates, axes_, reduce_type_);
-        break;
-      case uint32:
-        dispatch_scatter<uint32_t>(out, inds, updates, axes_, reduce_type_);
-        break;
-      case uint64:
-        dispatch_scatter<uint64_t>(out, inds, updates, axes_, reduce_type_);
-        break;
-      case int8:
-        dispatch_scatter<int8_t>(out, inds, updates, axes_, reduce_type_);
-        break;
-      case int16:
-        dispatch_scatter<int16_t>(out, inds, updates, axes_, reduce_type_);
-        break;
-      case int32:
-        dispatch_scatter<int32_t>(out, inds, updates, axes_, reduce_type_);
-        break;
-      case int64:
-        dispatch_scatter<int64_t>(out, inds, updates, axes_, reduce_type_);
-        break;
-      case float16:
-        dispatch_scatter<float16_t>(out, inds, updates, axes_, reduce_type_);
-        break;
-      case float32:
-        dispatch_scatter<float>(out, inds, updates, axes_, reduce_type_);
-        break;
-      case float64:
-        dispatch_scatter<double>(out, inds, updates, axes_, reduce_type_);
-        break;
-      case bfloat16:
-        dispatch_scatter<bfloat16_t>(out, inds, updates, axes_, reduce_type_);
-        break;
-      case complex64:
-        dispatch_scatter<complex64_t>(out, inds, updates, axes_, reduce_type_);
-        break;
-    }
+    dispatch_all_types(out.dtype(), [&](auto type_tag) {
+      using T = MLX_GET_TYPE(type_tag);
+      dispatch_scatter<T>(out, inds, updates, axes_, reduce_type_);
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

CPU Scatter repeats the same `dispatch_scatter<T>` call for each supported
payload dtype. Replace only that payload switch with `dispatch_all_types`,
preserving all 14 existing payload instantiations.

The separate eight-way index dispatch, five assignment/reduction modes, their
operation bodies, and the unsupported-index diagnostic remain unchanged.

## Testing

- Release CPU build with C++20 and warnings as errors
- 1,960 cases covering all 14 payload dtypes, all 8 index dtypes, assignment,
  sum, product, maximum, and minimum, plus strided, signed-negative-index, and
  empty variants; baseline and candidate transcripts are byte-identical
- Exact invalid-index diagnostic preserved across all five modes
- Applies cleanly in either order with #4105 and #4109; the combined three-patch
  tree passes the Release/Werror build and full native suite
- `python/tests/test_ops.py` on current main (150 passed)
- Native C++ suite (247/247 cases, 3,326/3,326 assertions)
- `pre-commit` and `git diff --check`
