### PR TITLE
docs: document softmax's `precise` argument

### DIFF
--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -3278,7 +3278,7 @@ void init_ops(nb::module_& m) {
       "precise"_a = false,
       "stream"_a = nb::none(),
       nb::sig(
-          "def softmax(a: array, /, axis: None | int | Sequence[int] = None, *, stream: StreamOrDevice = None) -> array"),
+          "def softmax(a: array, /, axis: None | int | Sequence[int] = None, *, precise: bool = False, stream: StreamOrDevice = None) -> array"),
       R"pbdoc(
         Perform the softmax along the given axis.
 
@@ -3293,6 +3293,10 @@ void init_ops(nb::module_& m) {
             axis (int or list(int), optional): Optional axis or axes to compute
              the softmax over. If unspecified this performs the softmax over
              the full array.
+            precise (bool, optional): Accumulate in ``float32`` for inputs of
+              lower precision. Otherwise the accumulation type matches the
+              input, which can lose precision over long reduction axes.
+              Default: ``False``.
 
         Returns:
             array: The output of the softmax.


### PR DESCRIPTION
`precise` is bound in `python/src/ops.cpp` but appears in neither the `nb::sig` signature nor the docstring, so it isn't discoverable from Python.

It selects the accumulation type — `AccT` defaults to the input type in `softmax.h`, so a bf16 softmax accumulates in bf16, which can lose precision over long reduction axes.

Docs only.