### PR TITLE
Jaccl ring multi wire fix

### DIFF
--- a/mlx/distributed/jaccl/lib/jaccl/ring_impl.h
+++ b/mlx/distributed/jaccl/lib/jaccl/ring_impl.h
@@ -121,19 +121,19 @@ class RingImpl {
       int n_wires,
       int lw,
       ReduceOp reduce_op) {
-    // The element offset (within a chunk) of this wire's slice in each
-    // direction and the end of each direction's region. Wire slices are
-    // contiguous rather than interleaved. Direction lr owns the chunk region
-    // [lr * n_wires * size_per_wire, (lr + 1) * n_wires * size_per_wire) (the
-    // last region is clamped to chunk_size).
+    // This wire's slice within the chunk: [wire_offset, wire_end). Clamp to the
+    // per wire end (not the whole region) so the last frame can't spill into
+    // the next wire's slice when size_per_wire is not a multiple of N.
     int64_t wire_offset[MAX_DIR];
-    int64_t region_end[MAX_DIR];
+    int64_t wire_end[MAX_DIR];
     int64_t send_offset[MAX_DIR];
     int64_t recv_offset[MAX_DIR];
     for (int lr = 0; lr < MAX_DIR; lr++) {
       wire_offset[lr] = lr * n_wires * size_per_wire +
           static_cast<int64_t>(lw) * size_per_wire;
-      region_end[lr] = std::min(chunk_size, (lr + 1) * n_wires * size_per_wire);
+      int64_t region_end =
+          std::min(chunk_size, (lr + 1) * n_wires * size_per_wire);
+      wire_end[lr] = std::min(region_end, wire_offset[lr] + size_per_wire);
       send_offset[lr] = rank_ * chunk_size;
     }
     recv_offset[0] = ((rank_ + size_ - 1) % size_) * chunk_size;
@@ -152,7 +152,7 @@ class RingImpl {
           size_ * chunk_size,
           size_per_wire,
           wire_offset,
-          region_end,
+          wire_end,
           send_offset,
           recv_offset,
           in_ptr,
@@ -166,7 +166,7 @@ class RingImpl {
           size_ * chunk_size,
           size_per_wire,
           wire_offset,
-          region_end,
+          wire_end,
           send_offset,
           recv_offset,
           in_ptr,
@@ -180,7 +180,7 @@ class RingImpl {
         size_ * chunk_size,
         size_per_wire,
         wire_offset,
-        region_end,
+        wire_end,
         send_offset,
         recv_offset,
         out_ptr,
@@ -219,7 +219,10 @@ class RingImpl {
     // Both directions send the same contiguous slice of each rank's region.
     int64_t slice = static_cast<int64_t>(lw) * n_bytes_per_wire;
     int64_t wire_offset[2] = {slice, slice};
-    int64_t region_end[2] = {n_bytes, n_bytes};
+    // Clamp to this wire's slice end so the last frame can't spill into the
+    // next wire's slice.
+    int64_t wire_end_bytes = std::min(n_bytes, slice + n_bytes_per_wire);
+    int64_t wire_end[2] = {wire_end_bytes, wire_end_bytes};
     int64_t send_offset[2] = {rank_ * n_bytes, rank_ * n_bytes};
     int64_t recv_offset[2] = {
         ((rank_ + size_ - 1) % size_) * n_bytes,
@@ -232,7 +235,7 @@ class RingImpl {
         n_bytes * size_,
         n_bytes_per_wire,
         wire_offset,
-        region_end,
+        wire_end,
         send_offset,
         recv_offset,
         out_ptr,
@@ -298,14 +301,16 @@ class RingImpl {
     int64_t N = buffer_bytes / sizeof(T);
     int64_t total = static_cast<int64_t>(size_) * chunk;
 
-    // This wire's element offset within the output chunk in each direction and
-    // the end of each direction's region.
+    // This wire's slice within the chunk: [wire_offset, wire_end). Clamp to the
+    // per wire end (not the whole region) so the last frame can't spill into
+    // the next wire's slice when size_per_wire is not a multiple of N.
     int64_t wire_offset[MAX_DIR];
-    int64_t region_end[MAX_DIR];
+    int64_t wire_end[MAX_DIR];
     for (int lr = 0; lr < MAX_DIR; lr++) {
       wire_offset[lr] = lr * n_wires * size_per_wire +
           static_cast<int64_t>(lw) * size_per_wire;
-      region_end[lr] = std::min(chunk, (lr + 1) * n_wires * size_per_wire);
+      int64_t region_end = std::min(chunk, (lr + 1) * n_wires * size_per_wire);
+      wire_end[lr] = std::min(region_end, wire_offset[lr] + size_per_wire);
     }
 
     // Input windows (count space, chunk aligned). Both directions converge on
@@ -337,7 +342,7 @@ class RingImpl {
         int slice = recv_count[lr];
         int b = slice % PIPELINE;
         int64_t offset = wire_offset[lr] + static_cast<int64_t>(slice) * N;
-        int64_t n = std::min(N, region_end[lr] - offset);
+        int64_t n = std::min(N, wire_end[lr] - offset);
         reduce_op(
             recv_buffer(sz, b, lr, lw).template begin<T>(),
             in_ptr + in_recv_offset[lr] + offset,
@@ -374,7 +379,7 @@ class RingImpl {
           std::copy(
               send_base + send_base_offset[lr] + offset,
               send_base + send_base_offset[lr] +
-                  std::max(offset, std::min(offset + N, region_end[lr])),
+                  std::max(offset, std::min(offset + N, wire_end[lr])),
               send_buffer(sz, buff, lr, lw).template begin<T>());
           send_count[lr]++;
           send_to(sz, buff, lr, lw);
@@ -401,7 +406,7 @@ class RingImpl {
               std::copy(
                   send_base + send_base_offset[lr] + offset,
                   send_base + send_base_offset[lr] +
-                      std::max(offset, std::min(offset + N, region_end[lr])),
+                      std::max(offset, std::min(offset + N, wire_end[lr])),
                   send_buffer(sz, buff, lr, lw).template begin<T>());
               send_count[lr]++;
               send_to(sz, buff, lr, lw);
@@ -444,10 +449,10 @@ class RingImpl {
   // The first step sends from in_ptr, later steps from out_ptr; this lets the
   // all reduce seed its output without an up front copy. Callers that stage
   // into out_ptr (both all gather paths) pass out_ptr for in_ptr. wire_offset
-  // is this wire's element offset within a chunk, region_end the end of each
-  // direction's region. send_offset and recv_offset are the starting windows,
-  // updated in place so callers can chain passes. stride is the elements a
-  // window moves per step and total is the wrap around modulus.
+  // is this wire's element offset within a chunk, wire_end the end of its
+  // slice. send_offset and recv_offset are the starting windows, updated in
+  // place so callers can chain passes. stride is the elements a window moves
+  // per step and total is the wrap around modulus.
   template <int MAX_DIR, typename T, typename RecvOp>
   inline void ring_pass(
       int lw,
@@ -456,7 +461,7 @@ class RingImpl {
       int64_t total,
       int64_t size_per_wire,
       const int64_t (&wire_offset)[MAX_DIR],
-      const int64_t (&region_end)[MAX_DIR],
+      const int64_t (&wire_end)[MAX_DIR],
       int64_t (&send_offset)[MAX_DIR],
       int64_t (&recv_offset)[MAX_DIR],
       const T* in_ptr,
@@ -477,9 +482,9 @@ class RingImpl {
     auto set_limits = [&]() {
       for (int lr = 0; lr < MAX_DIR; lr++) {
         send_limits[lr] = std::min(
-            region_end[lr], std::max<int64_t>(0, size - send_offset[lr]));
+            wire_end[lr], std::max<int64_t>(0, size - send_offset[lr]));
         recv_limits[lr] = std::min(
-            region_end[lr], std::max<int64_t>(0, size - recv_offset[lr]));
+            wire_end[lr], std::max<int64_t>(0, size - recv_offset[lr]));
       }
     };
     set_limits();


### PR DESCRIPTION
Fixes a bug where if the size per wire is not a multiple of the rdma buffer we overwrite some data in the chunk that is handled by the other wire.

It finally showed up when I was testing `mlx_lm.share` over multi wire rings.