### PR TITLE
Refactor inexact CPU binary dtype dispatch

### DIFF
--- a/mlx/backend/cpu/binary.h
+++ b/mlx/backend/cpu/binary.h
@@ -360,26 +360,9 @@ void binary_float_op_cpu(
                     b = array::unsafe_weak_copy(b),
                     out = array::unsafe_weak_copy(out),
                     bopt]() mutable {
-    switch (out.dtype()) {
-      case float16:
-        binary_op<float16_t, Op>(a, b, out, bopt);
-        break;
-      case float32:
-        binary_op<float, Op>(a, b, out, bopt);
-        break;
-      case float64:
-        binary_op<double, Op>(a, b, out, bopt);
-        break;
-      case bfloat16:
-        binary_op<bfloat16_t, Op>(a, b, out, bopt);
-        break;
-      case complex64:
-        binary_op<complex64_t, Op>(a, b, out, bopt);
-        break;
-      default:
-        throw std::runtime_error(
-            "[binary_float] Only supports floating point types.");
-    }
+    dispatch_inexact_types(out.dtype(), "[binary_float]", [&](auto type_tag) {
+      binary_op<MLX_GET_TYPE(type_tag), Op>(a, b, out, bopt);
+    });
   });
 }
 


### PR DESCRIPTION
## Proposed changes

The inexact CPU binary path currently repeats a switch over the supported floating-point and complex dtypes. Route this path through `dispatch_inexact_types` instead, preserving the same dtype coverage and kernel instantiations while removing the duplicated dispatch logic. The defensive invalid-dtype error now names the rejected dtype consistently with the shared dispatcher.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `clang-format --dry-run --Werror mlx/backend/cpu/binary.h`
- [x] I have tested the change with 247/247 native tests, 248/248 CTest tests, 154 `test_ops` tests, and paired binary and empty-K AddMM parity probes
- [ ] Documentation update not needed; this does not change a public API
