### PR TITLE
Fix compile leaking multi-output arrays

### DIFF
--- a/mlx/compile.cpp
+++ b/mlx/compile.cpp
@@ -469,6 +469,9 @@ std::pair<std::vector<array>, ParentsMap> compile_dfs(
 
   // Deep copy the tape and parents map while preserving inputs and outputs
   std::vector<array> new_tape;
+  // One member of each multi-output group that gets replaced below, see the
+  // comment where this is cleared
+  std::vector<array> replaced_multi_outputs;
   std::unordered_set<uintptr_t> io_set;
   std::unordered_map<uintptr_t, array> old_to_new;
   for (auto& o : outputs) {
@@ -510,6 +513,7 @@ std::pair<std::vector<array>, ParentsMap> compile_dfs(
         old_to_new.insert({out[i].id(), as[i]});
       }
       new_tape.push_back(as[arr.sibling_position()]);
+      replaced_multi_outputs.push_back(arr);
     } else {
       auto a = array(
           arr.shape(), arr.dtype(), arr.primitive_ptr(), std::move(inputs));
@@ -543,6 +547,15 @@ std::pair<std::vector<array>, ParentsMap> compile_dfs(
     new_parents_map[old_to_new.find(id)->second.id()] = std::move(vec);
   }
   parents_map = std::move(new_parents_map);
+
+  // The replaced multi-output arrays reference each other through their
+  // siblings, so they only go away when array::~array() breaks that cycle, and
+  // it does so only for the last external reference. Both the tape and the
+  // parents map still held them until just above, so drop them here instead.
+  // Any group the caller still holds is left alone, since the reference count
+  // stays above the threshold and nothing is detached.
+  replaced_multi_outputs.clear();
+
   return {tape, parents_map};
 }
 

--- a/python/tests/test_compile.py
+++ b/python/tests/test_compile.py
@@ -1244,6 +1244,41 @@ class TestCompile(mlx_tests.MLXTestCase):
 
         self.assertEqual(mem_pre, mem_post)
 
+    def test_multi_output_leak(self):
+        # A multi-output primitive inside a compiled function used to leave the
+        # traced arrays orphaned in their sibling reference cycle, which pinned
+        # every array they had captured.
+        dim, blocks = 128, 4
+        x = mx.random.normal((2, dim))
+        mx.eval(x)
+
+        def run():
+            weights = [mx.random.normal((dim, dim)) for _ in range(blocks)]
+            mx.eval(weights)
+
+            def forward(y):
+                for w in weights:
+                    a, b = mx.split(y @ w, 2, axis=-1)
+                    y = mx.concatenate([b, a], axis=-1)
+                return y
+
+            fn = mx.compile(forward)
+            mx.eval(fn(x))
+            del fn, forward, weights
+
+        # Warm up so the allocator is not growing for unrelated reasons
+        run()
+        gc.collect()
+        mx.synchronize()
+        mem_pre = mx.get_active_memory()
+
+        for _ in range(10):
+            run()
+            gc.collect()
+        mx.synchronize()
+
+        self.assertEqual(mx.get_active_memory(), mem_pre)
+
     def test_double_constant(self):
         with mx.stream(mx.cpu):
             x = mx.array(1.0, dtype=mx.float64)


### PR DESCRIPTION
## Proposed changes

Fixes #3932.

A compiled function containing a multi-output primitive leaks every array the
traced function captured, once per call:

```python
def make_forward(weights):
    def forward(x):
        for w in weights:
            a, b = mx.split(x @ w, 2, axis=-1)
            x = mx.concatenate([b, a], axis=-1)
        return x
    return forward

# 8 x (256, 256) float32 weights, evaluated outside the compiled function
# before: 2097152 bytes retained per call, forever
# after:  0
```

Replacing the `mx.split` with plain slicing (a single-output op) leaks nothing,
which is what pointed at the multi-output path.

### Cause

`compile_dfs` deep copies the traced tape, so the originals of any multi-output
node should die once the new tape and the parents map are in place. They cannot:

- The outputs of a multi-output primitive hold each other through `siblings`
  (`array::make_arrays`), which is a strong reference cycle by construction.
- `array::~array()` is the only thing that breaks that cycle, and only when the
  destructing array is the last external holder (`use_count() == n + 1`).
- At `tape = std::move(new_tape)` the old arrays are destroyed, but the parents
  map still holds copies of them, so the count is too high and nothing is
  detached.
- The parents map then drops its references through `array::operator=`, which
  reseats `array_desc_` and has no cycle-breaking counterpart.

The group ends up orphaned at `use_count() == 1` each, referenced only by each
other, still holding `ArrayDesc::inputs` — which pins the captured weights.

That also explains why all three ingredients are needed to see it: single-output
originals have no cycle, `compile_dfs` is the only place doing this deep copy
plus `operator=` rewiring, and an already-evaluated capture is shared into the
new tape rather than copied, so the orphan holds a real buffer.

### Fix

Rather than adding a new liveness rule, keep one member of each replaced group
alive until both the tape and the parents map have been rewired, then drop it,
so the existing destructor test runs at a point where its arithmetic is valid.

This is deliberately conservative. If the caller still holds the group — for
example a lazy `mx.split` created before tracing and captured by the closure —
the reference count stays above the threshold and nothing is mutated at all. I
checked that case explicitly against `main` and against this branch, and both
behave identically. Nothing is force-detached, so the compile cache's record of
each node's primitive is untouched.

Also worth a line: `compile_simplify`'s `merge_one` rewires parents through the
same `array::operator=` and `split_one` clones nodes, so a similar shape may
exist there. I have not investigated it and am not claiming simplify is clean.

### Testing

New `test_multi_output_leak` in `python/tests/test_compile.py`, which loops so a
single-cycle fluke cannot pass it. It fails before this change and passes after.
The existing `test_leaks` gates on `mx.metal.is_available()`, so it is a no-op
on a CPU-only build; this one does not.

- Full Python suite: 820 tests, no new failures.
- Full C++ suite: 247 cases, all pass.

Built CPU-only (`MLX_BUILD_METAL=OFF`); the GPU suite was not run on my machine.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed) — no documentation change needed, this is an internal lifetime fix
