### PR TITLE
Only use MPI backend for world size > 1

### DIFF
--- a/mlx/distributed/mpi/mpi.cpp
+++ b/mlx/distributed/mpi/mpi.cpp
@@ -166,6 +166,11 @@ struct MPIWrapper {
     if (!is_available()) {
       return false;
     }
+    // MPI_Init is an error to call twice, and init() can run more than once
+    // when it returns without a group.
+    if (initialized_) {
+      return true;
+    }
     bool success = init(nullptr, nullptr) == MPI_SUCCESS;
 
     // Initialize custom types and ops
@@ -491,6 +496,19 @@ std::shared_ptr<GroupImpl> init(bool strict /* = false */) {
   if (!mpi().init_safe()) {
     if (strict) {
       throw std::runtime_error("Cannot initialize MPI");
+    }
+    return nullptr;
+  }
+
+  // Open MPI initializes a world of size 1 for a program that was not started
+  // with mpirun, which is not a distributed group.
+  int size = 1;
+  mpi().size(mpi().world(), &size);
+  if (size <= 1) {
+    if (strict) {
+      throw std::runtime_error(
+          "[mpi] The world has a single process. Launch with mpirun to "
+          "initialize the mpi backend.");
     }
     return nullptr;
   }


### PR DESCRIPTION

Related to #3442.

`init(backend="any")` tries backends in order and takes the first that initializes. Open MPI
initializes successfully for a program that was not started with `mpirun`, giving an
`MPI_COMM_WORLD` of size 1. That counted as success, so the chain stopped at mpi and never
reached the backends after it. A correctly configured JACCL job would then run single node and
report nothing.

`mpi::init` now returns `nullptr` when the world holds a single process, so `any` carries on to
the next backend. Asking for it directly with `backend="mpi"` and `strict=true` raises instead:

```
[mpi] The world has a single process. Launch with mpirun to initialize the mpi backend.
```

The size comes from `mpi().world()` rather than from a constructed `MPIGroup`, because building
one and discarding it runs `~MPIGroup()`, which calls `finalize_safe()` when `global_` is set,
and `MPI_Init` cannot be called again after that.

The second hunk is needed to make the first safe. `register_group` only caches under `"any"` for
a non-null group, so once `mpi::init` can decline, nothing is cached and the next `init()` call
re-runs the whole chain. `init_safe()` called `MPI_Init` unconditionally, and Open MPI treats a
second `MPI_Init` as fatal:

```
Open MPI has detected that this process has attempted to initialize
MPI (via MPI_INIT or MPI_INIT_THREAD) more than once.  This is erroneous.
*** MPI_ERRORS_ARE_FATAL
```

That is unreachable on main today, because a successful mpi group is cached and `init_safe` never
runs twice. `init_safe` is idempotent now.

#### Verified

Open MPI 5.0.9, macOS 26.6.

| case | result |
|---|---|
| libmpi present, no mpirun, `init()` | mpi not selected |
| libmpi present, no mpirun, `init(strict=true)` | `[distributed] Couldn't initialize any backend` |
| libmpi present, `init(backend="mpi", strict=true)` | raises the message above |
| libmpi present, `init()` twice | no crash |
| `mpirun -n 2`, `init()` | size 2, ranks 0 and 1 |
| `mpirun -n 2`, `init(backend="mpi", strict=true)` | size 2, no raise |
| `mpirun -n 2`, `all_sum` | `[3.0, 3.0, 3.0, 3.0]` |

The first two rows match running with `MLX_MPI_LIBNAME` pointed at a missing file, which is the
intent: with Open MPI installed but no `mpirun`, MLX behaves as though it were not there.

