### PR TITLE
Optimize BF16 quantized matmul with FP16 tiles

### DIFF
--- a/mlx/backend/metal/kernels/quantized.h
+++ b/mlx/backend/metal/kernels/quantized.h
@@ -690,6 +690,263 @@ struct QuantizedBlockLoader {
   }
 };
 
+// Experimental variant of QuantizedBlockLoader used by the
+// MLX_BF16_QMM_FP16 path (see mlx/backend/metal/quantized.cpp). The
+// device-resident scales/biases are TExt (bfloat16_t) while the
+// dequantized weights are written into TTile (float16_t) threadgroup
+// memory so that the per-element dequantize math and the downstream
+// simdgroup MMA both run in (fast, hardware accelerated) fp16 instead of
+// the software-emulated bf16 arithmetic. Only the load path differs from
+// QuantizedBlockLoader; the tiling/group-stride bookkeeping is identical.
+template <
+    typename TExt,
+    typename TTile,
+    short BROWS,
+    short BCOLS,
+    short dst_ld,
+    short reduction_dim,
+    short tgp_size,
+    short group_size,
+    short bits>
+struct QuantizedBlockLoaderCast {
+  static_assert(
+      BCOLS <= group_size,
+      "The group size should be larger than the columns");
+  static_assert(
+      group_size % BCOLS == 0,
+      "The group size should be divisible by the columns");
+  static_assert(
+      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
+          bits == 8,
+      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+
+  MLX_MTL_CONST short pack_factor = get_pack_factor<bits, 8>();
+  MLX_MTL_CONST short bytes_per_pack = get_bytes_per_pack<bits>();
+  MLX_MTL_CONST short BCOLS_PACKED = BCOLS / pack_factor;
+  MLX_MTL_CONST short n_reads =
+      (BCOLS_PACKED * BROWS < tgp_size) ? 1 : (BCOLS_PACKED * BROWS) / tgp_size;
+  MLX_MTL_CONST short group_steps = group_size / BCOLS;
+
+  const int src_ld;
+  const int tile_stride;
+  short group_step_cnt;
+  const int group_stride;
+
+  const short thread_idx;
+  const short bi;
+  const short bj;
+
+  threadgroup TTile* dst;
+  const device uint8_t* src;
+  const device TExt* scales;
+  const device TExt* biases;
+
+  QuantizedBlockLoaderCast(
+      const device uint8_t* src_,
+      const device TExt* scales_,
+      const device TExt* biases_,
+      const int src_ld_,
+      threadgroup TTile* dst_,
+      ushort simd_group_id [[simdgroup_index_in_threadgroup]],
+      ushort simd_lane_id [[thread_index_in_simdgroup]])
+      : src_ld(src_ld_),
+        tile_stride(
+            reduction_dim ? BCOLS_PACKED * bytes_per_pack
+                          : BROWS * src_ld * bytes_per_pack / pack_factor),
+        group_step_cnt(0),
+        group_stride(BROWS * src_ld / group_size),
+        thread_idx(simd_group_id * 32 + simd_lane_id),
+        bi(n_reads * thread_idx / BCOLS_PACKED),
+        bj((n_reads * thread_idx) % BCOLS_PACKED),
+        dst(dst_ + bi * dst_ld + bj * pack_factor),
+        src(src_ + bi * src_ld * bytes_per_pack / pack_factor +
+            bj * bytes_per_pack),
+        scales(scales_ + bi * src_ld / group_size),
+        biases(biases_ + bi * src_ld / group_size) {}
+
+  void load_unsafe() const {
+    if (BCOLS_PACKED * BROWS < tgp_size && bi >= BROWS) {
+      return;
+    }
+
+    TTile scale = static_cast<TTile>(*scales);
+    TTile bias = static_cast<TTile>(*biases);
+    for (int i = 0; i < n_reads; i++) {
+      dequantize<TTile, pack_factor, bits>(
+          src + i * bytes_per_pack, scale, bias, dst + i * pack_factor);
+    }
+  }
+
+  void load_safe(short2 src_tile_dim) const {
+    if (BCOLS_PACKED * BROWS < tgp_size && bi >= BROWS) {
+      return;
+    }
+
+    if (reduction_dim == 1 && bi >= src_tile_dim.x) {
+      for (int i = 0; i < n_reads * pack_factor; i++) {
+        dst[i] = TTile(0);
+      }
+      return;
+    }
+
+    if (reduction_dim == 0 && bi >= src_tile_dim.y) {
+      for (int i = 0; i < n_reads * pack_factor; i++) {
+        dst[i] = TTile(0);
+      }
+      return;
+    }
+
+    TTile scale = static_cast<TTile>(*scales);
+    TTile bias = static_cast<TTile>(*biases);
+    for (int i = 0; i < n_reads; i++) {
+      dequantize<TTile, pack_factor, bits>(
+          (device uint8_t*)(src + i * bytes_per_pack),
+          scale,
+          bias,
+          dst + i * pack_factor);
+    }
+  }
+
+  void next() {
+    src += tile_stride;
+    if (reduction_dim == 1) {
+      if (group_steps > 1) {
+        group_step_cnt++;
+        if (group_step_cnt == group_steps) {
+          group_step_cnt = 0;
+          scales++;
+          biases++;
+        }
+      } else {
+        scales++;
+        biases++;
+      }
+    } else {
+      scales += group_stride;
+      biases += group_stride;
+    }
+  }
+};
+
+// Experimental BlockLoader variant used by the MLX_BF16_QMM_FP16 path: reads
+// device-resident TExt (bfloat16_t) activations and casts them into TTile
+// (float16_t) threadgroup memory. Unlike mlx::steel::BlockLoader this cannot
+// rely on a vectorized same-width memcpy since the source and destination
+// element types differ (even though they happen to share the same byte
+// width), so every element is read and cast individually.
+template <
+    typename TExt,
+    typename TTile,
+    short BROWS,
+    short BCOLS,
+    short dst_ld,
+    short reduction_dim,
+    short tgp_size,
+    short alignment = 1,
+    short n_reads = (BCOLS * BROWS) / (tgp_size),
+    short TCOLS = BCOLS / n_reads,
+    short TROWS = tgp_size / TCOLS>
+struct BlockLoaderCast {
+  STEEL_CONST short n_rows = (BROWS + TROWS - 1) / TROWS;
+  STEEL_CONST short vec_size = n_reads;
+  // bf16 and fp16 are both 16-bit scalar types, so a run of `vec_size`
+  // contiguous per-thread elements can be read/cast/written using Metal's
+  // native `vec<T, W>` types instead of `vec_size` scalar loads + casts.
+  // This turns e.g. 8 scalar 16-bit loads + 8 scalar casts + 8 scalar
+  // stores into 2 vectorized 64-bit loads + 2 vectorized casts + 2
+  // vectorized stores (W=4), which is both fewer instructions and fewer,
+  // wider memory transactions. Fall back to W=2 or W=1 when vec_size does
+  // not divide evenly (e.g. small/unaligned tail configurations).
+  STEEL_CONST short cast_vec_width =
+      (vec_size % 4 == 0) ? 4 : ((vec_size % 2 == 0) ? 2 : 1);
+
+  const int src_ld;
+  const int tile_stride;
+
+  const short thread_idx;
+  const short bi;
+  const short bj;
+
+  threadgroup TTile* dst;
+  const device TExt* src;
+
+  METAL_FUNC BlockLoaderCast(
+      const device TExt* src_,
+      const int src_ld_,
+      threadgroup TTile* dst_,
+      ushort simd_group_id [[simdgroup_index_in_threadgroup]],
+      ushort simd_lane_id [[thread_index_in_simdgroup]])
+      : src_ld(src_ld_),
+        tile_stride(reduction_dim ? BCOLS : BROWS * src_ld),
+        thread_idx(simd_group_id * 32 + simd_lane_id),
+        bi(thread_idx / TCOLS),
+        bj(vec_size * (thread_idx % TCOLS)),
+        dst(dst_ + bi * dst_ld + bj),
+        src(src_ + bi * src_ld + bj) {}
+
+  METAL_FUNC void load_unsafe() const {
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < BROWS; i += TROWS) {
+      if constexpr (cast_vec_width > 1) {
+        STEEL_PRAGMA_UNROLL
+        for (short j = 0; j < vec_size; j += cast_vec_width) {
+          auto v = *((const device metal::vec<TExt, cast_vec_width>*)(
+              &src[i * src_ld + j]));
+          *((threadgroup metal::vec<TTile, cast_vec_width>*)(
+              &dst[i * dst_ld + j])) =
+              static_cast<metal::vec<TTile, cast_vec_width>>(v);
+        }
+      } else {
+        STEEL_PRAGMA_UNROLL
+        for (short j = 0; j < vec_size; j++) {
+          dst[i * dst_ld + j] = static_cast<TTile>(src[i * src_ld + j]);
+        }
+      }
+    }
+  }
+
+  METAL_FUNC void load_safe(short2 src_tile_dim) const {
+    src_tile_dim = src_tile_dim - short2(bj, bi);
+
+    if (src_tile_dim.x <= 0 || src_tile_dim.y <= 0) {
+      STEEL_PRAGMA_UNROLL
+      for (short i = 0; i < BROWS; i += TROWS) {
+        STEEL_PRAGMA_UNROLL
+        for (short j = 0; j < vec_size; j++) {
+          dst[i * dst_ld + j] = TTile(0);
+        }
+      }
+      return;
+    }
+
+    bool tmp_idx[vec_size];
+    TExt tmp_val[vec_size];
+
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < BROWS; i += TROWS) {
+      STEEL_PRAGMA_UNROLL
+      for (short j = 0; j < vec_size; j++) {
+        tmp_idx[j] = (i < src_tile_dim.y) && (j < src_tile_dim.x);
+      }
+
+      STEEL_PRAGMA_UNROLL
+      for (short j = 0; j < vec_size; j++) {
+        tmp_val[j] = src[(tmp_idx[j] ? i * src_ld + j : 0)];
+      }
+
+      STEEL_PRAGMA_UNROLL
+      for (short j = 0; j < vec_size; j++) {
+        dst[i * dst_ld + j] =
+            tmp_idx[j] ? static_cast<TTile>(tmp_val[j]) : TTile(0);
+      }
+    }
+  }
+
+  METAL_FUNC void next() {
+    src += tile_stride;
+  }
+};
+
 template <typename T, int group_size, int bits, int D>
 METAL_FUNC void qmv_quad_impl(
     const device uint32_t* w,
@@ -1225,6 +1482,153 @@ METAL_FUNC void qmm_t_impl(
       mlx::steel::BlockLoader<T, BM, BK, BK_padded, 1, WM * WN * SIMD_SIZE>;
   using loader_w_t = QuantizedBlockLoader<
       T,
+      BN,
+      BK,
+      BK_padded,
+      1,
+      WM * WN * SIMD_SIZE,
+      group_size,
+      bits>;
+
+  // Set the block
+  const int K_w = K * bytes_per_pack / pack_factor;
+  const int K_g = K / group_size;
+  const int y_row = tid.y * BM;
+  const int y_col = tid.x * BN;
+
+  auto wl = (const device uint8_t*)w;
+
+  x += y_row * static_cast<int64_t>(K);
+  wl += y_col * K_w;
+  scales += y_col * K_g;
+  biases += y_col * K_g;
+  y += y_row * static_cast<int64_t>(N) + y_col;
+
+  // Make the x loader and mma operation
+  const short num_els = min(BM, M - y_row);
+  const short num_outs = min(BN, N - y_col);
+  loader_x_t loader_x(x, K, Xs, simd_gid, simd_lid);
+  loader_w_t loader_w(wl, scales, biases, K, Ws, simd_gid, simd_lid);
+  mma_t mma_op(simd_gid, simd_lid);
+
+  if (num_els < BM) {
+    if (!aligned_N && num_outs < BN) {
+      for (int k = 0; k < K_eff; k += BK) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_safe(short2(BK, num_els));
+        loader_w.load_safe(short2(BK, num_outs));
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(Xs, Ws);
+        loader_x.next();
+        loader_w.next();
+      }
+    } else {
+      for (int k = 0; k < K_eff; k += BK) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_safe(short2(BK, num_els));
+        loader_w.load_unsafe();
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(Xs, Ws);
+        loader_x.next();
+        loader_w.next();
+      }
+    }
+  } else {
+    if (!aligned_N && num_outs < BN) {
+      for (int k = 0; k < K_eff; k += BK) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_unsafe();
+        loader_w.load_safe(short2(BK, num_outs));
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(Xs, Ws);
+        loader_x.next();
+        loader_w.next();
+      }
+    } else {
+      for (int k = 0; k < K_eff; k += BK) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_unsafe();
+        loader_w.load_unsafe();
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        mma_op.mma(Xs, Ws);
+        loader_x.next();
+        loader_w.next();
+      }
+    }
+  }
+
+  // Store results to device memory
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  if (num_els < BM || num_outs < BN) {
+    mma_op.store_result_safe(y, N, short2(num_outs, num_els));
+  } else {
+    mma_op.store_result(y, N);
+  }
+}
+
+// Experimental MLX_BF16_QMM_FP16 variant of qmm_t_impl. External
+// x/scales/biases/y buffers remain bfloat16_t (TExt) but the threadgroup
+// tiles (Xs, Ws) and the simdgroup MMA operands are float16_t (TTile); the
+// simdgroup accumulator stays float (BlockMMA's default AccumType), and the
+// float/fp16 result is cast back to bfloat16_t only at the final store. This
+// avoids doing the per-weight dequantize arithmetic and the tiled load casts
+// in software-emulated bf16 while keeping the externally visible dtype
+// unchanged.
+template <
+    typename TExt,
+    typename TTile,
+    const int group_size,
+    const int bits,
+    const bool aligned_N,
+    const int BM = 32,
+    const int BK = 32,
+    const int BN = 32>
+METAL_FUNC void qmm_t_impl_bf16fp16(
+    const device uint32_t* w,
+    const device TExt* scales,
+    const device TExt* biases,
+    const device TExt* x,
+    device TExt* y,
+    threadgroup TTile* Xs,
+    threadgroup TTile* Ws,
+    const constant int& K,
+    const constant int& N,
+    const constant int& M,
+    const constant int& K_eff,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint lid [[thread_index_in_threadgroup]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  static_assert(BK >= SIMD_SIZE, "BK should be larger than SIMD_SIZE");
+  static_assert(BK % SIMD_SIZE == 0, "BK should be divisible by SIMD_SIZE");
+
+  (void)lid;
+
+  constexpr int WM = 2;
+  constexpr int WN = 2;
+  constexpr int pack_factor = get_pack_factor<bits, 8>();
+  constexpr int bytes_per_pack = get_bytes_per_pack<bits>();
+
+  constexpr int BK_padded = (BK + 16 / sizeof(TTile));
+
+  // Instantiate the appropriate BlockMMA and Loader. The MMA tile type is
+  // TTile (float16_t); the output type is TExt (bfloat16_t) and is only
+  // used by BlockMMA at the final (device-memory) store, where the float
+  // accumulator is cast down to bfloat16_t.
+  using mma_t = mlx::steel::
+      BlockMMA<TTile, TExt, BM, BN, BK, WM, WN, false, true, BK_padded, BK_padded>;
+  using loader_x_t = BlockLoaderCast<
+      TExt,
+      TTile,
+      BM,
+      BK,
+      BK_padded,
+      1,
+      WM * WN * SIMD_SIZE>;
+  using loader_w_t = QuantizedBlockLoaderCast<
+      TExt,
+      TTile,
       BN,
       BK,
       BK_padded,
@@ -1938,6 +2342,83 @@ template <
         tid);
   }
   qmm_t_impl<T, group_size, bits, aligned_N, BM, BK, BN>(
+      w,
+      scales,
+      biases,
+      x,
+      y,
+      Xs,
+      Ws,
+      K,
+      N,
+      M,
+      K,
+      tid,
+      lid,
+      simd_gid,
+      simd_lid);
+}
+
+// Experimental MLX_BF16_QMM_FP16 kernel: external buffers stay bfloat16_t
+// (matching affine_qmm_t's ABI), but the threadgroup tiles and simdgroup MMA
+// run in float16_t. See qmm_t_impl_bf16fp16 for details. Only instantiated
+// for group_size=32, bits=4 (see quantized.metal) and dispatched from
+// mlx::qmm() when MLX_BF16_QMM_FP16=1.
+template <
+    const int group_size,
+    const int bits,
+    const bool aligned_N,
+    const bool batched,
+    const int BM = 32,
+    const int BK = 32,
+    const int BN = 32>
+[[kernel]] void affine_qmm_t_bf16fp16(
+    const device uint32_t* w [[buffer(0)]],
+    const device bfloat16_t* scales [[buffer(1)]],
+    const device bfloat16_t* biases [[buffer(2)]],
+    const device bfloat16_t* x [[buffer(3)]],
+    device bfloat16_t* y [[buffer(4)]],
+    const constant int& K [[buffer(5)]],
+    const constant int& N [[buffer(6)]],
+    const constant int& M [[buffer(7)]],
+    const constant int& x_batch_ndims [[buffer(8)]],
+    const constant int* x_shape [[buffer(9)]],
+    const constant int64_t* x_strides [[buffer(10)]],
+    const constant int& w_batch_ndims [[buffer(11)]],
+    const constant int* w_shape [[buffer(12)]],
+    const constant int64_t* w_strides [[buffer(13)]],
+    const constant int64_t* s_strides [[buffer(14)]],
+    const constant int64_t* b_strides [[buffer(15)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint lid [[thread_index_in_threadgroup]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  (void)lid;
+
+  constexpr int BK_padded = (BK + 16 / sizeof(float16_t));
+
+  threadgroup float16_t Xs[BM * BK_padded];
+  threadgroup float16_t Ws[BN * BK_padded];
+
+  if (batched) {
+    adjust_matrix_offsets<bfloat16_t>(
+        x,
+        w,
+        scales,
+        biases,
+        y,
+        M * N,
+        x_batch_ndims,
+        x_shape,
+        x_strides,
+        w_batch_ndims,
+        w_shape,
+        w_strides,
+        s_strides,
+        b_strides,
+        tid);
+  }
+  qmm_t_impl_bf16fp16<bfloat16_t, float16_t, group_size, bits, aligned_N, BM, BK, BN>(
       w,
       scales,
       biases,

--- a/mlx/backend/metal/kernels/quantized.h
+++ b/mlx/backend/metal/kernels/quantized.h
@@ -890,10 +890,11 @@ struct BlockLoaderCast {
       if constexpr (cast_vec_width > 1) {
         STEEL_PRAGMA_UNROLL
         for (short j = 0; j < vec_size; j += cast_vec_width) {
-          auto v = *((const device metal::vec<TExt, cast_vec_width>*)(
-              &src[i * src_ld + j]));
-          *((threadgroup metal::vec<TTile, cast_vec_width>*)(
-              &dst[i * dst_ld + j])) =
+          auto v =
+              *((const device
+                     metal::vec<TExt, cast_vec_width>*)(&src[i * src_ld + j]));
+          *((threadgroup
+                 metal::vec<TTile, cast_vec_width>*)(&dst[i * dst_ld + j])) =
               static_cast<metal::vec<TTile, cast_vec_width>>(v);
         }
       } else {
@@ -1616,16 +1617,20 @@ METAL_FUNC void qmm_t_impl_bf16fp16(
   // TTile (float16_t); the output type is TExt (bfloat16_t) and is only
   // used by BlockMMA at the final (device-memory) store, where the float
   // accumulator is cast down to bfloat16_t.
-  using mma_t = mlx::steel::
-      BlockMMA<TTile, TExt, BM, BN, BK, WM, WN, false, true, BK_padded, BK_padded>;
-  using loader_x_t = BlockLoaderCast<
-      TExt,
+  using mma_t = mlx::steel::BlockMMA<
       TTile,
+      TExt,
       BM,
+      BN,
       BK,
+      WM,
+      WN,
+      false,
+      true,
       BK_padded,
-      1,
-      WM * WN * SIMD_SIZE>;
+      BK_padded>;
+  using loader_x_t =
+      BlockLoaderCast<TExt, TTile, BM, BK, BK_padded, 1, WM * WN * SIMD_SIZE>;
   using loader_w_t = QuantizedBlockLoaderCast<
       TExt,
       TTile,
@@ -2418,7 +2423,15 @@ template <
         b_strides,
         tid);
   }
-  qmm_t_impl_bf16fp16<bfloat16_t, float16_t, group_size, bits, aligned_N, BM, BK, BN>(
+  qmm_t_impl_bf16fp16<
+      bfloat16_t,
+      float16_t,
+      group_size,
+      bits,
+      aligned_N,
+      BM,
+      BK,
+      BN>(
       w,
       scales,
       biases,

--- a/mlx/backend/metal/kernels/quantized.metal
+++ b/mlx/backend/metal/kernels/quantized.metal
@@ -134,6 +134,53 @@
   instantiate_quantized_split_k(affine_qvm_split_k, type, group_size, bits, 8)   \
   instantiate_quantized_split_k(affine_qvm_split_k, type, group_size, bits, 32)  \
 
+// Experimental MLX_BF16_QMM_FP16 kernel (bfloat16_t external I/O, float16_t
+// threadgroup tiles / simdgroup MMA). Fixed-type kernel, no `type` template
+// parameter. Only instantiated for the affine int4, group_size=32 case
+// targeted by mlx/backend/metal/quantized.cpp's env-gated dispatch.
+#define instantiate_quantized_bf16fp16_aligned_batched(group_size, bits, aligned, batched)     \
+  instantiate_kernel(                                                                     \
+      "affine_qmm_t_bf16fp16_gs_" #group_size "_b_" #bits "_alN_" #aligned "_batch_" #batched, \
+      affine_qmm_t_bf16fp16,                                                                  \
+      group_size,                                                            \
+      bits,                                                                  \
+      aligned,                                                               \
+      batched)
+
+#define instantiate_quantized_bf16fp16(group_size, bits) \
+  instantiate_quantized_bf16fp16_aligned_batched(group_size, bits, true, 1) \
+  instantiate_quantized_bf16fp16_aligned_batched(group_size, bits, true, 0) \
+  instantiate_quantized_bf16fp16_aligned_batched(group_size, bits, false, 1) \
+  instantiate_quantized_bf16fp16_aligned_batched(group_size, bits, false, 0)
+
+instantiate_quantized_bf16fp16(32, 4)
+
+// Wider-tile variant (BM=64, BN=64, BK stays 32 since BK is capped by
+// group_size for the quantized-weight loader) used to explore tiling
+// tradeoffs for the MLX_BF16_QMM_FP16 kernel. Selected at runtime via
+// MLX_BF16_QMM_FP16_TILE=64 (see qmm_bf16_fp16() in quantized.cpp).
+#define instantiate_quantized_bf16fp16_wide_aligned_batched(          \
+    group_size, bits, aligned, batched)                               \
+  instantiate_kernel(                                                 \
+      "affine_qmm_t_bf16fp16_wide_gs_" #group_size "_b_" #bits         \
+      "_alN_" #aligned "_batch_" #batched,                            \
+      affine_qmm_t_bf16fp16,                                          \
+      group_size,                                                     \
+      bits,                                                           \
+      aligned,                                                        \
+      batched,                                                        \
+      64,                                                             \
+      32,                                                             \
+      64)
+
+#define instantiate_quantized_bf16fp16_wide(group_size, bits) \
+  instantiate_quantized_bf16fp16_wide_aligned_batched(group_size, bits, true, 1) \
+  instantiate_quantized_bf16fp16_wide_aligned_batched(group_size, bits, true, 0) \
+  instantiate_quantized_bf16fp16_wide_aligned_batched(group_size, bits, false, 1) \
+  instantiate_quantized_bf16fp16_wide_aligned_batched(group_size, bits, false, 0)
+
+instantiate_quantized_bf16fp16_wide(32, 4)
+
 #define instantiate_quantized_splitk_qmm(name, type, group_size, bits, aligned) \
   instantiate_kernel(                                                           \
       #name "_" #type "_gs_" #group_size "_b_" #bits "_alN_" #aligned,         \

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -1020,6 +1020,95 @@ void gather_qmm_nax(
   compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
 }
 
+// Experimental MLX_BF16_QMM_FP16 kernel dispatch. Same grid/threadgroup
+// layout as qmm()'s transposed path, but routes to affine_qmm_t_bf16fp16,
+// which keeps bfloat16_t at the device I/O boundary while running the
+// threadgroup tiles and simdgroup MMA in float16_t (float accumulation).
+// Only affine_qmm_t_bf16fp16 with group_size=32, bits=4 is instantiated in
+// quantized.metal, so this must only be called for that exact combination
+// (see the guard in qmm() below).
+void qmm_bf16_fp16(
+    const array& x,
+    const array& w,
+    const array& scales,
+    const std::optional<array>& biases,
+    array& out,
+    int group_size,
+    int bits,
+    int M,
+    int N,
+    int K,
+    metal::Device& d,
+    const Stream& s) {
+  int B = out.size() / M / N;
+
+  // Experimental tiling selection for the MLX_BF16_QMM_FP16 kernel.
+  // Defaults (MLX_BF16_QMM_FP16_TILE unset or 64) to a wider BM=64/BN=64
+  // tiling (BK stays 32, capped by group_size) instantiated as
+  // affine_qmm_t_bf16fp16_wide_* in quantized.metal, which benchmarks
+  // faster than the BM=32/BN=32 tiling (matching the stock qmm_t kernels)
+  // for the target Muse shapes. Set MLX_BF16_QMM_FP16_TILE=32 to force the
+  // narrower tiling (affine_qmm_t_bf16fp16_*) for comparison.
+  bool wide_tile = env::bf16_qmm_fp16_tile() != 32;
+
+  int wm = 2;
+  int wn = 2;
+  int bm = wide_tile ? 64 : 32;
+  int bn = wide_tile ? 64 : 32;
+  int bk = 32;
+  MTL::Size group_dims(32, wn, wm);
+  MTL::Size grid_dims((N + bn - 1) / bn, (M + bm - 1) / bm, B);
+
+  bool aligned = N % bn == 0;
+  bool batched = B > 1;
+
+  std::string kname;
+  kname.reserve(64);
+  concatenate(
+      kname,
+      wide_tile ? "affine_qmm_t_bf16fp16_wide_gs_" : "affine_qmm_t_bf16fp16_gs_",
+      group_size,
+      "_b_",
+      bits,
+      aligned ? "_alN_true" : "_alN_false",
+      batched ? "_batch_1" : "_batch_0");
+  // IMPORTANT: BM/BK/BN must be passed here explicitly and must match the
+  // exact tiling encoded in `kname`/`bm`/`bn` above and the static
+  // instantiations in quantized.metal (affine_qmm_t_bf16fp16_wide_* uses
+  // 64,32,64; affine_qmm_t_bf16fp16_* uses the 32,32,32 defaults). In the
+  // default (non-JIT) build, get_quantized_kernel() ignores template_def
+  // and looks up the pre-compiled kernel purely by `kname`, so this
+  // omission was previously harmless there. But with MLX_METAL_JIT=ON,
+  // get_quantized_kernel() JIT-compiles `template_def` at runtime -- if
+  // BM/BK/BN are omitted, the kernel silently falls back to its *default*
+  // template arguments (32,32,32) regardless of `kname`/`wide_tile`, which
+  // would compile a 32x32-tiled kernel while the host still dispatches a
+  // grid and threadgroup-relative addressing computed for 64x64 tiles,
+  // producing wrong results.
+  std::string template_def = get_template_definition(
+      kname, "affine_qmm_t_bf16fp16", group_size, bits, aligned, batched, bm, bk, bn);
+  MTL::ComputePipelineState* kernel =
+      get_quantized_kernel(d, kname, template_def, "affine");
+
+  auto& compute_encoder = metal::get_command_encoder(s);
+  compute_encoder.set_compute_pipeline_state(kernel);
+
+  int c = 0;
+  compute_encoder.set_input_array(w, c++);
+  compute_encoder.set_input_array(scales, c++);
+  if (biases) {
+    compute_encoder.set_input_array(*biases, c++);
+  }
+  compute_encoder.set_input_array(x, c++);
+  compute_encoder.set_output_array(out, c++);
+  compute_encoder.set_bytes(K, c++);
+  compute_encoder.set_bytes(N, c++);
+  compute_encoder.set_bytes(M, c++);
+  add_strides_and_shapes(compute_encoder, B <= 1, x, w, scales, biases, c);
+
+  compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+}
+
 void qmm(
     const array& x,
     const array& w,
@@ -1035,6 +1124,17 @@ void qmm(
     metal::Device& d,
     const Stream& s,
     const std::string& mode) {
+  // Experimental: MLX_BF16_QMM_FP16=1 opts in to running the transposed
+  // affine int4/group_size=32 bfloat16_t qmm through a kernel whose
+  // threadgroup tiles and simdgroup MMA are float16_t instead of
+  // bfloat16_t. Restricted to the exact instantiation compiled into
+  // quantized.metal; falls through to the default kernels otherwise.
+  if (env::bf16_qmm_fp16() && transpose && mode == "affine" &&
+      x.dtype() == bfloat16 && group_size == 32 && bits == 4) {
+    return qmm_bf16_fp16(
+        x, w, scales, biases, out, group_size, bits, M, N, K, d, s);
+  }
+
   bool has_nax_kernel =
       metal::is_nax_available() && (transpose || mode == "affine");
   if (has_nax_kernel && transpose && (K % 64 == 0) &&

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -1066,7 +1066,8 @@ void qmm_bf16_fp16(
   kname.reserve(64);
   concatenate(
       kname,
-      wide_tile ? "affine_qmm_t_bf16fp16_wide_gs_" : "affine_qmm_t_bf16fp16_gs_",
+      wide_tile ? "affine_qmm_t_bf16fp16_wide_gs_"
+                : "affine_qmm_t_bf16fp16_gs_",
       group_size,
       "_b_",
       bits,
@@ -1086,7 +1087,15 @@ void qmm_bf16_fp16(
   // grid and threadgroup-relative addressing computed for 64x64 tiles,
   // producing wrong results.
   std::string template_def = get_template_definition(
-      kname, "affine_qmm_t_bf16fp16", group_size, bits, aligned, batched, bm, bk, bn);
+      kname,
+      "affine_qmm_t_bf16fp16",
+      group_size,
+      bits,
+      aligned,
+      batched,
+      bm,
+      bk,
+      bn);
   MTL::ComputePipelineState* kernel =
       get_quantized_kernel(d, kname, template_def, "affine");
 

--- a/mlx/utils.h
+++ b/mlx/utils.h
@@ -201,6 +201,29 @@ inline bool enable_tf32() {
   return enable_tf32_;
 }
 
+// Experimental: route affine int4/group_size=32 transposed quantized
+// matrix-matrix multiplies (bfloat16_t activations/output) through a Metal
+// kernel whose threadgroup tiles and simdgroup MMA use float16_t (with float
+// accumulation) instead of bfloat16_t, casting at load/store time. Disabled
+// by default; see mlx/backend/metal/quantized.cpp.
+inline bool bf16_qmm_fp16() {
+  static bool bf16_qmm_fp16_ = get_var("MLX_BF16_QMM_FP16", 0);
+  return bf16_qmm_fp16_;
+}
+
+// Experimental: select the threadgroup tile size used by the
+// MLX_BF16_QMM_FP16 kernel. Defaults to 64, using a wider BM=64/BN=64
+// (BK=32, capped by group_size) tiling that benchmarks ~14% faster than the
+// BM=32/BN=32 tiling (matching the stock qmm_t kernels) for the target
+// M=512/K=6656/N=19968 Muse shape, at identical numerical results (bit-
+// identical to the BM=32/BN=32 path). Set MLX_BF16_QMM_FP16_TILE=32 to force
+// the narrower tiling for comparison; see qmm_bf16_fp16() in
+// mlx/backend/metal/quantized.cpp.
+inline int bf16_qmm_fp16_tile() {
+  static int bf16_qmm_fp16_tile_ = get_var("MLX_BF16_QMM_FP16_TILE", 64);
+  return bf16_qmm_fp16_tile_;
+}
+
 inline int nccl_timeout(int default_value) {
   static int nccl_timeout = get_var("MLX_NCCL_TIMEOUT", default_value);
   return nccl_timeout;

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -3,6 +3,7 @@
 import os
 import platform
 import subprocess
+import sys
 import unittest
 from itertools import product
 
@@ -284,6 +285,100 @@ class TestQuantized(mlx_tests.MLXTestCase):
                 y_hat = x_hat @ mx.swapaxes(w_hat, -1, -2)
                 self.assertEqual(y_q.shape, y_hat.shape)
                 self.assertLess((y_q - y_hat).abs().max(), 1e-3)
+
+    def test_qmm_bf16_fp16_experimental(self):
+        # Regression test for the experimental MLX_BF16_QMM_FP16 transposed
+        # affine int4/group_size=32 qmm kernel (see
+        # mlx/backend/metal/quantized.cpp's qmm_bf16_fp16()). The kernel
+        # keeps bfloat16_t at the device I/O boundary but runs threadgroup
+        # tiles / simdgroup MMA in float16_t, and is dispatched with either
+        # a BM=64/BN=64 ("wide", default) or BM=32/BN=32 ("narrow",
+        # MLX_BF16_QMM_FP16_TILE=32) threadgroup tiling.
+        #
+        # This guards specifically against a JIT-mode bug where the host
+        # dispatch's grid/threadgroup-relative addressing (computed from
+        # `bm`/`bn`) disagreed with the *compiled* kernel's BM/BN template
+        # arguments: get_template_definition() must be given the exact same
+        # BM/BK/BN used to size the host-side grid, or -- only under
+        # MLX_METAL_JIT=ON, since the default non-JIT build looks up a
+        # statically pre-instantiated kernel purely by name -- the JIT
+        # compiler silently falls back to the template's default (32,32,32)
+        # arguments regardless of the requested tiling, corrupting results
+        # (observed max abs error ~468 instead of ~1.5-2.7 for these
+        # shapes/seeds when the bug is present).
+        #
+        # env::bf16_qmm_fp16()/bf16_qmm_fp16_tile() cache the env var value
+        # for the lifetime of the process, so each tile/dtype configuration
+        # below must run in its own subprocess to take effect.
+        if not mx.metal.is_available():
+            return
+
+        group_size = 32
+        bits = 4
+        # (M, K, N, B) shapes: the Muse-style aligned matrix-matrix case,
+        # small-M (vector/"safe" load path), and a non-64-aligned N (only
+        # a multiple of 32) that exercises the wide tile's aligned_N=false
+        # branch specifically.
+        shapes = [
+            (512, 6656, 19968, 1),
+            (17, 6656, 19968, 1),
+            (512, 6656, 96, 1),
+            (512, 6656, 256, 3),
+        ]
+
+        script = (
+            "import sys, mlx.core as mx\n"
+            "M, K, N, B = map(int, sys.argv[1:5])\n"
+            "group_size, bits = 32, 4\n"
+            "mx.random.seed(1)\n"
+            "shape_x = (B, M, K) if B > 1 else (M, K)\n"
+            "x32 = mx.random.normal(shape_x)\n"
+            "w32 = mx.random.normal((N, K))\n"
+            "x = x32.astype(mx.bfloat16)\n"
+            "w_full = w32.astype(mx.bfloat16)\n"
+            "w, scales, biases = mx.quantize(w_full, group_size=group_size, bits=bits)\n"
+            "y = mx.quantized_matmul(x, w, scales, biases, transpose=True, "
+            "group_size=group_size, bits=bits)\n"
+            "mx.eval(y)\n"
+            "yref = x32.astype(mx.float32) @ mx.dequantize(w, scales, biases, "
+            "group_size=group_size, bits=bits).astype(mx.float32).T\n"
+            "err = (y.astype(mx.float32) - yref).abs()\n"
+            "print(float(err.max()))\n"
+        )
+
+        for M, K, N, B in shapes:
+            for tile_env in (None, "64", "32"):
+                env = os.environ.copy()
+                env["MLX_BF16_QMM_FP16"] = "1"
+                if tile_env is None:
+                    env.pop("MLX_BF16_QMM_FP16_TILE", None)
+                else:
+                    env["MLX_BF16_QMM_FP16_TILE"] = tile_env
+                out = subprocess.run(
+                    [sys.executable, "-c", script, str(M), str(K), str(N), str(B)],
+                    env=env,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(
+                    out.returncode,
+                    0,
+                    msg=f"subprocess failed for shape={(M, K, N, B)} "
+                    f"tile={tile_env}: {out.stderr}",
+                )
+                max_abs_err = float(out.stdout.strip().splitlines()[-1])
+                # Correct fp16-tile rounding noise for these shapes/seed is
+                # ~1.3-2.7; a tile-size/JIT-template mismatch blows this up
+                # by two orders of magnitude (observed ~468), so 10.0 gives
+                # ample margin against false positives while still catching
+                # the regression.
+                self.assertLess(
+                    max_abs_err,
+                    10.0,
+                    msg=f"MLX_BF16_QMM_FP16 experimental kernel produced "
+                    f"excessive error for shape={(M, K, N, B)} "
+                    f"tile={tile_env}: max_abs_err={max_abs_err}",
+                )
 
     def test_qmm(self):
         key = mx.random.key(0)


### PR DESCRIPTION
## Summary
- add an opt-in affine INT4/group-32 QMM path with BF16 device I/O, FP16 threadgroup/MMA tiles, and FP32 accumulation
- vectorize BF16-to-FP16 activation loads and use 64x64 output tiling
- keep AOT and Metal JIT tile instantiations consistent and test both wide/narrow variants

Enable with `MLX_BF16_QMM_FP16=1`; `MLX_BF16_QMM_FP16_TILE=32` selects the narrow comparison path.

## Performance
M1 Max, M=512, K=6656, N=19968, affine INT4 group size 32:

| Path | Time |
|---|---:|
| Stock BF16 | 30.6 ms |
| Stock FP16 | 17.2 ms |
| BF16 I/O + FP16 tiles | 17.32 ms |

The mixed path is ~1.77x faster than stock BF16 and effectively matches pure FP16 while preserving BF16 I/O.

## Validation
- `python/tests/test_quantized.py`: 33 tests / 2896 subtests pass
- AOT and `MLX_METAL_JIT=ON` builds
- wide/narrow tiles, small M/N, non-64 K, and batched inputs
- JIT regression test reproduces the pre-fix tile mismatch and passes with the fix