### PR TITLE
Make abs a no-op for unsigned types in the simd helpers

### DIFF
--- a/mlx/backend/cpu/simd/base_simd.h
+++ b/mlx/backend/cpu/simd/base_simd.h
@@ -84,18 +84,6 @@ Simd<T, 1> recip(Simd<T, 1> in) {
 
 DEFAULT_UNARY(operator-, std::negate{})
 DEFAULT_UNARY(operator!, std::logical_not{})
-// std::abs has no overload for the wider unsigned types, so calling it is
-// ambiguous rather than a no-op. Abs::eval_cpu already skips unsigned inputs,
-// but the compiled kernels reach this directly.
-template <typename T>
-Simd<T, 1> abs(Simd<T, 1> in) {
-  if constexpr (std::is_unsigned_v<T>) {
-    return in;
-  } else {
-    return std::abs(in.value);
-  }
-}
-
 DEFAULT_UNARY(acos, std::acos)
 DEFAULT_UNARY(acosh, std::acosh)
 DEFAULT_UNARY(asin, std::asin)
@@ -113,6 +101,15 @@ DEFAULT_UNARY(sinh, std::sinh)
 DEFAULT_UNARY(sqrt, std::sqrt)
 DEFAULT_UNARY(tan, std::tan)
 DEFAULT_UNARY(tanh, std::tanh)
+
+template <typename T>
+Simd<T, 1> abs(Simd<T, 1> in) {
+  if constexpr (std::is_unsigned_v<T>) {
+    return in;
+  } else {
+    return std::abs(in.value);
+  }
+}
 
 template <typename T>
 Simd<T, 1> log1p(Simd<T, 1> in) {

--- a/mlx/backend/cpu/simd/base_simd.h
+++ b/mlx/backend/cpu/simd/base_simd.h
@@ -84,7 +84,18 @@ Simd<T, 1> recip(Simd<T, 1> in) {
 
 DEFAULT_UNARY(operator-, std::negate{})
 DEFAULT_UNARY(operator!, std::logical_not{})
-DEFAULT_UNARY(abs, std::abs)
+// std::abs has no overload for the wider unsigned types, so calling it is
+// ambiguous rather than a no-op. Abs::eval_cpu already skips unsigned inputs,
+// but the compiled kernels reach this directly.
+template <typename T>
+Simd<T, 1> abs(Simd<T, 1> in) {
+  if constexpr (std::is_unsigned_v<T>) {
+    return in;
+  } else {
+    return std::abs(in.value);
+  }
+}
+
 DEFAULT_UNARY(acos, std::acos)
 DEFAULT_UNARY(acosh, std::acosh)
 DEFAULT_UNARY(asin, std::asin)

--- a/python/tests/test_compile.py
+++ b/python/tests/test_compile.py
@@ -1569,6 +1569,13 @@ class TestCompile(mlx_tests.MLXTestCase):
         expected = w[::-1, :, ::-1, :] + 1.0
         self.assertTrue(mx.array_equal(p(w[::-1, :, ::-1, :]), expected))
 
+    def test_compile_abs_unsigned(self):
+        # abs has to compile for the wider unsigned types too
+        fun = lambda x: mx.abs(x) + 1
+        for dtype in [mx.uint8, mx.uint16, mx.uint32, mx.uint64]:
+            x = mx.array([1, 2, 3], dtype)
+            self.assertTrue(mx.array_equal(mx.compile(fun)(x), fun(x)))
+
 
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner()


### PR DESCRIPTION
## Proposed changes

Compiling any fused kernel that contains `mx.abs` on a `uint32` or `uint64` array fails:

```python
>>> x = mx.array([1, 2, 3], mx.uint32)
>>> mx.compile(lambda z: mx.abs(z) + 1)(x)
RuntimeError: [Compile::eval_cpu] Failed to compile function Cu4IAbsADu4IB...
```

Eager works, so it only bites once the graph is compiled:

```python
>>> (mx.abs(x) + 1).tolist()
[2, 3, 4]
```

The reason for the split is that `Abs::eval_cpu` sidesteps the problem:

```cpp
if (issubdtype(in.dtype(), unsignedinteger) || in.dtype() == bool_) {
  // No-op for unsigned types
  out.copy_shared_buffer(in);
}
```

The compiled kernels do not go through that, they emit `detail::Abs` directly, which lands on `DEFAULT_UNARY(abs, std::abs)`. `std::abs` has overloads for `int`, `long`, `long long` and the floating point types, so `uint8` and `uint16` promote to `int` and resolve, while `uint32_t` and `uint64_t` are ambiguous and the generated source fails to compile.

`abs` in the simd helpers is now a no-op for unsigned types, which is what the eager path already decided and means the two agree without the codegen needing to know about it.

```python
>>> for dtype in (mx.uint8, mx.uint16, mx.uint32, mx.uint64):
...     x = mx.array([1, 2, 3], dtype)
...     mx.compile(lambda z: mx.abs(z) + 1)(x).tolist()
[2, 3, 4]
[2, 3, 4]
[2, 3, 4]
[2, 3, 4]
```

`bool` takes the same branch, matching `Abs::eval_cpu`, which also treats it as a no-op.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

CPU only build (`MLX_BUILD_METAL=OFF`) at 52960f8. Checked compiled against eager for `abs` fused with another op across all eleven dtypes, and for `power(a, abs(b))`, `a << abs(b % 4)`, `abs(a) * abs(b)` and `sum(abs(a))` on both `uint32` and `uint64`. Signed integers, float16, bfloat16, float32 and complex are unchanged. `test_compile.py`, `test_ops.py` and `test_autograd.py` pass, and the new test raises `RuntimeError` on main.

---

freshman contributor, i lean on Claude Code while digging. this one turned up sideways: i was comparing eager against vmap and compiled for integer dtypes, my script died with a C++ compiler error rather than a python failure, and it took a minute to realise that was mlx's own JIT rather than something wrong with my build.
