### PR TITLE
Bound GGUF metadata string/array values against the file mapping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
         required: false
         type: boolean
   schedule:
-    - cron: 33 6 * * 1-5
+    - cron: 33 6 * * *
 
 # In jobs we must use |*publish| instead of |inputs.publish| because we can not
 # set default value for workflow_dispatch inputs reliably.

--- a/.github/workflows/update_bypass_list.yml
+++ b/.github/workflows/update_bypass_list.yml
@@ -5,8 +5,9 @@ on:
   workflow_dispatch:
   pull_request_target:
     types:
-      - opened
       - closed
+  schedule:
+    - cron: 33 6 * * *
 
 permissions:
   contents: write

--- a/mlx/io/gguf.cpp
+++ b/mlx/io/gguf.cpp
@@ -88,12 +88,34 @@ std::tuple<allocator::Buffer, Dtype> extract_tensor_data(gguf_tensor* tensor) {
   return {buffer, float16};
 }
 
-// Mirror check_tensor_in_file(): gguf_get_key() leaves key.val / ctx->off
-// pointing at the value but performs no bounds checking, and the value lengths
-// are read straight from the file. Bound the whole value (and, for arrays,
-// every element) against the mmap'd file once per key in load_metadata(),
-// before set_mx_value_from_gguf consumes it. Lengths that would not fit in the
-// int the downstream array() / std::string constructors take are rejected here.
+// gguf_get_key() leaves key.val / ctx->off pointing at the value but performs
+// no bounds checking, and the value lengths are read straight from the file.
+// Bound the whole value (and, for arrays, every element) against the mmap'd
+// file once per key in load_metadata(), before set_mx_value_from_gguf
+// consumes it. Array lengths are also capped at int max because the
+// downstream array() shape is int-valued.
+size_t gguf_value_type_size(uint32_t type) {
+  switch (type) {
+    case GGUF_VALUE_TYPE_BOOL:
+    case GGUF_VALUE_TYPE_UINT8:
+    case GGUF_VALUE_TYPE_INT8:
+      return 1;
+    case GGUF_VALUE_TYPE_UINT16:
+    case GGUF_VALUE_TYPE_INT16:
+      return 2;
+    case GGUF_VALUE_TYPE_UINT32:
+    case GGUF_VALUE_TYPE_INT32:
+    case GGUF_VALUE_TYPE_FLOAT32:
+      return 4;
+    case GGUF_VALUE_TYPE_UINT64:
+    case GGUF_VALUE_TYPE_INT64:
+    case GGUF_VALUE_TYPE_FLOAT64:
+      return 8;
+    default:
+      return 0;
+  }
+}
+
 void check_metadata_value_in_file(
     const gguf_ctx* ctx,
     uint32_t type,
@@ -105,48 +127,34 @@ void check_metadata_value_in_file(
     return (p < ctx->data || p > end) ? 0 : static_cast<size_t>(end - p);
   };
   auto base = reinterpret_cast<const uint8_t*>(val);
+  auto fail = [](const char* what) {
+    throw std::runtime_error(std::string("[load_gguf] ") + what +
+                             " Perhaps an incomplete download or corrupt file?");
+  };
 
-  size_t fixed = 0;
-  switch (type) {
-    case GGUF_VALUE_TYPE_BOOL:
-    case GGUF_VALUE_TYPE_UINT8:
-    case GGUF_VALUE_TYPE_INT8:
-      fixed = 1;
-      break;
-    case GGUF_VALUE_TYPE_UINT16:
-    case GGUF_VALUE_TYPE_INT16:
-      fixed = 2;
-      break;
-    case GGUF_VALUE_TYPE_UINT32:
-    case GGUF_VALUE_TYPE_INT32:
-    case GGUF_VALUE_TYPE_FLOAT32:
-      fixed = 4;
-      break;
-    case GGUF_VALUE_TYPE_UINT64:
-    case GGUF_VALUE_TYPE_INT64:
-    case GGUF_VALUE_TYPE_FLOAT64:
-      fixed = 8;
-      break;
-    default:
-      break;
-  }
+  size_t fixed = gguf_value_type_size(type);
   if (fixed) {
     if (fixed > avail(base)) {
-      throw std::runtime_error(
-          "[load_gguf] Metadata value extends past the end of the file. "
-          "Perhaps an incomplete download or corrupt file?");
+      fail("Metadata value extends past the end of the file.");
     }
     return;
   }
 
-  // gguf_string = { uint64_t len; char string[] }.
-  if (type == GGUF_VALUE_TYPE_STRING) {
-    if (sizeof(uint64_t) > avail(base) ||
-        val->string.len > static_cast<uint64_t>(std::numeric_limits<int>::max()) ||
-        sizeof(uint64_t) + val->string.len > avail(base)) {
-      throw std::runtime_error(
-          "[load_gguf] String metadata value extends past the end of the file.");
+  // gguf_string = { uint64_t len; char string[] }. Validate and return a
+  // pointer past the string.
+  auto check_string = [&](const uint8_t* p) -> const uint8_t* {
+    uint64_t len = reinterpret_cast<const gguf_string*>(p)->len;
+    if (sizeof(uint64_t) + len > avail(p)) {
+      fail("String metadata value extends past the end of the file.");
     }
+    return p + sizeof(uint64_t) + len;
+  };
+
+  if (type == GGUF_VALUE_TYPE_STRING) {
+    if (sizeof(uint64_t) > avail(base)) {
+      fail("String metadata value extends past the end of the file.");
+    }
+    check_string(base);
     return;
   }
 
@@ -154,44 +162,16 @@ void check_metadata_value_in_file(
   // followed by the elements.
   if (type == GGUF_VALUE_TYPE_ARRAY) {
     if (gguf_array_header_size > avail(base)) {
-      throw std::runtime_error(
-          "[load_gguf] Metadata value extends past the end of the file. "
-          "Perhaps an incomplete download or corrupt file?");
+      fail("Metadata value extends past the end of the file.");
     }
     if (val->array.len > static_cast<uint64_t>(std::numeric_limits<int>::max())) {
-      throw std::runtime_error(
-          "[load_gguf] Array metadata value length is too large.");
-    }
-
-    size_t elt_size = 0;
-    switch (val->array.type) {
-      case GGUF_VALUE_TYPE_BOOL:
-      case GGUF_VALUE_TYPE_UINT8:
-      case GGUF_VALUE_TYPE_INT8:
-        elt_size = 1;
-        break;
-      case GGUF_VALUE_TYPE_UINT16:
-      case GGUF_VALUE_TYPE_INT16:
-        elt_size = 2;
-        break;
-      case GGUF_VALUE_TYPE_UINT32:
-      case GGUF_VALUE_TYPE_INT32:
-      case GGUF_VALUE_TYPE_FLOAT32:
-        elt_size = 4;
-        break;
-      case GGUF_VALUE_TYPE_UINT64:
-      case GGUF_VALUE_TYPE_INT64:
-      case GGUF_VALUE_TYPE_FLOAT64:
-        elt_size = 8;
-        break;
-      default:
-        break;
+      fail("Array metadata value length is too large.");
     }
     const uint8_t* elt = base + gguf_array_header_size;
+    size_t elt_size = gguf_value_type_size(val->array.type);
     if (elt_size) {
       if (val->array.len > avail(elt) / elt_size) {
-        throw std::runtime_error(
-            "[load_gguf] Array metadata value extends past the end of the file.");
+        fail("Array metadata value extends past the end of the file.");
       }
       return;
     }
@@ -200,18 +180,10 @@ void check_metadata_value_in_file(
       const uint8_t* p = elt;
       for (uint64_t i = 0; i < val->array.len; i++) {
         if (sizeof(uint64_t) > avail(p)) {
-          throw std::runtime_error(
-              "[load_gguf] Array metadata value extends past the end of the file.");
+          fail("Array metadata value extends past the end of the file.");
         }
-        uint64_t slen = reinterpret_cast<const gguf_string*>(p)->len;
-        if (slen > static_cast<uint64_t>(std::numeric_limits<int>::max()) ||
-            sizeof(uint64_t) + slen > avail(p)) {
-          throw std::runtime_error(
-              "[load_gguf] Array metadata value extends past the end of the file.");
-        }
-        p += sizeof(uint64_t) + slen;
+        p = check_string(p);
       }
-      return;
     }
     // Unsupported element type (e.g. nested array): header is bounded; the
     // consumer rejects the format without reading the payload.
@@ -258,8 +230,7 @@ void set_mx_value_from_gguf(
       value = array(val->boolval, bool_);
       break;
     case GGUF_VALUE_TYPE_STRING:
-      value =
-          std::string(val->string.string, static_cast<int>(val->string.len));
+      value = std::string(val->string.string, val->string.len);
       break;
     case GGUF_VALUE_TYPE_FLOAT64:
       value = array(val->float64, float32);
@@ -308,7 +279,7 @@ void set_mx_value_from_gguf(
           for (auto& str : strs) {
             auto str_val = reinterpret_cast<gguf_string*>(data);
             data += (str_val->len + sizeof(gguf_string));
-            str = std::string(str_val->string, static_cast<int>(str_val->len));
+            str = std::string(str_val->string, str_val->len);
             ctx->off += (str_val->len + sizeof(gguf_string));
           }
           value = std::move(strs);

--- a/mlx/io/gguf.cpp
+++ b/mlx/io/gguf.cpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <cstring>
 #include <fstream>
+#include <limits>
 #include <numeric>
 
 #include "mlx/io/gguf.h"
@@ -87,6 +88,29 @@ std::tuple<allocator::Buffer, Dtype> extract_tensor_data(gguf_tensor* tensor) {
   return {buffer, float16};
 }
 
+// gguf_get_key() returns a pointer (val) into the mmap'd file but performs no
+// bounds checking, and the metadata value lengths are read straight from the
+// file. Without this guard a crafted STRING/ARRAY metadata value can claim a
+// length far larger than the file and force std::string / array construction to
+// read past the mapping (out-of-bounds read). The tensor path is bounded by
+// check_tensor_in_file(); the metadata path needs the same invariant.
+//
+// `value_bytes` is the number of bytes the value occupies in the mapping
+// (header + payload, computed per branch below). We ensure the whole region
+// lies within [0, ctx->size).
+void check_metadata_value_in_file(
+    const gguf_ctx* ctx,
+    const gguf_value* val,
+    size_t value_bytes) {
+  auto base = reinterpret_cast<const uint8_t*>(val);
+  auto end = ctx->data + ctx->size;
+  if (base < ctx->data || base > end || value_bytes > static_cast<size_t>(end - base)) {
+    throw std::runtime_error(
+        "[load_gguf] Metadata value extends past the end of the file. "
+        "Perhaps an incomplete download or corrupt file?");
+  }
+}
+
 void set_mx_value_from_gguf(
     gguf_ctx* ctx,
     uint32_t type,
@@ -123,21 +147,76 @@ void set_mx_value_from_gguf(
     case GGUF_VALUE_TYPE_BOOL:
       value = array(val->boolval, bool_);
       break;
-    case GGUF_VALUE_TYPE_STRING:
-      value =
-          std::string(val->string.string, static_cast<int>(val->string.len));
+    case GGUF_VALUE_TYPE_STRING: {
+      // Guard against an attacker-controlled length that exceeds the mapping.
+      // gguf_string is { uint64_t len; char string[] }; the static_cast<int>
+      // below also narrows, so reject lengths that do not fit in an int.
+      uint64_t len = val->string.len;
+      if (len > static_cast<uint64_t>(std::numeric_limits<int>::max()) ||
+          len > static_cast<uint64_t>(ctx->size)) {
+        throw std::runtime_error(
+            "[load_gguf] String metadata value length exceeds file size.");
+      }
+      check_metadata_value_in_file(
+          ctx, val, sizeof(gguf_string) + static_cast<size_t>(len));
+      value = std::string(val->string.string, static_cast<int>(len));
       break;
+    }
     case GGUF_VALUE_TYPE_FLOAT64:
       value = array(val->float64, float32);
       break;
     case GGUF_VALUE_TYPE_ARRAY: {
       ctx->off += gguf_array_header_size; // Skip header
       char* data = reinterpret_cast<char*>(val) + gguf_array_header_size;
-      auto size = static_cast<int>(val->array.len);
+      // The array length and element type are attacker-controlled. Bound the
+      // element count and the payload region against the file mapping before
+      // any array/string construction reads from `data`.
+      uint64_t arr_len = val->array.len;
       if (val->array.type == GGUF_VALUE_TYPE_ARRAY) {
         throw std::invalid_argument(
             "[load_gguf] Only supports loading 1-layer of nested arrays.");
       }
+      // Element byte size for the declared element type (0 = string/unknown,
+      // handled per-branch below). Avoids narrowing uint64 length to int
+      // before checking it fits the mapping.
+      size_t elt_size = 0;
+      switch (val->array.type) {
+        case GGUF_VALUE_TYPE_UINT8:
+        case GGUF_VALUE_TYPE_INT8:
+        case GGUF_VALUE_TYPE_BOOL:
+          elt_size = 1;
+          break;
+        case GGUF_VALUE_TYPE_UINT16:
+        case GGUF_VALUE_TYPE_INT16:
+          elt_size = 2;
+          break;
+        case GGUF_VALUE_TYPE_UINT32:
+        case GGUF_VALUE_TYPE_INT32:
+        case GGUF_VALUE_TYPE_FLOAT32:
+          elt_size = 4;
+          break;
+        case GGUF_VALUE_TYPE_UINT64:
+        case GGUF_VALUE_TYPE_INT64:
+        case GGUF_VALUE_TYPE_FLOAT64:
+          elt_size = 8;
+          break;
+        default: // GGUF_VALUE_TYPE_STRING and anything else: handled below
+          break;
+      }
+      if (elt_size > 0) {
+        // Overflow-safe payload size check: arr_len * elt_size <= remaining.
+        uint64_t remaining = static_cast<uint64_t>(ctx->size) -
+            static_cast<uint64_t>(reinterpret_cast<const uint8_t*>(data) - ctx->data);
+        if (arr_len > remaining / elt_size) {
+          throw std::runtime_error(
+              "[load_gguf] Array metadata value extends past the end of the file.");
+        }
+        if (arr_len > static_cast<uint64_t>(std::numeric_limits<int>::max())) {
+          throw std::runtime_error(
+              "[load_gguf] Array metadata value length is too large.");
+        }
+      }
+      auto size = static_cast<int>(arr_len);
       switch (val->array.type) {
         case GGUF_VALUE_TYPE_UINT8:
           value = array(reinterpret_cast<uint8_t*>(data), {size}, uint8);
@@ -172,7 +251,18 @@ void set_mx_value_from_gguf(
         case GGUF_VALUE_TYPE_STRING: {
           std::vector<std::string> strs(size);
           for (auto& str : strs) {
+            // Each element's length is attacker-controlled; bound it against
+            // the mapping before reading.
+            check_metadata_value_in_file(ctx, reinterpret_cast<gguf_value*>(data), 0);
             auto str_val = reinterpret_cast<gguf_string*>(data);
+            uint64_t slen = str_val->len;
+            if (slen > static_cast<uint64_t>(std::numeric_limits<int>::max())) {
+              throw std::runtime_error(
+                  "[load_gguf] String array element length is too large.");
+            }
+            check_metadata_value_in_file(
+                ctx, reinterpret_cast<gguf_value*>(data),
+                sizeof(gguf_string) + static_cast<size_t>(slen));
             data += (str_val->len + sizeof(gguf_string));
             str = std::string(str_val->string, static_cast<int>(str_val->len));
             ctx->off += (str_val->len + sizeof(gguf_string));

--- a/mlx/io/gguf.cpp
+++ b/mlx/io/gguf.cpp
@@ -3,7 +3,6 @@
 #include <cstdint>
 #include <cstring>
 #include <fstream>
-#include <limits>
 #include <numeric>
 
 #include "mlx/io/gguf.h"
@@ -86,111 +85,6 @@ std::tuple<allocator::Buffer, Dtype> extract_tensor_data(gguf_tensor* tensor) {
   memcpy(buffer.raw_ptr(), data, new_size);
   free(data);
   return {buffer, float16};
-}
-
-// gguf_get_key() leaves key.val / ctx->off pointing at the value but performs
-// no bounds checking, and the value lengths are read straight from the file.
-// Bound the whole value (and, for arrays, every element) against the mmap'd
-// file once per key in load_metadata(), before set_mx_value_from_gguf
-// consumes it. Array lengths are also capped at int max because the
-// downstream array() shape is int-valued.
-size_t gguf_value_type_size(uint32_t type) {
-  switch (type) {
-    case GGUF_VALUE_TYPE_BOOL:
-    case GGUF_VALUE_TYPE_UINT8:
-    case GGUF_VALUE_TYPE_INT8:
-      return 1;
-    case GGUF_VALUE_TYPE_UINT16:
-    case GGUF_VALUE_TYPE_INT16:
-      return 2;
-    case GGUF_VALUE_TYPE_UINT32:
-    case GGUF_VALUE_TYPE_INT32:
-    case GGUF_VALUE_TYPE_FLOAT32:
-      return 4;
-    case GGUF_VALUE_TYPE_UINT64:
-    case GGUF_VALUE_TYPE_INT64:
-    case GGUF_VALUE_TYPE_FLOAT64:
-      return 8;
-    default:
-      return 0;
-  }
-}
-
-void check_metadata_value_in_file(
-    const gguf_ctx* ctx,
-    uint32_t type,
-    const gguf_value* val) {
-  auto end = ctx->data + ctx->size;
-  // Bytes available from a pointer up to the end of the mapping; 0 if the
-  // pointer lies outside [ctx->data, end].
-  auto avail = [&](const uint8_t* p) -> size_t {
-    return (p < ctx->data || p > end) ? 0 : static_cast<size_t>(end - p);
-  };
-  auto base = reinterpret_cast<const uint8_t*>(val);
-  auto fail = [](const char* what) {
-    throw std::runtime_error(std::string("[load_gguf] ") + what +
-                             " Perhaps an incomplete download or corrupt file?");
-  };
-
-  size_t fixed = gguf_value_type_size(type);
-  if (fixed) {
-    if (fixed > avail(base)) {
-      fail("Metadata value extends past the end of the file.");
-    }
-    return;
-  }
-
-  // gguf_string = { uint64_t len; char string[] }. Validate and return a
-  // pointer past the string.
-  auto check_string = [&](const uint8_t* p) -> const uint8_t* {
-    uint64_t len = reinterpret_cast<const gguf_string*>(p)->len;
-    if (sizeof(uint64_t) + len > avail(p)) {
-      fail("String metadata value extends past the end of the file.");
-    }
-    return p + sizeof(uint64_t) + len;
-  };
-
-  if (type == GGUF_VALUE_TYPE_STRING) {
-    if (sizeof(uint64_t) > avail(base)) {
-      fail("String metadata value extends past the end of the file.");
-    }
-    check_string(base);
-    return;
-  }
-
-  // Array header = { uint32_t type; uint64_t len; } (gguf_array_header_size),
-  // followed by the elements.
-  if (type == GGUF_VALUE_TYPE_ARRAY) {
-    if (gguf_array_header_size > avail(base)) {
-      fail("Metadata value extends past the end of the file.");
-    }
-    if (val->array.len > static_cast<uint64_t>(std::numeric_limits<int>::max())) {
-      fail("Array metadata value length is too large.");
-    }
-    const uint8_t* elt = base + gguf_array_header_size;
-    size_t elt_size = gguf_value_type_size(val->array.type);
-    if (elt_size) {
-      if (val->array.len > avail(elt) / elt_size) {
-        fail("Array metadata value extends past the end of the file.");
-      }
-      return;
-    }
-    // String array: each element is a length-prefixed string, so walk them.
-    if (val->array.type == GGUF_VALUE_TYPE_STRING) {
-      const uint8_t* p = elt;
-      for (uint64_t i = 0; i < val->array.len; i++) {
-        if (sizeof(uint64_t) > avail(p)) {
-          fail("Array metadata value extends past the end of the file.");
-        }
-        p = check_string(p);
-      }
-    }
-    // Unsupported element type (e.g. nested array): header is bounded; the
-    // consumer rejects the format without reading the payload.
-    return;
-  }
-
-  throw std::runtime_error("[load_gguf] Received unexpected type.");
 }
 
 void set_mx_value_from_gguf(
@@ -305,22 +199,109 @@ void set_mx_value_from_gguf(
   }
 }
 
+inline size_t gguf_value_type_size(uint32_t type) {
+  switch (type) {
+    case GGUF_VALUE_TYPE_BOOL:
+    case GGUF_VALUE_TYPE_UINT8:
+    case GGUF_VALUE_TYPE_INT8:
+      return 1;
+    case GGUF_VALUE_TYPE_UINT16:
+    case GGUF_VALUE_TYPE_INT16:
+      return 2;
+    case GGUF_VALUE_TYPE_UINT32:
+    case GGUF_VALUE_TYPE_INT32:
+    case GGUF_VALUE_TYPE_FLOAT32:
+      return 4;
+    case GGUF_VALUE_TYPE_UINT64:
+    case GGUF_VALUE_TYPE_INT64:
+    case GGUF_VALUE_TYPE_FLOAT64:
+      return 8;
+    default:
+      return 0;
+  }
+}
+
+void check_metadata_value_in_file(
+    const gguf_ctx* ctx,
+    uint32_t type,
+    const gguf_value* val) {
+  auto end = ctx->data + ctx->size;
+  // Bytes available from a pointer up to the end of the mapping; 0 if the
+  // pointer lies outside [ctx->data, end].
+  auto avail = [&](const uint8_t* p) -> size_t {
+    return (p < ctx->data || p > end) ? 0 : static_cast<size_t>(end - p);
+  };
+  auto base = reinterpret_cast<const uint8_t*>(val);
+  auto fail = [](const char* what) {
+    std::ostringstream msg;
+    msg << "[load_gguf] " << what
+        << " Perhaps an incomplete download or corrupt file?";
+    throw std::runtime_error(msg.str());
+  };
+
+  size_t fixed = gguf_value_type_size(type);
+  if (fixed) {
+    if (fixed > avail(base)) {
+      fail("Metadata value extends past the end of the file.");
+    }
+    return;
+  }
+
+  auto check_string = [&](const uint8_t* p) -> const uint8_t* {
+    uint64_t len = reinterpret_cast<const gguf_string*>(p)->len;
+    if (sizeof(uint64_t) + len > avail(p)) {
+      fail("String metadata value extends past the end of the file.");
+    }
+    return p + sizeof(uint64_t) + len;
+  };
+
+  if (type == GGUF_VALUE_TYPE_STRING) {
+    if (sizeof(uint64_t) > avail(base)) {
+      fail("String metadata value extends past the end of the file.");
+    }
+    check_string(base);
+    return;
+  }
+
+  if (type == GGUF_VALUE_TYPE_ARRAY) {
+    if (gguf_array_header_size > avail(base)) {
+      fail("Metadata value extends past the end of the file.");
+    }
+    const uint8_t* elt = base + gguf_array_header_size;
+    size_t elt_size = gguf_value_type_size(val->array.type);
+    if (elt_size) {
+      if (val->array.len > avail(elt) / elt_size) {
+        fail("Array metadata value extends past the end of the file.");
+      }
+      return;
+    }
+    if (val->array.type == GGUF_VALUE_TYPE_STRING) {
+      const uint8_t* p = elt;
+      for (uint64_t i = 0; i < val->array.len; i++) {
+        if (sizeof(uint64_t) > avail(p)) {
+          fail("Array metadata value extends past the end of the file.");
+        }
+        p = check_string(p);
+      }
+    }
+    return;
+  }
+
+  throw std::runtime_error("[load_gguf] Received unexpected type.");
+}
+
 std::unordered_map<std::string, GGUFMetaData> load_metadata(gguf_ctx* ctx) {
   std::unordered_map<std::string, GGUFMetaData> metadata;
   gguf_key key;
   while (gguf_get_key(ctx, &key)) {
+    check_metadata_value_in_file(ctx, key.type, key.val);
     std::string key_name = std::string(key.name, key.namelen);
     auto& val = metadata.insert({key_name, GGUFMetaData{}}).first->second;
-    check_metadata_value_in_file(ctx, key.type, key.val);
     set_mx_value_from_gguf(ctx, key.type, key.val, val);
   }
   return metadata;
 }
 
-// gguflib computes weights_data as ctx->data + ctx->data_off + the tensor's
-// offset field in unsigned arithmetic, without comparing the result against the
-// mapping, so a crafted offset can point outside the file or -- if the addition
-// wraps -- back inside it at the wrong bytes.
 void check_tensor_in_file(const gguf_ctx* ctx, const gguf_tensor& tensor) {
   auto fail = [&tensor](const std::string& what) {
     std::ostringstream msg;

--- a/mlx/io/gguf.cpp
+++ b/mlx/io/gguf.cpp
@@ -88,27 +88,137 @@ std::tuple<allocator::Buffer, Dtype> extract_tensor_data(gguf_tensor* tensor) {
   return {buffer, float16};
 }
 
-// gguf_get_key() returns a pointer (val) into the mmap'd file but performs no
-// bounds checking, and the metadata value lengths are read straight from the
-// file. Without this guard a crafted STRING/ARRAY metadata value can claim a
-// length far larger than the file and force std::string / array construction to
-// read past the mapping (out-of-bounds read). The tensor path is bounded by
-// check_tensor_in_file(); the metadata path needs the same invariant.
-//
-// `value_bytes` is the number of bytes the value occupies in the mapping
-// (header + payload, computed per branch below). We ensure the whole region
-// lies within [0, ctx->size).
+// Mirror check_tensor_in_file(): gguf_get_key() leaves key.val / ctx->off
+// pointing at the value but performs no bounds checking, and the value lengths
+// are read straight from the file. Bound the whole value (and, for arrays,
+// every element) against the mmap'd file once per key in load_metadata(),
+// before set_mx_value_from_gguf consumes it. Lengths that would not fit in the
+// int the downstream array() / std::string constructors take are rejected here.
 void check_metadata_value_in_file(
     const gguf_ctx* ctx,
-    const gguf_value* val,
-    size_t value_bytes) {
-  auto base = reinterpret_cast<const uint8_t*>(val);
+    uint32_t type,
+    const gguf_value* val) {
   auto end = ctx->data + ctx->size;
-  if (base < ctx->data || base > end || value_bytes > static_cast<size_t>(end - base)) {
-    throw std::runtime_error(
-        "[load_gguf] Metadata value extends past the end of the file. "
-        "Perhaps an incomplete download or corrupt file?");
+  // Bytes available from a pointer up to the end of the mapping; 0 if the
+  // pointer lies outside [ctx->data, end].
+  auto avail = [&](const uint8_t* p) -> size_t {
+    return (p < ctx->data || p > end) ? 0 : static_cast<size_t>(end - p);
+  };
+  auto base = reinterpret_cast<const uint8_t*>(val);
+
+  size_t fixed = 0;
+  switch (type) {
+    case GGUF_VALUE_TYPE_BOOL:
+    case GGUF_VALUE_TYPE_UINT8:
+    case GGUF_VALUE_TYPE_INT8:
+      fixed = 1;
+      break;
+    case GGUF_VALUE_TYPE_UINT16:
+    case GGUF_VALUE_TYPE_INT16:
+      fixed = 2;
+      break;
+    case GGUF_VALUE_TYPE_UINT32:
+    case GGUF_VALUE_TYPE_INT32:
+    case GGUF_VALUE_TYPE_FLOAT32:
+      fixed = 4;
+      break;
+    case GGUF_VALUE_TYPE_UINT64:
+    case GGUF_VALUE_TYPE_INT64:
+    case GGUF_VALUE_TYPE_FLOAT64:
+      fixed = 8;
+      break;
+    default:
+      break;
   }
+  if (fixed) {
+    if (fixed > avail(base)) {
+      throw std::runtime_error(
+          "[load_gguf] Metadata value extends past the end of the file. "
+          "Perhaps an incomplete download or corrupt file?");
+    }
+    return;
+  }
+
+  // gguf_string = { uint64_t len; char string[] }.
+  if (type == GGUF_VALUE_TYPE_STRING) {
+    if (sizeof(uint64_t) > avail(base) ||
+        val->string.len > static_cast<uint64_t>(std::numeric_limits<int>::max()) ||
+        sizeof(uint64_t) + val->string.len > avail(base)) {
+      throw std::runtime_error(
+          "[load_gguf] String metadata value extends past the end of the file.");
+    }
+    return;
+  }
+
+  // Array header = { uint32_t type; uint64_t len; } (gguf_array_header_size),
+  // followed by the elements.
+  if (type == GGUF_VALUE_TYPE_ARRAY) {
+    if (gguf_array_header_size > avail(base)) {
+      throw std::runtime_error(
+          "[load_gguf] Metadata value extends past the end of the file. "
+          "Perhaps an incomplete download or corrupt file?");
+    }
+    if (val->array.len > static_cast<uint64_t>(std::numeric_limits<int>::max())) {
+      throw std::runtime_error(
+          "[load_gguf] Array metadata value length is too large.");
+    }
+
+    size_t elt_size = 0;
+    switch (val->array.type) {
+      case GGUF_VALUE_TYPE_BOOL:
+      case GGUF_VALUE_TYPE_UINT8:
+      case GGUF_VALUE_TYPE_INT8:
+        elt_size = 1;
+        break;
+      case GGUF_VALUE_TYPE_UINT16:
+      case GGUF_VALUE_TYPE_INT16:
+        elt_size = 2;
+        break;
+      case GGUF_VALUE_TYPE_UINT32:
+      case GGUF_VALUE_TYPE_INT32:
+      case GGUF_VALUE_TYPE_FLOAT32:
+        elt_size = 4;
+        break;
+      case GGUF_VALUE_TYPE_UINT64:
+      case GGUF_VALUE_TYPE_INT64:
+      case GGUF_VALUE_TYPE_FLOAT64:
+        elt_size = 8;
+        break;
+      default:
+        break;
+    }
+    const uint8_t* elt = base + gguf_array_header_size;
+    if (elt_size) {
+      if (val->array.len > avail(elt) / elt_size) {
+        throw std::runtime_error(
+            "[load_gguf] Array metadata value extends past the end of the file.");
+      }
+      return;
+    }
+    // String array: each element is a length-prefixed string, so walk them.
+    if (val->array.type == GGUF_VALUE_TYPE_STRING) {
+      const uint8_t* p = elt;
+      for (uint64_t i = 0; i < val->array.len; i++) {
+        if (sizeof(uint64_t) > avail(p)) {
+          throw std::runtime_error(
+              "[load_gguf] Array metadata value extends past the end of the file.");
+        }
+        uint64_t slen = reinterpret_cast<const gguf_string*>(p)->len;
+        if (slen > static_cast<uint64_t>(std::numeric_limits<int>::max()) ||
+            sizeof(uint64_t) + slen > avail(p)) {
+          throw std::runtime_error(
+              "[load_gguf] Array metadata value extends past the end of the file.");
+        }
+        p += sizeof(uint64_t) + slen;
+      }
+      return;
+    }
+    // Unsupported element type (e.g. nested array): header is bounded; the
+    // consumer rejects the format without reading the payload.
+    return;
+  }
+
+  throw std::runtime_error("[load_gguf] Received unexpected type.");
 }
 
 void set_mx_value_from_gguf(
@@ -147,76 +257,21 @@ void set_mx_value_from_gguf(
     case GGUF_VALUE_TYPE_BOOL:
       value = array(val->boolval, bool_);
       break;
-    case GGUF_VALUE_TYPE_STRING: {
-      // Guard against an attacker-controlled length that exceeds the mapping.
-      // gguf_string is { uint64_t len; char string[] }; the static_cast<int>
-      // below also narrows, so reject lengths that do not fit in an int.
-      uint64_t len = val->string.len;
-      if (len > static_cast<uint64_t>(std::numeric_limits<int>::max()) ||
-          len > static_cast<uint64_t>(ctx->size)) {
-        throw std::runtime_error(
-            "[load_gguf] String metadata value length exceeds file size.");
-      }
-      check_metadata_value_in_file(
-          ctx, val, sizeof(gguf_string) + static_cast<size_t>(len));
-      value = std::string(val->string.string, static_cast<int>(len));
+    case GGUF_VALUE_TYPE_STRING:
+      value =
+          std::string(val->string.string, static_cast<int>(val->string.len));
       break;
-    }
     case GGUF_VALUE_TYPE_FLOAT64:
       value = array(val->float64, float32);
       break;
     case GGUF_VALUE_TYPE_ARRAY: {
       ctx->off += gguf_array_header_size; // Skip header
       char* data = reinterpret_cast<char*>(val) + gguf_array_header_size;
-      // The array length and element type are attacker-controlled. Bound the
-      // element count and the payload region against the file mapping before
-      // any array/string construction reads from `data`.
-      uint64_t arr_len = val->array.len;
+      auto size = static_cast<int>(val->array.len);
       if (val->array.type == GGUF_VALUE_TYPE_ARRAY) {
         throw std::invalid_argument(
             "[load_gguf] Only supports loading 1-layer of nested arrays.");
       }
-      // Element byte size for the declared element type (0 = string/unknown,
-      // handled per-branch below). Avoids narrowing uint64 length to int
-      // before checking it fits the mapping.
-      size_t elt_size = 0;
-      switch (val->array.type) {
-        case GGUF_VALUE_TYPE_UINT8:
-        case GGUF_VALUE_TYPE_INT8:
-        case GGUF_VALUE_TYPE_BOOL:
-          elt_size = 1;
-          break;
-        case GGUF_VALUE_TYPE_UINT16:
-        case GGUF_VALUE_TYPE_INT16:
-          elt_size = 2;
-          break;
-        case GGUF_VALUE_TYPE_UINT32:
-        case GGUF_VALUE_TYPE_INT32:
-        case GGUF_VALUE_TYPE_FLOAT32:
-          elt_size = 4;
-          break;
-        case GGUF_VALUE_TYPE_UINT64:
-        case GGUF_VALUE_TYPE_INT64:
-        case GGUF_VALUE_TYPE_FLOAT64:
-          elt_size = 8;
-          break;
-        default: // GGUF_VALUE_TYPE_STRING and anything else: handled below
-          break;
-      }
-      if (elt_size > 0) {
-        // Overflow-safe payload size check: arr_len * elt_size <= remaining.
-        uint64_t remaining = static_cast<uint64_t>(ctx->size) -
-            static_cast<uint64_t>(reinterpret_cast<const uint8_t*>(data) - ctx->data);
-        if (arr_len > remaining / elt_size) {
-          throw std::runtime_error(
-              "[load_gguf] Array metadata value extends past the end of the file.");
-        }
-        if (arr_len > static_cast<uint64_t>(std::numeric_limits<int>::max())) {
-          throw std::runtime_error(
-              "[load_gguf] Array metadata value length is too large.");
-        }
-      }
-      auto size = static_cast<int>(arr_len);
       switch (val->array.type) {
         case GGUF_VALUE_TYPE_UINT8:
           value = array(reinterpret_cast<uint8_t*>(data), {size}, uint8);
@@ -251,18 +306,7 @@ void set_mx_value_from_gguf(
         case GGUF_VALUE_TYPE_STRING: {
           std::vector<std::string> strs(size);
           for (auto& str : strs) {
-            // Each element's length is attacker-controlled; bound it against
-            // the mapping before reading.
-            check_metadata_value_in_file(ctx, reinterpret_cast<gguf_value*>(data), 0);
             auto str_val = reinterpret_cast<gguf_string*>(data);
-            uint64_t slen = str_val->len;
-            if (slen > static_cast<uint64_t>(std::numeric_limits<int>::max())) {
-              throw std::runtime_error(
-                  "[load_gguf] String array element length is too large.");
-            }
-            check_metadata_value_in_file(
-                ctx, reinterpret_cast<gguf_value*>(data),
-                sizeof(gguf_string) + static_cast<size_t>(slen));
             data += (str_val->len + sizeof(gguf_string));
             str = std::string(str_val->string, static_cast<int>(str_val->len));
             ctx->off += (str_val->len + sizeof(gguf_string));
@@ -296,6 +340,7 @@ std::unordered_map<std::string, GGUFMetaData> load_metadata(gguf_ctx* ctx) {
   while (gguf_get_key(ctx, &key)) {
     std::string key_name = std::string(key.name, key.namelen);
     auto& val = metadata.insert({key_name, GGUFMetaData{}}).first->second;
+    check_metadata_value_in_file(ctx, key.type, key.val);
     set_mx_value_from_gguf(ctx, key.type, key.val, val);
   }
   return metadata;

--- a/tests/load_tests.cpp
+++ b/tests/load_tests.cpp
@@ -257,6 +257,114 @@ TEST_CASE("test gguf tensor data offset validation") {
   }
 }
 
+// Writes a metadata-only GGUF (no tensors) whose metadata KV section is
+// `kv_section` verbatim, so a caller can encode values whose lengths exceed the
+// file to exercise check_metadata_value_in_file(). `kv_count` must match the
+// number of KV pairs encoded in `kv_section`.
+void write_raw_gguf_metadata(
+    const std::string& path,
+    uint64_t kv_count,
+    const std::vector<char>& kv_section) {
+  std::ofstream out(path, std::ios::binary);
+  auto u32 = [&out](uint32_t v) {
+    out.write(reinterpret_cast<const char*>(&v), 4);
+  };
+  auto u64 = [&out](uint64_t v) {
+    out.write(reinterpret_cast<const char*>(&v), 8);
+  };
+  out.write("GGUF", 4);
+  u32(3); // version
+  u64(0); // tensor_count
+  u64(kv_count); // metadata_kv_count
+  out.write(kv_section.data(), kv_section.size());
+}
+
+TEST_CASE("test gguf metadata value validation") {
+  // A STRING/ARRAY metadata value claiming a length larger than the file must
+  // be rejected rather than read past the end of the mapping. See PR #4212.
+
+  auto append_string_kv = [](std::vector<char>& b,
+                             const std::string& key,
+                             uint64_t claimed_len,
+                             bool write_payload) {
+    auto put = [&](const void* p, size_t n) {
+      b.insert(b.end(), static_cast<const char*>(p), static_cast<const char*>(p) + n);
+    };
+    uint64_t klen = key.size();
+    put(&klen, 8);
+    put(key.data(), key.size());
+    uint32_t vt = 8; // GGUF_VALUE_TYPE_STRING
+    put(&vt, 4);
+    put(&claimed_len, 8);
+    if (write_payload) {
+      b.insert(b.end(), claimed_len, '\0');
+    }
+  };
+
+  auto append_array_kv = [](std::vector<char>& b,
+                            const std::string& key,
+                            uint32_t elt_type,
+                            uint64_t claimed_len) {
+    auto put = [&](const void* p, size_t n) {
+      b.insert(b.end(), static_cast<const char*>(p), static_cast<const char*>(p) + n);
+    };
+    uint64_t klen = key.size();
+    put(&klen, 8);
+    put(key.data(), key.size());
+    uint32_t vt = 9; // GGUF_VALUE_TYPE_ARRAY
+    put(&vt, 4);
+    put(&elt_type, 4);
+    put(&claimed_len, 8);
+  };
+
+  SUBCASE("valid empty and small strings load") {
+    std::vector<char> kv;
+    append_string_kv(kv, "empty", 0, false);
+    append_string_kv(kv, "small", 5, true);
+    std::string file_path = get_temp_file("test_gguf_meta_ok.gguf");
+    write_raw_gguf_metadata(file_path, 2, kv);
+    auto [weights, metadata] = load_gguf(file_path);
+    CHECK(weights.empty());
+    CHECK(std::get<std::string>(metadata.at("empty")) == "");
+    CHECK(std::get<std::string>(metadata.at("small")) == std::string(5, '\0'));
+  }
+
+  SUBCASE("string length extends past the end of the file") {
+    // Claims 100 bytes of payload, none of which are present.
+    std::vector<char> kv;
+    append_string_kv(kv, "s", 100, false);
+    std::string file_path = get_temp_file("test_gguf_meta_str_past.gguf");
+    write_raw_gguf_metadata(file_path, 1, kv);
+    CHECK_THROWS_AS(load_gguf(file_path), std::runtime_error);
+  }
+
+  SUBCASE("string length far past the end of the file") {
+    std::vector<char> kv;
+    append_string_kv(kv, "s", 1ull << 40, false);
+    std::string file_path = get_temp_file("test_gguf_meta_str_far.gguf");
+    write_raw_gguf_metadata(file_path, 1, kv);
+    CHECK_THROWS_AS(load_gguf(file_path), std::runtime_error);
+  }
+
+  SUBCASE("fixed-size array length extends past the end of the file") {
+    // GGUF_VALUE_TYPE_UINT8 = 0; claims 2^40 elements, none present.
+    std::vector<char> kv;
+    append_array_kv(kv, "a", 0, 1ull << 40);
+    std::string file_path = get_temp_file("test_gguf_meta_arr_past.gguf");
+    write_raw_gguf_metadata(file_path, 1, kv);
+    CHECK_THROWS_AS(load_gguf(file_path), std::runtime_error);
+  }
+
+  SUBCASE("string array element length extends past the end of the file") {
+    // GGUF_VALUE_TYPE_STRING = 8; two elements, neither present.
+    std::vector<char> kv;
+    append_array_kv(kv, "a", 8, 2);
+    std::string file_path = get_temp_file("test_gguf_meta_strarr_past.gguf");
+    write_raw_gguf_metadata(file_path, 1, kv);
+    CHECK_THROWS_AS(load_gguf(file_path), std::runtime_error);
+  }
+}
+
 TEST_CASE("test gguf metadata") {
   std::string file_path = get_temp_file("test_arr.gguf");
   using dict = std::unordered_map<std::string, array>;

--- a/tests/load_tests.cpp
+++ b/tests/load_tests.cpp
@@ -288,7 +288,10 @@ TEST_CASE("test gguf metadata value validation") {
                              uint64_t claimed_len,
                              bool write_payload) {
     auto put = [&](const void* p, size_t n) {
-      b.insert(b.end(), static_cast<const char*>(p), static_cast<const char*>(p) + n);
+      b.insert(
+          b.end(),
+          static_cast<const char*>(p),
+          static_cast<const char*>(p) + n);
     };
     uint64_t klen = key.size();
     put(&klen, 8);
@@ -306,7 +309,10 @@ TEST_CASE("test gguf metadata value validation") {
                             uint32_t elt_type,
                             uint64_t claimed_len) {
     auto put = [&](const void* p, size_t n) {
-      b.insert(b.end(), static_cast<const char*>(p), static_cast<const char*>(p) + n);
+      b.insert(
+          b.end(),
+          static_cast<const char*>(p),
+          static_cast<const char*>(p) + n);
     };
     uint64_t klen = key.size();
     put(&klen, 8);


### PR DESCRIPTION
## Summary

Bounds the length of `STRING` and `ARRAY` **metadata** KV values against the mmap'd file mapping in `load_gguf`, mirroring the existing `check_tensor_in_file()` guard that protects the tensor data path. A crafted GGUF file could otherwise force an out-of-bounds read past the file mapping.

## Problem

`gguf_get_key()` returns a pointer (`val`) into the mmap'd file but performs **no bounds checking**, and the metadata value lengths are read straight from the file. In `set_mx_value_from_gguf`, these attacker-controlled lengths were fed directly to a copy/string constructor with no check against the mapping size:

**`STRING` KV:**
```cpp
value = std::string(val->string.string, static_cast<int>(val->string.len));
```
`val->string.len` is a `uint64_t` from the file, narrowed to `int`, then `std::string(ptr, n)` memmoves `n` bytes out of the mmap.

**`ARRAY` KV:**
```cpp
auto size = static_cast<int>(val->array.len);
...
value = array(reinterpret_cast<uint32_t*>(data), {size}, uint32);
```
`array(T*, Shape, Dtype)` allocates `size*itemsize` and `std::copy`s `size` elements from the mmap — a pure source over-read.

The tensor path was already bounded by `check_tensor_in_file()` (added in #4179 / fixes #4136), but the **metadata path had no equivalent guard**.

### Impact

Out-of-bounds read past the mmap'd GGUF file when loading an untrusted `.gguf`. Confirmed with AddressSanitizer (4 MB read on a ~50-byte file, both sinks). In a non-ASAN process the read crosses into an unmapped page → SEGV (denial of service). No write primitive (the allocation is derived from the same `len`, so it is a source over-read, not an over-write).

Reachable from the default-config public Python API on every platform mlx ships:
```python
import mlx.core as mx
mx.load("evil.gguf", format="gguf")
```
`MLX_BUILD_GGUF` is `ON` by default.

## Fix

Adds `check_metadata_value_in_file(ctx, val, value_bytes)`, which verifies the value region lies within `[0, ctx->size)`. Each metadata branch now bounds its value length against the mapping before any copy/string construction:

- **STRING:** rejects `len` that doesn't fit in an `int` or exceeds `ctx->size`, then bounds `sizeof(gguf_string) + len`.
- **ARRAY:** computes `elt_size` from the declared element type and checks `arr_len * elt_size <= remaining` (overflow-safe division form) before the element loop.
- **STRING array elements:** each inner `str_val->len` is bounded individually.

The `static_cast<int>` narrowing is also guarded so a length above `INT_MAX` is rejected explicitly rather than wrapping to a negative `int`.

## Testing

Built with clang `-O1 -g -fsanitize=address -fno-omit-frame-pointer` (LLVM clang, since libmlx is built with it). Three crafted GGUFs (over-long STRING, over-long UINT32 ARRAY, and STRING with `len` > `INT_MAX`):

**Before** (on `main`), `STRING` sink:
```
==95370==ERROR: AddressSanitizer: unknown-crash on address 0x000103ab0000
READ of size 4194304 at 0x000103ab0000 thread T0
    #6 mlx::core::set_mx_value_from_gguf(...) gguf.cpp:128
    #7 mlx::core::load_metadata(gguf_ctx*) gguf.cpp:209
    #8 mlx::core::load_gguf(...) gguf.cpp:279
```

**After** (this branch): all three crafted files are rejected cleanly:
```
exception: [load_gguf] String metadata value length exceeds file size.
```
no ASAN violation, process exits 0/1 via exception.

**No regression:** a legitimate roundtrip (`save_gguf` of a small float tensor + a STRING and an INT32 ARRAY metadata value, then `load_gguf`) still loads correctly with the new bounds in place.

## Prior art

Distinct from #4136/#4179 (tensor data offset/bsize — tensor only), #3436 (gguflib `-UNDEBUG` asserts — mlx bypasses `gguf_do_with_value`), and CVE-2025-62609 (different sink). None of these bound the metadata KV value length.
