### PR TITLE
Require pytorch 2.12 for metal dlpack tests

### DIFF
--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -22,10 +22,19 @@ try:
 except ImportError:
     has_tf = False
 
+
 try:
     import torch
 
-    has_torch_mps = hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
+    torch_version = [int(v) for v in torch.__version__.split("+")[0].split(".")]
+    is_torch_212 = torch_version[0] > 2 or (
+        torch_version[0] == 2 and torch_version[1] >= 12
+    )
+    has_torch_mps = (
+        is_torch_212
+        and hasattr(torch.backends, "mps")
+        and torch.backends.mps.is_available()
+    )
 except ImportError:
     torch = None
     has_torch_mps = False


### PR DESCRIPTION
The tests added by #3531 assumes pytorch 2.12 which supports sharing metal buffers between other frameworks, older versions of pytorch still work it is just we could not do non-copy data sharing. It does not really worth the efforts to refactor the tests to support old versions of pytorch so just skip them.