### PR TITLE
Implement Group.split() for the ring backend

### DIFF
--- a/mlx/distributed/ring/ring.cpp
+++ b/mlx/distributed/ring/ring.cpp
@@ -6,6 +6,7 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <fstream>
 #include <future>
@@ -357,20 +358,28 @@ class RingGroup : public GroupImpl {
     }
 
     size_ = nodes.size();
+    nodes_ = std::move(nodes);
+
+    // A ring of one has no neighbors to connect to. Collectives over a group
+    // this size are resolved before they reach a backend.
+    if (size_ == 1) {
+      return;
+    }
+
     int connect_to = (rank_ + 1) % size_;
 
     // We define the connection order by having the rank_ == size_ - 1 connect
     // first and accept after.
     if (rank_ < connect_to) {
       log_info(verbose_, "Rank", rank_, "accepting");
-      sockets_left_ = accept_connections(nodes[rank_]);
+      sockets_left_ = accept_connections(nodes_[rank_]);
       log_info(verbose_, "Rank", rank_, "connecting to", connect_to);
-      sockets_right_ = make_connections(nodes[connect_to], verbose);
+      sockets_right_ = make_connections(nodes_[connect_to], verbose);
     } else {
       log_info(verbose_, "Rank", rank_, "connecting to", connect_to);
-      sockets_right_ = make_connections(nodes[connect_to], verbose);
+      sockets_right_ = make_connections(nodes_[connect_to], verbose);
       log_info(verbose_, "Rank", rank_, "accepting");
-      sockets_left_ = accept_connections(nodes[rank_]);
+      sockets_left_ = accept_connections(nodes_[rank_]);
     }
 
     // Failure if we couldn't make right or left sockets
@@ -462,7 +471,47 @@ class RingGroup : public GroupImpl {
   }
 
   std::shared_ptr<GroupImpl> split(int color, int key = -1) override {
-    throw std::runtime_error("[ring] Group split not supported.");
+    key = (key < 0) ? rank_ : key;
+
+    // Rotate every rank's color and key around the ring so that each one can
+    // work out the subgroups on its own.
+    std::vector<std::array<int, 2>> colors_keys(size_);
+    colors_keys[rank_] = {color, key};
+    constexpr size_t nbytes = 2 * sizeof(int);
+    for (int i = 1; i < size_; i++) {
+      int send_from = (rank_ - i + 1 + size_) % size_;
+      int recv_into = (rank_ - i + size_) % size_;
+      send(
+          sockets_right_,
+          reinterpret_cast<const char*>(colors_keys[send_from].data()),
+          nbytes);
+      recv(
+          sockets_left_,
+          reinterpret_cast<char*>(colors_keys[recv_into].data()),
+          nbytes);
+    }
+
+    // Ranks sharing our color, ordered by key with the parent rank breaking
+    // ties.
+    std::vector<int> members;
+    for (int r = 0; r < size_; r++) {
+      if (colors_keys[r][0] == color) {
+        members.push_back(r);
+      }
+    }
+    std::stable_sort(members.begin(), members.end(), [&](int a, int b) {
+      return colors_keys[a][1] < colors_keys[b][1];
+    });
+
+    std::vector<std::vector<detail::address_t>> nodes;
+    nodes.reserve(members.size());
+    for (int r : members) {
+      nodes.push_back(nodes_[r]);
+    }
+    int rank =
+        std::find(members.begin(), members.end(), rank_) - members.begin();
+
+    return std::make_shared<RingGroup>(rank, std::move(nodes), verbose_);
   }
 
   void all_gather(const array& input, array& output, Stream stream) override {
@@ -805,6 +854,7 @@ class RingGroup : public GroupImpl {
 
   int rank_;
   int size_;
+  std::vector<std::vector<detail::address_t>> nodes_;
 
   bool verbose_;
 

--- a/python/tests/ring_test_distributed.py
+++ b/python/tests/ring_test_distributed.py
@@ -20,8 +20,33 @@ class TestRingDistributed(mlx_distributed_tests.MLXDistributedCommonTestCase):
         self.assertEqual(world.size(), world2.size())
         self.assertEqual(world.rank(), world2.rank())
 
-        with self.assertRaises(RuntimeError):
-            sub = world.split(world.rank() % 2)
+        n = world.size()
+        r = world.rank()
+
+        sub = world.split(r % 2)
+        members = [x for x in range(n) if x % 2 == r % 2]
+        self.assertEqual(sub.size(), len(members))
+        self.assertEqual(sub.rank(), members.index(r))
+        self.assertEqual(
+            mx.distributed.all_sum(mx.array(r), group=sub).item(), sum(members)
+        )
+
+        # The key decides the order within the subgroup.
+        sub = world.split(r % 2, key=n - r)
+        self.assertEqual(sub.rank(), list(reversed(members)).index(r))
+
+        # A color nobody shares gives a group of one.
+        solo = world.split(r)
+        self.assertEqual(solo.size(), 1)
+        self.assertEqual(solo.rank(), 0)
+
+        # Subgroups split again.
+        half = world.split(r < n // 2)
+        members = [x for x in range(n) if (x < n // 2) == (r < n // 2)]
+        self.assertEqual(half.size(), len(members))
+        self.assertEqual(
+            mx.distributed.all_sum(mx.array(r), group=half).item(), sum(members)
+        )
 
     def test_all_reduce_extra(self):
         world = mx.distributed.init()


### PR DESCRIPTION
Part of #3205. `RingGroup::split` threw, so `mx.distributed.init().split(...)` was unavailable
on ring. MPI and NCCL both implement it, so this brings ring to the same contract:

- ranks sharing a color end up in the same group,
- new ranks are ordered by ascending key, with the parent rank breaking ties,
- `key < 0` (the default) means keep the parent's order.

Two things made this smaller than expected.

`TCPSocket::listen` already sets `SO_REUSEADDR` and `SO_REUSEPORT`, and the parent's listening
sockets are closed once `accept()` returns, so a subgroup rebinds the same hostfile addresses.
No port negotiation is needed.

`RingGroup` is constructed from the full address table, so once every rank knows every color it
can work out the subgroups by itself. The constructor was dropping that table, it is kept now.
The colors and keys rotate around the existing ring, so the connection side channel is not
involved.

`RingGroup` also returns early at size one instead of trying to connect to itself, which is what
a color nobody else shares produces. Collectives over a group that size are resolved in
`ops.cpp` before they reach a backend.

`test_groups` in `ring_test_distributed.py` asserted that split raises. It now covers the
behaviour instead.

### Verified

Ring backend on localhost at 2, 4 and 8 ranks. Beyond rank and size, every case checks an
`all_sum` inside the subgroup to confirm the collective is carried by the subgroup and not the
parent.

| | 2 ranks | 4 ranks | 8 ranks |
|---|---|---|---|
| even/odd split | pass | pass | pass |
| uneven blocks (`rank // 3`) | pass | pass | pass |
| nested split of a subgroup | pass | pass | pass |
| identity split reproduces the world | pass | pass | pass |
| singleton subgroups | pass | pass | pass |
| key-driven reordering | pass | pass | pass |
| `ring_test_distributed.py` | 13/13 | 13/13 | 13/13 |
