### PR TITLE
Use a 32-row block in qmm_t_nax when one block covers all of M

### DIFF
--- a/mlx/backend/metal/kernels/fp_quantized_nax.metal
+++ b/mlx/backend/metal/kernels/fp_quantized_nax.metal
@@ -24,7 +24,7 @@
       type,        \
       group_size,          \
       bits,           \
-      aligned)
+      aligned, bm, bk, bn, wm, wn)
 
 #define instantiate_quantized_aligned_batched(mode, name, type, bm, bn, bk, wm, wn, aligned, batched, group_size, bits) \
   instantiate_kernel( \
@@ -34,7 +34,7 @@
       group_size,      \
       bits,       \
       aligned, \
-      batched)
+      batched, bm, bk, bn, wm, wn)
 
 #define instantiate_gather_qmm_rhs(func, name, type, bm, bn, bk, wm, wn, transpose, mode, group_size, bits) \
   instantiate_kernel( \
@@ -57,7 +57,11 @@
   instantiate_quantized_aligned_batched(mode, qmm_t_nax, type, 64, 64, 64, 2, 2, true, 1, group_size, bits)  \
   instantiate_quantized_aligned_batched(mode, qmm_t_nax, type, 64, 64, 64, 2, 2, true, 0, group_size, bits)  \
   instantiate_quantized_aligned_batched(mode, qmm_t_nax, type, 64, 64, 64, 2, 2, false, 1, group_size, bits) \
-  instantiate_quantized_aligned_batched(mode, qmm_t_nax, type, 64, 64, 64, 2, 2, false, 0, group_size, bits)
+  instantiate_quantized_aligned_batched(mode, qmm_t_nax, type, 64, 64, 64, 2, 2, false, 0, group_size, bits) \
+  instantiate_quantized_aligned_batched(mode, qmm_t_nax, type, 32, 64, 64, 2, 2, true, 1, group_size, bits)  \
+  instantiate_quantized_aligned_batched(mode, qmm_t_nax, type, 32, 64, 64, 2, 2, true, 0, group_size, bits)  \
+  instantiate_quantized_aligned_batched(mode, qmm_t_nax, type, 32, 64, 64, 2, 2, false, 1, group_size, bits) \
+  instantiate_quantized_aligned_batched(mode, qmm_t_nax, type, 32, 64, 64, 2, 2, false, 0, group_size, bits)
 
 
 #define instantiate_quantized_all_rhs(type, mode, group_size, bits) \

--- a/mlx/backend/metal/kernels/quantized_nax.metal
+++ b/mlx/backend/metal/kernels/quantized_nax.metal
@@ -74,7 +74,11 @@
   instantiate_quantized_aligned_batched(affine_qmm_t_nax, type, group_size, bits, 64, 64, 64, 2, 2, true, 1) \
   instantiate_quantized_aligned_batched(affine_qmm_t_nax, type, group_size, bits, 64, 64, 64, 2, 2, true, 0) \
   instantiate_quantized_aligned_batched(affine_qmm_t_nax, type, group_size, bits, 64, 64, 64, 2, 2, false, 1) \
-  instantiate_quantized_aligned_batched(affine_qmm_t_nax, type, group_size, bits, 64, 64, 64, 2, 2, false, 0)
+  instantiate_quantized_aligned_batched(affine_qmm_t_nax, type, group_size, bits, 64, 64, 64, 2, 2, false, 0) \
+  instantiate_quantized_aligned_batched(affine_qmm_t_nax, type, group_size, bits, 32, 64, 64, 2, 2, true, 1) \
+  instantiate_quantized_aligned_batched(affine_qmm_t_nax, type, group_size, bits, 32, 64, 64, 2, 2, true, 0) \
+  instantiate_quantized_aligned_batched(affine_qmm_t_nax, type, group_size, bits, 32, 64, 64, 2, 2, false, 1) \
+  instantiate_quantized_aligned_batched(affine_qmm_t_nax, type, group_size, bits, 32, 64, 64, 2, 2, false, 0)
 
 #define instantiate_quantized_all_rhs(type, group_size, bits) \
   instantiate_gather_qmm_rhs(affine_gather_qmm_rhs_nax, affine_gather_qmm_rhs_nax_nt, type, group_size, bits, 64, 64, 64, 2, 2, true) \

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -830,7 +830,8 @@ void qmm_nax(
 
   int wm = 2;
   int wn = 2;
-  int bm = 64;
+  // Use smaller bm when one block covers all of M.
+  int bm = (M <= 32) ? 32 : 64;
   int bn = 64;
   int bk = 64;
   MTL::Size group_dims(32, wn, wm);

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -335,6 +335,7 @@ class TestQuantized(mlx_tests.MLXTestCase):
         K = 128
         tests = [
             (16, 32840),  # unaligned N > 2**15, M < 32: partial M-tile
+            (32, 32840),  # M at the small-block dispatch boundary
             (33, 32840),  # unaligned N > 2**15, M % 32 != 0
             (33000, 64),  # M > 2**15: row distance overflows (aligned N)
         ]
@@ -439,6 +440,42 @@ class TestQuantized(mlx_tests.MLXTestCase):
                     for mode in modes:
                         with self.subTest(M=M, K=K, mode=mode, dtype=dtype):
                             check_fp(M, K, 128, mode, dtype)
+
+    def test_qmm_small_m_block(self):
+        # The batched and fp-mode variants of the small-M block, which the
+        # test_qmm_large_dims shapes cannot reach.
+        if mx.default_device() == mx.cpu:
+            self.skipTest("Covers GPU kernels only")
+        key = mx.random.key(0)
+        k1, k2 = mx.random.split(key)
+        K = 1024
+        tests = [
+            # mode, group_size, bits, M, N, batch
+            ("affine", 64, 4, 14, 8256, (2,)),  # batched w
+            ("mxfp4", None, None, 14, 8256, ()),
+        ]
+        for mode, group_size, bits, M, N, batch in tests:
+            dtype = mx.float16 if mode == "affine" else mx.bfloat16
+            with self.subTest(
+                mode=mode, group_size=group_size, bits=bits, M=M, N=N, batch=batch
+            ):
+                x = (mx.random.normal(batch + (M, K), key=k1) / K**0.5).astype(dtype)
+                w = (mx.random.normal(batch + (N, K), key=k2) / K**0.5).astype(dtype)
+                if mode == "affine":
+                    wq = mx.quantize(w, group_size=group_size, bits=bits)
+                else:
+                    wq = mx.quantize(w, mode=mode)
+                w_hat = mx.dequantize(*wq, group_size=group_size, bits=bits, mode=mode)
+                y_ref = x @ w_hat.swapaxes(-1, -2)
+                y = mx.quantized_matmul(
+                    x,
+                    *wq,
+                    transpose=True,
+                    group_size=group_size,
+                    bits=bits,
+                    mode=mode,
+                )
+                self.assertLess((y_ref - y).abs().max(), 1e-3)
 
     def test_qmm_vjp(self):
         key = mx.random.key(0)


### PR DESCRIPTION
A small follow-up to #3925 and #4023, which tuned the block size for
`gather_qmm_rhs_nax`: the same question applied to the plain quantized
matmul. `qmm_t_nax` always runs 64-row blocks; for M <= 32 we measured
modest gains from a 32-row block.

Only wide matrices reach this kernel at small M: below the qmv batch
limit the vector kernel serves the product, and up to 256 column tiles
the split-K path does, so N > 8192 is what arrives here with M <= 32.
In practice that is vocabulary heads and wide MLP projections during
speculative-decode verification, batch serving, and short prompts.

Unlike the gather case, a shorter block here is not free: every row
block reads all the weight columns it touches, so BM=32 pays only while
one block still covers all of M (forcing it at M=128 measures 13%
slower). The dispatch shrinks the block exactly when it stays a single
block.

Measured on a base M5 (10-core GPU), fp16, 4-bit gs64, against merged
main (5ec30acd5), both arms built from one tree, alternating in one
session, fresh process per cell, three passes with the last recorded
(drift on the repeated first cell: 0.7%):

| M | K | N | main | this branch | |
|---|---|---|---|---|---|
| 14 | 5120 | 13824 | 1011.0 us | 833.1 us | 1.21x |
| 32 | 5120 | 13824 | 980.7 us | 804.2 us | 1.22x |
| 48 | 5120 | 13824 | same path in both builds | | |

BM=16 was also measured and dropped: 6% over BM=32 at M=14 on the one
shape where it showed, not worth its instantiations.

Two notes for review:

1. The `fp_quantized_nax.metal` instantiation macros did not forward
   their tile-size arguments into the template, so every fp tile landed
   on the defaults; a new tile would have compiled to a mis-labeled
   64-row kernel. They now forward bm/bk/bn/wm/wn. No behavior change
   for existing instantiations, which all pass the defaults.

2. The new instantiations grow the metallib by 4.02%; half of that is
   the batch_1 and alN_false variants, which I can drop behind a
   dispatch guard if size matters more.

Tests: the existing test_qmm_large_dims shapes (16 and 33 rows at
N=32840) already land on either side of the new dispatch, so one added
row pins the boundary itself (M=32). A small new test covers the two
variants no existing shape reaches, batched and fp-mode; the fp row is
what exercises the macro fix.

Repro:

    python -c "
    import time
    import mlx.core as mx
    M, K, N = 32, 5120, 13824
    x = (mx.random.normal((M, K)) / K**0.5).astype(mx.float16)
    w = (mx.random.normal((N, K)) / K**0.5).astype(mx.float16)
    wq = mx.quantize(w, group_size=64, bits=4)
    def f(): mx.eval(mx.quantized_matmul(x, *wq, transpose=True, group_size=64, bits=4))
    for _ in range(30): f()
    t0 = time.perf_counter()
    for _ in range(300): f()
    print(f'{(time.perf_counter()-t0)/300*1e6:.1f} us per matmul')"
