### PR TITLE
Refactor CPU Copy source dtype dispatch

### DIFF
--- a/mlx/backend/cpu/copy.cpp
+++ b/mlx/backend/cpu/copy.cpp
@@ -209,50 +209,10 @@ inline void copy_inplace_dispatch(
     array& dst,
     CopyType ctype,
     Args&&... args) {
-  switch (src.dtype()) {
-    case bool_:
-      copy<bool>(src, dst, ctype, std::forward<Args>(args)...);
-      break;
-    case uint8:
-      copy<uint8_t>(src, dst, ctype, std::forward<Args>(args)...);
-      break;
-    case uint16:
-      copy<uint16_t>(src, dst, ctype, std::forward<Args>(args)...);
-      break;
-    case uint32:
-      copy<uint32_t>(src, dst, ctype, std::forward<Args>(args)...);
-      break;
-    case uint64:
-      copy<uint64_t>(src, dst, ctype, std::forward<Args>(args)...);
-      break;
-    case int8:
-      copy<int8_t>(src, dst, ctype, std::forward<Args>(args)...);
-      break;
-    case int16:
-      copy<int16_t>(src, dst, ctype, std::forward<Args>(args)...);
-      break;
-    case int32:
-      copy<int32_t>(src, dst, ctype, std::forward<Args>(args)...);
-      break;
-    case int64:
-      copy<int64_t>(src, dst, ctype, std::forward<Args>(args)...);
-      break;
-    case float16:
-      copy<float16_t>(src, dst, ctype, std::forward<Args>(args)...);
-      break;
-    case float32:
-      copy<float>(src, dst, ctype, std::forward<Args>(args)...);
-      break;
-    case float64:
-      copy<double>(src, dst, ctype, std::forward<Args>(args)...);
-      break;
-    case bfloat16:
-      copy<bfloat16_t>(src, dst, ctype, std::forward<Args>(args)...);
-      break;
-    case complex64:
-      copy<complex64_t>(src, dst, ctype, std::forward<Args>(args)...);
-      break;
-  }
+  dispatch_all_types(src.dtype(), [&](auto type_tag) {
+    using SrcT = MLX_GET_TYPE(type_tag);
+    copy<SrcT>(src, dst, ctype, std::forward<Args>(args)...);
+  });
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

CPU Copy repeats the same `copy<SrcT>` call for each source dtype. Replace only
the source switch with `dispatch_all_types`, leaving the destination dispatch
and all four `CopyType` implementations unchanged.

All 14 source and destination dtype mappings remain unchanged.

## Testing

- Exact-current-main Release CPU-only build with C++20 and warnings as errors
- Baseline/candidate parity across 616 dtype and copy-mode cases
- `python/tests/test_ops.py` (150/150)
- `python/tests/test_array.py` (98/98, 20 skipped)
- Native C++ suite (247/247 cases, 3,326/3,326 assertions)
- Exact one-file `+4/-44` diff and `git diff --check`
- `copy.cpp.o` -4,056 bytes; unchanged stripped-library size, byte-identical
  core extension, and identical exports
