### PR TITLE
Use larger tiles for qmm_t at large M

### DIFF
--- a/mlx/backend/metal/kernels/quantized.h
+++ b/mlx/backend/metal/kernels/quantized.h
@@ -644,7 +644,31 @@ struct QuantizedBlockLoader {
       return;
     }
 
-    if (reduction_dim == 1 && bi >= src_tile_dim.x) {
+    // `bi` indexes BROWS. When reduction_dim == 1, K is BCOLS (the
+    // reduction axis) and BROWS is the *output* axis (M for the x loader,
+    // N for the w loader in qmm_t_impl/affine_gather_qmm_rhs's transpose
+    // path) -- so the valid-count to guard `bi` against is the caller's
+    // BROWS bound. Every call site already passes that bound as
+    // src_tile_dim.y by convention (qmm_t_impl: `short2(BK, num_outs)`;
+    // affine_gather_qmm_rhs: `short2(k_remain, tgp_bn)`), but this line
+    // compared `bi` against src_tile_dim.x instead -- the BCOLS/K count,
+    // not the BROWS/output count. Comparing against the wrong field means
+    // this early-return under-fires: whenever the true BROWS bound (.y) is
+    // smaller than the BCOLS one (.x), some `bi` in [.y, .x) fall through
+    // to the real dequantize-and-load below and read live weight memory
+    // past the valid output boundary, instead of being zero-filled here.
+    // In every kernel instantiation shipped to date BROWS == BK == 32, so
+    // .x (== BK == BROWS) is never smaller than the true bound and the
+    // bug was unreachable; the resulting rows -- always >= the true bound
+    // either way -- are outside `num_outs`/`tgp_bn` and get discarded by
+    // the caller's store_result_safe regardless of what garbage they read,
+    // so output was correct by luck, not by this check doing anything.
+    // Fixing the compared field to .y makes the guard actually fire (and
+    // is a strict no-op for every existing BROWS==BK instantiation, since
+    // .x == BROWS there too -- the two fields were interchangeable exactly
+    // in that one case). It matters once BROWS is parametrized
+    // independently of BK, e.g. qmm_t_impl's new large-M tile below.
+    if (reduction_dim == 1 && bi >= src_tile_dim.y) {
       for (int i = 0; i < n_reads * pack_factor; i++) {
         dst[i] = T(0);
       }

--- a/mlx/backend/metal/kernels/quantized.h
+++ b/mlx/backend/metal/kernels/quantized.h
@@ -1213,7 +1213,9 @@ template <
     const bool aligned_N,
     const int BM = 32,
     const int BK = 32,
-    const int BN = 32>
+    const int BN = 32,
+    const int WM = 2,
+    const int WN = 2>
 METAL_FUNC void qmm_t_impl(
     const device uint32_t* w,
     const device T* scales,
@@ -1235,8 +1237,6 @@ METAL_FUNC void qmm_t_impl(
 
   (void)lid;
 
-  constexpr int WM = 2;
-  constexpr int WN = 2;
   constexpr int pack_factor = get_pack_factor<bits, 8>();
   constexpr int bytes_per_pack = get_bytes_per_pack<bits>();
 
@@ -1914,7 +1914,9 @@ template <
     const bool batched,
     const int BM = 32,
     const int BK = 32,
-    const int BN = 32>
+    const int BN = 32,
+    const int WM = 2,
+    const int WN = 2>
 [[kernel]] void affine_qmm_t(
     const device uint32_t* w [[buffer(0)]],
     const device T* scales [[buffer(1)]],
@@ -1961,7 +1963,7 @@ template <
         b_strides,
         tid);
   }
-  qmm_t_impl<T, group_size, bits, aligned_N, BM, BK, BN>(
+  qmm_t_impl<T, group_size, bits, aligned_N, BM, BK, BN, WM, WN>(
       w,
       scales,
       biases,

--- a/mlx/backend/metal/kernels/quantized.metal
+++ b/mlx/backend/metal/kernels/quantized.metal
@@ -42,6 +42,25 @@
       aligned,                                                               \
       batched)
 
+// Like instantiate_quantized_aligned_batched, but also pins BM/BK/BN (the
+// qmm_t tile size), for kernels that need a non-default tile ahead-of-time
+// compiled. Name must match quantized.cpp's qmm() kname exactly ("_bmX_bnY"
+// suffix, no separate "_bk" component since BK is always 32 here).
+#define instantiate_quantized_aligned_batched_tile(                          \
+    name, type, group_size, bits, aligned, batched, bm, bk, bn)              \
+  instantiate_kernel(                                                        \
+      #name "_" #type "_gs_" #group_size "_b_" #bits "_alN_" #aligned        \
+            "_batch_" #batched "_bm" #bm "_bn" #bn,                          \
+      name,                                                                  \
+      type,                                                                  \
+      group_size,                                                            \
+      bits,                                                                  \
+      aligned,                                                               \
+      batched,                                                               \
+      bm,                                                                    \
+      bk,                                                                    \
+      bn)
+
 #define instantiate_quantized_quad(name, type, group_size, bits, D, batched)     \
   instantiate_kernel(                                                            \
       #name "_" #type "_gs_" #group_size "_b_" #bits "_d_" #D "_batch_" #batched, \
@@ -179,4 +198,36 @@
   instantiate_quantized_groups(6) \
   instantiate_quantized_groups(8)
 
-instantiate_quantized_all() // clang-format on
+instantiate_quantized_all()
+
+// Large-M tile (BM=128, BN=64, BK=32) for affine_qmm_t, ahead-of-time
+// compiled so the default (MLX_METAL_JIT=OFF) build -- what `pip install
+// mlx` actually ships -- has this kernel available without falling back to
+// runtime JIT compilation. See qmm()'s large-M dispatch branch in
+// quantized.cpp: it only takes this path for the (group_size, bits)
+// combos instantiated here, so a shape that lands outside this set at
+// large M safely falls through to the original 32x32x32 tile instead of
+// hitting a missing kernel. Scoped to bf16/fp16 x {gs=32,64} x {bits=4,8}
+// -- the combo this fork's actual workload (evidence/2026-08-09-mlx-fork/)
+// uses -- rather than instantiated across the full type/group_size/bits
+// matrix above, to keep this addition's compile-time and binary-size cost
+// bounded until a wider need is demonstrated. Naming must exactly match
+// the kname built in quantized.cpp's qmm().
+#define instantiate_quantized_large_m_tile(type, group_size, bits)          \
+  instantiate_quantized_aligned_batched_tile(                               \
+      affine_qmm_t, type, group_size, bits, true, 1, 128, 32, 64)           \
+  instantiate_quantized_aligned_batched_tile(                               \
+      affine_qmm_t, type, group_size, bits, true, 0, 128, 32, 64)           \
+  instantiate_quantized_aligned_batched_tile(                               \
+      affine_qmm_t, type, group_size, bits, false, 1, 128, 32, 64)          \
+  instantiate_quantized_aligned_batched_tile(                               \
+      affine_qmm_t, type, group_size, bits, false, 0, 128, 32, 64)
+
+#define instantiate_quantized_large_m_tile_types(group_size, bits)  \
+  instantiate_quantized_large_m_tile(float16_t, group_size, bits)   \
+  instantiate_quantized_large_m_tile(bfloat16_t, group_size, bits)
+
+instantiate_quantized_large_m_tile_types(32, 4)
+instantiate_quantized_large_m_tile_types(32, 8)
+instantiate_quantized_large_m_tile_types(64, 4)
+instantiate_quantized_large_m_tile_types(64, 8) // clang-format on

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -1048,16 +1048,73 @@ void qmm(
 
   int B = out.size() / M / N;
 
+  // qmm_t's tile is fixed at 32x32x32 regardless of M/N/K/device, which is
+  // sized for small-M (decode) calls. At large M (prefill-shaped calls)
+  // this dispatches far more threadgroups than the dense steel GEMM path
+  // takes at the same shape, and each one re-reads a larger share of both
+  // operand matrices from device memory -- see
+  // evidence/2026-08-09-mlx-fork/ in the minimax-h3-mlx repo for the
+  // measured gap, dispatch trace, and tile-size sweep that motivated this
+  // branch and this specific 128x64 choice (64x64 got partway there;
+  // 128x64 landed closest to the dense baseline of the sizes tried;
+  // 128x128 was a large regression, likely too few threadgroups per core
+  // to hide memory latency once M/BM * N/BN drops far enough. See
+  // fix-report.md's config table for the full sweep).
+  //
+  // affine_qmm_t / qmm_t_impl (kernels/quantized.h) already accept
+  // BM/BK/BN (and, after this change, WM/WN) as template parameters with
+  // defaults matching the old fixed 32x32x32/WM=2/WN=2 config -- this
+  // dispatch layer simply never varied them. This branch opts large-M,
+  // transpose=true calls into a 128x64 output tile (BK stays 32:
+  // QuantizedBlockLoader requires BK <= group_size, and group_size can be
+  // as small as 32, so BK can't grow without also constraining
+  // group_size). wm/wn are left at their existing defaults (2, 2) --
+  // varying them (tried wm=1,wn=2, mirroring dense's simdgroup config) made
+  // no measurable difference at this tile size, so there was no reason to
+  // deviate from the existing default. Every other call -- small M,
+  // transpose=false, or M below the threshold -- takes the exact same path
+  // and kernel as before.
+  //
+  // kLargeMTileThreshold is intentionally a compile-time constant (not a
+  // runtime knob) to keep this a pure, auditable tuning branch; bump it
+  // temporarily to force the old 32x32 tile at a given M for A/B
+  // benchmarking.
+  //
+  // The (type, group_size, bits) guard below matters because this same
+  // qmm() is linked into both the JIT build (jit_kernels.cpp, compiles any
+  // template instantiation on demand at runtime -- would work for any
+  // combo unguarded) and the default, non-JIT build (nojit_kernels.cpp,
+  // `pip install mlx`'s actual configuration -- looks up a *fixed* set of
+  // ahead-of-time-compiled kernel names and throws if the name it computes
+  // isn't in that set). The 128x64 tile is only ahead-of-time instantiated
+  // for {float16_t, bfloat16_t} x {group_size 32, 64} x {bits 4, 8} (see
+  // quantized.metal's instantiate_quantized_large_m_tile_types calls) --
+  // this fork's actual workload (evidence/2026-08-09-mlx-fork/) -- so this
+  // guard keeps behavior identical across both builds: every combo outside
+  // this scoped set falls through to the original 32x32x32 path at every M,
+  // whether or not the running build happens to have JIT available to
+  // synthesize it on demand. Widening this list is a matter of adding the
+  // corresponding instantiate_quantized_large_m_tile_types(...) call.
+  constexpr int kLargeMTileThreshold = 4096;
+  constexpr int kLargeMBlockDimM = 128;
+  constexpr int kLargeMBlockDimN = 64;
+  bool large_m_tile_dtype_supported =
+      x.dtype() == float16 || x.dtype() == bfloat16;
+  bool large_m_tile_quant_supported =
+      (group_size == 32 || group_size == 64) && (bits == 4 || bits == 8);
+  bool large_m_tile = transpose && M >= kLargeMTileThreshold &&
+      large_m_tile_dtype_supported && large_m_tile_quant_supported;
+
   int wm = 2;
   int wn = 2;
-  int bm = 32;
-  int bn = 32;
+  int bm = large_m_tile ? kLargeMBlockDimM : 32;
+  int bn = large_m_tile ? kLargeMBlockDimN : 32;
   MTL::Size group_dims(32, wn, wm);
   MTL::Size grid_dims((N + bn - 1) / bn, (M + bm - 1) / bm, B);
 
   std::string kname;
   kname.reserve(64);
-  bool aligned = N % 32 == 0;
+  bool aligned = N % bn == 0;
   bool batched = B > 1;
   std::string type_string = get_type_string(x.dtype());
   concatenate(
@@ -1069,20 +1126,38 @@ void qmm(
       "_b_",
       bits,
       transpose ? (aligned ? "_alN_true" : "_alN_false") : "",
-      batched ? "_batch_1" : "_batch_0");
+      batched ? "_batch_1" : "_batch_0",
+      large_m_tile ? "_bm" + std::to_string(bm) + "_bn" + std::to_string(bn)
+                   : "");
   std::string template_def;
   MTL::ComputePipelineState* kernel;
   if (transpose) {
-    kernel = get_quantized_kernel_wrapped(
-        d,
-        kname,
-        "qmm_t",
-        mode,
-        type_string,
-        group_size,
-        bits,
-        aligned,
-        batched);
+    if (large_m_tile) {
+      kernel = get_quantized_kernel_wrapped(
+          d,
+          kname,
+          "qmm_t",
+          mode,
+          type_string,
+          group_size,
+          bits,
+          aligned,
+          batched,
+          bm,
+          /* BK = */ 32,
+          bn);
+    } else {
+      kernel = get_quantized_kernel_wrapped(
+          d,
+          kname,
+          "qmm_t",
+          mode,
+          type_string,
+          group_size,
+          bits,
+          aligned,
+          batched);
+    }
   } else {
     kernel = get_quantized_kernel_wrapped(
         d, kname, "qmm_n", mode, type_string, group_size, bits, batched);


### PR DESCRIPTION
This branch also includes the one-line `QuantizedBlockLoader::load_safe`
bounds fix submitted standalone as #4203, since the tile change below
depends on it (see "Why this was never observed" in #4203 for why).

## Summary

`mx.quantized_matmul`'s `transpose=True` path (`qmm_t`) dispatches a
fixed `32x32x32` output tile with `2x2` simdgroups regardless of
`M`/`N`/`K`/device — sized for small-M (decode) calls. At large `M`
(prefill-shaped calls, e.g. `M >= 4096`), this is ~1.7x slower than the
equivalent dense `bf16` matmul at the same shape, despite the quantized
weight being ~4x smaller on disk.

## Root cause

`qmm()`'s dispatch (`mlx/backend/metal/quantized.cpp`, around the tile
selection before `get_quantized_kernel_wrapped`) hardcodes
`bm=32, bn=32, wm=2, wn=2` unconditionally. `affine_qmm_t` / `qmm_t_impl`
(`mlx/backend/metal/kernels/quantized.h`) already accept `BM`/`BK`/`BN` as
template parameters with defaults matching that fixed config — the
dispatch layer simply never varies them. (`WM`/`WN` were hardcoded
`constexpr` inside `qmm_t_impl` itself, not even template parameters,
until this change.) A sibling kernel, `get_gather_qmm_kernel`
(`jit_kernels.cpp`), already threads `bm/bn/bk/wm/wn` through as JIT
template params — this change brings `qmm_t`'s dispatch up to the same
pattern.

At the fixed `32x32x32` tile, `qmm_t` dispatches ~4x more threadgroups
than the dense path's adaptive `64x64` tile at the same shape (528,192
vs. 132,160 at the measured production shape below), and each
threadgroup does 8x less useful output work per thread — concretely,
each of the `N/bn` column-tile-groups re-reads the same row of `x` from
device memory, and each of the `M/bm` row-tile-groups re-reads (and
re-dequantizes) the same weight columns, roughly doubling redundant
reads of both operands versus the dense tile.

## The fix

Add a dispatch branch in `qmm()` that selects a `128x64` output tile
(`BM=128, BN=64`, `BK` unchanged at 32) for `transpose=true` calls with
`M >= 4096`, scoped to `{float16, bfloat16} x {group_size 32, 64} x
{bits 4, 8}`. `BK` stays 32 in every config tried:
`QuantizedBlockLoader` requires `BK <= group_size`, and `group_size` can
be as small as 32, so `BK` can't grow without also constraining which
`group_size`s the fast path supports. `WM`/`WN` are promoted to template
parameters (still defaulting to `2, 2` — an `wm=1,wn=2` variant, mirroring
the dense path's own simdgroup split, showed no measurable difference at
this tile size, so there was no reason to deviate from the existing
default). Every other call — small `M`, `transpose=false` (`qmm_n`), or a
dtype/group_size/bits combination outside the scoped set — takes the
exact original path and kernel, unconditionally.

Also fixes `aligned = N % bn == 0` (was hardcoded `% 32`), which would
otherwise silently mis-detect alignment for any `bn != 32` — latent until
this change since `bn` was always 32 before.

## Why AOT instantiation matters

`mlx/backend/metal/CMakeLists.txt` sets `MLX_METAL_JIT` `OFF` by default —
the configuration `pip install mlx` actually ships — which links
`nojit_kernels.cpp` and looks up kernels by name from a fixed,
ahead-of-time-compiled set; there is no runtime JIT fallback in that
build. This PR adds a scoped AOT instantiation
(`instantiate_quantized_large_m_tile_types` in
`mlx/backend/metal/kernels/quantized.metal`) for exactly the
`(dtype, group_size, bits)` combinations the dispatch guard allows, kept
separate from the existing exhaustive `instantiate_quantized_all()` sweep
to bound this addition's compile-time/binary-size cost. Both
`MLX_METAL_JIT=ON` and the default `OFF` build were verified to produce
identical dispatch and numbers — a tile change that only touched
`quantized.cpp` would work under `MLX_METAL_JIT=ON` and then throw
`[metal::Device] Unable to load kernel ...` under the actual default
build the first time `M >= 4096` was hit.

## Config sweep

Measured on M2 Ultra (non-NAX), production shape `M=37723, K=5376,
N=14336`, `group_size=32`, `bits=8`:

| config | median ms | vs dense | threadgroups | notes |
|---|---:|---:|---:|---|
| dense-bf16 (reference) | ~359 | 1.00x | 132,160 | steel `bm=64,bn=64,bk=16,wm=1,wn=2` |
| old (32x32x32, wm=2,wn=2) | 624.1 | 1.74x | 528,192 | baseline |
| 64x64x32, wm=2,wn=2 | 559.0 | 1.56x | 132,160 | first attempt — helped, short of target |
| 64x64x32, wm=1,wn=2 | 557.1 | 1.55x | 132,160 | mirrors dense's simdgroup config; no measurable gain |
| 128x64x32, wm=2,wn=2 (**shipped**) | 474.4 | 1.31x | 66,080 | closest to dense of the configs tried |
| 128x128x32, wm=2,wn=2 | 1993.1 | 5.53x | 33,040 | severe regression — too few threadgroups to hide memory latency; stopped here |

Tried 64x64 first, then 128x64 (the winner) and 128x128 (a regression) as
the two additional configs per a fixed "at most 2 more configs" search
budget, then stopped.

## Correctness

Reference for all checks: `mx.dequantize(w_q, ...)` followed by an fp32
dense matmul — not the original `bf16` weight — so quantization noise is
isolated from tile-dispatch bugs.

**Targeted edge cases** (10/10 pass, identical on both `MLX_METAL_JIT=ON`
and the default `OFF` build): `M` just below/at/above the 4096 threshold;
`N` a multiple of 32 but not 64 (exercises the corrected alignment check);
`N` not a multiple of 32 at all; `group_size` 32 and 64; `bits` 4 and 8;
decode-shaped `M` (old path, sanity that it's untouched); the production
shape.

**Broad stress sweep**: 550 combinations (`M` in `{1, 7, 33, 4095, 4096,
4097, 4159, 5000, 8192, 20000, 40000}` x `N` in `{1, 17, 32, 63, 64, 65,
100, 4096, 4160, 8000}` x `(group_size, bits)` in `{(32,4), (32,8),
(64,4), (64,8), (128,4)}`, `K = group_size * 7`) against the same
dequantize+matmul reference, `rel_l2 < 1e-2` threshold: **547/550 passed**.
The 3 failures are all at `M=1` (far below the 4096 threshold — the
large-M branch is never taken) with `group_size=64, bits=4` and tiny `N`;
these reproduce identically on unmodified `upstream/main` and are
pre-existing 4-bit quantization noise at a small-sample output size,
unrelated to this change.

**Guard verification**: out-of-scope combinations at large `M`
(`bits=6`, `group_size=128`, `dtype=float32`, `M=5000`) correctly fall
through to the original `32x32x32` path with correct output — spot-checked
on the `MLX_METAL_JIT=OFF` build, where a missing-AOT-kernel bug would
actually throw rather than silently JIT-compile.

## Test suite

`python -m unittest test_quantized -v` (from `python/tests/`): **34/34
pass** on both `MLX_METAL_JIT=ON` (35.6s) and the default
`MLX_METAL_JIT=OFF` build (9.1s). Includes `test_qmm_large_dims`,
`test_qmm_shapes`, `test_qmm`, `test_qmv*`, `test_gather_qmm*`,
`test_non_multiples`, `test_small_matrix`.

## Scoping / what's out of scope

- `qmm_n` (`transpose=False`) and `qmv`/`qvm`/gather variants are
  untouched — this stays scoped to the `qmm_t`/`transpose=true` path.
- AOT coverage is `{fp16, bf16} x {gs 32, 64} x {bits 4, 8}`, not the
  full `{float, float16_t, bfloat16_t} x {32, 64, 128} x {2, 3, 4, 5, 6,
  8}` matrix. Widening is mechanical — one more
  `instantiate_quantized_large_m_tile_types(...)` call per combination —
  but not done here; happy to extend if maintainers want broader coverage
  before merge.
- `wm`/`wn` are template parameters now but not varied from the existing
  default (2, 2) in the shipped config — left as knobs for a future shape
  class if one needs them, not exercised here.

## Open items

- 474ms doesn't quite clear a 470ms internal viability target (~0.8-0.9%
  over) or dense parity (359ms). The remaining gap is most plausibly the
  per-K-tile dequantization cost inside `QuantizedBlockLoader` (bit-unpack
  + affine transform every K-iteration, real additive-vs-dense work that
  no tile-size change removes) rather than remaining tile-geometry
  overhead, since the K-loop trip count is identical across every config
  tried. Not separated from tile-geometry cost by a profiler in this
  round — GPU capture / per-shader-stage counters would settle it.
- **End-to-end pipeline result**: on our H3 workload (the `M=37723` GEMMs
  measured above occur inside a 31B-parameter DiT's denoise step, run on a
  64GB machine already at its wired-memory limit for this configuration),
  the per-GEMM 1.31x improvement does not change end-to-end step time —
  ~466 s/step post-fix vs. ~442 s/step pre-fix, within machine-to-machine
  variance but not an improvement — because the step is bound by
  unified-memory pressure (denoise-phase peak ~58 GB, unchanged by this
  fix) rather than by GEMM dispatch cost. The kernel win here is real and
  should benefit workloads that aren't already sitting at the memory
  ceiling; it just doesn't compose with this particular resident-INT8
  choreography on this machine.

This surfaced a separate, latent bug in `QuantizedBlockLoader::load_safe`
(comparing the wrong `short2` field, unreachable until `BROWS != BK`,
which this PR is the first change to trigger) — split out into its own
PR (#4203) since it stands alone and is correct independent of
this change.
