### PR TITLE
Keep double precision for python floats in float64 operations

### DIFF
--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -3487,18 +3487,18 @@ void init_ops(nb::module_& m) {
          const ScalarOrArray& constant_value,
          mx::StreamOrDevice s) {
         if (auto pv = std::get_if<int>(&pad_width); pv) {
-          return mx::pad(a, *pv, to_array(constant_value), mode, s);
+          return mx::pad(a, *pv, to_array(constant_value, a.dtype()), mode, s);
         } else if (auto pv = std::get_if<std::tuple<int>>(&pad_width); pv) {
           return mx::pad(
-              a, std::get<0>(*pv), to_array(constant_value), mode, s);
+              a, std::get<0>(*pv), to_array(constant_value, a.dtype()), mode, s);
         } else if (auto pv = std::get_if<std::pair<int, int>>(&pad_width); pv) {
-          return mx::pad(a, *pv, to_array(constant_value), mode, s);
+          return mx::pad(a, *pv, to_array(constant_value, a.dtype()), mode, s);
         } else {
           auto v = std::get<std::vector<std::pair<int, int>>>(pad_width);
           if (v.size() == 1) {
-            return mx::pad(a, v[0], to_array(constant_value), mode, s);
+            return mx::pad(a, v[0], to_array(constant_value, a.dtype()), mode, s);
           } else {
-            return mx::pad(a, v, to_array(constant_value), mode, s);
+            return mx::pad(a, v, to_array(constant_value, a.dtype()), mode, s);
           }
         }
       },

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -3494,13 +3494,18 @@ void init_ops(nb::module_& m) {
           return mx::pad(a, *pv, to_array(constant_value, a.dtype()), mode, s);
         } else if (auto pv = std::get_if<std::tuple<int>>(&pad_width); pv) {
           return mx::pad(
-              a, std::get<0>(*pv), to_array(constant_value, a.dtype()), mode, s);
+              a,
+              std::get<0>(*pv),
+              to_array(constant_value, a.dtype()),
+              mode,
+              s);
         } else if (auto pv = std::get_if<std::pair<int, int>>(&pad_width); pv) {
           return mx::pad(a, *pv, to_array(constant_value, a.dtype()), mode, s);
         } else {
           auto v = std::get<std::vector<std::pair<int, int>>>(pad_width);
           if (v.size() == 1) {
-            return mx::pad(a, v[0], to_array(constant_value, a.dtype()), mode, s);
+            return mx::pad(
+                a, v[0], to_array(constant_value, a.dtype()), mode, s);
           } else {
             return mx::pad(a, v, to_array(constant_value, a.dtype()), mode, s);
           }

--- a/python/src/utils.cpp
+++ b/python/src/utils.cpp
@@ -31,9 +31,15 @@ mx::array to_array(
     return mx::array(val, (out_t == mx::bool_) ? mx::int32 : out_t);
   } else if (auto pv = std::get_if<nb::float_>(&v); pv) {
     auto out_t = dtype.value_or(mx::float32);
-    return mx::array(
-        nb::cast<float>(*pv),
-        mx::issubdtype(out_t, mx::floating) ? out_t : mx::float32);
+    if (!mx::issubdtype(out_t, mx::floating)) {
+      out_t = mx::float32;
+    }
+    if (out_t == mx::float64) {
+      // Cast straight to double: going through float would round the value
+      // to float32 precision while the result still advertises float64.
+      return mx::array(nb::cast<double>(*pv), out_t);
+    }
+    return mx::array(nb::cast<float>(*pv), out_t);
   } else if (auto pv = std::get_if<std::complex<float>>(&v); pv) {
     return mx::array(static_cast<mx::complex64_t>(*pv), mx::complex64);
   } else if (auto pv = std::get_if<mx::array>(&v); pv) {

--- a/python/tests/test_double.py
+++ b/python/tests/test_double.py
@@ -296,6 +296,42 @@ class TestDouble(mlx_tests.MLXTestCase):
         b = a.tolist()
         self.assertEqual(b, [1.0, 2.0])
 
+    def test_python_float_keeps_double_precision(self):
+        with mx.stream(mx.cpu):
+            # https://github.com/ml-explore/mlx/issues/4160
+            for v in (0.37, 0.1, math.pi):
+                self.assertEqual(mx.full((3,), v, dtype=mx.float64).tolist(), [v] * 3)
+
+            # https://github.com/ml-explore/mlx/issues/4159
+            a = mx.array([1.0], dtype=mx.float64)
+            for v in (0.1, 1e-4, math.pi):
+                out = a * v
+                self.assertEqual(out.dtype, mx.float64)
+                self.assertEqual(out.tolist(), [v])
+
+            # values outside the float32 range used to saturate to inf or zero
+            self.assertEqual((a * 1e300).tolist(), [1e300])
+            self.assertEqual((a * 1e-300).tolist(), [1e-300])
+
+            # every op that pairs a scalar with an array goes through the same
+            # conversion
+            zero = mx.array([0.0], dtype=mx.float64)
+            self.assertEqual(mx.maximum(zero, 0.1).tolist(), [0.1])
+            self.assertEqual(mx.minimum(a, 0.1).tolist(), [0.1])
+            self.assertEqual(mx.clip(a, None, 0.1).tolist(), [0.1])
+            self.assertEqual(mx.where(mx.array([False]), zero, 0.1).tolist(), [0.1])
+            self.assertEqual(mx.pad(a, 1, constant_values=0.1).tolist(), [0.1, 1.0, 0.1])
+
+            # the python float is still weak: it does not widen the array
+            for dtype in (mx.float16, mx.bfloat16, mx.float32):
+                self.assertEqual((mx.array([1.0], dtype=dtype) * 0.1).dtype, dtype)
+            self.assertEqual((mx.array([1], dtype=mx.int32) * 0.1).dtype, mx.float32)
+
+            # pad() keeps returning the input's dtype for every input type
+            for dtype in (mx.int32, mx.float16, mx.bfloat16, mx.float32):
+                padded = mx.pad(mx.array([1.0], dtype=dtype), 1, constant_values=0.5)
+                self.assertEqual(padded.dtype, dtype)
+
     def test_linspace(self):
         with mx.stream(mx.cpu):
             vals = mx.linspace(0, math.pi, 2, mx.float64)

--- a/python/tests/test_double.py
+++ b/python/tests/test_double.py
@@ -320,7 +320,9 @@ class TestDouble(mlx_tests.MLXTestCase):
             self.assertEqual(mx.minimum(a, 0.1).tolist(), [0.1])
             self.assertEqual(mx.clip(a, None, 0.1).tolist(), [0.1])
             self.assertEqual(mx.where(mx.array([False]), zero, 0.1).tolist(), [0.1])
-            self.assertEqual(mx.pad(a, 1, constant_values=0.1).tolist(), [0.1, 1.0, 0.1])
+            self.assertEqual(
+                mx.pad(a, 1, constant_values=0.1).tolist(), [0.1, 1.0, 0.1]
+            )
 
             # the python float is still weak: it does not widen the array
             for dtype in (mx.float16, mx.bfloat16, mx.float32):


### PR DESCRIPTION
Fixes #4160, fixes #4159.

Both issues come down to the same line in `to_array` (python/src/utils.cpp): a python float is converted with `nb::cast<float>` before the target dtype is applied, so the value is rounded to float32 precision and then stored in a float64 array. That's why `mx.full((3,), 0.37, dtype=mx.float64)` holds `0.3700000047683716`, and why `float64_array * 0.1` computes with `float32(0.1)` while reporting a float64 result. `to_arrays` routes weak python scalars through this same function with the other operand's dtype, which is how the arithmetic case ends up here too.

The fix casts to double when the resolved output dtype is float64, and leaves every other path exactly as it was. This mirrors what `create_array` in convert.cpp already does for `mx.array(v, dtype=mx.float64)`, which is why the workaround in #4160 produced the right value. Weak promotion is untouched: a python float still doesn't promote a float32 array, it just stops losing digits when the expression is already float64.

Added a regression test to `test_double.py` covering `mx.full` with an explicit float64 dtype, float64-array-times-python-float for a few non-float32-exact literals (0.1, 1e-4, pi), and a check that float32 stays the default and isn't promoted. The new test fails on main and passes with this change. `test_double`, `test_array`, `test_ops`, `test_autograd`, and `test_blas` all pass on CPU (Linux, no Metal). clang-format and black are clean.


---

Behavior note on the pad change (thanks @AxelNoun for flagging it): since `pad` now resolves `constant_values` in the input's dtype, an out-of-range python int raises instead of wrapping silently. `mx.pad(mx.array([1], mx.int8), 1, constant_values=300)` used to produce 44, and `constant_values=-1` on a uint8 array produced 255; both now raise "Converting ... would result in overflow", which is exactly what `mx.full(shape, 300, dtype=mx.int8)` already did for the same value and dtype.
