### PR TITLE
Make CPU JIT-generated code consistently C++20

### DIFF
--- a/mlx/backend/cpu/jit_compiler.cpp
+++ b/mlx/backend/cpu/jit_compiler.cpp
@@ -248,7 +248,7 @@ std::string JitCompiler::build_command(
   return fmt::format(
       "\""
       "cd /D \"{0}\" && "
-      "\"{1}\" /LD /EHsc /MD /Ox /nologo /std:c++17{2} \"{3}\" "
+      "\"{1}\" /LD /EHsc /MD /Ox /nologo /std:c++20{2} \"{3}\" "
       "/link /out:\"{4}\" {5} 2>&1"
       "\"",
       dir.string(),
@@ -271,7 +271,7 @@ std::string JitCompiler::build_command(
   }
 #endif
   return fmt::format(
-      "g++ -std=c++17 -O3 -Wall -fPIC -shared {} \"{}\" -o \"{}\" 2>&1",
+      "g++ -std=c++20 -O3 -Wall -fPIC -shared {} \"{}\" -o \"{}\" 2>&1",
       extra_flags,
       (dir / source_file_name).string(),
       (dir / shared_lib_name).string());

--- a/mlx/backend/cpu/make_compiled_preamble.ps1
+++ b/mlx/backend/cpu/make_compiled_preamble.ps1
@@ -20,10 +20,10 @@ $IS_MSVC_LIKE = ($CL_NAME -eq 'cl') -or ($CL_NAME -eq 'clang-cl')
 # (splatting a single-element array can degrade to char-by-char expansion).
 $CL_ARGS = [System.Collections.ArrayList]::new()
 if ($IS_MSVC_LIKE) {
-  [void]$CL_ARGS.Add('/std:c++17')
+  [void]$CL_ARGS.Add('/std:c++20')
   [void]$CL_ARGS.Add('/EP')
 } else {
-  [void]$CL_ARGS.Add('-std=c++17')
+  [void]$CL_ARGS.Add('-std=c++20')
   [void]$CL_ARGS.Add('-E')
   [void]$CL_ARGS.Add('-P')
 }

--- a/mlx/backend/cpu/make_compiled_preamble.sh
+++ b/mlx/backend/cpu/make_compiled_preamble.sh
@@ -25,7 +25,7 @@ if [ "$CLANG" = "TRUE" ]; then
 EOM
 CC_FLAGS="-arch ${ARCH} -nobuiltininc -nostdinc"
 else
-CC_FLAGS="-std=c++17"
+CC_FLAGS="-std=c++20"
 fi
 
 CONTENT=$("$GCC" $CC_FLAGS $SIMD_FLAGS -I "$SRCDIR" -E -P "$SRCDIR/mlx/backend/cpu/compiled_preamble.h" 2>/dev/null)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,10 @@ target_sources(
           linalg_tests.cpp
           ${METAL_TEST_SOURCES})
 
+if(MLX_BUILD_CPU AND NOT IOS)
+  target_sources(tests PRIVATE jit_compiler_tests.cpp)
+endif()
+
 target_link_libraries(tests PRIVATE mlx doctest)
 target_compile_options(tests PRIVATE ${SANITIZER_COMPILE_FLAGS})
 target_link_options(tests PRIVATE ${SANITIZER_LINK_FLAGS})

--- a/tests/jit_compiler_tests.cpp
+++ b/tests/jit_compiler_tests.cpp
@@ -1,0 +1,64 @@
+// Copyright © 2026 Apple Inc.
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <tuple>
+
+#include "doctest/doctest.h"
+
+#include "mlx/backend/cpu/jit_compiler.h"
+
+using namespace mlx::core;
+
+TEST_CASE("test CPU JIT compiler supports C++20") {
+  if (!JitCompiler::available()) {
+    return;
+  }
+
+  namespace fs = std::filesystem;
+  auto suffix =
+      std::chrono::high_resolution_clock::now().time_since_epoch().count();
+  auto test_dir =
+      fs::temp_directory_path() / ("mlx-cxx20-jit-" + std::to_string(suffix));
+  std::error_code error;
+  REQUIRE(fs::create_directory(test_dir, error));
+
+  struct Cleanup {
+    fs::path path;
+    ~Cleanup() {
+      std::error_code error;
+      fs::remove_all(path, error);
+    }
+  } cleanup{test_dir};
+
+  const std::string source_name = "cxx20_probe.cpp";
+#ifdef _WIN32
+  const std::string library_name = "cxx20_probe.dll";
+#else
+  const std::string library_name = "libcxx20_probe.so";
+#endif
+
+  std::ofstream source(test_dir / source_name);
+  REQUIRE(source.good());
+  source << std::get<2>(JitCompiler::get_preamble());
+  source << R"code(
+template <typename T>
+concept Addable = requires(T value) {
+  value + value;
+};
+
+static_assert(Addable<int>);
+
+extern "C" int mlx_cxx20_probe(int value) {
+  return value;
+}
+)code";
+  source.close();
+  REQUIRE(source.good());
+
+  JitCompiler::exec(
+      JitCompiler::build_command(test_dir, source_name, library_name));
+  CHECK(fs::is_regular_file(test_dir / library_name));
+}


### PR DESCRIPTION
## Proposed changes

The CPU JIT and generated preamble still select C++17 on MSVC and GNU-like
toolchains even though MLX requires C++20 for CMake consumers. Use C++20
consistently across those runtime compilation paths and add a regression test
that compiles and links a C++20 concept through the real CPU JIT. AppleClang
compiler selection and the public API remain unchanged.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run the relevant `clang-format --dry-run --Werror`, shell syntax, and diff checks
- [x] I have added a focused regression test; it passes 1/1 case and 4/4 assertions
- [x] I have run the native suite (248/248 cases, 3,335/3,335 assertions) and CTest (249/249)
- [ ] Documentation update not needed; this does not change a public API
