### PR TITLE
Stabilize reduced-precision InstanceNorm

### DIFF
--- a/python/mlx/nn/layers/normalization.py
+++ b/python/mlx/nn/layers/normalization.py
@@ -64,12 +64,19 @@ class InstanceNorm(Module):
                 f"InstanceNorm expects inputs with at least 3 dimensions"
                 f" (N, ..., C) but the input has {x.ndim} dimensions."
             )
-        reduction_axes = tuple(range(1, x.ndim - 1))
-        # Compute stats
-        mean = mx.mean(x, axis=reduction_axes, keepdims=True)
-        var = mx.var(x, axis=reduction_axes, keepdims=True)
-        # Normalize
-        x = (x - mean) * mx.rsqrt(var + self.eps)
+        batch_size, features = x.shape[0], x.shape[-1]
+        spatial_shape = x.shape[1:-1]
+        channels_first = mx.transpose(x, (0, x.ndim - 1, *range(1, x.ndim - 1)))
+        x = mx.fast.layer_norm(
+            channels_first.reshape(batch_size, features, -1),
+            None,
+            None,
+            self.eps,
+        )
+        x = mx.transpose(
+            x.reshape(batch_size, features, *spatial_shape),
+            (0, *range(2, len(spatial_shape) + 2), 1),
+        )
         # Scale and shift if necessary
         return (self.weight * x + self.bias) if "weight" in self else x
 

--- a/python/tests/test_nn.py
+++ b/python/tests/test_nn.py
@@ -693,6 +693,21 @@ class TestLayers(mlx_tests.MLXTestCase):
         ]
         self.assertTrue(x.shape == y.shape)
         self.assertTrue(np.allclose(y, expected_y, atol=1e-5))
+        # Reduced-precision statistics must not overflow for finite feature maps.
+        checkerboard = np.indices((4, 4, 4)).sum(axis=0) % 2
+        x = mx.array(
+            np.stack(
+                [
+                    np.where(checkerboard, -512, 512),
+                    np.where(checkerboard, -256, 256),
+                ],
+                axis=-1,
+            ).astype(np.float16)
+        )[None]
+        y = nn.InstanceNorm(dims=2)(x)
+        self.assertEqual(y.dtype, mx.float16)
+        self.assertTrue(mx.allclose(y.min(), mx.array(-1.0, dtype=mx.float16)))
+        self.assertTrue(mx.allclose(y.max(), mx.array(1.0, dtype=mx.float16)))
         # Test repr
         self.assertTrue(str(inorm) == "InstanceNorm(3, eps=1e-05, affine=False)")
         # Raise for inputs without spatial dimensions


### PR DESCRIPTION
## Proposed changes

Fixes #4228.

This PR stabilizes reduced-precision `InstanceNorm` without changing its public `(N, ..., C)` layout or output dtype:

- reshape each input to `(N, C, spatial_voxels)` and use the stable fused `mx.fast.layer_norm` reduction;
- restore the original channels-last shape before the optional affine transform;
- add an FP16 regression case whose direct variance overflows even though every input value is finite.

## Why

The current FP16 path computes `mx.var` in FP16. A channel alternating between `-512` and `512` therefore gets `var=inf`, and `InstanceNorm` collapses the channel to zero instead of returning values near `-1` and `1`.

`mx.fast.layer_norm` already performs the same reduction needed by `InstanceNorm` after the spatial dimensions are flattened. It avoids a full FP32 input cast and uses the optimized normalization kernel.

## Performance

Apple M4, MLX 0.32.0 core, FP16 input, five warmups and 20 measured calls:

| NDHWC shape | Existing p50 | FP32-cast p50 | This PR p50 |
| --- | ---: | ---: | ---: |
| `1 x 32 x 64 x 64 x 30` | `0.785 ms` | `0.789 ms` | `0.196 ms` |
| `1 x 128 x 96 x 96 x 30` | `2.357 ms` | `5.145 ms` | `1.098 ms` |

The larger shape is the first-stage feature map from the 3D segmentation route that exposed the overflow.

## Validation

- `PYTHONPATH=python:python/tests python -m unittest test_nn.TestLayers`
- `PYTHONPATH=python:python/tests python -m unittest test_nn`
- `pre-commit run --all-files`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed; no public API or documented behavior changed)
