### PR TITLE
Bound GGUF tensor data offsets against the file mapping

### DIFF
--- a/mlx/io/gguf.cpp
+++ b/mlx/io/gguf.cpp
@@ -211,6 +211,28 @@ std::unordered_map<std::string, GGUFMetaData> load_metadata(gguf_ctx* ctx) {
   return metadata;
 }
 
+// gguflib computes weights_data as ctx->data + ctx->data_off + the tensor's
+// offset field in unsigned arithmetic, without comparing the result against the
+// mapping, so a crafted offset can point outside the file or -- if the addition
+// wraps -- back inside it at the wrong bytes.
+void check_tensor_in_file(const gguf_ctx* ctx, const gguf_tensor& tensor) {
+  auto fail = [&tensor](const std::string& what) {
+    std::ostringstream msg;
+    msg << "[load_gguf] Tensor '" << std::string(tensor.name, tensor.namelen)
+        << "' " << what << ". Perhaps an incomplete download or corrupt file?";
+    throw std::runtime_error(msg.str());
+  };
+  if (tensor.offset < ctx->data_off) {
+    fail("has a data offset that overflows the data section");
+  }
+  if (tensor.offset > ctx->size) {
+    fail("has a data offset past the end of the file");
+  }
+  if (tensor.bsize > ctx->size - tensor.offset) {
+    fail("extends past the end of the file");
+  }
+}
+
 std::unordered_map<std::string, array> load_arrays(gguf_ctx* ctx) {
   std::unordered_map<std::string, array> array_map;
   gguf_tensor tensor;
@@ -225,6 +247,7 @@ std::unordered_map<std::string, array> load_arrays(gguf_ctx* ctx) {
   };
 
   while (gguf_get_tensor(ctx, &tensor)) {
+    check_tensor_in_file(ctx, tensor);
     if (tensor.type == GGUF_TYPE_Q4_0 || tensor.type == GGUF_TYPE_Q4_1 ||
         tensor.type == GGUF_TYPE_Q8_0) {
       gguf_load_quantized(array_map, tensor);

--- a/tests/load_tests.cpp
+++ b/tests/load_tests.cpp
@@ -168,6 +168,95 @@ TEST_CASE("test gguf") {
   }
 }
 
+// Writes a one-tensor GGUF (name "t", ndim 1, dim 4, type F32) whose tensor
+// data offset field is set verbatim to `tensor_data_offset`. Writes
+// `data_bytes` bytes of tensor data, defaulting to the full four floats.
+void write_raw_gguf(
+    const std::string& path,
+    uint64_t tensor_data_offset,
+    size_t data_bytes = 4 * sizeof(float)) {
+  std::ofstream out(path, std::ios::binary);
+  auto u32 = [&out](uint32_t v) {
+    out.write(reinterpret_cast<const char*>(&v), 4);
+  };
+  auto u64 = [&out](uint64_t v) {
+    out.write(reinterpret_cast<const char*>(&v), 8);
+  };
+  out.write("GGUF", 4);
+  u32(3); // version
+  u64(1); // tensor_count
+  u64(0); // metadata_kv_count
+  u64(1); // tensor name length
+  out.write("t", 1);
+  u32(1); // ndim
+  u64(4); // dim[0]
+  u32(0); // GGUF_TYPE_F32
+  u64(tensor_data_offset);
+  while (out.tellp() % 32 != 0) { // default GGUF alignment
+    out.put(0);
+  }
+  std::vector<char> data(data_bytes, 0);
+  out.write(data.data(), data.size());
+}
+
+TEST_CASE("test gguf tensor data offset validation") {
+  // A crafted tensor data offset must be rejected rather than turned into a
+  // pointer outside the mapping. See ml-explore/mlx#4136.
+  SUBCASE("valid offset loads") {
+    std::string file_path = get_temp_file("test_gguf_offset_ok.gguf");
+    write_raw_gguf(file_path, 0);
+    auto [weights, metadata] = load_gguf(file_path);
+    CHECK_EQ(weights.size(), 1);
+    CHECK(array_equal(weights.at("t"), zeros({4}, float32)).item<bool>());
+  }
+
+  SUBCASE("offset past the end of the file") {
+    std::string file_path = get_temp_file("test_gguf_offset_past_end.gguf");
+    write_raw_gguf(file_path, 1ull << 20);
+    CHECK_THROWS_AS(load_gguf(file_path), std::runtime_error);
+  }
+
+  SUBCASE("offset far past the end of the file") {
+    std::string file_path = get_temp_file("test_gguf_offset_far_past.gguf");
+    write_raw_gguf(file_path, 1ull << 40);
+    CHECK_THROWS_AS(load_gguf(file_path), std::runtime_error);
+  }
+
+  SUBCASE("offset that overflows the data section base") {
+    // Wraps back to an in-mapping address, so an end-pointer-only check would
+    // silently read the wrong bytes instead of reading out of bounds.
+    std::string file_path = get_temp_file("test_gguf_offset_wrap.gguf");
+    write_raw_gguf(file_path, ~0ull - 8);
+    CHECK_THROWS_AS(load_gguf(file_path), std::runtime_error);
+  }
+
+  SUBCASE("tensor extends past the end of the file") {
+    // In-range offset, but the data is truncated: only the extent check
+    // catches this.
+    std::string file_path = get_temp_file("test_gguf_truncated.gguf");
+    write_raw_gguf(file_path, 0, 4 * sizeof(float) - 1);
+    CHECK_THROWS_AS(load_gguf(file_path), std::runtime_error);
+  }
+
+  SUBCASE("tensor starts inside the file but ends past it") {
+    // A small offset, so the start is in range and only the extent decides.
+    // Pins the extent check to the tensor's own start rather than to the
+    // start of the data section.
+    std::string file_path = get_temp_file("test_gguf_partial_overrun.gguf");
+    write_raw_gguf(file_path, 8);
+    CHECK_THROWS_AS(load_gguf(file_path), std::runtime_error);
+  }
+
+  SUBCASE("offset just past the end of the file") {
+    // Only a few bytes past the end rather than far outside it, so the
+    // resulting pointer is still in the mapped page and reads succeed
+    // silently. Pins the offset bound to the file size exactly.
+    std::string file_path = get_temp_file("test_gguf_offset_just_past.gguf");
+    write_raw_gguf(file_path, 20);
+    CHECK_THROWS_AS(load_gguf(file_path), std::runtime_error);
+  }
+}
+
 TEST_CASE("test gguf metadata") {
   std::string file_path = get_temp_file("test_arr.gguf");
   using dict = std::unordered_map<std::string, array>;


### PR DESCRIPTION
## Proposed changes

Fixes #4136 (thanks @professor-moody for the report).

`gguflib` sets `tensor->weights_data = ctx->data + ctx->data_off + *offset` from a
file-controlled offset without bounding it against `ctx->size` (`gguflib.c:297-298`), and
mlx's `memcpy` in `extract_tensor_data` (`mlx/io/gguf.cpp:71`) reads through it. A crafted
offset points outside the mapping; if the addition wraps it points back inside, so the load
silently returns wrong bytes instead of faulting.

This validates offset and extent in `load_arrays`, the one point both the plain and the
quantized paths pass through, using only `gguf_ctx` fields mlx already has. mlx does the same
a few lines away at `gguf.cpp:67` (CVE-2025-62609) and for safetensors at
`safetensors.cpp:196`.

It is still needed if gguflib is fixed upstream. The pending fix there,
antirez/gguf-tools#33, signals a rejected tensor with `return 0`, which in a
`while (gguf_get_tensor(...))` loop is indistinguishable from "no tensors left". Patching
the pinned gguflib with #33 locally, a 2-tensor file with one bad offset loads 1 tensor,
`left_tensors == 0`, no error — silently missing weights rather than a raise.

Not addressed by #3436: the only assert on this path is `ndim` (`gguflib.c:275`), so
`-UNDEBUG` has nothing to keep alive for `offset`/`bsize`.

Scope: this bounds the tensor data region against the file. It does not make GGUF loading
safe against arbitrary crafted files -- internally consistent but false metadata is a
separate class, not addressed here.

Without the guard two of the new subcases crash (SIGSEGV, or SIGBUS depending on where the
bad pointer lands) and four read wrong bytes without raising; all pass with it. The helper
follows `write_raw_safetensors` above it.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)

---
AI assistance was used in developing this change (Opus 5); I reviewed every changed line and
ran the commands above myself.
