### PR TITLE
Compute float64 exp, sin, cos and erf in double

### DIFF
--- a/mlx/backend/cpu/simd/math.h
+++ b/mlx/backend/cpu/simd/math.h
@@ -9,6 +9,21 @@ namespace mlx::core::simd {
 constexpr float inf = std::numeric_limits<float>::infinity();
 
 /**
+ * Evaluate a scalar function on each lane.
+ *
+ * The approximations in this file are tuned for float32. They are not accurate
+ * enough for float64, so double precision falls back to libm through here.
+ */
+template <typename T, int N, typename Op>
+Simd<T, N> lanewise(Simd<T, N> in, Op op) {
+  Simd<T, N> out;
+  for (int i = 0; i < N; ++i) {
+    out[i] = op(in[i]);
+  }
+  return out;
+}
+
+/**
  * Compute exp(x) in an optimizer friendly way as follows:
  *
  * First change the problem to computing 2**y where y = x / ln(2).
@@ -28,6 +43,10 @@ template <typename T, int N>
 Simd<T, N> exp(Simd<T, N> in) {
   if constexpr (is_complex<T>) {
     return Simd<T, 1>{std::exp(in.value)};
+  } else if constexpr (std::is_same_v<T, double>) {
+    // The polynomial below also saturates outside of float's range, which
+    // would clamp double results to zero or infinity beyond +-88.
+    return lanewise(in, [](double v) { return std::exp(v); });
   } else {
     Simd<float, N> x_init = in;
     auto x = x_init * 1.442695f; // multiply with log_2(e)
@@ -119,6 +138,8 @@ template <typename T, int N>
 Simd<T, N> sin(Simd<T, N> x) {
   if constexpr (is_complex<T>) {
     return std::sin(x.value);
+  } else if constexpr (std::is_same_v<T, double>) {
+    return lanewise(x, [](double v) { return std::sin(v); });
   } else {
     return sincos<true>(x);
   }
@@ -128,6 +149,8 @@ template <typename T, int N>
 Simd<T, N> cos(Simd<T, N> x) {
   if constexpr (is_complex<T>) {
     return std::cos(x.value);
+  } else if constexpr (std::is_same_v<T, double>) {
+    return lanewise(x, [](double v) { return std::cos(v); });
   } else {
     return sincos<false>(x);
   }
@@ -135,16 +158,20 @@ Simd<T, N> cos(Simd<T, N> x) {
 
 template <typename T, int N>
 Simd<T, N> erf(Simd<T, N> x) {
-  // https://github.com/pytorch/pytorch/blob/abf28982a8cb43342e7669d859de9543fd804cc9/aten/src/ATen/cpu/vec/vec256/vec256_float.h#L175
-  Simd<float, N> v = x;
-  auto t = recip(fma(Simd<float, N>(0.3275911f), abs(v), 1.0f));
-  auto r = fma(Simd<float, N>(1.061405429f), t, -1.453152027f);
-  r = fma(r, t, 1.421413741f);
-  r = fma(r, t, -0.284496736f);
-  r = fma(r, t, 0.254829592f);
-  auto e = -exp(-v * v);
-  auto result = Simd<T, N>(fma(e * t, r, 1.0f));
-  return select(x > 0, result, -result);
+  if constexpr (std::is_same_v<T, double>) {
+    return lanewise(x, [](double v) { return std::erf(v); });
+  } else {
+    // https://github.com/pytorch/pytorch/blob/abf28982a8cb43342e7669d859de9543fd804cc9/aten/src/ATen/cpu/vec/vec256/vec256_float.h#L175
+    Simd<float, N> v = x;
+    auto t = recip(fma(Simd<float, N>(0.3275911f), abs(v), 1.0f));
+    auto r = fma(Simd<float, N>(1.061405429f), t, -1.453152027f);
+    r = fma(r, t, 1.421413741f);
+    r = fma(r, t, -0.284496736f);
+    r = fma(r, t, 0.254829592f);
+    auto e = -exp(-v * v);
+    auto result = Simd<T, N>(fma(e * t, r, 1.0f));
+    return select(x > 0, result, -result);
+  }
 }
 
 template <typename T, int N>

--- a/python/tests/test_double.py
+++ b/python/tests/test_double.py
@@ -301,6 +301,42 @@ class TestDouble(mlx_tests.MLXTestCase):
             vals = mx.linspace(0, math.pi, 2, mx.float64)
             self.assertEqual(vals.tolist()[1], math.pi)
 
+    def test_transcendental_precision(self):
+        # exp, sin, cos and erf use a fast float32 polynomial on the CPU. For
+        # float64 inputs they must be evaluated in double precision, otherwise
+        # the result silently carries only float32 accuracy.
+        with mx.stream(mx.cpu):
+            x_np = np.linspace(-3.0, 3.0, 257, dtype=np.float64)
+            x = mx.array(x_np, dtype=mx.float64)
+
+            erf_np = np.vectorize(math.erf, otypes=[np.float64])
+            for mx_op, np_op in [
+                (mx.exp, np.exp),
+                (mx.sin, np.sin),
+                (mx.cos, np.cos),
+                (mx.erf, erf_np),
+            ]:
+                y = np.array(mx_op(x), copy=False)
+                self.assertEqual(y.dtype, np.float64)
+                self.assertTrue(
+                    np.allclose(y, np_op(x_np), rtol=1e-14, atol=1e-300),
+                    msg=f"{mx_op.__name__} on float64 is not double precision",
+                )
+
+    def test_exp_range(self):
+        # The float32 implementation saturates outside [-88, 88]. A float64
+        # exp must cover the whole double range instead.
+        with mx.stream(mx.cpu):
+            x_np = np.array([-700.0, -200.0, -89.0, 89.0, 200.0, 700.0])
+            y = np.array(mx.exp(mx.array(x_np, dtype=mx.float64)), copy=False)
+            self.assertTrue(np.all(np.isfinite(y)))
+            self.assertTrue(np.all(y > 0))
+            self.assertTrue(np.allclose(y, np.exp(x_np), rtol=1e-14))
+
+            # float32 keeps saturating, as before.
+            y32 = np.array(mx.exp(mx.array(x_np, dtype=mx.float32)), copy=False)
+            self.assertTrue(np.isinf(y32[-1]))
+
 
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner()


### PR DESCRIPTION
## Proposed changes

Fixes #4158.

`exp`, `sin`, `cos` and `erf` in `mlx/backend/cpu/simd/math.h` are hand-rolled
float32 approximations, and they convert their input to `Simd<float, N>`
unconditionally. float64 therefore gets float32 accuracy:

| max rel. error, float64 | before | after |
| --- | --- | --- |
| `exp` | 3.00e-07 | 0.00e+00 |
| `sin` | 7.75e-07 | 0.00e+00 |
| `cos` | 3.42e-04 | 0.00e+00 |
| `erf` | 9.44e-04 | 0.00e+00 |

`exp` is worse than imprecise, because it also inherited float's saturation
points, so a float64 array returns the wrong value outright:

```
exp(100.0)  -> inf   (should be 2.688e+43)
exp(709.0)  -> inf   (should be 8.218e+307)
exp(-200.0) -> 0     (should be 1.384e-87)
```

This routes double through libm and leaves float32 untouched.

Worth flagging: the existing `test_unary_ops` in `python/tests/test_double.py`
asserts `allclose(y, y_double.astype(mx.float32, mx.cpu))` — it compares the
float64 result against the float32 one, so it could not catch any of this.

### Performance

This is a real cost. 2^20 elements, M2 Pro, best of 7 runs:

| | float32 (unchanged) | float64 before | float64 after |
| --- | --- | --- | --- |
| `exp` | 0.437 -> 0.438 ms | 0.573 ms | 5.908 ms |
| `sin` | 0.804 -> 0.807 ms | 1.067 ms | 6.659 ms |
| `cos` | 0.786 -> 0.791 ms | 1.032 ms | 6.743 ms |
| `erf` | 0.877 -> 0.878 ms | 1.160 ms | 11.641 ms |

float32 is unchanged, as expected from a compile-time branch. The old float64
speed was the speed of computing the wrong answer.

I checked whether that speed can be recovered. Accelerate's vectorized double
math (`simd::exp` / `simd::erf` on `double4`) measured no faster than scalar
libm on this machine — 2.456 vs 2.558 ms for `exp`, 9.653 vs 9.951 ms for `erf`,
with bit-identical results — so the cost looks intrinsic to evaluating these at
double precision rather than a poor choice of implementation. Happy to take
direction if you would prefer a different trade-off here.

`erfinv` still narrows to float. It has no libm equivalent and would need a
double precision polynomial, so I left it for a separate change rather than
half-do it.

### Testing

Two new tests in `python/tests/test_double.py`: one pins the four ops to double
accuracy against numpy, one pins the range of `exp`. Both fail before this
change and pass after.

- Full Python suite: 821 tests, no new failures.
- Full C++ suite: 247 cases, 3326 assertions, all pass.

Built CPU-only (`MLX_BUILD_METAL=OFF`). float64 is CPU-only in MLX, so that is
where this behaviour lives, but note the GPU suite was not run on my machine.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed) — no documentation change needed, there is no API change
