### PR TITLE
Report when no usable GID is found

### DIFF
--- a/mlx/distributed/jaccl/lib/jaccl/rdma.cpp
+++ b/mlx/distributed/jaccl/lib/jaccl/rdma.cpp
@@ -181,16 +181,28 @@ const Destination& Connection::info() {
 
   ibv_port_attr port_attr;
   ibv().query_port(ctx, 1, &port_attr);
-  ibv_gid gid;
+  ibv_gid gid = {};
+  bool found_gid = false;
   for (int i = 0; i < port_attr.gid_tbl_len; i++) {
     ibv_gid tmp;
     if (ibv().query_gid(ctx, 1, i, &tmp) == 0) {
       if (*(uint64_t*)&tmp.raw[0] == 0 && *(uint16_t*)&tmp.raw[8] == 0 &&
           *(uint16_t*)&tmp.raw[10] == 0xffff) {
         gid = tmp;
+        found_gid = true;
         break;
       }
     }
+  }
+
+  // Fail here rather than hand an unset GID to the queue pair.
+  if (!found_gid) {
+    std::ostringstream msg;
+    msg << "[jaccl] No IPv4-mapped GID for this device. Thunderbolt RDMA ports "
+        << "only publish one once the interface has an IPv4 address; assign a "
+        << "link-local address to it, for example: ifconfig <interface> inet "
+        << "169.254.0.1 netmask 255.255.0.0 alias";
+    throw std::runtime_error(msg.str());
   }
 
   src.local_id = port_attr.lid;


### PR DESCRIPTION
Related to #3467.

`Connection::info()` scans the GID table for an IPv4-mapped GID. If none matches, the loop
simply ends: `ibv_gid gid;` is never assigned and never initialized, and that value is
written into `src.global_identifier` and used for the queue pair. The error surfaces later
from the RTR transition as `errno 22`, which does not point at the GID table.

This is not a rare path. Thunderbolt RDMA ports publish only a link-local IPv6 GID until the
interface has an IPv4 address, so any Thunderbolt setup hits it before configuring one:

```
rdma_en3:  link_layer: Thunderbolt
           GID[0] = fe80::347c:94ff:fecd:45c4      <- no IPv4-mapped GID
```

After the change, the same configuration reports the cause and the remedy at the point of
failure:

```
[jaccl] No IPv4-mapped GID for this device. Thunderbolt RDMA ports only publish one
once the interface has an IPv4 address; assign a link-local address to it, for
example: ifconfig <interface> inet 169.254.0.1 netmask 255.255.0.0 alias
```

### Verified

Two M4 Pro Mac minis on macOS 26.5.1, connected directly over Thunderbolt 5,
RDMA enabled from Recovery OS.

- With no IPv4 on the port, stock fails at RTR with `errno 22`; with this change it throws
  the message above from `info()`.
- With an IPv4 assigned, behaviour is unchanged: `info()` returns `::ffff:169.254.10.1` and
  a two-rank mesh runs a correct `all_sum`.
- Checked on an active port. An inactive one fails earlier, in
  `allocate_protection_domain`, and never reaches this code.
