### PR TITLE
Add force_fused option to scaled_dot_product_attention

### DIFF
--- a/mlx/backend/cuda/scaled_dot_product_attention.cpp
+++ b/mlx/backend/cuda/scaled_dot_product_attention.cpp
@@ -549,6 +549,33 @@ void sdpa_vector(
 
 namespace fast {
 
+namespace {
+
+std::tuple<bool, std::string> has_fused_kernel(
+    const array& q,
+    const array& k,
+    const array& v,
+    bool has_arr_mask,
+    bool do_causal,
+    bool output_logsumexp,
+    Stream s) {
+  if (s.device != Device::gpu) {
+    return {false, "the fused kernels require a GPU stream."};
+  }
+  if (!supports_sdpa_cudnn(q, k, v, has_arr_mask, do_causal, s) &&
+      !supports_sdpa_vector(q, k, v, has_arr_mask, output_logsumexp)) {
+    std::ostringstream msg;
+    msg << "neither the cuDNN attention nor the vector attention kernel "
+        << "supports this configuration; got query shape " << q.shape()
+        << ", key shape " << k.shape() << ", value shape " << v.shape()
+        << " with dtype " << q.dtype() << ".";
+    return {false, msg.str()};
+  }
+  return {true, ""};
+}
+
+} // namespace
+
 bool ScaledDotProductAttention::use_fallback(
     const array& q,
     const array& k,
@@ -558,13 +585,21 @@ bool ScaledDotProductAttention::use_fallback(
     bool do_causal,
     bool is_training,
     bool output_logsumexp,
+    bool force_fused,
     Stream s) {
-  if (s.device == Device::cpu) {
-    return true;
+  auto [has_fused, reason] =
+      has_fused_kernel(q, k, v, has_arr_mask, do_causal, output_logsumexp, s);
+  if (force_fused) {
+    if (!has_fused) {
+      std::ostringstream msg;
+      msg << "[scaled_dot_product_attention] force_fused=True but no fused "
+             "kernel is available: "
+          << reason;
+      throw std::invalid_argument(msg.str());
+    }
+    return false;
   }
-
-  return !supports_sdpa_cudnn(q, k, v, has_arr_mask, do_causal, s) &&
-      !supports_sdpa_vector(q, k, v, has_arr_mask, output_logsumexp);
+  return !has_fused;
 }
 
 bool ScaledDotProductAttention::supports_bool_mask() {

--- a/mlx/backend/metal/kernels/scaled_dot_product_attention.metal
+++ b/mlx/backend/metal/kernels/scaled_dot_product_attention.metal
@@ -33,10 +33,12 @@ using namespace metal;
   instantiate_sdpa_vector(type, 96, 96)          \
   instantiate_sdpa_vector(type, 128, 128)        \
   instantiate_sdpa_vector(type, 192, 128)        \
+  instantiate_sdpa_vector(type, 192, 192)        \
   instantiate_sdpa_vector(type, 256, 256)        \
   instantiate_sdpa_vector_aggregation(type, 64)  \
   instantiate_sdpa_vector_aggregation(type, 96)  \
   instantiate_sdpa_vector_aggregation(type, 128) \
+  instantiate_sdpa_vector_aggregation(type, 192) \
   instantiate_sdpa_vector_aggregation(type, 256)
 
 instantiate_sdpa_vector_heads(float)

--- a/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention.h
+++ b/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention.h
@@ -428,7 +428,7 @@ template <
       for (short id = 0; id < TD; id++) {
         STEEL_PRAGMA_UNROLL
         for (short ik = 0; ik < TK; ik++) {
-          if constexpr (BD == 128) {
+          if constexpr (BD >= 128) {
             simdgroup_barrier(mem_flags::mem_none);
           }
 
@@ -438,7 +438,7 @@ template <
           Vtile.template load<T, 1, 1, LDV_tgp, 1>(
               &Vs[Vs_offset + kk * LDV_tgp + dd]);
 
-          if constexpr (BD == 128) {
+          if constexpr (BD >= 128) {
             simdgroup_barrier(mem_flags::mem_none);
           }
 

--- a/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention.metal
+++ b/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention.metal
@@ -12,6 +12,8 @@
   attention, dtype, bq, bk, bd, wm, wn, mtype, float)
 
 #define instantiate_attn_shapes_helper(iname, itype, mname, mtype)  \
+    instantiate_attn(iname, itype, 32, 16, 256, 4, 1, mname, mtype) \
+    instantiate_attn(iname, itype, 32, 16, 192, 4, 1, mname, mtype) \
     instantiate_attn(iname, itype, 32, 16, 128, 4, 1, mname, mtype) \
     instantiate_attn(iname, itype, 32, 32,  96, 4, 1, mname, mtype) \
     instantiate_attn(iname, itype, 32, 32,  80, 4, 1, mname, mtype) \

--- a/mlx/backend/metal/scaled_dot_product_attention.cpp
+++ b/mlx/backend/metal/scaled_dot_product_attention.cpp
@@ -160,6 +160,7 @@ void sdpa_full_self_attention_nax(
   MTL::Size grid_dims = MTL::Size(NQ, H, B);
   MTL::Size group_dims = MTL::Size(32, wm, wn);
 
+  check_kernel_threadgroup_size(kernel, group_dims, hash_name);
   compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
 }
 
@@ -174,9 +175,8 @@ void sdpa_full_self_attention_metal(
     bool do_causal_,
     const std::optional<array>& mask,
     const std::optional<array>& sinks) {
-  // NAX tiles the head dim in units of kU=16 and steps TD by 2, so it needs
-  // a multiple of 32; 72 and 80 take the classic steel kernel.
-  if (metal::is_nax_available() && q.shape(3) != 80 && q.shape(3) != 72 &&
+  if (metal::is_nax_available() &&
+      (q.shape(3) == 64 || q.shape(3) == 96 || q.shape(3) == 128) &&
       (env::enable_tf32() || q.dtype() != float32)) {
     return sdpa_full_self_attention_nax(
         /* const Stream& s = */ s,
@@ -325,6 +325,7 @@ void sdpa_full_self_attention_metal(
   MTL::Size grid_dims = MTL::Size(NQ, H, B);
   MTL::Size group_dims = MTL::Size(32, wm, wn);
 
+  check_kernel_threadgroup_size(kernel, group_dims, hash_name);
   compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
 }
 
@@ -591,6 +592,86 @@ void sdpa_vector_2pass(
   compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
 }
 
+std::tuple<bool, std::string> has_fused_kernel(
+    const array& q,
+    const array& k,
+    const array& v,
+    bool has_mask,
+    bool has_arr_mask,
+    bool do_causal,
+    bool output_logsumexp,
+    Stream s) {
+  if (s.device != Device::gpu) {
+    return {false, "the fused kernels require a GPU (Metal) stream."};
+  }
+  if (output_logsumexp) {
+    return {
+        false,
+        "the fused forward does not produce the logsumexp required for "
+        "the fused VJP; use default routing when training."};
+  }
+
+  const int value_head_dim = v.shape(-1);
+  const int query_head_dim = q.shape(-1);
+  const int query_sequence_length = q.shape(2);
+  const int key_sequence_length = k.shape(2);
+  const int num_query_heads = q.shape(1);
+  const int num_kv_heads = k.shape(1);
+  const int gqa_factor = num_query_heads / num_kv_heads;
+
+  std::ostringstream msg;
+  if (query_sequence_length > 8) {
+    const bool supported_head_dim = query_head_dim == value_head_dim &&
+        (query_head_dim == 64 || query_head_dim == 72 || query_head_dim == 80 ||
+         query_head_dim == 96 || query_head_dim == 128 ||
+         query_head_dim == 192 || query_head_dim == 256);
+    if (!supported_head_dim) {
+      msg << "the full attention kernel supports head dims "
+          << "{64, 72, 80, 96, 128, 192, 256} with matching query/value head "
+          << "dims; got query head dim " << query_head_dim
+          << " and value head dim " << value_head_dim << ".";
+      return {false, msg.str()};
+    }
+    if (has_mask && !has_arr_mask &&
+        !(query_sequence_length <= key_sequence_length && do_causal)) {
+      msg << "the full attention kernel with a causal mask requires the "
+          << "query sequence to be no longer than the key sequence; got "
+          << "query length " << query_sequence_length << " and key length "
+          << key_sequence_length << ".";
+      return {false, msg.str()};
+    }
+  } else {
+    const bool supported_head_dim =
+        (query_head_dim == value_head_dim &&
+         (query_head_dim == 64 || query_head_dim == 96 ||
+          query_head_dim == 128 || query_head_dim == 192 ||
+          query_head_dim == 256)) ||
+        (query_head_dim == 192 && value_head_dim == 128);
+    if (!supported_head_dim) {
+      msg << "the vector attention kernel supports head dims "
+          << "{64, 96, 128, 192, 256} with matching query/value head dims, "
+          << "or query head dim 192 with value head dim 128; got query head "
+          << "dim " << query_head_dim << " and value head dim "
+          << value_head_dim << ".";
+      return {false, msg.str()};
+    }
+    if (query_sequence_length > key_sequence_length) {
+      msg << "the vector attention kernel requires the query sequence to be "
+          << "no longer than the key sequence; got query length "
+          << query_sequence_length << " and key length " << key_sequence_length
+          << ".";
+      return {false, msg.str()};
+    }
+    if (query_sequence_length * gqa_factor > 32) {
+      msg << "the vector attention kernel requires the query length times "
+          << "the GQA factor to be at most 32; got query length "
+          << query_sequence_length << " and GQA factor " << gqa_factor << ".";
+      return {false, msg.str()};
+    }
+  }
+  return {true, ""};
+}
+
 } // namespace
 
 bool ScaledDotProductAttention::use_fallback(
@@ -602,48 +683,39 @@ bool ScaledDotProductAttention::use_fallback(
     bool do_causal,
     bool is_training,
     bool output_logsumexp,
+    bool force_fused,
     Stream s) {
+  auto [has_fused, reason] = has_fused_kernel(
+      q, k, v, has_mask, has_arr_mask, do_causal, output_logsumexp, s);
+  if (force_fused) {
+    if (!has_fused) {
+      std::ostringstream msg;
+      msg << "[scaled_dot_product_attention] force_fused=True but no fused "
+             "kernel is available: "
+          << reason;
+      throw std::invalid_argument(msg.str());
+    }
+    return false;
+  }
+
   if (is_training) {
     // It's faster for training on Metal to use the unfused SDPA for both
     // forward and backward.
     return true;
   }
-  if (output_logsumexp) {
-    return true;
-  }
-  if (s.device == Device::cpu) {
+  if (!has_fused) {
     return true;
   }
 
-  const int value_head_dim = v.shape(-1);
-  const int query_head_dim = q.shape(-1);
+  // Unfused path is faster for following shapes.
   const int query_sequence_length = q.shape(2);
-  const int key_sequence_length = k.shape(2);
-  const int num_query_heads = q.shape(1);
-  const int num_kv_heads = k.shape(1);
-  const int gqa_factor = num_query_heads / num_kv_heads;
-
-  const bool sdpa_vector_supported_head_dim =
-      (query_head_dim == value_head_dim &&
-       (query_head_dim == 64 || query_head_dim == 96 || query_head_dim == 128 ||
-        query_head_dim == 256)) ||
-      (query_head_dim == 192 && value_head_dim == 128);
-  const bool sdpa_full_supported_head_dim = query_head_dim == value_head_dim &&
-      (query_head_dim == 64 || query_head_dim == 72 || query_head_dim == 80 ||
-       query_head_dim == 96 || query_head_dim == 128);
-
-  const bool sdpa_full_supported_mask = !has_mask || has_arr_mask ||
-      (query_sequence_length <= key_sequence_length && do_causal);
-
-  const bool supports_sdpa_full = query_sequence_length > 8 &&
-      sdpa_full_supported_mask && sdpa_full_supported_head_dim;
-
-  const bool supports_sdpa_vector = (query_sequence_length <= 8) &&
-      (query_sequence_length <= key_sequence_length) &&
-      sdpa_vector_supported_head_dim &&
-      (query_sequence_length * gqa_factor) <= 32;
-
-  return !(supports_sdpa_full || supports_sdpa_vector);
+  const int query_head_dim = q.shape(-1);
+  const int value_head_dim = v.shape(-1);
+  if (query_sequence_length > 8) {
+    return query_head_dim == 192 || query_head_dim == 256;
+  } else {
+    return query_head_dim == value_head_dim && query_head_dim == 192;
+  }
 }
 
 bool ScaledDotProductAttention::supports_bool_mask() {

--- a/mlx/backend/no_gpu/primitives.cpp
+++ b/mlx/backend/no_gpu/primitives.cpp
@@ -32,18 +32,24 @@ bool fast::ScaledDotProductAttention::use_fallback(
     bool do_causal,
     bool is_training,
     bool output_logsumexp,
+    bool force_fused,
     Stream s) {
+  if (force_fused) {
+    throw std::invalid_argument(
+        "[scaled_dot_product_attention] force_fused=True but no fused "
+        "kernel is available in CPU backend.");
+  }
   return true;
-}
-
-bool fast::ScaledDotProductAttention::supports_bool_mask() {
-  return false;
 }
 
 bool fast::ScaledDotProductAttentionVJP::use_fallback(
     const array& q,
     Stream s) {
   return true;
+}
+
+bool fast::ScaledDotProductAttention::supports_bool_mask() {
+  return false;
 }
 
 NO_GPU(Abs)

--- a/mlx/fast.cpp
+++ b/mlx/fast.cpp
@@ -618,7 +618,8 @@ array scaled_dot_product_attention(
     const std::string& mask_mode /* = "" */,
     std::optional<array> mask_arr /* = {} */,
     const std::optional<array>& sinks /* = {} */,
-    StreamOrDevice s /* = {}*/) {
+    bool force_fused /* = false */,
+    StreamOrDevice s /* = {} */) {
   for (const auto& tensor : {queries, keys, values}) {
     if (tensor.ndim() != 4) {
       std::ostringstream msg;
@@ -834,6 +835,7 @@ array scaled_dot_product_attention(
           do_causal,
           is_training,
           output_logsumexp,
+          force_fused,
           stream)) {
     if (has_bool_mask && !ScaledDotProductAttention::supports_bool_mask()) {
       // Convert bool mask to additive mask.
@@ -846,7 +848,13 @@ array scaled_dot_product_attention(
     }
     Shape out_shape{q.shape(0), q.shape(1), q.shape(2), v.shape(-1)};
     auto primitive = std::make_shared<ScaledDotProductAttention>(
-        stream, fallback, scale, do_causal, has_sinks, output_logsumexp);
+        stream,
+        fallback,
+        scale,
+        do_causal,
+        has_sinks,
+        output_logsumexp,
+        force_fused);
     if (output_logsumexp) {
       return array::make_arrays(
           {std::move(out_shape), Shape{q.shape(0), q.shape(1), q.shape(2), 1}},
@@ -912,7 +920,8 @@ bool ScaledDotProductAttention::is_equivalent(const Primitive& other) const {
       static_cast<const ScaledDotProductAttention&>(other);
   return scale_ == a_other.scale_ && do_causal_ == a_other.do_causal_ &&
       has_sinks_ == a_other.has_sinks_ &&
-      output_logsumexp_ == a_other.output_logsumexp_;
+      output_logsumexp_ == a_other.output_logsumexp_ &&
+      force_fused_ == a_other.force_fused_;
 }
 
 bool ScaledDotProductAttentionVJP::is_equivalent(const Primitive& other) const {

--- a/mlx/fast.h
+++ b/mlx/fast.h
@@ -53,6 +53,7 @@ MLX_API array scaled_dot_product_attention(
     const std::string& mask_mode = "",
     std::optional<array> mask_arr = {},
     const std::optional<array>& sinks = {},
+    bool force_fused = false,
     StreamOrDevice s = {});
 
 using TemplateArg = std::variant<int, bool, Dtype>;

--- a/mlx/fast_primitives.h
+++ b/mlx/fast_primitives.h
@@ -212,12 +212,14 @@ class ScaledDotProductAttention : public Custom {
       float scale,
       bool do_causal,
       bool has_sinks,
-      bool output_logsumexp)
+      bool output_logsumexp,
+      bool force_fused)
       : Custom(stream, std::move(fallback)),
         scale_(scale),
         do_causal_(do_causal),
         has_sinks_(has_sinks),
-        output_logsumexp_(output_logsumexp) {}
+        output_logsumexp_(output_logsumexp),
+        force_fused_(force_fused) {}
 
   static bool use_fallback(
       const array& q,
@@ -228,6 +230,7 @@ class ScaledDotProductAttention : public Custom {
       bool do_causal,
       bool is_training,
       bool output_logsumexp,
+      bool force_fused,
       Stream s);
   static bool supports_bool_mask();
 
@@ -251,7 +254,12 @@ class ScaledDotProductAttention : public Custom {
   DEFINE_INPUT_OUTPUT_SHAPE()
   auto state() const {
     return std::make_tuple(
-        nullptr, scale_, do_causal_, has_sinks_, output_logsumexp_);
+        nullptr,
+        scale_,
+        do_causal_,
+        has_sinks_,
+        output_logsumexp_,
+        force_fused_);
   }
 
  private:
@@ -259,6 +267,7 @@ class ScaledDotProductAttention : public Custom {
   bool do_causal_;
   bool has_sinks_;
   bool output_logsumexp_;
+  bool force_fused_;
 };
 
 class ScaledDotProductAttentionVJP : public Custom {

--- a/python/src/fast.cpp
+++ b/python/src/fast.cpp
@@ -234,6 +234,7 @@ void init_fast(nb::module_& parent_module) {
          const float scale,
          const std::variant<std::monostate, std::string, mx::array>& mask,
          const std::optional<mx::array>& sinks,
+         bool force_fused,
          mx::StreamOrDevice s) {
         bool has_mask = !std::holds_alternative<std::monostate>(mask);
         bool has_str_mask =
@@ -250,16 +251,32 @@ void init_fast(nb::module_& parent_module) {
               throw std::invalid_argument(msg.str());
             }
             return mx::fast::scaled_dot_product_attention(
-                queries, keys, values, scale, mask_str, std::nullopt, sinks, s);
+                queries,
+                keys,
+                values,
+                scale,
+                mask_str,
+                std::nullopt,
+                sinks,
+                force_fused,
+                s);
           } else {
             auto mask_arr = std::get<mx::array>(mask);
             return mx::fast::scaled_dot_product_attention(
-                queries, keys, values, scale, "", mask_arr, sinks, s);
+                queries,
+                keys,
+                values,
+                scale,
+                "",
+                mask_arr,
+                sinks,
+                force_fused,
+                s);
           }
 
         } else {
           return mx::fast::scaled_dot_product_attention(
-              queries, keys, values, scale, "", {}, sinks, s);
+              queries, keys, values, scale, "", {}, sinks, force_fused, s);
         }
       },
       "q"_a,
@@ -269,9 +286,10 @@ void init_fast(nb::module_& parent_module) {
       "scale"_a,
       "mask"_a = nb::none(),
       "sinks"_a = nb::none(),
+      "force_fused"_a = false,
       "stream"_a = nb::none(),
       nb::sig(
-          "def scaled_dot_product_attention(q: array, k: array, v: array, *, scale: float,  mask: None | str | array = None, sinks: array | None = None, stream: StreamOrDevice = None) -> array"),
+          "def scaled_dot_product_attention(q: array, k: array, v: array, *, scale: float,  mask: None | str | array = None, sinks: array | None = None, force_fused: bool = False, stream: StreamOrDevice = None) -> array"),
       R"pbdoc(
         A fast implementation of multi-head attention: ``O = softmax(Q @ K.T, dim=-1) @ V``.
 
@@ -313,6 +331,11 @@ void init_fast(nb::module_& parent_module) {
                last query aligns with the last key.
             sinks (array, optional): An optional array of attention sinks.
                Default: ``None``.
+            force_fused (bool, optional): If ``True``, use a fused kernel
+               regardless of the builtin heuristics and raise error when no
+               fused kernel is available. For certain configurations this would
+               result in slower kernel getting used but can reduce memory
+               consumption. Default: ``False``.
 
         Returns:
             array: The output array.

--- a/python/tests/test_fast_sdpa.py
+++ b/python/tests/test_fast_sdpa.py
@@ -722,6 +722,100 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
                 ).sum()
                 test_grad(loss_slow, loss_fast, [q, k, v])
 
+    @unittest.skipIf(not mx.metal.is_available(), "Metal kernel path only")
+    def test_sdpa_force_fused_metal(self):
+        if mx.default_device() != mx.gpu:
+            self.skipTest("requires GPU")
+
+        def make_qkv(qL, kL, D, qH=8, kH=8):
+            q = mx.random.normal((1, qH, qL, D), mx.float16)
+            k = mx.random.normal((1, kH, kL, D), mx.float16)
+            v = mx.random.normal((1, kH, kL, D), mx.float16)
+            return q, k, v
+
+        # Full attention kernel.
+        for D, qL, mask in product((192, 256), (9, 16), (None, "causal")):
+            with self.subTest(head_dim=D, qL=qL, mask=mask):
+                q, k, v = make_qkv(qL, 512, D, 8, 4)
+                scale = D**-0.5
+                ref = mlx_ref_attn(q, k, v, scale=scale, mask=mask)
+                out = mx.fast.scaled_dot_product_attention(
+                    q, k, v, scale=scale, mask=mask, force_fused=True
+                )
+                self.assertTrue(mx.allclose(ref, out, atol=1e-3, rtol=1e-3))
+
+        # Vector attention kernel.
+        for D in (192, 256):
+            with self.subTest(head_dim=D):
+                q, k, v = make_qkv(4, 16385, D, 4, 2)
+                scale = D**-0.5
+                ref = mlx_ref_attn(q, k, v, scale=scale)
+                out = mx.fast.scaled_dot_product_attention(
+                    q, k, v, scale=scale, force_fused=True
+                )
+                self.assertTrue(mx.allclose(ref, out, atol=1e-3, rtol=1e-3))
+
+        # No full attention fused kernels.
+        with self.assertRaisesRegex(ValueError, "supports head dims"):
+            q, k, v = make_qkv(16, 512, 512)
+            mx.fast.scaled_dot_product_attention(
+                q, k, v, scale=512**-0.5, force_fused=True
+            )
+        with self.assertRaisesRegex(
+            ValueError, "query sequence to be no longer than the key sequence"
+        ):
+            q, k, v = make_qkv(32, 16, 64)
+            mx.fast.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                scale=64**-0.5,
+                mask="causal",
+                force_fused=True,
+            )
+
+        # No vector attention fused kernels.
+        with self.assertRaisesRegex(ValueError, "supports head dims"):
+            q, k, v = make_qkv(1, 128, 72)
+            mx.fast.scaled_dot_product_attention(
+                q, k, v, scale=72**-0.5, force_fused=True
+            )
+        with self.assertRaisesRegex(ValueError, "GQA factor to be at most 32"):
+            q, k, v = make_qkv(8, 128, 64, qH=8, kH=1)
+            mx.fast.scaled_dot_product_attention(
+                q, k, v, scale=64**-0.5, force_fused=True
+            )
+
+        # No CPU fused kernel.
+        with mx.stream(mx.cpu):
+            q, k, v = make_qkv(8, 128, 8)
+            with self.assertRaisesRegex(ValueError, "require a GPU"):
+                mx.fast.scaled_dot_product_attention(
+                    q, k, v, scale=64**-0.5, force_fused=True
+                )
+
+    @unittest.skipIf(not mx.cuda.is_available(), "CUDA kernel path only")
+    def test_sdpa_force_fused_cuda(self):
+        if mx.default_device() != mx.gpu:
+            self.skipTest("requires GPU")
+
+        def make_qkv(qL, kL, D, qH=8, kH=8):
+            q = mx.random.normal((1, qH, qL, D), mx.float16)
+            k = mx.random.normal((1, kH, kL, D), mx.float16)
+            v = mx.random.normal((1, kH, kL, D), mx.float16)
+            return q, k, v
+
+        # Vector attention kernel.
+        for D in (64, 96, 128):
+            with self.subTest(head_dim=D):
+                q, k, v = make_qkv(3, 128, D, 4, 2)
+                scale = D**-0.5
+                ref = mlx_ref_attn(q, k, v, scale=scale)
+                out = mx.fast.scaled_dot_product_attention(
+                    q, k, v, scale=scale, force_fused=True
+                )
+                self.assertTrue(mx.allclose(ref, out, atol=1e-3, rtol=1e-3))
+
     def test_sdpa_sliced(self):
         N = 8
         D = 64


### PR DESCRIPTION
## Proposed changes

Add a `force_fused` option to `mx.fast.scaled_dot_product_attention` that
ignores the automatic dispatch heuristics, uses a fused kernel, and raises
with the unsupported constraint when no fused kernel is available. This lets
inference runtimes — the only party that knows their resident weights, KV
cache size, and memory budget — decide when the fused path's bounded-memory
behavior is worth its throughput cost.

Also restores the fused full-attention support for `head_dim=192/256` that was
proposed in #3293/#3660. Those kernels are now reachable **only** through
`force_fused`; the default dispatch does not route to them.

Follow-up hardening incorporates the full-dispatch threadgroup safety check
and capability-diagnostic concerns raised by @apocryphx in #4186, while
retaining this PR's 192/256 kernels and C++ positional-call compatibility.

## Background

#3658 tracks models with genuine `head_dim=192/256` full-attention layers. At
long context, the unfused path materializes a score
transient of `O(n_heads × qL × kL)` per full-attention layer. The fused
full-attention kernel tiles K/V so its transient stays bounded regardless of
`kL`. However, benchmark measurements on a genuine `head_dim=256` workload
(the Qwen 3.6 35B checkpoint measured in #3658) show the fused path trades
prompt throughput for that memory floor:

| context | main prompt_tps | fused prompt_tps | main peak | fused peak |
|---:|---:|---:|---:|---:|
| 32K | 1005.743 | 871.489 | 41.316 | 39.882 |
| 64K | 802.929 | 624.513 | 44.201 | 40.068 |

These stock `mlx-lm` benchmark arms were separated by other main-branch
commits, so they are supporting workload evidence rather than a strict
single-commit A/B. The optional 131K fused arm aborted with an
interactivity-impacting command-buffer error and is intentionally omitted.

A fixed dispatch threshold cannot pick correctly for all runtimes, so the
decision is exposed to the caller instead. This PR is the follow-up to the
maintainer request in #3658:

> Let's add a `force_fused=True` option to `mx.fast.scaled_dot_product_attention` API that ignores the heuristics and uses fused path, and throws when a fused kernel is not available for the shape. — @zcbenz

Supersedes the closed #3660.
Addresses #3658.

## API

```python
mx.fast.scaled_dot_product_attention(
    q, k, v, *, scale, mask=None, sinks=None, force_fused=False, stream=None
)
```

- `force_fused=False` (default): preserves existing dispatch for previously
  supported shapes. The missing `head_dim=192` vector kernel is added but
  reachable only through `force_fused`.
- `force_fused=True`: bypass the dispatch heuristics and use a fused kernel.
  Raises `ValueError` with the unsupported constraint when no fused kernel is
  available, which covers:
  - shapes not covered by the full- or vector-attention fused kernels
    (including unsupported `head_dim`s, e.g. 512);
  - CPU execution;
  - training mode that requires a `logsumexp` output (the fused kernels do not
    emit one).

`is_training` on its own (when the VJP path already falls back) is allowed to
use the fused forward kernel — the output is identical.

## Kernel support

- Full-attention (`steel_attention`): add `head_dim=192/256` instantiations.
  Selected only when `force_fused=True`. Extend the existing large-head-dim
  V-tile synchronization barriers from `BD == 128` to `BD >= 128`, covering
  192/256 as well as 128. This synchronization gap was also independently
  identified in [giaki3003/mlx@1175b4d](https://github.com/giaki3003/mlx/commit/1175b4dc4f26a3befe01cbc8e56dacaf55d31820).
- Vector (decode) (`sdpa_vector`): add the missing `head_dim=192` (192,192)
  and aggregation instantiations. The new 192 vector kernel is opt-in via
  `force_fused` like the new full-attention kernels; the existing `head_dim=256`
  vector kernel keeps its automatic routing.
- Route `head_dim >= 192` away from the NAX kernel family, which has no
  192/256 instantiations.
- Check the compiled pipeline's maximum threadgroup size before both full
  attention dispatches, avoiding silent zero output on register-limited GPUs.
- Use each backend's actual support matrix: Metal full/vector kernels and CUDA
  cuDNN/vector kernels share the same opt-in semantics.

## Validation

- Focused tests in `python/tests/test_fast_sdpa.py`:
  - `force_fused=True` full attention for `head_dim` 192/256 at short key
    lengths (where the default dispatch stays unfused) matches the reference;
  - `force_fused=True` full attention for `head_dim` 192/256 at `kL=16385`
    matches the reference, covering the Steel V-tile barrier path;
  - `force_fused=True` on an already-supported `head_dim=128` matches;
  - `force_fused=True` on an unsupported shape (`head_dim=512`) raises;
  - unsupported full/vector head dims, causal `qL > kL`, vector GQA limits,
    and CPU execution raise with the specific violated constraint;
  - default dispatch with `head_dim` 192/256 full attention stays unfused and
    matches the reference;
  - `head_dim=192` vector attention matches the reference.
- Existing `test_fast_sdpa.py` and `test_fast.py` suites continue to pass.

## Scope

- Gemma 4 26B/31B are **not** affected: their long-context global layers use
  `head_dim=512`, which is outside this PR's scope (see #3885).
  `head_dim=256` layers there are bounded sliding-window layers.
- The Qwen 3.6 35B checkpoint measured in #3658 uses genuine
  `head_dim=256` full attention and demonstrates the intended memory/throughput
  tradeoff. The optional 131K fused arm did not complete, so this PR does not
  claim a valid 131K A/B result.
- CUDA uses its cuDNN/vector support matrix for `force_fused`; a no-GPU build
  raises rather than silently ignoring the flag. CUDA compilation remains a
  GitHub CI validation boundary because the local validation host is macOS/Metal.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (API docstring)
