### PR TITLE
add complex to scalar to avoid raising warnings by linters

### DIFF
--- a/python/mlx/_stub_patterns.txt
+++ b/python/mlx/_stub_patterns.txt
@@ -13,7 +13,7 @@ mlx.core.__prefix__:
 
 mlx.core.__suffix__:
   from typing import Union
-  scalar: TypeAlias = Union[int, float, bool]
+  scalar: TypeAlias = Union[int, float, bool, complex]
   list_or_scalar: TypeAlias = Union[scalar, list["list_or_scalar"]]
   bool_: Dtype = ...
 


### PR DESCRIPTION
## Proposed changes

This pull request makes a small change to the `python/mlx/_stub_patterns.txt` file by updating the `scalar` type alias to include the `complex` type in addition to `int`, `float`, and `bool`. This allows the codebase to support complex numbers where `scalar` is used.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
