### PR TITLE
Decode the e4m3 NaN encodings in from_fp8

### DIFF
--- a/mlx/backend/cpu/unary_ops.h
+++ b/mlx/backend/cpu/unary_ops.h
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <cmath>
 #include <complex>
+#include <limits>
 
 #include "mlx/backend/cpu/simd/simd.h"
 
@@ -165,6 +166,13 @@ struct FromFP8 {
         out[i] = converted * 256.0;
       }
     }
+    // 0x7f/0xff are e4m3's only NaN encodings. Shifted into float16 they land
+    // on a finite exponent (15, not 31), so the reinterpret above decodes them
+    // as 480.
+    out = select(
+        Simd<bool, N>((x & 127) == 127),
+        Simd<float, N>(std::numeric_limits<float>::quiet_NaN()),
+        out);
     auto sign = Simd<bool, N>(x & 128);
     return select(sign, -out, out);
   }

--- a/mlx/backend/metal/kernels/fp8.h
+++ b/mlx/backend/metal/kernels/fp8.h
@@ -33,6 +33,12 @@ struct fp8_e4m3 {
     uint16_t v = (bits & 127) << 7;
     half converted = as_type<half>(v);
     converted *= 256.0;
+    // 0x7f/0xff are e4m3's only NaN encodings. Shifted into half they land on a
+    // finite exponent (15, not 31), so the reinterpret above decodes them as
+    // 480.
+    if ((bits & 127) == 127) {
+      converted = NAN;
+    }
     auto sign = bits & 128;
     return (sign ? -converted : converted);
   }

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -3609,6 +3609,23 @@ class TestOps(mlx_tests.MLXTestCase):
         self.assertTrue(mx.array_equal(mx.from_fp8(mx.to_fp8(vals)), vals))
         self.assertTrue(mx.array_equal(mx.from_fp8(mx.to_fp8(-vals)), -vals))
 
+    def test_from_fp8_nan(self):
+        # 0x7f/0xff are e4m3's only NaN encodings. Shifted into float16 they land on
+        # a finite exponent, so a plain reinterpret decodes them as +/-480.
+        nans = mx.array([0x7F, 0xFF], mx.uint8)
+        for dtype in [mx.float16, mx.bfloat16, mx.float32]:
+            for stream in [mx.cpu, mx.gpu]:
+                if stream == mx.gpu and not mx.metal.is_available():
+                    continue
+                out = mx.from_fp8(nans, dtype=dtype, stream=stream)
+                self.assertTrue(
+                    mx.all(mx.isnan(out)).item(), msg=f"{dtype} {stream}: {out}"
+                )
+
+        # the largest finite magnitude is 448 (0x7e), and must stay finite
+        finite = mx.from_fp8(mx.array([0x7E, 0xFE], mx.uint8), dtype=mx.float32)
+        self.assertTrue(mx.array_equal(finite, mx.array([448.0, -448.0])))
+
     def test_zeros_ones_empty_like_dtype(self):
         x = mx.array([1, 2, 3], dtype=mx.int32)
 


### PR DESCRIPTION
## Proposed changes

Fixes #4135.

`0x7f` and `0xff` are e4m3's only NaN encodings, and `from_fp8` decoded both as `+/-480.0`.

The decode reinterprets `(bits & 127) << 7` as a float16 and scales by 256, which is exact for every finite e4m3 value. It does not carry NaN: the shift leaves those two patterns on exponent field 15 rather than 31, so float16 reads them as a normal number, and `1.875 * 256 = 480`.

Worth noting beyond the issue: 480 is above the format's largest finite magnitude of 448, so a NaN weight did not merely lose its NaN-ness, it silently became an out-of-range value that reads as ordinary data.

Both decoders had the same defect. `mlx/backend/metal/kernels/fp8.h`'s `fp8_e4m3` is not a native Metal type, it performs the same shift-and-scale as the CPU path, so CPU and GPU agreed on the wrong answer.

## Verification

Exhaustive over all 256 byte values against `torch.float8_e4m3fn`, on both streams:

| stream | mismatches before | mismatches after |
| --- | --- | --- |
| CPU | 2 (`0x7f`, `0xff`) | 0 |
| Metal | 2 (`0x7f`, `0xff`) | 0 |

Those two bytes were the only ones that ever disagreed, so nothing finite moves.

The new test fails without the change with `array([480, -480], dtype=float16)`. It pins both NaN encodings across float16, bfloat16 and float32 on both streams, and pins 448 as finite so a future change cannot swallow the maximum. The pre-existing round-trip test only covers finite values, which is why this went unnoticed.

Full suites on an M2 Pro (macOS 26.5.2, Metal build): 759 passed / 46 skipped / 10804 subtests in Python, and 261 C++ cases with 3521 assertions.

## Out of scope

`to_fp8` does not preserve NaN either, saturating it to `0x7e` (448) the way it saturates overflow, where torch maps both to NaN. That is a separate call and its saturating behaviour looks deliberate, so this PR leaves it alone. Happy to follow up if you want it changed.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
