### PR TITLE
Fix MultiOptimizer on models containing empty modules

### DIFF
--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -22,7 +22,6 @@ MLX was developed with contributions from the following individuals:
 - Gökdeniz Gülmez: Added the `Muon (MomentUm Orthogonalized by Newton-schulz)` optimizer, and the `ReLU²` activation function.
 - katlun-lgtm: Added `reflect` and `symmetric` padding modes.
 - Erwin Zhang: Added `searchsorted`. Fixed the ring backend hanging when a peer disconnects. Improved JACCL error reporting.
-- Eren Menges: Fixed `MultiOptimizer` not working on models with parameter-free layers (like `ReLU`).
 
 <a href="https://github.com/ml-explore/mlx/graphs/contributors">
   <img class="dark-light" src="https://contrib.rocks/image?repo=ml-explore/mlx&anon=0&columns=20&max=100&r=true" />

--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -21,6 +21,7 @@ MLX was developed with contributions from the following individuals:
 - Max-Heinrich Laves: Added `conv_transpose1d`, `conv_transpose2d`, and `conv_transpose3d` ops.
 - Gökdeniz Gülmez: Added the `Muon (MomentUm Orthogonalized by Newton-schulz)` optimizer, and the `ReLU²` activation function.
 - katlun-lgtm: Added `reflect` and `symmetric` padding modes.
+- Eren Menges: Fixed `MultiOptimizer` not working on models with parameter-free layers (like `ReLU`).
 
 <a href="https://github.com/ml-explore/mlx/graphs/contributors">
   <img class="dark-light" src="https://contrib.rocks/image?repo=ml-explore/mlx&anon=0&columns=20&max=100&r=true" />

--- a/python/mlx/utils.py
+++ b/python/mlx/utils.py
@@ -294,7 +294,8 @@ def tree_reduce(fn, tree, initializer=None, is_leaf=None):
 
 def tree_merge(tree_a, tree_b, merge_fn=None):
     """Merge two Python trees in one containing the values of both. It can be
-    thought of as a deep dict.update method.
+    thought of as a deep dict.update method. Empty containers are treated as
+    empty subtrees.
 
     Args:
         tree_a (Any): The first Python tree.
@@ -305,9 +306,19 @@ def tree_merge(tree_a, tree_b, merge_fn=None):
         The Python tree containing the values of both ``tree_a`` and
         ``tree_b``.
     """
-    if isinstance(tree_a, (dict, list, tuple)) and len(tree_a) == 0:
+    empty_a = isinstance(tree_a, (dict, list, tuple)) and len(tree_a) == 0
+    empty_b = isinstance(tree_b, (dict, list, tuple)) and len(tree_b) == 0
+
+    if empty_a and empty_b:
+        if type(tree_a) is not type(tree_b):
+            raise ValueError(
+                f"Cannot merge {type(tree_a).__name__} with {type(tree_b).__name__}"
+            )
+        return type(tree_a)()
+
+    if empty_a:
         tree_a = None
-    if isinstance(tree_b, (dict, list, tuple)) and len(tree_b) == 0:
+    if empty_b:
         tree_b = None
     if tree_a is None and tree_b is not None:
         return tree_b

--- a/python/tests/test_optimizers.py
+++ b/python/tests/test_optimizers.py
@@ -613,6 +613,27 @@ class TestSchedulers(mlx_tests.MLXTestCase):
         self.assertFalse(any("bias" in k for k, v in adam_states))
         self.assertFalse(any("weight" in k for k, v in sgd_states))
 
+    def test_multi_optimizer_with_parameterless_layers(self):
+        mx.random.seed(0)
+        # test a sequential that has a no parameter module like ReLU
+        model = nn.Sequential(nn.Linear(4, 4), nn.ReLU(), nn.Linear(4, 4))
+        mx.eval(model.parameters())
+
+        optimizer = opt.MultiOptimizer(
+            [opt.Muon(learning_rate=0.01), opt.AdamW(learning_rate=0.01)],
+            [lambda _, w: w.ndim >= 2],
+        )
+
+        loss_and_grad = nn.value_and_grad(model, lambda m, x: m(x).sum())
+        _, grads = loss_and_grad(model, mx.ones((1, 4)))
+        optimizer.update(model, grads)
+
+        w, b = model.layers[0].weight, model.layers[0].bias
+        optimizer.update(model, grads)
+        mx.eval(model.parameters())
+        self.assertFalse(mx.array_equal(w, model.layers[0].weight))
+        self.assertFalse(mx.array_equal(b, model.layers[0].bias))
+
 
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner()

--- a/python/tests/test_tree.py
+++ b/python/tests/test_tree.py
@@ -46,6 +46,40 @@ class TestTreeUtils(mlx_tests.MLXTestCase):
             self.assertEqual(k1, k2)
             self.assertTrue(mx.array_equal(v1, v2))
 
+    def test_empty_subtree_merge(self):
+        # make sure mlx pytrees treat empty dict {} as an empty node
+        self.assertEqual([], mlx.utils.tree_flatten({"a": {}}))
+
+        # empty dict merging
+        self.assertEqual({}, mlx.utils.tree_merge({}, {}))
+        self.assertEqual(
+            [{"a": 1, "b": 2}, {}], mlx.utils.tree_merge([{"a": 1}, {}], [{"b": 2}, {}])
+        )
+        self.assertEqual({"a": {}}, mlx.utils.tree_merge({"a": {}}, {"a": {}}))
+        self.assertEqual(
+            {"a": 1, "b": {}, "c": 2},
+            mlx.utils.tree_merge(
+                {"a": 1, "b": {}, "c": {}}, {"a": {}, "b": {}, "c": 2}
+            ),
+        )
+
+        # empty list merging
+        self.assertEqual({"a": []}, mlx.utils.tree_merge({"a": []}, {"a": []}))
+
+        # empty tuple merging
+        self.assertEqual({"a": ()}, mlx.utils.tree_merge({"a": ()}, {"a": ()}))
+
+        # merging different empty structures
+        with self.assertRaises(ValueError):
+            mlx.utils.tree_merge({}, [])
+
+        def merge_called(a, b):
+            raise AssertionError("merge_fn called on empty subtrees")
+
+        self.assertEqual(
+            {"a": {}}, mlx.utils.tree_merge({"a": {}}, {"a": {}}, merge_called)
+        )
+
     def test_supported_trees(self):
 
         from typing import NamedTuple


### PR DESCRIPTION
## Description
MultiOptimizer raised ValueError on any model that had parameterless modules (e.g. ReLU/GELU). I hit this while writing a ternary transformer that included something like a MLP = Sequential(BitLinear, GELU, BitLinear), where BitLinear is a custom module with both 2D weights and RMSNorm inside, therefore requiring different optimizers. I've reproduced this issue with stock MLX without any custom modules as well.

This is because MultiOptimizer uses tree_merge underneath to merge each optimizer's updates during optimizer.update. Normally, tree_merge treats empty containers ({}, [], ()) as None so it can merge with a non-empty tree. This works. But when both containers at the same position are empty, they both become None, and there is no condition in the function to handle that. Therefore it defaults to the `else` branch which acts as a conflict resolver with a passed function merge_fn. The `else` branch attempts to call merge_fn, but fails since a merge_fn isn't passed by MultiOptimizer.

This happens with parameterless modules, since their optimizer slice is empty.

MLX already treats empty containers as empty subtrees:
```python
>>> tree_flatten({"a": {}})
[]
```
This being absent in tree_merge is inconsistent, since it would be the only util that wouldn't treat an empty container as an empty subtree.


## Reproduction

```python
import mlx.core as mx
import mlx.nn as nn
import mlx.optimizers as optim

model = nn.Sequential(nn.Linear(4, 4), nn.ReLU(), nn.Linear(4, 4))
mx.eval(model.parameters())
opt = optim.MultiOptimizer(
    [optim.Muon(learning_rate=0.01), optim.AdamW(learning_rate=0.01)],
    [lambda path, w: w.ndim >= 2],
)
loss_and_grad = nn.value_and_grad(model, lambda m, x: m(x).sum())
loss, grads = loss_and_grad(model, mx.zeros((1, 4)))
opt.update(model, grads)
```

## Proposed changes

My fix makes tree_merge return an empty container of the same type if two empty containers of the same type are being merged. This fixes the MultiOptimizer issue, as evidenced by the two tests I wrote. It throws a ValueError if two empty containers of different types are being merged, since there's no way to decide which one is to use, other than their ordering. Also adds my name and fix description to the acknowledgments.

## Tests

`test_optimizers.py/test_multi_optimizer_with_parameterless_layers`
`test_tree.py/test_empty_subtree_merge`

## Checklist

Put an `x` in the boxes that apply.

- [X] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [X] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have updated the necessary documentation (if needed)