### PR TITLE
Fix SliceUpdate JVPs with one traced input

### DIFF
--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -5177,12 +5177,15 @@ std::vector<array> SliceUpdate::jvp(
   // Check inputs
   assert(primals.size() == 2);
 
-  if (argnums.size() != 2) {
-    throw std::runtime_error(
-        "[SliceUpdate] JVP for one argument not implemented yet.");
+  array result_tan = zeros_like(primals[0], stream());
+  array update_tan = zeros_like(primals[1], stream());
+  for (int i = 0; i < argnums.size(); ++i) {
+    if (argnums[i] == 0) {
+      result_tan = tangents[i];
+    } else if (argnums[i] == 1) {
+      update_tan = tangents[i];
+    }
   }
-
-  auto result_tan = tangents[0];
 
   switch (reduce_type_) {
     case SliceUpdate::None:
@@ -5191,14 +5194,14 @@ std::vector<array> SliceUpdate::jvp(
           result_tan.dtype(),
           std::make_shared<SliceUpdate>(
               stream(), reduce_type_, start_indices_, end_indices_, strides_),
-          {result_tan, tangents[1]})};
+          {result_tan, update_tan})};
     case SliceUpdate::Sum:
       return {array(
           result_tan.shape(),
           result_tan.dtype(),
           std::make_shared<SliceUpdate>(
               stream(), reduce_type_, start_indices_, end_indices_, strides_),
-          {result_tan, tangents[1]})};
+          {result_tan, update_tan})};
     case SliceUpdate::Prod:
     case SliceUpdate::Max:
     case SliceUpdate::Min: {

--- a/tests/autograd_tests.cpp
+++ b/tests/autograd_tests.cpp
@@ -857,15 +857,15 @@ TEST_CASE("test slice update jvp with one tangent") {
 
   for (bool add : {false, true}) {
     auto update_fn = [&src, add](array x) {
-      return add ? slice_update_add(src, x, {1}, {3})
-                 : slice_update(src, x, {1}, {3});
+      return add ? slice_update_add(src, x, Shape{1}, Shape{3})
+                 : slice_update(src, x, Shape{1}, Shape{3});
     };
     auto out = jvp(update_fn, update, update_tan).second;
     CHECK(array_equal(out, array({0.0f, 7.0f, 8.0f, 0.0f})).item<bool>());
 
     auto src_fn = [&update, add](array x) {
-      return add ? slice_update_add(x, update, {1}, {3})
-                 : slice_update(x, update, {1}, {3});
+      return add ? slice_update_add(x, update, Shape{1}, Shape{3})
+                 : slice_update(x, update, Shape{1}, Shape{3});
     };
     out = jvp(src_fn, src, src_tan).second;
     auto expected = add ? src_tan : array({1.0f, 0.0f, 0.0f, 4.0f});

--- a/tests/autograd_tests.cpp
+++ b/tests/autograd_tests.cpp
@@ -849,6 +849,30 @@ TEST_CASE("test slice grads") {
   CHECK_EQ(out.size(), 0);
 }
 
+TEST_CASE("test slice update jvp with one tangent") {
+  auto src = array({1.0f, 2.0f, 3.0f, 4.0f});
+  auto update = array({5.0f, 6.0f});
+  auto src_tan = array({1.0f, 2.0f, 3.0f, 4.0f});
+  auto update_tan = array({7.0f, 8.0f});
+
+  for (bool add : {false, true}) {
+    auto update_fn = [&src, add](array x) {
+      return add ? slice_update_add(src, x, {1}, {3})
+                 : slice_update(src, x, {1}, {3});
+    };
+    auto out = jvp(update_fn, update, update_tan).second;
+    CHECK(array_equal(out, array({0.0f, 7.0f, 8.0f, 0.0f})).item<bool>());
+
+    auto src_fn = [&update, add](array x) {
+      return add ? slice_update_add(x, update, {1}, {3})
+                 : slice_update(x, update, {1}, {3});
+    };
+    out = jvp(src_fn, src, src_tan).second;
+    auto expected = add ? src_tan : array({1.0f, 0.0f, 0.0f, 4.0f});
+    CHECK(array_equal(out, expected).item<bool>());
+  }
+}
+
 TEST_CASE("test min and max vjp") {
   // Test min
   {


### PR DESCRIPTION
## Proposed changes

`SliceUpdate::jvp` currently rejects transforms when only the source or update input is traced. Initialize the absent tangent with zeros so assignment and sum slice updates support source-only and update-only JVPs while preserving the existing two-input behavior. Product, minimum, and maximum JVPs remain unsupported.

The focused regression passes 4/4 assertions. The full native suite passes 249/249 tests with 3,346 assertions.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
