### PR TITLE
Raise instead of hanging when reflect/symmetric pad gets an empty axis

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -1489,6 +1489,12 @@ array reflect_pad(
     if (L == 0 && H == 0) {
       continue;
     }
+    if (n == 0) {
+      std::ostringstream msg;
+      msg << "[pad] Cannot pad empty axis " << ax << " using mode '"
+          << (include_edge ? "symmetric" : "reflect") << "'.";
+      throw std::invalid_argument(msg.str());
+    }
     // reflect skips the edge value (period 2(n-1)); symmetric repeats it
     // (period 2n).
     int offset = (!include_edge && n > 1) ? 1 : 0;

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -2305,6 +2305,17 @@ class TestOps(mlx_tests.MLXTestCase):
                 )
                 self.assertEqual(b_mlx.dtype, mx.float32)
 
+        # An empty axis cannot be extended; numpy raises for these too.
+        # Used to hang in an infinite loop rather than raise.
+        for mode in ("reflect", "symmetric"):
+            with self.assertRaises(ValueError):
+                mx.pad(mx.array([]), 2, mode=mode)
+            with self.assertRaises(ValueError):
+                mx.pad(mx.zeros((0, 3)), [(1, 1), (0, 0)], mode=mode)
+            # A zero-width pad on the empty axis stays allowed
+            out = mx.pad(mx.zeros((0, 3)), [(0, 0), (2, 1)], mode=mode)
+            self.assertEqual(out.shape, (0, 6))
+
     def test_as_strided(self):
         x_npy = np.random.randn(128).astype(np.float32)
         x_mlx = mx.array(x_npy)


### PR DESCRIPTION
## Proposed changes

`mx.pad` with `mode="reflect"` or `mode="symmetric"` never returns when a padded axis has size 0. The spin happens during graph construction, so there is no eval to interrupt — the process hangs at ~100% CPU (and grows the graph unboundedly):

```python
>>> mx.pad(mx.array([]), 2, mode="reflect")      # never returns
>>> mx.pad(mx.array([]), 2, mode="symmetric")    # never returns
>>> mx.pad(mx.zeros((0, 3)), [(1, 1), (0, 0)], mode="reflect")  # any padded size-0 axis
```

numpy raises for the same inputs: `ValueError: can't extend empty axis 0 using modes other than 'constant' or 'empty'`. mlx's `mode="constant"` on an empty axis already works and matches numpy.

The fill loops in `reflect_pad` (`mlx/ops.cpp`) copy `tile = n - offset` elements per iteration. With `n == 0`, `tile` is `0`, so `chunk = std::min(remaining, tile)` is always `0` and `remaining -= chunk` never decreases:

```cpp
int offset = (!include_edge && n > 1) ? 1 : 0;
int tile = n - offset;

if (L > 0) {
  int remaining = L;
  while (remaining > 0) {
    int chunk = std::min(remaining, tile);   // 0 when the axis is empty
    ...
    remaining -= chunk;                      // never decreases
  }
}
```

`n == 1` is special-cased by the `n > 1` in `offset`, but `n == 0` is not. This fix raises `std::invalid_argument` (a `ValueError` in Python) for a non-zero pad on an empty axis, matching numpy's behavior. A zero-width pad on an empty axis takes the `L == 0 && H == 0` continue right above and keeps working, also matching numpy:

```python
>>> mx.pad(mx.array([]), 2, mode="reflect")
ValueError: [pad] Cannot pad empty axis 0 using mode 'reflect'.
>>> mx.pad(mx.zeros((0, 3)), [(0, 0), (2, 1)], mode="reflect").shape
(0, 6)
```

The regression test asserts both modes raise for 1-D and 2-D empty-axis inputs and that the zero-width case stays allowed. Worth flagging that on main the new assertions hang rather than fail, since that is the bug (still spinning after 8 s under a watchdog vs ~0.3 s normal runtime for the whole test).

Fixes #4221

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

CPU-only build (`MLX_BUILD_METAL=OFF`) at 7729d58: `python/tests/test_ops.py` passes 155 tests with 1 skip (a Metal-only case, expected on a CPU build), same as main. The loop is in graph construction, so the fix is backend-independent.

As noted in #4221, there are two adjacent issues only reachable from the C++ `pad(a, axes, ...)` overload (negative axes are not normalized before indexing, and `edge_pad` ignores its `axes` argument); I kept them out of this PR deliberately.

---

Disclosure: I used an AI assistant while investigating and preparing this change. I reproduced the hang, reviewed every line of the diff, and ran the builds and tests locally on an Apple Silicon Mac myself.
