### PR TITLE
Refactor CPU ArgPartition dtype dispatch

### DIFF
--- a/mlx/backend/cpu/sort.cpp
+++ b/mlx/backend/cpu/sort.cpp
@@ -370,36 +370,9 @@ void ArgPartition::eval_cpu(const std::vector<array>& inputs, array& out) {
                     out = array::unsafe_weak_copy(out),
                     axis_ = axis_,
                     kth_ = kth_]() mutable {
-    switch (in.dtype()) {
-      case bool_:
-        return argpartition<bool>(in, out, axis_, kth_);
-      case uint8:
-        return argpartition<uint8_t>(in, out, axis_, kth_);
-      case uint16:
-        return argpartition<uint16_t>(in, out, axis_, kth_);
-      case uint32:
-        return argpartition<uint32_t>(in, out, axis_, kth_);
-      case uint64:
-        return argpartition<uint64_t>(in, out, axis_, kth_);
-      case int8:
-        return argpartition<int8_t>(in, out, axis_, kth_);
-      case int16:
-        return argpartition<int16_t>(in, out, axis_, kth_);
-      case int32:
-        return argpartition<int32_t>(in, out, axis_, kth_);
-      case int64:
-        return argpartition<int64_t>(in, out, axis_, kth_);
-      case float32:
-        return argpartition<float>(in, out, axis_, kth_);
-      case float64:
-        return argpartition<double>(in, out, axis_, kth_);
-      case float16:
-        return argpartition<float16_t>(in, out, axis_, kth_);
-      case bfloat16:
-        return argpartition<bfloat16_t>(in, out, axis_, kth_);
-      case complex64:
-        return argpartition<complex64_t>(in, out, axis_, kth_);
-    }
+    dispatch_all_types(in.dtype(), [&](auto type_tag) {
+      argpartition<MLX_GET_TYPE(type_tag)>(in, out, axis_, kth_);
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

Replace CPU `ArgPartition`'s exhaustive dtype switch with
`dispatch_all_types`. The common dispatcher covers the same 14 current dtypes
and leaves the nth-element implementation, kth handling, axes, and output
dtype unchanged.

This removes 27 net lines from one function.

## Testing

- Release CPU-only build with C++20 and warnings as errors
- Baseline/candidate parity across all 14 dtypes, contiguous, transposed,
  strided, reversed, broadcast, and empty inputs, flattened and signed axes,
  kth boundaries, floating special values, and exact diagnostics (2,114
  cases); transcripts byte-identical
- Native C++ suite (247/247 cases, 3,326/3,326 assertions)
- Generated argpartition implementation entries and global library symbols
  preserved
- All six application orders with #4123 and #4035 produce one tree; combined
  Release/Werror build, native suite, and parity transcript pass
- `pre-commit` and `git diff --check`
