### PR TITLE
Fix elementwise unary ops giving different results for strided vs contiguous inputs (CPU) (#4163)

### DIFF
--- a/mlx/backend/cpu/unary.h
+++ b/mlx/backend/cpu/unary.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <algorithm>
+
 #include "mlx/backend/common/unary.h"
 #include "mlx/backend/cpu/encoder.h"
 #include "mlx/backend/cpu/simd/simd.h"
@@ -10,11 +12,34 @@
 
 namespace mlx::core {
 
+// Apply Op to `shape` elements read with `stride`, always through the
+// simd kernel so results are bit-identical to the contiguous fast path.
+// The tail (and any block when N == 1) is padded by repeating the last
+// element; only the first `rem` lanes are stored.
 template <typename T, typename U = T, typename Op>
 void unary_op(const T* a, U* out, size_t shape, size_t stride) {
-  for (size_t i = 0; i < shape; i += 1) {
-    out[i] = Op{}(*a);
-    a += stride;
+  constexpr int N = std::min(simd::max_size<T>, simd::max_size<U>);
+  if constexpr (N == 1) {
+    for (size_t i = 0; i < shape; ++i) {
+      out[i] = Op{}(a[i * stride]);
+    }
+    return;
+  }
+  T buf[N];
+  size_t i = 0;
+  for (; i + N <= shape; i += N) {
+    for (int k = 0; k < N; ++k) {
+      buf[k] = a[(i + k) * stride];
+    }
+    simd::store(out + i, simd::Simd<U, N>(Op{}(simd::load<T, N>(buf))));
+  }
+  if (size_t rem = shape - i; rem > 0) {
+    for (size_t k = 0; k < static_cast<size_t>(N); ++k) {
+      buf[k] = a[(i + std::min(k, rem - 1)) * stride];
+    }
+    U tmp[N];
+    simd::store(tmp, simd::Simd<U, N>(Op{}(simd::load<T, N>(buf))));
+    std::copy(tmp, tmp + rem, out + i);
   }
 }
 

--- a/mlx/backend/cpu/unary.h
+++ b/mlx/backend/cpu/unary.h
@@ -57,11 +57,10 @@ void unary_op(const array& a, array& out, Op) {
       src += N;
       dst += N;
     }
-    while (size > 0) {
-      *dst = Op{}(*src);
-      size--;
-      dst++;
-      src++;
+    // Residual via the shared SIMD kernel (padded gather) so results do
+    // not depend on lane index / Accelerate vs libm (#4161).
+    if (size > 0) {
+      unary_op<T, U, Op>(src, dst, size, /*stride=*/1);
     }
   } else {
     size_t shape = ndim > 0 ? a.shape().back() : 1;

--- a/python/tests/test_double.py
+++ b/python/tests/test_double.py
@@ -301,6 +301,52 @@ class TestDouble(mlx_tests.MLXTestCase):
             vals = mx.linspace(0, math.pi, 2, mx.float64)
             self.assertEqual(vals.tolist()[1], math.pi)
 
+    def test_strided_matches_contiguous_elementwise(self):
+        # Regression for #4163 / #4161: f(view) must be bit-identical to
+        # f(contiguous_copy) for elementwise unary ops, and results must
+        # not depend on element position (simd body vs residual path).
+        # Binary/ternary ops share the same Accelerate-vs-libm pattern
+        # (e.g. x**2) and are left for a follow-up.
+        ops = [
+            ("tan", mx.tan),
+            ("sin", mx.sin),
+            ("cos", mx.cos),
+            ("exp", mx.exp),
+            ("log1p", mx.log1p),
+            ("sqrt", mx.sqrt),
+        ]
+        dtypes = [mx.float32, mx.float64]
+        rng = np.random.default_rng(0)
+        with mx.stream(mx.cpu):
+            for dtype in dtypes:
+                for n in [1, 3, 4, 5, 7, 8, 16, 33]:
+                    v = rng.uniform(0.1, 1.4, n)
+                    M = mx.array(np.stack([v, v], 1), dtype=dtype)
+                    strided = M[:, 0]
+                    contig = mx.array(np.ascontiguousarray(v), dtype=dtype)
+                    for name, op in ops:
+                        t1, t2 = op(strided), op(contig)
+                        mx.eval(t1, t2)
+                        self.assertTrue(
+                            np.array_equal(np.asarray(t1), np.asarray(t2)),
+                            msg=f"{name} dtype={dtype} n={n}: strided != contiguous",
+                        )
+                        full_arr = op(contig)
+                        mx.eval(full_arr)
+                        full = np.asarray(full_arr)
+                        for i in range(n):
+                            single_arr = op(contig[i : i + 1])
+                            mx.eval(single_arr)
+                            single = np.asarray(single_arr)[0]
+                            self.assertEqual(
+                                full[i].tobytes(),
+                                np.asarray(single).tobytes(),
+                                msg=(
+                                    f"{name} dtype={dtype} n={n} pos={i}: "
+                                    f"position-dependent result"
+                                ),
+                            )
+
 
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner()


### PR DESCRIPTION
## Summary
- On Apple Silicon, CPU unary ops used Accelerate SIMD for contiguous inputs and scalar libm for strided views (and for the contiguous residual), so the same values could differ by ~1 ULP depending on memory layout / lane index.
- Route strided loads and the contiguous residual through the same padded SIMD kernel so results are bit-identical to the contiguous fast path.
- Commits are split: (1) strided gather, (2) contiguous residual, (3) regression tests so the residual-only fix remains submittable if bit-identity across layouts is considered out of scope (NumPy does not guarantee it either).

Fixes #4163.

Possibly related to #4161: this PR fixes the **unary** lane-index / length dependence shown there (	an, rctan, etc.). Binary cases in that issue (x**2, x**0.5, …) share the same Accelerate-vs-libm pattern in inary.h and are **not** fixed here happy to follow up the same way in inary.h/	ernary.h if this approach is accepted. Leaving #4161 open for the binary remainder.

## Validation (no local Mac GitHub Actions macos-26 / Accelerate)

| | Run | Result |
|---|---|---|
| Before (main) | [baseline](https://github.com/AxelNoun/mlx/actions/runs/31515581697) | **296/300** mismatches (issue repro) |
| After (this fix) | [fix](https://github.com/AxelNoun/mlx/actions/runs/31515577187) | **0/300**, position-independence OK, **full** `python -m unittest discover python/tests` green |

## Micro-benchmark (strided **before vs after**, float64, n=1e6, 50 iters, same runner)

The useful comparison is strided-before vs strided-after (not strided vs contiguous). Trivial ops included because gather overhead is most visible there:

| Op (strided) | cols | Before (main) | After (fix) |
|---|---|---|---|
| `abs` | 2 | 14.14 ms | **7.91 ms** |
| `negative` | 2 | 11.86 ms | **3.23 ms** |
| `tan` | 2 | 20.03 ms | **9.29 ms** |
| `abs` | 8 | 11.01 ms | **8.37 ms** |
| `negative` | 8 | 10.52 ms | **3.38 ms** |
| `tan` | 8 | 17.28 ms | **9.06 ms** |

No regression observed: SIMD+gather is faster than the previous pure-scalar strided path for both trivial and expensive ops on this runner.

## Test plan
- [x] Issue #4163 repro script: 296/300 on main → 0/300 with fix (CI links above)
- [x] Position-independence check from #4161 (unary `tan`)
- [x] Full `python -m unittest discover python/tests` on macos-26 CPU/Accelerate
- [x] `pre-commit` (clang-format / black) on touched files
