### PR TITLE
docs: fix stale CLI invocations in LLM inference example

### DIFF
--- a/docs/src/examples/llama-inference.rst
+++ b/docs/src/examples/llama-inference.rst
@@ -322,14 +322,14 @@ several unnecessary copies from disk to numpy and then from numpy to MLX. It
 will be replaced in the future with direct loading to MLX.
 
 You can download the full example code in `mlx-examples`_. Assuming, the
-existence of ``weights.pth`` and ``tokenizer.model`` in the current working
-directory we can play around with our inference script as follows (the timings
-are representative of an M1 Ultra and the 7B parameter Llama model):
+existence of the PyTorch Llama weights in ``llama-7B/`` we can play around
+with our inference script as follows (the timings are representative of an M1
+Ultra and the 7B parameter Llama model):
 
 .. code-block:: bash
 
-    $ python convert.py weights.pth llama-7B.mlx.npz
-    $ python llama.py llama-7B.mlx.npz tokenizer.model 'Call me Ishmael. Some years ago never mind how long precisely'
+    $ python convert.py --torch-path llama-7B/
+    $ python llama.py --prompt 'Call me Ishmael. Some years ago never mind how long precisely'
     [INFO] Loading model from disk: 5.247 s
     Press enter to start generation
     ------
@@ -347,7 +347,7 @@ time as well as the prompt processing time remains almost constant.
 
 .. code-block:: bash
 
-    $ python llama.py llama-7B.mlx.npz tokenizer.model 'Call me Ishmael. Some years ago never mind how long precisely, having little or no money in my purse, and nothing of greater consequence in my mind, I happened to be walking down Gower Street in the afternoon, in the heavy rain, and I saw a few steps off, a man in rags, who sat upon his bundle and looked hard into the wet as if he were going to cry. I watched him attentively for some time, and could not but observe that, though a numerous crowd was hurrying up and down, nobody took the least notice of him. I stopped at last, at a little distance, as if I had been in doubt, and after looking on a few minutes, walked straight up to him. He slowly raised his eyes, and fixed them upon me for a moment, without speaking, and then resumed his place and posture as before. I stood looking at him for a while, feeling very much pain at heart, and then said to him, “What are you doing there?” Something like a smile passed over his face, as he said slowly, “I am waiting for someone; but it has been three quarters of an hour now, and he has not come.” “What is it you are waiting for?” said I. Still he made no immediate reply, but again put his face down upon his hands, and did not'
+    $ python llama.py --prompt 'Call me Ishmael. Some years ago never mind how long precisely, having little or no money in my purse, and nothing of greater consequence in my mind, I happened to be walking down Gower Street in the afternoon, in the heavy rain, and I saw a few steps off, a man in rags, who sat upon his bundle and looked hard into the wet as if he were going to cry. I watched him attentively for some time, and could not but observe that, though a numerous crowd was hurrying up and down, nobody took the least notice of him. I stopped at last, at a little distance, as if I had been in doubt, and after looking on a few minutes, walked straight up to him. He slowly raised his eyes, and fixed them upon me for a moment, without speaking, and then resumed his place and posture as before. I stood looking at him for a while, feeling very much pain at heart, and then said to him, “What are you doing there?” Something like a smile passed over his face, as he said slowly, “I am waiting for someone; but it has been three quarters of an hour now, and he has not come.” “What is it you are waiting for?” said I. Still he made no immediate reply, but again put his face down upon his hands, and did not'
     [INFO] Loading model from disk: 5.247 s
     Press enter to start generation
     ------
@@ -355,7 +355,7 @@ time as well as the prompt processing time remains almost constant.
     ------
     [INFO] Prompt processing: 0.579 s
     [INFO] Full generation: 4.690 s
-    $ python llama.py --num-tokens 500 llama-7B.mlx.npz tokenizer.model 'Call me Ishmael. Some years ago never mind how long precisely, having little or no money in my purse, and nothing of greater consequence in my mind, I happened to be walking down Gower Street in the afternoon, in the heavy rain, and I saw a few steps off, a man in rags, who sat upon his bundle and looked hard into the wet as if he were going to cry. I watched him attentively for some time, and could not but observe that, though a numerous crowd was hurrying up and down, nobody took the least notice of him. I stopped at last, at a little distance, as if I had been in doubt, and after looking on a few minutes, walked straight up to him. He slowly raised his eyes, and fixed them upon me for a moment, without speaking, and then resumed his place and posture as before. I stood looking at him for a while, feeling very much pain at heart, and then said to him, “What are you doing there?” Something like a smile passed over his face, as he said slowly, “I am waiting for someone; but it has been three quarters of an hour now, and he has not come.” “What is it you are waiting for?” said I. Still he made no immediate reply, but again put his face down upon his hands, and did not'
+    $ python llama.py --max-tokens 500 --prompt 'Call me Ishmael. Some years ago never mind how long precisely, having little or no money in my purse, and nothing of greater consequence in my mind, I happened to be walking down Gower Street in the afternoon, in the heavy rain, and I saw a few steps off, a man in rags, who sat upon his bundle and looked hard into the wet as if he were going to cry. I watched him attentively for some time, and could not but observe that, though a numerous crowd was hurrying up and down, nobody took the least notice of him. I stopped at last, at a little distance, as if I had been in doubt, and after looking on a few minutes, walked straight up to him. He slowly raised his eyes, and fixed them upon me for a moment, without speaking, and then resumed his place and posture as before. I stood looking at him for a while, feeling very much pain at heart, and then said to him, “What are you doing there?” Something like a smile passed over his face, as he said slowly, “I am waiting for someone; but it has been three quarters of an hour now, and he has not come.” “What is it you are waiting for?” said I. Still he made no immediate reply, but again put his face down upon his hands, and did not'
     [INFO] Loading model from disk: 5.628 s
     Press enter to start generation
     ------


### PR DESCRIPTION
## Proposed changes## Proposed changes

The example commands in the LLM inference guide no longer run as written, tried copying and pasting them and all failed.

Both scripts in `mlx-examples/llms/llama` now accept flags only:

- `llama.py`: `--model-path` (default `mlx_model`), `--prompt`, `--few-shot`,
  `--max-tokens`/`-m`, `--write-every`, `--temp`, `--seed`. No positional arguments.
- `convert.py`: `--torch-path`, `--mlx-path`, `--model-name`, `--quantize`,
  `--q-group-size`, `--q-bits`, `--dtype`. Writes a directory (default `mlx_model`),
  not a single `.npz` file.

`docs/src/examples/llama-inference.rst` still passes the weights and tokenizer
positionally, and uses `--num-tokens`, which no longer exists. This updates the
`convert.py` call, the three `llama.py` calls, and the surrounding sentence to
match the current CLI. Prompts, sample output, and timings are unchanged.

This is only a doc change, found when following the guide, no corresponding issues. 

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)