### PR TITLE
Remove grouped output in CI

### DIFF
--- a/.github/actions/build-macos/action.yml
+++ b/.github/actions/build-macos/action.yml
@@ -15,10 +15,7 @@ runs:
   steps:
     - name: Install dependencies
       shell: bash
-      run: |
-        echo "::group::Install dependencies"
-        uv pip install 'build<=1.4.2' setuptools
-        echo "::endgroup::"
+      run: uv pip install 'build<=1.4.2' setuptools
 
     - name: Build wheel
       shell: bash
@@ -26,17 +23,13 @@ runs:
         DEBUG: 1
         CMAKE_ARGS: ${{ inputs.cmake-args }}
         MACOSX_DEPLOYMENT_TARGET: ${{ inputs.macos-target }}
-      run: |
-        echo "::group::Build wheel"
-        python -m build -w
-        echo "::endgroup::"
+      run: python -m build -w
 
     - name: Build CPP only
       shell: bash
       env:
         MACOSX_DEPLOYMENT_TARGET: ${{ inputs.macos-target }}
       run: |
-        echo "::group::Build CPP only"
         if ${{ contains(inputs.cmake-args, 'CMAKE_BUILD_TYPE') }} ; then
           cmake . -B build ${{ inputs.cmake-args }}
         else
@@ -44,4 +37,3 @@ runs:
             -DCMAKE_BUILD_TYPE=Debug
         fi
         cmake --build build -j $(sysctl -n hw.physicalcpu)
-        echo "::endgroup::"

--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -34,13 +34,11 @@ runs:
     - name: Install dependencies
       shell: bash
       run: |
-        echo "::group::Install dependencies"
         uv pip install 'build<=1.4.2' setuptools
         if ${{ runner.os == 'Linux' }} ; then
           uv pip install auditwheel patchelf
         fi
         mkdir -p wheelhouse
-        echo "::endgroup::"
 
     - name: Build frontend package
       if: inputs.build-frontend == 'true'
@@ -49,16 +47,13 @@ runs:
         CMAKE_ARGS: ${{ inputs.cmake-args }}
         MACOSX_DEPLOYMENT_TARGET: ${{ inputs.macos-target }}
       run: |
-        echo "::group::Build frontend package"
         python setup.py clean --all
         MLX_BUILD_STAGE=1 python -m build -w
-        echo "::endgroup::"
 
     - name: Post-process frontend package
       if: inputs.build-frontend == 'true'
       shell: bash
       run: |
-        echo "::group::Post-process frontend package"
         if ${{ runner.os == 'Linux' }} ; then
           auditwheel repair dist/mlx-*.whl \
             --plat manylinux_2_35_${{ inputs.arch-tag }} \
@@ -67,7 +62,6 @@ runs:
         else
           mv dist/mlx-*.whl wheelhouse/
         fi
-        echo "::endgroup::"
 
     - name: Build backend package
       if: inputs.build-backend == 'true'
@@ -76,16 +70,13 @@ runs:
         CMAKE_ARGS: ${{ inputs.cmake-args }}
         MACOSX_DEPLOYMENT_TARGET: ${{ inputs.macos-target }}
       run: |
-        echo "::group::Build backend package"
         python setup.py clean --all
         MLX_BUILD_STAGE=2 python -m build -w
-        echo "::endgroup::"
 
     - name: Post-process backend package
       if: inputs.build-backend == 'true'
       shell: bash
       run: |
-        echo "::group::Post-process backend package"
         if ${{ runner.os == 'Linux' }} ; then
           if [ -f dist/mlx_cpu*.whl ]; then
             auditwheel repair dist/mlx_cpu*.whl \
@@ -112,4 +103,3 @@ runs:
             mv dist/mlx_metal*.whl wheelhouse/
           fi
         fi
-        echo "::endgroup::"

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -18,11 +18,9 @@ runs:
         DEBUG: ${{ inputs.debug == 'true' && 1 || 0 }}
         CMAKE_ARGS: ${{ inputs.cmake-args }}
       run: |
-        echo "::group::Install Python package"
         # Install cpu-only torch to save space.
         uv pip install torch --torch-backend=cpu
         uv pip install --no-build-isolation -e ".[dev]" -v
-        echo "::endgroup::"
 
     - name: Build CPP only
       shell: bash
@@ -35,10 +33,8 @@ runs:
         CCACHE_BASEDIR: ${{ github.workspace }}/build/cpp/mlx
         CCACHE_NOHASHDIR: true
       run: |
-        echo "::group::Build CPP only"
         cmake . -B build/cpp/mlx ${{ inputs.cmake-args }} \
           -DBUILD_SHARED_LIBS=ON \
           -DCMAKE_BUILD_TYPE=${{ inputs.debug == 'true' && 'Debug' || 'Release' }}
         cmake --build build/cpp/mlx \
           -j ${{ runner.os == 'Windows' && '$NUMBER_OF_PROCESSORS' || '$(nproc)' }}
-        echo "::endgroup::"

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -39,30 +39,25 @@ runs:
       if: runner.os == 'Linux'
       shell: bash
       run: |
-        echo "::group::Install common dependencies"
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends \
             gdb g++ ninja-build zip \
             libblas-dev liblapack-dev liblapacke-dev \
             openmpi-bin openmpi-common libopenmpi-dev
-        echo "::endgroup::"
 
     - name: Install macOS dependencies
       if: runner.os == 'macOS'
       shell: bash
       run: |
-        echo "::group::Install macOS dependencies"
         brew update
         brew install openmpi
         xcodebuild -showComponent MetalToolchain
         sysctl -a | grep machdep.cpu
-        echo "::endgroup::"
 
     - name: Setup Windows environment
       if: runner.os == 'Windows'
       shell: cmd
       run: |
-        echo "::group::Setup environment"
         :: Find out path to Visual Studio.
         pushd "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
         for /f "delims=" %%x in ('.\vswhere.exe -latest -property InstallationPath') do set VSPATH=%%x
@@ -78,7 +73,6 @@ runs:
         set CCACHE_SLOPPINESS=include_file_ctime,include_file_mtime
         :: Export to all steps.
         >>%GITHUB_ENV% set
-        echo "::endgroup::"
 
     - uses: astral-sh/setup-uv@v8.2.0
       with:
@@ -120,7 +114,6 @@ runs:
       if: runner.os != 'Windows'
       shell: bash
       run: |
-        echo "::group::Setup Python venv"
         uv venv --python ${{ inputs.python-version }} --managed-python
         # Make sure all builds use the same cmake binary.
         uv pip install cmake
@@ -132,18 +125,15 @@ runs:
         if ${{ startsWith(inputs.toolkit, 'cuda') }} ; then
           echo MLX_PTX_CACHE_DIR=/tmp/mlx-ptx-cache >> $GITHUB_ENV
         fi
-        echo "::endgroup::"
 
     - name: Setup Python venv (Windows)
       if: runner.os == 'Windows'
       shell: cmd
       run: |
-        echo "::group::Setup Python venv"
         uv venv --python ${{ inputs.python-version }}${{ runner.arch == 'arm64' && '-arm64' || ''}} || exit /b
         uv pip install cmake
         call ".venv/Scripts/activate.bat"
         >>%GITHUB_ENV% set
-        echo "::endgroup::"
 
     - name: Install CUDA toolkit (Linux)
       if: runner.os == 'Linux' && startsWith(inputs.toolkit, 'cuda')
@@ -156,7 +146,6 @@ runs:
             "cuda-13.0": "libcudnn9-dev-cuda-13 cuda-compiler-13-0 cuda-libraries-dev-13-0"
           }
       run: |
-        echo "::group::Install CUDA toolkit"
         # The CUDA binaries are hosted in the "sbsa" repo, the "arm64" repo is
         # Jetson specific. SBSA means Arm Server Base System Architecture.
         ARCH=${{ runner.arch == 'arm64' && 'sbsa' || 'x86_64' }}
@@ -167,7 +156,6 @@ runs:
             libnccl2 libnccl-dev \
             ${{ fromJson(env.PACKAGES)[inputs.toolkit] }}
         echo "/usr/local/${{ inputs.toolkit }}/bin" >> $GITHUB_PATH
-        echo "::endgroup::"
 
     - name: Install CUDA Toolkit (Windows)
       if: runner.os == 'Windows' && startsWith(inputs.toolkit, 'cuda')
@@ -186,7 +174,6 @@ runs:
             "cuda-13.0": ["cudart_13.0", "nvcc_13.0", "cublas_13.0", "cublas_dev_13.0", "cufft_13.0", "cufft_dev_13.0", "nvrtc_13.0", "nvrtc_dev_13.0", "crt_13.0", "nvvm_13.0", "nvptxcompiler_13.0"],
           }
       run: |
-        echo "::group::Install CUDA toolkit"
         $ErrorActionPreference = "Stop"
         $cudaUrl = "${{ fromJson(env.INSTALLERS)[inputs.toolkit] }}"
         $cudaInstaller = "./install.exe"
@@ -201,7 +188,6 @@ runs:
         Start-Process -FilePath $cudaInstaller -ArgumentList "$args" -NoNewWindow -Wait
         $cudaPath = (Resolve-Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\*").path
         echo "$cudaPath\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        echo "::endgroup::"
 
     - name: Install cuDNN (Windows)
       if: runner.os == 'Windows' && startsWith(inputs.toolkit, 'cuda')
@@ -215,7 +201,6 @@ runs:
             "cuda-13.0": "https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/windows-x86_64/cudnn-windows-x86_64-9.23.2.1_cuda13-archive.zip"
           }
       run: |
-        echo "::group::Install cuDNN"
         $ErrorActionPreference = "Stop"
         $cudnnUrl = "${{ fromJson(env.ARCHIVES)[inputs.toolkit] }}"
         $cudnnZip = "cudnn.zip"
@@ -229,13 +214,11 @@ runs:
         Expand-Archive -Path $cudnnZip -DestinationPath cudnn-extracted
         $cudnnDir = (Get-ChildItem -Path cudnn-extracted -Directory)[0].FullName
         echo "cudnnDir=$($cudnnDir -replace '\\', '/')" | Out-File -FilePath $env:GITHUB_OUTPUT
-        echo "::endgroup::"
 
     - name: Generate CMake args
       id: cmake-args
       shell: bash
       run: |
-        echo "::group::Generate CMake args"
         cmakeArgs=(
           "-G Ninja"
         )
@@ -292,4 +275,3 @@ runs:
         IFS=" "
         echo ${cmakeArgs[*]}
         echo "cmakeArgs=${cmakeArgs[*]}" >> $GITHUB_OUTPUT
-        echo "::endgroup::"

--- a/.github/actions/test-linux/action.yml
+++ b/.github/actions/test-linux/action.yml
@@ -8,83 +8,62 @@ runs:
       id: gpu-check
       shell: bash
       run: |
-        echo "::group::Check GPU support"
         if __nvcc_device_query ; then
           echo "good=true" >> $GITHUB_OUTPUT
         else
           echo "good=false" >> $GITHUB_OUTPUT
         fi
         echo
-        echo "::endgroup::"
 
     - name: Run MPI tests
       if: steps.gpu-check.outputs.good == 'false'
       shell: bash
-      run: |
-        echo "::group::MPI tests"
-        mpirun --bind-to none --allow-run-as-root -host localhost:8 -np 8 python python/tests/mpi_test_distributed.py
-        echo "::endgroup::"
+      run: mpirun --bind-to none --allow-run-as-root -host localhost:8 -np 8 python python/tests/mpi_test_distributed.py
 
     - name: Run distributed tests
       if: steps.gpu-check.outputs.good == 'false'
       shell: bash
       run: |
-        echo "::group::Distributed tests"
         mlx.launch --verbose -n 8 python python/tests/ring_test_distributed.py -v 2> >(tee -a stderr.log >&2)
         if grep -Fq '[WARN]' stderr.log ; then
           grep -F '[WARN]' stderr.log
           echo "Distributed ring test failed";
           exit 1;
         fi
-        echo "::endgroup::"
 
     - name: Run Python tests - CPU
       if: steps.gpu-check.outputs.good == 'false'
       shell: bash
       env:
         DEVICE: cpu
-      run: |
-        echo "::group::Python tests - CPU"
-        python -m unittest discover python/tests -v
-        echo "::endgroup::"
+      run: python -m unittest discover python/tests -v
 
     - name: Run Python tests - GPU
       if: steps.gpu-check.outputs.good == 'true'
       shell: bash
       env:
         DEVICE: gpu
-      run: |
-        echo "::group::Python tests - GPU"
-        python -m tests discover python/tests -v
-        echo "::endgroup::"
+      run: python -m tests discover python/tests -v
 
     - name: Run CPP tests - CPU
       shell: bash
       env:
         DEVICE: cpu
-      run: |
-        echo "::group::CPP tests - CPU"
-        ./build/cpp/mlx/tests/tests
-        echo "::endgroup::"
+      run: ./build/cpp/mlx/tests/tests
 
     - name: Run CPP tests - GPU
       if: steps.gpu-check.outputs.good == 'true'
       shell: bash
       env:
         DEVICE: gpu
-      run: |
-        echo "::group::CPP tests - GPU"
-        ./build/cpp/mlx/tests/tests -sfe="*linalg_tests.cpp"
-        echo "::endgroup::"
+      run: ./build/cpp/mlx/tests/tests -sfe="*linalg_tests.cpp"
 
     - name: Show stack trace on crash
       if: failure()
       shell: bash
       run: |
-        echo "::group::Show stack trace on crash"
         set +e
         sleep 10
         if coredumpctl list; then
           coredumpctl debug --debugger-arguments="-batch -ex 'thread apply all bt'"
         fi
-        echo "::endgroup::"

--- a/.github/actions/test-macos/action.yml
+++ b/.github/actions/test-macos/action.yml
@@ -12,12 +12,9 @@ runs:
   steps:
     - name: Install tests dependencies
       shell: bash
-      run: |
-        echo "::group::Install tests dependencies"
-        uv pip install tensorflow
-        echo "::endgroup::"
+      run: uv pip install tensorflow
 
-    - name: Run Python tests
+    - name: Run tests
       shell: bash
       env:
         METAL_DEBUG_ERROR_MODE: 0

--- a/.github/actions/test-wheel/action.yml
+++ b/.github/actions/test-wheel/action.yml
@@ -30,7 +30,6 @@ runs:
     - name: Test local packages
       shell: bash
       run: |
-        echo "::group::Test local packages"
         # Fall back to PyPI if PyTorch index has issues.
         uv pip install torch --torch-backend=cpu
         uv pip install numpy
@@ -48,4 +47,3 @@ runs:
           exit 1
         fi
         python -m unittest discover -v python/tests
-        echo "::endgroup::"

--- a/.github/actions/test-windows/action.yml
+++ b/.github/actions/test-windows/action.yml
@@ -8,16 +8,10 @@ runs:
       shell: bash
       env:
         DEVICE: cpu
-      run: |
-        echo "::group::Python tests - CPU"
-        python -m unittest discover python/tests -v
-        echo "::endgroup::"
+      run: python -m unittest discover python/tests -v
 
     - name: Run CPP tests - CPU
       shell: bash
       env:
         DEVICE: cpu
-      run: |
-        echo "::group::CPP tests - CPU"
-        ./build/cpp/mlx/tests.exe -tce="*gguf*"
-        echo "::endgroup::"
+      run: ./build/cpp/mlx/tests.exe -tce="*gguf*"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -77,6 +77,7 @@ jobs:
     name: macOS (${{ matrix.macos-target }}, ${{ matrix.toolkit }})
     if: github.repository == 'ml-explore/mlx'
     strategy:
+      fail-fast: false
       matrix:
         macos-target: ['14.0', '15.0', '26.2']
         toolkit: ['cpu', 'metal', 'jit']


### PR DESCRIPTION
GitHub now groups the steps automatically in composited jobs so there is no need to add groups ourselves.

<img width="816" height="445" alt="double group" src="https://github.com/user-attachments/assets/e984fe7a-dc6e-4723-8079-c5ea2f05101e" />
