### PR TITLE
Break monolithic MTLResidencySet into smaller sets

### DIFF
--- a/mlx/backend/metal/allocator.cpp
+++ b/mlx/backend/metal/allocator.cpp
@@ -44,13 +44,13 @@ namespace metal {
 
 MetalAllocator::MetalAllocator(Device& d)
     : device_(d.mtl_device()),
-      residency_set_(d.residency_set()),
+      residency_sets_(d.residency_sets()),
       buffer_cache_(
           vm_page_size,
           [](MTL::Buffer* buf) { return buf->length(); },
           [this](MTL::Buffer* buf) {
             if (!buf->heap()) {
-              residency_set_.erase(buf);
+              residency_sets_.erase(buf);
             }
             auto pool = metal::new_scoped_memory_pool();
             buf->release();
@@ -73,7 +73,7 @@ MetalAllocator::MetalAllocator(Device& d)
   heap_desc->setResourceOptions(resource_options);
   heap_desc->setSize(heap_size_);
   heap_ = NS::TransferPtr(device_->newHeap(heap_desc));
-  residency_set_.insert(heap_.get());
+  residency_sets_.insert(heap_.get());
 }
 
 MetalAllocator::~MetalAllocator() = default;
@@ -100,7 +100,7 @@ size_t MetalAllocator::get_memory_limit() {
 size_t MetalAllocator::set_wired_limit(size_t limit) {
   std::unique_lock lk(mutex_);
   std::swap(limit, wired_limit_);
-  residency_set_.resize(wired_limit_);
+  residency_sets_.resize(wired_limit_);
   return limit;
 };
 
@@ -159,7 +159,7 @@ Buffer MetalAllocator::malloc(size_t size) {
     lk.lock();
     num_resources_++;
     if (!buf->heap()) {
-      residency_set_.insert(buf);
+      residency_sets_.insert(buf);
     }
   }
 
@@ -192,7 +192,7 @@ void MetalAllocator::free(Buffer buffer) {
   } else {
     num_resources_--;
     if (!buf->heap()) {
-      residency_set_.erase(buf);
+      residency_sets_.erase(buf);
     }
     lk.unlock();
     auto pool = metal::new_scoped_memory_pool();
@@ -210,7 +210,7 @@ Buffer MetalAllocator::make_buffer(void* ptr, size_t size) {
     return Buffer{nullptr};
   }
   std::unique_lock lk(mutex_);
-  residency_set_.insert(buf);
+  residency_sets_.insert(buf);
   active_memory_ += buf->length();
   peak_memory_ = std::max(peak_memory_, active_memory_);
   num_resources_++;
@@ -225,7 +225,7 @@ void MetalAllocator::release(Buffer buffer) {
   std::unique_lock lk(mutex_);
   active_memory_ -= buf->length();
   num_resources_--;
-  residency_set_.erase(buf);
+  residency_sets_.erase(buf);
   lk.unlock();
   auto pool = metal::new_scoped_memory_pool();
   buf->release();

--- a/mlx/backend/metal/allocator.h
+++ b/mlx/backend/metal/allocator.h
@@ -57,7 +57,7 @@ class MetalAllocator : public allocator::Allocator {
   friend MetalAllocator& allocator();
 
   NS::SharedPtr<MTL::Heap> heap_;
-  ResidencySet& residency_set_;
+  ResidencySets& residency_sets_;
 
   // Caching allocator
   BufferCache<MTL::Buffer> buffer_cache_;

--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -309,17 +309,16 @@ MTL::Library* load_library(
 CommandEncoder::CommandEncoder(
     Device& d,
     int index,
-    ResidencySet& residency_set)
-    : device_(d) {
+    ResidencySets& residency_sets)
+    : device_(d), residency_sets_(residency_sets) {
   auto pool = new_scoped_memory_pool();
   queue_ = NS::TransferPtr(device_.mtl_device()->newCommandQueue());
   if (!queue_) {
     throw std::runtime_error(
         "[metal::CommandEncoder] Failed to make new command queue.");
   }
-  if (residency_set.mtl_residency_set()) {
-    queue_->addResidencySet(residency_set.mtl_residency_set());
-  }
+  // Sets created later are attached in commit().
+  residency_sets_.attach_new_sets(queue_.get(), sets_attached_);
   debug_set_stream_queue_label(queue_.get(), index);
   buffer_ = NS::RetainPtr(queue_->commandBufferWithUnretainedReferences());
 }
@@ -519,6 +518,9 @@ bool CommandEncoder::needs_commit() const {
 }
 
 void CommandEncoder::commit(std::function<void()> completion) {
+  // Metal locks a command buffer's residency at commit time, so attach any
+  // sets created since the last commit first.
+  residency_sets_.attach_new_sets(queue_.get(), sets_attached_);
   buffer_->addCompletedHandler(
       [&error_ = error_,
        wait_events = std::move(wait_events_),
@@ -586,7 +588,7 @@ MTL::ComputeCommandEncoder* CommandEncoder::get_command_encoder() {
   return encoder_.get();
 }
 
-Device::Device() : device_(load_device()), residency_set_(device_.get()) {
+Device::Device() : device_(load_device()), residency_sets_(device_.get()) {
   auto pool = new_scoped_memory_pool();
   default_library_ = NS::TransferPtr(load_default_library(device_.get()));
   arch_ = env::metal_gpu_arch();

--- a/mlx/backend/metal/device.h
+++ b/mlx/backend/metal/device.h
@@ -25,7 +25,7 @@ class EventImpl;
 
 class MLX_API CommandEncoder {
  public:
-  CommandEncoder(Device& d, int index, ResidencySet& residency_set);
+  CommandEncoder(Device& d, int index, ResidencySets& residency_sets);
   ~CommandEncoder();
 
   CommandEncoder(const CommandEncoder&) = delete;
@@ -114,6 +114,10 @@ class MLX_API CommandEncoder {
   int buffer_ops_{0};
   size_t buffer_sizes_{0};
 
+  // The residency set and how many of its sets this queue has attached.
+  ResidencySets& residency_sets_;
+  uint64_t sets_attached_{0};
+
   // The events hooked to current command buffer.
   std::vector<std::shared_ptr<EventImpl>> wait_events_;
   std::vector<std::tuple<std::shared_ptr<EventImpl>, uint64_t>> signal_events_;
@@ -193,8 +197,8 @@ class MLX_API Device {
       const MTLFCList& func_consts = {},
       const std::vector<MTL::Function*>& linked_functions = {});
 
-  ResidencySet& residency_set() {
-    return residency_set_;
+  ResidencySets& residency_sets() {
+    return residency_sets_;
   }
 
  private:
@@ -230,7 +234,7 @@ class MLX_API Device {
       const std::vector<MTL::Function*>& linked_functions = {});
 
   NS::SharedPtr<MTL::Device> device_;
-  ResidencySet residency_set_;
+  ResidencySets residency_sets_;
 
   std::shared_mutex kernel_mtx_;
   std::shared_mutex library_mtx_;

--- a/mlx/backend/metal/eval.cpp
+++ b/mlx/backend/metal/eval.cpp
@@ -16,14 +16,14 @@ void new_stream(Stream s) {
   assert(s.device == Device::gpu);
   auto& encoders = metal::get_command_encoders();
   auto& d = metal::device(s.device);
-  encoders.try_emplace(s.index, d, s.index, d.residency_set());
+  encoders.try_emplace(s.index, d, s.index, d.residency_sets());
 }
 
 void new_thread_unsafe_stream(Stream s) {
   assert(s.device == Device::gpu);
   auto& encoders = metal::get_global_command_encoders();
   auto& d = metal::device(s.device);
-  encoders.try_emplace(s.index, d, s.index, d.residency_set());
+  encoders.try_emplace(s.index, d, s.index, d.residency_sets());
 }
 
 void eval(array& arr) {

--- a/mlx/backend/metal/resident.cpp
+++ b/mlx/backend/metal/resident.cpp
@@ -1,6 +1,7 @@
 // Copyright © 2024 Apple Inc.
 
 #include <algorithm>
+#include <cassert>
 #include <cstdio>
 #include <sstream>
 #include <stdexcept>
@@ -141,7 +142,8 @@ void ResidencySets::insert(MTL::Allocation* buf) {
 
   auto [it, inserted] = buf_to_set_.try_emplace(buf, Placement{kNoSet, bytes});
   if (!inserted) {
-    return; // already tracked
+    assert(false && "allocation is already tracked");
+    return;
   }
   // Stay within the wired limit. The excess is tracked but left out of any
   // set, and is added to one by resize() if the limit is raised later.
@@ -159,7 +161,8 @@ void ResidencySets::erase(MTL::Allocation* buf) {
   std::lock_guard<std::mutex> lk(mtx_);
   auto it = buf_to_set_.find(buf);
   if (it == buf_to_set_.end()) {
-    return; // a heap child, or never inserted
+    assert(false && "erasing an allocation that was never inserted");
+    return;
   }
   if (it->second.set_id != kNoSet) {
     const uint32_t idx = it->second.set_id;

--- a/mlx/backend/metal/resident.cpp
+++ b/mlx/backend/metal/resident.cpp
@@ -1,19 +1,39 @@
 // Copyright © 2024 Apple Inc.
 
-#include "mlx/backend/metal/resident.h"
+#include <algorithm>
+#include <cstdio>
+#include <sstream>
+#include <stdexcept>
+
 #include "mlx/backend/metal/device.h"
+#include "mlx/backend/metal/resident.h"
+#include "mlx/utils.h"
 
 namespace mlx::core::metal {
 
-ResidencySet::ResidencySet(MTL::Device* d) {
+ResidencySets::ResidencySets(MTL::Device* d) {
   if (!d->supportsFamily(MTL::GPUFamilyMetal3)) {
-    return;
-  } else if (__builtin_available(macOS 15, iOS 18, *)) {
-    auto pool = new_scoped_memory_pool();
-    auto desc = MTL::ResidencySetDescriptor::alloc()->init()->autorelease();
-    NS::Error* error;
-    wired_set_ = NS::TransferPtr(d->newResidencySet(desc, &error));
-    if (!wired_set_) {
+    return; // enabled_ stays false, so everything below is a no-op
+  }
+  if (__builtin_available(macOS 15, iOS 18, *)) {
+    device_ = d;
+    enabled_ = true;
+    int pct = env::residency_set_max_pct();
+    if (pct <= 0 || pct >= 100) {
+      max_bytes_per_set_ = 0; // a single set holds everything
+    } else {
+      size_t ws = static_cast<size_t>(d->recommendedMaxWorkingSetSize());
+      // Floor the cap so a small working set or a small percentage cannot ask
+      // for an absurd number of sets. 64 MiB comfortably exceeds the
+      // allocator's heap.
+      max_bytes_per_set_ = std::max<size_t>(
+          (ws / 100) * static_cast<size_t>(pct), size_t(64) << 20);
+    }
+    std::lock_guard<std::mutex> lk(mtx_);
+    // Set 0 always exists and is the fallback when a later set cannot be
+    // made, so failing to create it is fatal.
+    NS::Error* error = nullptr;
+    if (!add_set_locked(&error)) {
       std::ostringstream msg;
       msg << "[metal::Device] Unable to construct residency set.\n";
       if (error) {
@@ -21,75 +41,196 @@ ResidencySet::ResidencySet(MTL::Device* d) {
       }
       throw std::runtime_error(msg.str());
     }
-    wired_set_->requestResidency();
   }
 }
 
-void ResidencySet::insert(MTL::Allocation* buf) {
-  if (!wired_set_) {
-    return;
+ResidencySets::~ResidencySets() = default;
+
+bool ResidencySets::add_set_locked(NS::Error** error_out) {
+  NS::SharedPtr<MTL::ResidencySet> set;
+  if (__builtin_available(macOS 15, iOS 18, *)) {
+    auto pool = new_scoped_memory_pool();
+    auto desc = MTL::ResidencySetDescriptor::alloc()->init()->autorelease();
+    NS::Error* error = nullptr;
+    set = NS::TransferPtr(device_->newResidencySet(desc, &error));
+    if (set) {
+      // A standing request, so allocations added to this set later are
+      // covered without requesting residency again on every insert.
+      set->requestResidency();
+    } else if (error_out) {
+      *error_out = error;
+    }
   }
-  if (wired_set_->allocatedSize() + buf->allocatedSize() <= capacity_) {
-    wired_set_->addAllocation(buf);
-    wired_set_->commit();
-  } else {
-    unwired_set_.insert(buf);
+  if (!set) {
+    return false;
   }
+  sets_.push_back(Set{std::move(set), 0});
+  num_sets_.store(sets_.size(), std::memory_order_release);
+  if (env::residency_debug()) {
+    fprintf(
+        stderr,
+        "[residency] created residency set %zu (max_bytes_per_set=%zu MB)\n",
+        sets_.size() - 1,
+        max_bytes_per_set_ >> 20);
+  }
+  return true;
 }
 
-void ResidencySet::erase(MTL::Allocation* buf) {
-  if (!wired_set_) {
-    return;
+uint32_t ResidencySets::choose_set_locked(size_t bytes) {
+  if (max_bytes_per_set_ == 0) {
+    return 0;
   }
-  if (auto it = unwired_set_.find(buf); it != unwired_set_.end()) {
-    unwired_set_.erase(it);
-  } else {
-    wired_set_->removeAllocation(buf);
-    wired_set_->commit();
+  const uint32_t none = static_cast<uint32_t>(sets_.size());
+  uint32_t empty = none;
+  uint32_t emptiest = 0;
+  for (uint32_t i = 0; i < sets_.size(); ++i) {
+    const size_t size = sets_[i].size;
+    if (size + bytes <= max_bytes_per_set_) {
+      return i; // first fit
+    }
+    // Only reached by an allocation larger than the cap, which needs a set of
+    // its own. Reusing an emptied one keeps the set count from growing.
+    if (i != 0 && size == 0 && empty == none) {
+      empty = i;
+    }
+    if (size < sets_[emptiest].size) {
+      emptiest = i;
+    }
   }
+  if (empty != none) {
+    return empty;
+  }
+  if (sets_.size() < kMaxSets && add_set_locked()) {
+    return static_cast<uint32_t>(sets_.size() - 1);
+  }
+  // At the cap, or the driver would not make another set. Filling the emptiest
+  // set keeps them evenly sized, so each one still holds a bounded fraction of
+  // the wired bytes.
+  return emptiest;
 }
 
-void ResidencySet::resize(size_t size) {
-  if (!wired_set_) {
+uint32_t ResidencySets::add_to_set_locked(
+    const MTL::Allocation* buf,
+    Placement& at) {
+  uint32_t idx = choose_set_locked(at.bytes);
+  auto& s = sets_[idx];
+  s.set->addAllocation(buf);
+  s.size += at.bytes;
+  total_wired_ += at.bytes;
+  at.set_id = idx;
+  return idx;
+}
+
+void ResidencySets::remove_from_set_locked(
+    const MTL::Allocation* buf,
+    Placement& at) {
+  auto& s = sets_[at.set_id];
+  s.set->removeAllocation(buf);
+  // Subtract the size recorded at insert; allocatedSize() is never read back.
+  s.size -= at.bytes;
+  total_wired_ -= at.bytes;
+  at.set_id = kNoSet;
+}
+
+void ResidencySets::insert(MTL::Allocation* buf) {
+  if (!enabled_) {
     return;
   }
+  const size_t bytes = buf->allocatedSize();
+  std::lock_guard<std::mutex> lk(mtx_);
 
+  auto [it, inserted] = buf_to_set_.try_emplace(buf, Placement{kNoSet, bytes});
+  if (!inserted) {
+    return; // already tracked
+  }
+  // Stay within the wired limit. The excess is tracked but left out of any
+  // set, and is added to one by resize() if the limit is raised later.
+  if (total_wired_ + bytes > capacity_) {
+    return;
+  }
+  uint32_t idx = add_to_set_locked(buf, it->second);
+  sets_[idx].set->commit();
+}
+
+void ResidencySets::erase(MTL::Allocation* buf) {
+  if (!enabled_) {
+    return;
+  }
+  std::lock_guard<std::mutex> lk(mtx_);
+  auto it = buf_to_set_.find(buf);
+  if (it == buf_to_set_.end()) {
+    return; // a heap child, or never inserted
+  }
+  if (it->second.set_id != kNoSet) {
+    const uint32_t idx = it->second.set_id;
+    remove_from_set_locked(buf, it->second);
+    sets_[idx].set->commit();
+  }
+  buf_to_set_.erase(it);
+}
+
+void ResidencySets::resize(size_t size) {
+  if (!enabled_) {
+    return;
+  }
+  std::lock_guard<std::mutex> lk(mtx_);
   if (capacity_ == size) {
     return;
   }
   capacity_ = size;
 
-  size_t current_size = wired_set_->allocatedSize();
-
-  if (current_size < size) {
-    auto pool = new_scoped_memory_pool();
-    // Add unwired allocations to the set
-    for (auto it = unwired_set_.begin(); it != unwired_set_.end();) {
-      auto buf_size = (*it)->allocatedSize();
-      if (current_size + buf_size > size) {
-        it++;
-      } else {
-        current_size += buf_size;
-        wired_set_->addAllocation(*it);
-        unwired_set_.erase(it++);
+  auto pool = new_scoped_memory_pool();
+  std::vector<bool> touched(sets_.size(), false);
+  // The loops below only mutate map values, never insert or erase, so the
+  // iterators stay valid across the whole walk.
+  if (total_wired_ < capacity_) {
+    // The budget grew: add allocations that now fit.
+    for (auto& [buf, at] : buf_to_set_) {
+      if (at.set_id != kNoSet || total_wired_ + at.bytes > capacity_) {
+        continue;
       }
+      uint32_t idx = add_to_set_locked(buf, at);
+      if (idx >= touched.size()) {
+        touched.resize(sets_.size(), false); // a new set was made
+      }
+      touched[idx] = true;
     }
-    wired_set_->commit();
-  } else if (current_size > size) {
-    auto pool = new_scoped_memory_pool();
-    // Remove wired allocations until under capacity
-    auto allocations = wired_set_->allAllocations();
-    auto num_allocations = wired_set_->allocationCount();
-    for (int i = 0; i < num_allocations && current_size > size; ++i) {
-      auto buf = static_cast<const MTL::Allocation*>(allocations->object(i));
-      wired_set_->removeAllocation(buf);
-      current_size -= buf->allocatedSize();
-      unwired_set_.insert(buf);
+  } else {
+    // The budget shrank: remove allocations until we are back under it.
+    for (auto& [buf, at] : buf_to_set_) {
+      if (total_wired_ <= capacity_) {
+        break;
+      }
+      if (at.set_id == kNoSet) {
+        continue;
+      }
+      touched[at.set_id] = true;
+      remove_from_set_locked(buf, at);
     }
-    wired_set_->commit();
+  }
+  for (size_t i = 0; i < touched.size(); ++i) {
+    if (touched[i]) {
+      sets_[i].set->commit();
+    }
   }
 }
 
-ResidencySet::~ResidencySet() = default;
+void ResidencySets::attach_new_sets(MTL::CommandQueue* q, uint64_t& attached) {
+  // Lock-free when there is nothing new, which is the common case. It also
+  // covers the disabled case, where the count stays 0.
+  if (num_sets_.load(std::memory_order_acquire) == attached) {
+    return;
+  }
+  // Attach the new sets and record how far we got under a single lock hold,
+  // so a set created in between cannot be missed.
+  std::lock_guard<std::mutex> lk(mtx_);
+  std::vector<const MTL::ResidencySet*> sets;
+  sets.reserve(sets_.size() - attached);
+  for (uint64_t id = attached; id < sets_.size(); ++id) {
+    sets.push_back(sets_[id].set.get());
+  }
+  q->addResidencySets(sets.data(), sets.size());
+  attached = sets_.size();
+}
 
 } // namespace mlx::core::metal

--- a/mlx/backend/metal/resident.h
+++ b/mlx/backend/metal/resident.h
@@ -2,33 +2,122 @@
 
 #pragma once
 
-#include <unordered_set>
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
 
 #include <Metal/Metal.hpp>
 
 namespace mlx::core::metal {
 
-class ResidencySet {
+// Keeps allocations GPU-resident, up to the wired limit set by
+// `set_wired_limit` (0 by default, i.e. nothing is wired unless asked for).
+//
+// Within that budget the allocations are distributed over several size-capped
+// MTL::ResidencySets rather than one large one. macOS makes residency decisions
+// per residency set, so when a set loses residency under GPU memory pressure
+// only the allocations in that set have to be made resident again. Capping the
+// size of each set bounds the cost of one such event. Every set holds a
+// standing requestResidency() and is attached to every command queue.
+//
+// MLX_RESIDENCY_SET_MAX_PCT (env::residency_set_max_pct) sets the per-set cap.
+// The total wired budget is unaffected by it: that is still `set_wired_limit`.
+class ResidencySets {
  public:
-  ResidencySet(MTL::Device* d);
-  ~ResidencySet();
+  ResidencySets(MTL::Device* d);
+  ~ResidencySets();
 
-  ResidencySet(const ResidencySet&) = delete;
-  ResidencySet& operator=(const ResidencySet&) = delete;
+  ResidencySets(const ResidencySets&) = delete;
+  ResidencySets& operator=(const ResidencySets&) = delete;
 
-  const MTL::ResidencySet* mtl_residency_set() {
-    return wired_set_.get();
-  }
-
+  // Called with the allocator's mutex held.
   void insert(MTL::Allocation* buf);
   void erase(MTL::Allocation* buf);
 
   void resize(size_t size);
 
+  bool enabled() const {
+    return enabled_;
+  }
+
+  // Attaches the sets this queue has not seen yet. Called from the encoder
+  // thread before every command-buffer commit, because Metal locks a command
+  // buffer's residency at commit time.
+  void attach_new_sets(MTL::CommandQueue* q, uint64_t& attached);
+
+  // Total bytes currently wired across all sets.
+  size_t wired_size() const {
+    std::lock_guard<std::mutex> lk(mtx_);
+    return total_wired_;
+  }
+  size_t num_sets() const {
+    return num_sets_.load(std::memory_order_acquire);
+  }
+
+  // Testing only: sets the per-set cap for subsequent inserts, bypassing the
+  // size floor so tests can reach the multi-set paths cheaply. 0 selects the
+  // single-set layout.
+  void set_max_bytes_per_set(size_t bytes) {
+    std::lock_guard<std::mutex> lk(mtx_);
+    max_bytes_per_set_ = bytes;
+  }
+  size_t max_bytes_per_set() const {
+    std::lock_guard<std::mutex> lk(mtx_);
+    return max_bytes_per_set_;
+  }
+
  private:
-  NS::SharedPtr<MTL::ResidencySet> wired_set_;
-  std::unordered_set<const MTL::Allocation*> unwired_set_;
+  // A set id of kNoSet means the allocation is tracked but is not in any
+  // set, because it did not fit in the wired limit.
+  static constexpr uint32_t kNoSet = UINT32_MAX;
+  // A command queue accepts a limited number of residency sets and every set
+  // is attached to every queue, so the number of sets is capped. Once the cap
+  // is reached allocations go to the emptiest set, which then grows past
+  // max_bytes_per_set_. The limit is from the Metal feature set tables:
+  // https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf
+  static constexpr uint32_t kMaxSets = 32;
+
+  struct Set {
+    NS::SharedPtr<MTL::ResidencySet> set;
+    size_t size{0};
+  };
+
+  // The set an allocation lives in and the size it was inserted with. Sizes
+  // are recorded rather than read back from the allocation at erase, so the
+  // running totals cannot drift.
+  struct Placement {
+    uint32_t set_id;
+    size_t bytes;
+  };
+
+  // The following all require mtx_. add_set_locked reports whether the driver
+  // gave us a set; the new set is the last one. add_to_set_locked returns the
+  // set it used. Neither it nor remove_from_set_locked commits, so a bulk
+  // resize costs one commit per set instead of one per allocation.
+  bool add_set_locked(NS::Error** error = nullptr);
+  uint32_t choose_set_locked(size_t bytes);
+  uint32_t add_to_set_locked(const MTL::Allocation* buf, Placement& at);
+  void remove_from_set_locked(const MTL::Allocation* buf, Placement& at);
+
+  MTL::Device* device_{nullptr};
+  bool enabled_{false};
+
+  // Per-set cap in bytes (0 for a single set) and the total wired budget.
+  size_t max_bytes_per_set_{0};
   size_t capacity_{0};
+  size_t total_wired_{0};
+
+  // Sets indexed by id. Append-only, so ids stay valid and dense.
+  std::vector<Set> sets_;
+  // Every tracked allocation, wired or not.
+  std::unordered_map<const MTL::Allocation*, Placement> buf_to_set_;
+
+  // sets_.size(), published so a queue can check for new sets without
+  // taking the lock.
+  std::atomic<uint64_t> num_sets_{0};
+  mutable std::mutex mtx_;
 };
 
 } // namespace mlx::core::metal

--- a/mlx/utils.h
+++ b/mlx/utils.h
@@ -191,6 +191,21 @@ inline int max_mb_per_buffer(int default_value) {
   return max_mb_per_buffer_;
 }
 
+// Per-set residency-set size, as a percentage of the device's recommended
+// max working-set size. Controls only how wired memory is distributed across
+// residency sets, never how much is wired; see metal::ResidencySets. A value
+// <= 0 or >= 100 puts everything in a single set.
+inline int residency_set_max_pct() {
+  static int residency_set_max_pct_ = get_var("MLX_RESIDENCY_SET_MAX_PCT", 5);
+  return residency_set_max_pct_;
+}
+
+// Log each residency set as it is created.
+inline bool residency_debug() {
+  static bool residency_debug_ = get_var("MLX_RESIDENCY_DEBUG", 0);
+  return residency_debug_;
+}
+
 inline bool metal_fast_synch() {
   static bool metal_fast_synch = get_var("MLX_METAL_FAST_SYNCH", 0);
   return metal_fast_synch;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,10 @@ if(MLX_BUILD_METAL OR MLX_BUILD_CUDA)
   set(METAL_TEST_SOURCES gpu_tests.cpp)
 endif()
 
+if(MLX_BUILD_METAL)
+  list(APPEND METAL_TEST_SOURCES residency_tests.cpp)
+endif()
+
 include(${doctest_SOURCE_DIR}/scripts/cmake/doctest.cmake)
 
 target_sources(

--- a/tests/residency_tests.cpp
+++ b/tests/residency_tests.cpp
@@ -1,0 +1,296 @@
+// Copyright © 2026 Apple Inc.
+
+#include <vector>
+
+#include "doctest/doctest.h"
+
+#include "mlx/allocator.h"
+#include "mlx/backend/metal/device.h"
+#include "mlx/memory.h"
+#include "mlx/mlx.h"
+
+using namespace mlx::core;
+
+namespace {
+
+constexpr size_t MB = 1 << 20;
+
+metal::ResidencySets& residency() {
+  return metal::device(Device::gpu).residency_sets();
+}
+
+// Restores the wired limit, the cache limit and the set cap on scope exit so
+// a failing assertion can't leak global state into the rest of the suite. A
+// cache limit of 0 makes free() release (and unwire) immediately instead of
+// recycling, so residency accounting is observable synchronously.
+struct LimitGuard {
+  size_t wired;
+  size_t cache;
+  size_t max_per_set;
+  LimitGuard(size_t new_wired, size_t new_cache)
+      : cache(set_cache_limit(new_cache)),
+        max_per_set(residency().max_bytes_per_set()) {
+    clear_cache();
+    synchronize(); // retire command buffers still holding temporaries
+    wired = set_wired_limit(new_wired);
+  }
+  ~LimitGuard() {
+    residency().set_max_bytes_per_set(max_per_set);
+    set_cache_limit(cache);
+    set_wired_limit(wired);
+  }
+};
+
+// Sum of a small graph, used to drive a command-buffer commit (and with it the
+// residency attach path) while sets exist. Synchronizes so the command
+// buffer's temporaries are released before the caller checks accounting.
+void check_gpu_work() {
+  auto x = sum(ones({256, 256}, float32));
+  eval(x);
+  CHECK_EQ(x.item<float>(), 65536.0f);
+  synchronize();
+}
+
+} // namespace
+
+TEST_CASE("test residency set wires nothing when the wired limit is zero") {
+  if (!residency().enabled()) {
+    INFO("skipped: needs a Metal 3 GPU on macOS >= 15");
+    return;
+  }
+  LimitGuard guard(0, 0);
+
+  // The default wired limit is 0, and at 0 nothing may be wired -- not even
+  // the allocator's heap.
+  CHECK_EQ(residency().wired_size(), 0);
+
+  std::vector<allocator::Buffer> bufs;
+  for (int i = 0; i < 4; ++i) {
+    bufs.push_back(allocator::malloc(4 * MB));
+    CHECK_EQ(residency().wired_size(), 0);
+  }
+  for (auto buf : bufs) {
+    allocator::free(buf);
+  }
+  CHECK_EQ(residency().wired_size(), 0);
+}
+
+TEST_CASE("test residency set never wires more than the wired limit") {
+  if (!residency().enabled()) {
+    return;
+  }
+  LimitGuard guard(0, 0);
+  // Sample the baseline with a budget in place, so the allocator's heap is
+  // already wired and only our own allocations move the total.
+  set_wired_limit(256 * MB);
+  const size_t baseline = residency().wired_size();
+  const size_t limit = baseline + 8 * MB;
+  set_wired_limit(limit);
+
+  std::vector<allocator::Buffer> bufs;
+  for (int i = 0; i < 8; ++i) { // asks for 32 MB against an 8 MB budget
+    bufs.push_back(allocator::malloc(4 * MB));
+    CHECK_LE(residency().wired_size(), limit);
+  }
+  // Over budget overall, but the budget itself is still used.
+  CHECK_GE(residency().wired_size(), baseline + 4 * MB);
+
+  for (auto buf : bufs) {
+    allocator::free(buf);
+  }
+  // Everything of ours is unwired again, exactly.
+  CHECK_EQ(residency().wired_size(), baseline);
+}
+
+TEST_CASE("test raising the wired limit wires already-allocated buffers") {
+  if (!residency().enabled()) {
+    return;
+  }
+  LimitGuard guard(0, 0);
+
+  auto buf = allocator::malloc(8 * MB);
+  CHECK_EQ(residency().wired_size(), 0);
+
+  set_wired_limit(64 * MB);
+  CHECK_GE(residency().wired_size(), 8 * MB);
+
+  allocator::free(buf);
+}
+
+TEST_CASE("test lowering the wired limit unwires buffers") {
+  if (!residency().enabled()) {
+    return;
+  }
+  LimitGuard guard(64 * MB, 0);
+  const size_t baseline_with_budget = residency().wired_size();
+
+  auto buf = allocator::malloc(8 * MB);
+  CHECK_GE(residency().wired_size(), baseline_with_budget + 8 * MB);
+
+  set_wired_limit(0);
+  CHECK_EQ(residency().wired_size(), 0);
+
+  // ...and comes back when the budget is restored.
+  set_wired_limit(64 * MB);
+  CHECK_GE(residency().wired_size(), baseline_with_budget + 8 * MB);
+
+  allocator::free(buf);
+}
+
+TEST_CASE("test residency accounting is exact across free/realloc cycles") {
+  if (!residency().enabled()) {
+    return;
+  }
+  LimitGuard guard(64 * MB, 0);
+
+  // Baseline is whatever is wired with nothing of ours allocated (the heap).
+  const size_t baseline = residency().wired_size();
+
+  for (int i = 0; i < 32; ++i) {
+    auto buf = allocator::malloc(8 * MB);
+    CHECK_GE(residency().wired_size(), baseline + 8 * MB);
+    allocator::free(buf);
+    // Exact: erase subtracts the bytes recorded at insert, so repeated
+    // cycles must not drift the running total.
+    CHECK_EQ(residency().wired_size(), baseline);
+  }
+}
+
+TEST_CASE("test wired allocations are spread across size-capped sets") {
+  if (!residency().enabled()) {
+    return;
+  }
+  LimitGuard guard(0, 0);
+  const size_t max_per_set = 8 * MB;
+  residency().set_max_bytes_per_set(max_per_set);
+  set_wired_limit(128 * MB);
+  const size_t baseline = residency().wired_size();
+  const size_t baseline_sets = residency().num_sets();
+
+  // Each buffer is over half the cap, so no two share a set.
+  std::vector<allocator::Buffer> bufs;
+  for (int i = 0; i < 8; ++i) {
+    bufs.push_back(allocator::malloc(5 * MB));
+  }
+  CHECK_EQ(residency().wired_size(), baseline + 8 * 5 * MB);
+  CHECK_GT(residency().num_sets(), baseline_sets);
+  // No set may exceed the cap while there is room to make more.
+  CHECK_GE(residency().num_sets(), 8);
+
+  // Sets created after the queue exists must still be attached before the
+  // commit that could reference them.
+  check_gpu_work();
+
+  const size_t sets_before = residency().num_sets();
+  for (auto buf : bufs) {
+    allocator::free(buf);
+  }
+  CHECK_EQ(residency().wired_size(), baseline);
+
+  // Emptied sets are reused rather than leaked, so cycling the same
+  // allocations must not keep growing the set count.
+  for (int cycle = 0; cycle < 4; ++cycle) {
+    std::vector<allocator::Buffer> again;
+    for (int i = 0; i < 8; ++i) {
+      again.push_back(allocator::malloc(5 * MB));
+    }
+    CHECK_EQ(residency().num_sets(), sets_before);
+    for (auto buf : again) {
+      allocator::free(buf);
+    }
+  }
+  CHECK_EQ(residency().wired_size(), baseline);
+}
+
+TEST_CASE("test the set count stays within the command queue limit") {
+  if (!residency().enabled()) {
+    return;
+  }
+  LimitGuard guard(0, 0);
+  // A tiny cap against a large budget asks for far more sets than a command
+  // queue accepts; the count must saturate instead.
+  residency().set_max_bytes_per_set(2 * MB);
+  set_wired_limit(256 * MB);
+  const size_t baseline = residency().wired_size();
+
+  std::vector<allocator::Buffer> bufs;
+  for (int i = 0; i < 64; ++i) {
+    bufs.push_back(allocator::malloc(2 * MB));
+  }
+  CHECK_LE(residency().num_sets(), 32);
+  CHECK_EQ(residency().wired_size(), baseline + 64 * 2 * MB);
+
+  // Attaching a saturated set set to a queue must not fail.
+  check_gpu_work();
+
+  for (auto buf : bufs) {
+    allocator::free(buf);
+  }
+  CHECK_EQ(residency().wired_size(), baseline);
+}
+
+TEST_CASE("test an allocation larger than the set cap is still wired") {
+  if (!residency().enabled()) {
+    return;
+  }
+  LimitGuard guard(0, 0);
+  residency().set_max_bytes_per_set(4 * MB);
+  set_wired_limit(128 * MB);
+  const size_t baseline = residency().wired_size();
+
+  auto big = allocator::malloc(32 * MB);
+  CHECK_EQ(residency().wired_size(), baseline + 32 * MB);
+  check_gpu_work();
+
+  allocator::free(big);
+  CHECK_EQ(residency().wired_size(), baseline);
+}
+
+TEST_CASE("test a set cap of zero keeps everything in one set") {
+  if (!residency().enabled()) {
+    return;
+  }
+  LimitGuard guard(0, 0);
+  residency().set_max_bytes_per_set(0);
+  set_wired_limit(128 * MB);
+  const size_t baseline = residency().wired_size();
+  const size_t baseline_sets = residency().num_sets();
+
+  std::vector<allocator::Buffer> bufs;
+  for (int i = 0; i < 16; ++i) {
+    bufs.push_back(allocator::malloc(4 * MB));
+  }
+  CHECK_EQ(residency().num_sets(), baseline_sets);
+  CHECK_EQ(residency().wired_size(), baseline + 16 * 4 * MB);
+
+  for (auto buf : bufs) {
+    allocator::free(buf);
+  }
+  CHECK_EQ(residency().wired_size(), baseline);
+}
+
+TEST_CASE("test the wired limit is used up to its boundary") {
+  if (!residency().enabled()) {
+    return;
+  }
+  LimitGuard guard(0, 0);
+  // Sample the baseline with a budget in place, then leave room for exactly one
+  // more 4 MB allocation.
+  set_wired_limit(256 * MB);
+  const size_t baseline = residency().wired_size();
+  set_wired_limit(baseline + 4 * MB);
+
+  auto first = allocator::malloc(4 * MB);
+  CHECK_EQ(residency().wired_size(), baseline + 4 * MB);
+
+  // The budget is exactly full: the next allocation is tracked but not wired.
+  auto second = allocator::malloc(4 * MB);
+  CHECK_EQ(residency().wired_size(), baseline + 4 * MB);
+
+  // Freeing the wired one does not promote the pending one.
+  allocator::free(first);
+  CHECK_EQ(residency().wired_size(), baseline);
+
+  allocator::free(second);
+  CHECK_EQ(residency().wired_size(), baseline);
+}


### PR DESCRIPTION
Fix for performance issues observed when running large LLM models on MacOS 27. Issue was tracked to non-related GPU operations (desktop update etc) causing the entire model to be continuously re-wired to GPU memory.

MacOS 27 appears to make GPU residency decisions per `MTL::ResidencySet`, so with everything wired in one large set, losing residency once means the whole working set has to be made resident again — decode can't continue until it is. This spreads the wired allocations across several size-capped sets, so one such event costs one set instead of everything.

`set_wired_limit` is unchanged: still the total wired budget, still `0` by default. Only the distribution across sets changes, never how many bytes are wired. No public API or documented behaviour change.

`MLX_RESIDENCY_SET_MAX_PCT` caps each set as a percentage of `recommendedMaxWorkingSetSize` (default `5`); `<= 0` or `>= 100` gives a single set, the previous layout. The set count is capped at 32, the per-command-queue limit from the Metal feature set tables.

`tests/residency_tests.cpp` adds 10 cases for the wired-limit contract and the set behaviour; the suite passes with `MLX_RESIDENCY_SET_MAX_PCT` at 5, 1, 2, 0 and 200.

Decode Performance Before -> After as measured on M3 Ultra (512Gb)
0.46 -> 13.19 tokens/sec - (mlx-community/GLM-5.1-MXFP4-Q8)
0.39 -> 21.96 tokens/sec - (mlx-community/Kimi-K2.6-mlx-DQ3_K_M-q8) 
0.71 -> 24.48 tokens/sec - (mlx-community/MiniMax-M2.7)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)