### PR TITLE
Validate decay_steps and step_size in the schedulers

### DIFF
--- a/python/mlx/optimizers/schedulers.py
+++ b/python/mlx/optimizers/schedulers.py
@@ -51,6 +51,8 @@ def step_decay(init: float, decay_rate: float, step_size: int) -> Callable:
         >>> optimizer.learning_rate
         array(0.081, dtype=float32)
     """
+    if step_size < 1:
+        raise ValueError(f"step_size must be greater than 0, but got {step_size}.")
 
     def schedule(step):
         return init * (decay_rate ** (step // step_size))
@@ -79,6 +81,8 @@ def cosine_decay(init: float, decay_steps: int, end: float = 0.0) -> Callable:
         >>> optimizer.learning_rate
         array(0.0999961, dtype=float32)
     """
+    if decay_steps < 1:
+        raise ValueError(f"decay_steps must be greater than 0, but got {decay_steps}.")
 
     def schedule(step):
         s = mx.minimum(step, decay_steps)


### PR DESCRIPTION
## Proposed changes

`linear_schedule` checks its step count when the schedule is built:

```python
>>> optim.linear_schedule(0, 1, 0)
ValueError: steps must be greater than 0, but got 0.
```

`cosine_decay` and `step_decay` take the same kind of argument and check nothing, so the failure lands later, inside the optimizer step, as a bare Python error:

```python
>>> optim.cosine_decay(1.0, 0)(5)
ZeroDivisionError: float division by zero
>>> optim.step_decay(1.0, 0.9, 0)(5)
ZeroDivisionError: integer division or modulo by zero
```

A negative value is worse, because nothing raises at all and the schedule silently returns a wrong number:

```python
>>> optim.cosine_decay(1.0, -3)(5)
0.0
```

That one is the reason I bothered: a schedule built with a bad value keeps running and quietly holds the learning rate at the end value.

Added the same construction time check the sibling function already uses, with the message in the same shape:

```python
>>> optim.cosine_decay(1.0, -3)
ValueError: decay_steps must be greater than 0, but got -3.
>>> optim.step_decay(1.0, 0.9, 0)
ValueError: step_size must be greater than 0, but got 0.
```

`exponential_decay` is left alone since it has no such argument, and `join_schedules` already validates its boundaries.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

No test, since it is an argument check and a reviewer asked me to drop one on a fix this size before. Say the word if you would rather have it.

Checked by hand that valid schedules are untouched: `cosine_decay(1.0, 10)(5)`, `step_decay(1.0, 0.9, 10)(21)`, `exponential_decay(1.0, 0.9)(5)` and a `join_schedules` combination all give the same values as before, and `test_optimizers.py` passes. Python only, no rebuild.

---

freshman contributor, i use Claude Code alongside my own reading. this came out of feeding out of range arguments to each scheduler and noticing only one of the three complained. the negative case returning a number rather than raising is what pushed me to send it.
