### PR TITLE
Add multi-point closed-form gradient reference tests

### DIFF
--- a/python/tests/test_grad_reference.py
+++ b/python/tests/test_grad_reference.py
@@ -1,0 +1,164 @@
+# Copyright © 2023 Apple Inc.
+
+import math
+
+import mlx.core as mx
+import mlx_tests
+import numpy as np
+
+# Per-dtype tolerances for comparing a gradient against a closed-form
+# reference evaluated in float64.
+#
+# These are set from the measured agreement between MLX's float32 gradients
+# and the closed forms below on well-conditioned inputs, which sits at roughly
+# one float32 epsilon (~1.2e-7). The tolerances leave about two orders of
+# headroom so that ordinary rounding differences across machines never trip
+# them, while still being far tighter than a generic 1e-2 default.
+TOLERANCES = {
+    mx.float32: dict(rtol=1e-5, atol=1e-6),
+    mx.float16: dict(rtol=5e-3, atol=1e-4),
+}
+
+# (name, mlx op, closed-form derivative, evaluation range)
+#
+# Ranges are chosen to keep every point well inside the op's domain and away
+# from poles and kinks: a finite gradient compared at a non-differentiable
+# point tests nothing useful. Ops whose derivative is a selection (max, abs,
+# sort, ...) are deliberately not covered here for the same reason.
+UNARY_OPS = [
+    ("sin", mx.sin, lambda x: np.cos(x), (-1.5, 1.5)),
+    ("sinh", mx.sinh, lambda x: np.cosh(x), (-1.5, 1.5)),
+    ("cosh", mx.cosh, lambda x: np.sinh(x), (-1.5, 1.5)),
+    ("tan", mx.tan, lambda x: 1.0 / np.cos(x) ** 2, (-1.0, 1.0)),
+    ("arcsin", mx.arcsin, lambda x: 1.0 / np.sqrt(1.0 - x**2), (-0.8, 0.8)),
+    ("arccos", mx.arccos, lambda x: -1.0 / np.sqrt(1.0 - x**2), (-0.8, 0.8)),
+    ("arctan", mx.arctan, lambda x: 1.0 / (1.0 + x**2), (-1.5, 1.5)),
+    ("arcsinh", mx.arcsinh, lambda x: 1.0 / np.sqrt(1.0 + x**2), (-1.5, 1.5)),
+    ("arctanh", mx.arctanh, lambda x: 1.0 / (1.0 - x**2), (-0.8, 0.8)),
+    ("expm1", mx.expm1, lambda x: np.exp(x), (-1.5, 1.5)),
+    ("log1p", mx.log1p, lambda x: 1.0 / (1.0 + x), (-0.5, 1.5)),
+    ("reciprocal", mx.reciprocal, lambda x: -1.0 / x**2, (0.5, 2.0)),
+    ("rsqrt", mx.rsqrt, lambda x: -0.5 * x ** (-1.5), (0.5, 2.0)),
+    ("erf", mx.erf, lambda x: 2.0 / np.sqrt(np.pi) * np.exp(-(x**2)), (-2.0, 2.0)),
+    (
+        "sigmoid",
+        mx.sigmoid,
+        lambda x: np.exp(-x) / (1.0 + np.exp(-x)) ** 2,
+        (-2.0, 2.0),
+    ),
+]
+
+# (name, mlx op, d/da, d/db, range for a, range for b)
+BINARY_OPS = [
+    (
+        "logaddexp",
+        mx.logaddexp,
+        lambda a, b: 1.0 / (1.0 + np.exp(b - a)),
+        lambda a, b: 1.0 / (1.0 + np.exp(a - b)),
+        (-1.5, 1.5),
+        (-1.5, 1.5),
+    ),
+    (
+        "arctan2",
+        mx.arctan2,
+        lambda a, b: b / (a**2 + b**2),
+        lambda a, b: -a / (a**2 + b**2),
+        (0.5, 2.0),
+        (0.5, 2.0),
+    ),
+]
+
+# Enough points to catch a defect that only shows away from the origin. A
+# single evaluation point can hide one: rounding the exponential in the erf
+# backward pass through a lower precision, for example, is invisible at x = 0
+# because exp(0) is 1 in every float format.
+NUM_POINTS = 33
+
+
+def _grid(lo, hi, dtype):
+    x = np.linspace(lo, hi, NUM_POINTS)
+    # Skip points where a reference would be evaluated at or next to a
+    # singularity of one of the ops above.
+    x = x[np.abs(x) > 1e-3]
+    return mx.array(x).astype(dtype)
+
+
+class TestGradReference(mlx_tests.MLXTestCase):
+    """Compare gradients against closed-form references at many points.
+
+    These complement the existing autograd tests, which check a gradient
+    against a hand-written expected value at one or two points. Evaluating on
+    a grid catches defects whose effect depends on the input.
+    """
+
+    def _check(self, name, grad, expected, dtype):
+        tol = TOLERANCES[dtype]
+        self.assertEqual(grad.dtype, dtype, msg=f"{name}: gradient dtype changed")
+        got = np.array(grad.astype(mx.float32), dtype=np.float64)
+        self.assertTrue(np.isfinite(got).all(), msg=f"{name}: gradient is not finite")
+        np.testing.assert_allclose(
+            got, expected, err_msg=f"{name} gradient at {dtype}", **tol
+        )
+
+    def test_unary_op_gradients(self):
+        for name, op, d_op, (lo, hi) in UNARY_OPS:
+            for dtype in (mx.float32, mx.float16):
+                with self.subTest(op=name, dtype=dtype):
+                    x = _grid(lo, hi, dtype)
+                    grad = mx.grad(lambda a: mx.sum(op(a).astype(mx.float32)))(x)
+                    mx.eval(grad)
+                    expected = d_op(np.array(x.astype(mx.float32), dtype=np.float64))
+                    self._check(name, grad, expected, dtype)
+
+    def test_binary_op_gradients(self):
+        for name, op, d_a, d_b, ra, rb in BINARY_OPS:
+            for dtype in (mx.float32, mx.float16):
+                with self.subTest(op=name, dtype=dtype):
+                    a = _grid(*ra, dtype)
+                    b = _grid(*rb, dtype)
+                    ga, gb = mx.grad(
+                        lambda p, q: mx.sum(op(p, q).astype(mx.float32)),
+                        argnums=(0, 1),
+                    )(a, b)
+                    mx.eval(ga, gb)
+                    an = np.array(a.astype(mx.float32), dtype=np.float64)
+                    bn = np.array(b.astype(mx.float32), dtype=np.float64)
+                    self._check(f"{name} d/da", ga, d_a(an, bn), dtype)
+                    self._check(f"{name} d/db", gb, d_b(an, bn), dtype)
+
+    def test_erf_gradient_away_from_zero(self):
+        # The derivative of erf is 2/sqrt(pi) * exp(-x^2). At x = 0 the
+        # exponential is exactly 1, so a defect in how that factor is computed
+        # or stored does not show up there. Check a spread of magnitudes.
+        for x in (0.0, 0.25, 0.5, 1.0, 1.5, 2.0, 3.0):
+            with self.subTest(x=x):
+                xa = mx.array([x], dtype=mx.float32)
+                grad = mx.grad(lambda a: mx.sum(mx.erf(a)))(xa)
+                mx.eval(grad)
+                expected = 2.0 / math.sqrt(math.pi) * math.exp(-(x**2))
+                self.assertAlmostEqual(grad.item(), expected, delta=1e-6)
+
+    def test_second_order_gradients(self):
+        # A wrong constant in a first derivative usually survives into the
+        # second, so this is cheap extra coverage on the same references.
+        cases = [
+            (mx.sin, lambda x: -np.sin(x), (-1.5, 1.5)),
+            (mx.sinh, lambda x: np.sinh(x), (-1.5, 1.5)),
+            (mx.log1p, lambda x: -1.0 / (1.0 + x) ** 2, (-0.5, 1.5)),
+        ]
+        for op, d2_op, (lo, hi) in cases:
+            with self.subTest(op=op.__name__):
+                x = _grid(lo, hi, mx.float32)
+                first = mx.grad(lambda a: mx.sum(op(a)))
+                g2 = mx.grad(lambda a: mx.sum(first(a)))(x)
+                mx.eval(g2)
+                expected = d2_op(np.array(x, dtype=np.float64))
+                np.testing.assert_allclose(
+                    np.array(g2, dtype=np.float64),
+                    expected,
+                    **TOLERANCES[mx.float32],
+                )
+
+
+if __name__ == "__main__":
+    mlx_tests.MLXTestRunner()


### PR DESCRIPTION
### What this adds

A new test file, `python/tests/test_grad_reference.py`, comparing gradients against closed-form derivatives evaluated in float64:

- **15 elementwise ops** (`sin`, `sinh`, `cosh`, `tan`, `arcsin`, `arccos`, `arctan`, `arcsinh`, `arctanh`, `expm1`, `log1p`, `reciprocal`, `rsqrt`, `erf`, `sigmoid`) and **2 binary ops** (`logaddexp`, `arctan2`, both arguments).
- **33 points per op** instead of one or two, over ranges chosen to stay well inside each op's domain and away from poles.
- **Per-dtype tolerances** (`float32` rtol 1e-5, `float16` rtol 5e-3) rather than one generic value. These come from the measured agreement between MLX's float32 gradients and these closed forms on well-conditioned inputs, which sits at about one float32 epsilon (~1.2e-7); the tolerances leave roughly two orders of headroom so ordinary cross-machine rounding never trips them.
- A second-order check on three ops, and a dedicated multi-point `erf` check.

One new file, no changes to existing tests. Runs in ~0.05s, passes on `DEVICE=cpu` and `DEVICE=gpu`.

### Why

The existing autograd tests check a gradient against a hand-written expected value at one or two points. That is a real check, but a defect whose effect depends on the input can sit inside the gap.

`erf` is the clean example. Its derivative is `2/sqrt(pi) * exp(-x^2)`, and the current exact assertion evaluates it at **x = 0**:

```cpp
CHECK_EQ(out.second.item<float>(),
         static_cast<float>(1.12837916709551257389615890312154517));
```

That assertion is tight — it catches an error in the `2/sqrt(pi)` coefficient down to ~1e-6 relative. But at `x = 0` the exponential factor is exactly `1.0`, which is exactly representable in every float format. So anything that goes wrong in *how that factor is computed or stored* — a lower-precision intermediate, a rounded temporary — changes nothing at that point and passes.

Evaluating the same closed form on a grid closes that gap without touching any existing test.

### Evidence it works

I checked the current gradients first: across a sweep of these ops over several input classes, dtypes and both streams, I found **no gradient defects in v0.32.0**. This isn't a bug report — the gradients look healthy, and these tests guard the surface rather than fix anything.

To confirm the tests can detect something, I temporarily introduced two defects locally, one at a time, and reran both suites:

| local defect (temporary, not in this PR) | existing python suite | these tests |
|---|---|---|
| `erf` backward rounds `exp(-x^2)` through float16 (~2.4e-4 relative) | passes | **fails** — `op='erf', dtype=float32`, 30/32 points mismatched, e.g. `0.020661240` vs expected `0.020666985` |
| `arctan` backward rounds `(1+x^2)` through bfloat16 (~2.9e-3 relative) | fails (`test_trig_ops`) | **fails** — `op='arctan', dtype=float32` |

The first is the case that motivated this: a 2.4e-4 relative error in `erf`'s backward pass — four orders of magnitude larger than the coefficient error the x = 0 assertion catches — passes the existing suite because of where it's evaluated. The second is caught by both, which is what you'd expect when a defect is large enough to disturb an existing test.

Both defects were reverted and the tree rebuilt; the tests pass again on clean `v0.32.0`.

### Scope — what these tests do not cover

- **Small defects in float16 / bfloat16.** The legitimate spread between an fp16 gradient and a float64 reference is already ~6e-4 relative (~1e-3 for longer reductions), so a defect below that isn't distinguishable from rounding at that precision. The float16 tolerances here sit above that spread and will only catch coarse errors; bfloat16 isn't covered.
- **Long reductions.** Only elementwise and simple binary ops. Reassociation in a long reduction widens the legitimate spread and would need its own tolerances.
- **Selection ops** (`max`, `abs`, `sort`, `where`, `floor`, …) are deliberately excluded: their derivative isn't unique at ties and kinks, so a reference comparison there tests the tie-breaking convention rather than the gradient.
- **GPU-kernel-specific paths.** The tests run on whichever device is selected, so they exercise Metal under `DEVICE=gpu`, but they compare against a mathematical reference rather than against the CPU result — this isn't a CPU-vs-Metal parity check.
- Ops are covered via their closed form, so anything without a simple analytic derivative is out of scope.
- **The tolerances are deliberately conservative** and can be tightened per-op once there's CI history showing the real cross-machine spread. They're set for margin on hardware I can't test rather than for maximum sensitivity.

Happy to trim the op list, adjust tolerances, or split the file differently if you'd prefer a smaller footprint.
