### PR TITLE
fix: shell-quote the working directory in the distributed launch script

### DIFF
--- a/python/mlx/_distributed_utils/launch.py
+++ b/python/mlx/_distributed_utils/launch.py
@@ -121,11 +121,12 @@ class RemoteProcess(CommandProcess):
         # Change the working directory if one was requested. Otherwise attempt to
         # change to the current one but don't fail if it wasn't possible.
         d = cwd or os.getcwd()
-        script += f"if [[ -d {repr(d)} ]]; then "
-        script += f"  cd {repr(d)}; "
+        qd = shlex.quote(d)
+        script += f"if [[ -d {qd} ]]; then "
+        script += f"  cd {qd}; "
         if cwd is not None:
             script += "else "
-            script += f" echo 'Failed to change directory to' {repr(d)} >2; "
+            script += f" echo 'Failed to change directory to' {qd} >&2; "
         script += "fi; "
 
         # Add the environment variables that were requested


### PR DESCRIPTION
## What

`RemoteProcess.make_launch_script` in `python/mlx/_distributed_utils/launch.py` builds a bash script that is run on each node (locally via `Popen(..., shell=True, executable="/bin/bash")` and remotely over `ssh`). The working directory (`--cwd`, falling back to `os.getcwd()`) is interpolated into that script using Python's `repr()`:

```python
d = cwd or os.getcwd()
script += f"if [[ -d {repr(d)} ]]; then "
script += f"  cd {repr(d)}; "
```

`repr()` is not a shell-quoting function. When the string contains a single quote, `repr()` switches to a double-quoted form, and bash performs command substitution / variable expansion inside double quotes. Every other value interpolated into this same script (env values, file contents, the command itself, the host) is correctly escaped with `shlex.quote`; only the working directory uses `repr`.

## Why it matters

A working directory such as:

```
/tmp/a'$(touch /tmp/pwned)'b
```

renders as `cd "/tmp/a'$(touch /tmp/pwned)'b"`, and bash executes the `$(...)` substitution. This turns a value that is only supposed to name a directory into arbitrary shell execution, on every node the job is launched on. It also breaks legitimately-named directories that contain a `'` or `$`, so it is a correctness bug as well as an injection vector when the launch command (and its `--cwd`) is assembled programmatically or from a job/orchestration layer.

Reproduction:

```python
from mlx._distributed_utils.launch import RemoteProcess
print(RemoteProcess.make_launch_script(0, None, "/tmp/a'$(touch /tmp/pwned)'b", {}, [], ["true"], True))
# -> ... cd "/tmp/a'$(touch /tmp/pwned)'b"; ...   (the $(...) runs under /bin/bash)
```

## Fix

Quote the directory with `shlex.quote` (already imported and already used for every other interpolation in this function) instead of `repr`. Also corrects the adjacent `>2` typo to `>&2` so the error message goes to stderr. No API change.

```python
d = cwd or os.getcwd()
qd = shlex.quote(d)
script += f"if [[ -d {qd} ]]; then "
script += f"  cd {qd}; "
...
    script += f" echo 'Failed to change directory to' {qd} >&2; "
```

## Test

```python
import shlex, subprocess
d = "/tmp/a'$(touch /tmp/pwned)'b"
script = f"if [[ -d {shlex.quote(d)} ]]; then cd {shlex.quote(d)}; fi"
subprocess.run(script, shell=True, executable="/bin/bash")
# /tmp/pwned is NOT created; the value is treated as a literal path
```

Before the change the same test with `repr(d)` creates `/tmp/pwned`.
