### PR TITLE
Fix nan_to_num replacing inf with 0 for float16 and bfloat16

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -16,6 +16,7 @@
 #include "mlx/primitives.h"
 #include "mlx/transforms.h"
 #include "mlx/transforms_impl.h"
+#include "mlx/types/limits.h"
 #include "mlx/utils.h"
 
 namespace mlx::core {
@@ -2103,9 +2104,9 @@ array nan_to_num(
     if (dtype == float32) {
       return std::numeric_limits<float>::max();
     } else if (dtype == bfloat16) {
-      return std::numeric_limits<bfloat16_t>::max();
+      return static_cast<float>(numeric_limits<bfloat16_t>::max());
     } else if (dtype == float16) {
-      return std::numeric_limits<float16_t>::max();
+      return static_cast<float>(numeric_limits<float16_t>::max());
     } else {
       std::ostringstream msg;
       msg << "[nan_to_num] Does not yet support given type: " << dtype << ".";

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -2102,11 +2102,11 @@ array nan_to_num(
 
   auto type_to_max = [](const auto& dtype) -> float {
     if (dtype == float32) {
-      return std::numeric_limits<float>::max();
+      return numeric_limits<float>::max();
     } else if (dtype == bfloat16) {
-      return static_cast<float>(numeric_limits<bfloat16_t>::max());
+      return numeric_limits<bfloat16_t>::max();
     } else if (dtype == float16) {
-      return static_cast<float>(numeric_limits<float16_t>::max());
+      return numeric_limits<float16_t>::max();
     } else {
       std::ostringstream msg;
       msg << "[nan_to_num] Does not yet support given type: " << dtype << ".";

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -2262,7 +2262,7 @@ class TestOps(mlx_tests.MLXTestCase):
         self.assertTrue(np.allclose(out_mx, out_np))
 
         for t in [mx.float32, mx.float16]:
-            a = mx.array([float("inf"), 6.9, float("nan"), float("-inf")])
+            a = mx.array([float("inf"), 6.9, float("nan"), float("-inf")]).astype(t)
             out_mx = mx.nan_to_num(a)
             out_np = np.nan_to_num(a)
             self.assertTrue(np.allclose(out_mx, out_np))
@@ -2271,6 +2271,16 @@ class TestOps(mlx_tests.MLXTestCase):
             out_np = np.nan_to_num(a, nan=0.0, posinf=1000, neginf=-1000)
             out_mx = mx.nan_to_num(a, nan=0.0, posinf=1000, neginf=-1000)
             self.assertTrue(np.allclose(out_mx, out_np))
+
+        # bfloat16 has no numpy analogue; infinities should clamp to the
+        # dtype's largest finite value, not 0
+        a = mx.array([float("inf"), 6.9, float("nan"), float("-inf")]).astype(
+            mx.bfloat16
+        )
+        out_mx = mx.nan_to_num(a)
+        bf_max = mx.finfo(mx.bfloat16).max
+        expected = mx.array([bf_max, 6.9, 0.0, -bf_max]).astype(mx.bfloat16)
+        self.assertTrue(mx.array_equal(out_mx, expected))
 
     def test_pad_reflect_symmetric(self):
         # mx.pad reflect/symmetric must match numpy.pad exactly. Covers


### PR DESCRIPTION
## Proposed changes

`nan_to_num` documents that `posinf` / `neginf` default to the largest / smallest finite value of the input dtype, but for `float16` and `bfloat16` the defaults come out as `±0`, so infinities are silently zeroed:

```python
>>> a = mx.array([float("nan"), float("inf"), float("-inf"), 1.5], dtype=mx.float16)
>>> mx.nan_to_num(a)
array([0, 0, -0, 1.5], dtype=float16)
>>> mx.nan_to_num(a.astype(mx.bfloat16))
array([0, 0, -0, 1.5], dtype=bfloat16)
>>> mx.nan_to_num(a.astype(mx.float32))
array([0, 3.40282e+38, -3.40282e+38, 1.5], dtype=float32)
```

`np.nan_to_num` on the same float16 input returns `[0, 65504, -65504, 1.5]`.

The defaults are computed by `type_to_max` in `mlx/ops.cpp`:

```cpp
} else if (dtype == bfloat16) {
  return std::numeric_limits<bfloat16_t>::max();
} else if (dtype == float16) {
  return std::numeric_limits<float16_t>::max();
```

`std::numeric_limits` has no specialization for `float16_t` / `bfloat16_t` (neither the ARM `__fp16` / `__bf16` typedefs nor the fallback structs), so this instantiates the primary template: `is_specialized` is `false` and `max()` returns `T()`, which is `0`. The wrong constant is baked into the graph at construction time, so every backend is affected — the released 0.32.0 wheel gives the same output on CPU and Metal.

The fix switches to `mlx::core::numeric_limits` from `mlx/types/limits.h`, which carries the correct bit patterns (`0x7BFF` = 65504 for float16, `0x7F7F` ≈ 3.38953e38 for bfloat16) and is what `finfo`, `softmax` and `logsumexp` already use. After the change float16 maps `±inf` to `±65504` and bfloat16 to `±3.38953e+38`, matching numpy and `mx.finfo`.

The existing `test_nan_to_num` never caught this because its default-argument case builds the input without `.astype(t)`, so that path only ever ran in float32. The test now casts to the loop dtype — that one-line change alone fails on main for `float16` — and adds a bfloat16 check against `mx.finfo(mx.bfloat16).max`.

Fixes #4220

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

CPU-only build (`MLX_BUILD_METAL=OFF`) at 7729d58: `python/tests/test_ops.py` passes 155 tests with 1 skip (a Metal-only case, expected on a CPU build), same as main; the updated `test_nan_to_num` fails on main and passes with this change.

---

Disclosure: I used an AI assistant while investigating and preparing this change. I reproduced the bug, reviewed every line of the diff, and ran the builds and tests locally on an Apple Silicon Mac myself.
