### PR TITLE
Fix python float scalars rounding through float32

### DIFF
--- a/python/src/utils.cpp
+++ b/python/src/utils.cpp
@@ -31,9 +31,14 @@ mx::array to_array(
     return mx::array(val, (out_t == mx::bool_) ? mx::int32 : out_t);
   } else if (auto pv = std::get_if<nb::float_>(&v); pv) {
     auto out_t = dtype.value_or(mx::float32);
-    return mx::array(
-        nb::cast<float>(*pv),
-        mx::issubdtype(out_t, mx::floating) ? out_t : mx::float32);
+    if (!mx::issubdtype(out_t, mx::floating)) {
+      out_t = mx::float32;
+    }
+    // Casting to float first would lose precision for float64
+    if (out_t == mx::float64) {
+      return mx::array(nb::cast<double>(*pv), out_t);
+    }
+    return mx::array(nb::cast<float>(*pv), out_t);
   } else if (auto pv = std::get_if<std::complex<float>>(&v); pv) {
     return mx::array(static_cast<mx::complex64_t>(*pv), mx::complex64);
   } else if (auto pv = std::get_if<mx::array>(&v); pv) {

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -514,6 +514,18 @@ class TestArray(mlx_tests.MLXTestCase):
         out = mx.array([x], dtype=mx.float64).item()
         self.assertEqual(out, x)
 
+        with mx.stream(mx.cpu):
+            # A python float operand must not round through float32 before it
+            # is promoted to the float64 dtype of the other operand.
+            a = mx.array([1.0], dtype=mx.float64)
+            self.assertEqual((a * x).item(), x)
+            self.assertEqual((a + x).item(), 1.0 + x)
+            self.assertEqual(mx.maximum(a, x).item(), x)
+
+            # The fill value of full and full_like goes through the same path.
+            self.assertEqual(mx.full((2,), x, dtype=mx.float64)[0].item(), x)
+            self.assertEqual(mx.full_like(a, x).item(), x)
+
     def test_construction_from_lists_of_mlx_arrays(self):
         dtypes = [
             mx.bool_,


### PR DESCRIPTION
## Proposed changes

Fixes #4159 and Fixes #4160 — both come from the same line of code.

When a plain Python float is used together with a `float64` array, the value is
turned into a C `float` before the array is built. The dtype comes out correct,
but the number has already lost precision:

```python
a = mx.array([1.0], dtype=mx.float64)
(a * 0.1).item()                                 # 0.10000000149011612  (= float32(0.1))
mx.full((2,), 0.37, dtype=mx.float64)[0].item()  # 0.3700000047683716
```

Both should be exact.

This looks like a missed call site rather than a deliberate choice. #2861 fixed
this same pattern in `python/src/convert.cpp`, but `to_array` in
`python/src/utils.cpp` was never updated. This change mirrors that fix: cast to
`double` when the target dtype is `float64`, and keep casting to `float` for
every other dtype.

Since `to_array` is the path every Python-scalar operand takes, this also fixes
the same rounding in `mx.maximum`, `mx.minimum`, `mx.where`, `mx.clip`,
`full_like`, and the in-place operators on float64 arrays. Nothing changes for
float16, bfloat16 or float32.

### Testing

Extended `test_double_keeps_precision` (added by #2861) to cover the operand and
the `full` / `full_like` paths. It fails before this change and passes after.

Full Python suite on a CPU-only build (`MLX_BUILD_METAL=OFF`): 819 tests, no new
failures. `float64` is CPU-only in MLX, so that is where this behaviour lives,
but note the GPU suite was not run on my machine.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed) — no documentation change needed, there is no API or signature change
