### PR TITLE
Keep the winograd gemm at full float32 precision

### DIFF
--- a/mlx/backend/metal/conv.cpp
+++ b/mlx/backend/metal/conv.cpp
@@ -948,7 +948,13 @@ void winograd_conv_2D_gpu(
         /*b_cols = */ conv_params.O,
         /*a_transposed = */ false,
         /*b_transposed = */ false,
-        /*copies = */ empty_copies);
+        /*copies = */ empty_copies,
+        /*batch_shape = */ {},
+        /*A_batch_stride = */ {},
+        /*B_batch_stride = */ {},
+        // The winograd transforms amplify whatever the gemm rounds away, so
+        // this one stays at full float32 even when tf32 is allowed elsewhere.
+        /*allow_tf32 = */ false);
   }
 
   // Do output transform

--- a/mlx/backend/metal/matmul.cpp
+++ b/mlx/backend/metal/matmul.cpp
@@ -862,7 +862,8 @@ void steel_matmul_axpby(
     Strides B_batch_stride /* = {} */,
     Strides C_batch_stride /* = {} */,
     float alpha /* = 1.0f */,
-    float beta /* = 0.0f */) {
+    float beta /* = 0.0f */,
+    bool allow_tf32 /* = true */) {
   if (batch_shape.empty()) {
     /////////////////////////////////////////////////////////////////////////////
     // Check and collapse batch dimensions
@@ -916,7 +917,7 @@ void steel_matmul_axpby(
   int64_t matrix_size = static_cast<int64_t>(M) * N;
   bool use_nax = metal::is_nax_available() &&
       !issubdtype(a.dtype(), complexfloating) &&
-      (env::enable_tf32() || a.dtype() != float32);
+      ((allow_tf32 && env::enable_tf32()) || a.dtype() != float32);
   char devc = d.get_architecture().back();
   int min_tmn_threshold = (devc == 's' || devc == 'd') ? 2048 : 1024;
 

--- a/mlx/backend/metal/matmul.h
+++ b/mlx/backend/metal/matmul.h
@@ -100,7 +100,8 @@ void steel_matmul_axpby(
     Strides B_batch_stride = {},
     Strides C_batch_stride = {},
     float alpha = 1.0f,
-    float beta = 0.0f);
+    float beta = 0.0f,
+    bool allow_tf32 = true);
 
 inline void steel_matmul(
     const Stream& s,
@@ -119,7 +120,8 @@ inline void steel_matmul(
     std::vector<array>& copies,
     Shape batch_shape = {},
     Strides A_batch_stride = {},
-    Strides B_batch_stride = {}) {
+    Strides B_batch_stride = {},
+    bool allow_tf32 = true) {
   return steel_matmul_axpby<false>(
       /* const Stream& s = */ s,
       /* metal::Device& d = */ d,
@@ -138,7 +140,11 @@ inline void steel_matmul(
       /* std::vector<array>& copies = */ copies,
       /* Shape batch_shape = */ batch_shape,
       /* Strides A_batch_stride = */ A_batch_stride,
-      /* Strides B_batch_stride = */ B_batch_stride);
+      /* Strides B_batch_stride = */ B_batch_stride,
+      /* Strides C_batch_stride = */ {},
+      /* float alpha = */ 1.0f,
+      /* float beta = */ 0.0f,
+      /* bool allow_tf32 = */ allow_tf32);
 }
 
 } // namespace mlx::core

--- a/python/tests/test_conv.py
+++ b/python/tests/test_conv.py
@@ -2,6 +2,9 @@
 
 import math
 import os
+import subprocess
+import sys
+import textwrap
 import unittest
 from itertools import permutations
 
@@ -47,6 +50,34 @@ class TestConv(mlx_tests.MLXTestCase):
 
                     self.assertEqual(c_mx.shape, c_np.shape)
                     self.assertTrue(np.allclose(c_mx, c_np, atol=atol))
+
+    def test_conv_2d_winograd_float32_precision(self):
+        # The aligned conv takes winograd and the unaligned one does not, so
+        # the two have to agree to float32 precision.
+        script = textwrap.dedent("""
+            import mlx.core as mx
+
+            # Winograd also wants N * iH * iW >= 4096 and C + O >= 256.
+            N, S, K, C = 4, 32, 3, 128
+            x = mx.random.normal((N, S, S, C))
+            w = mx.random.normal((C, K, K, C))
+            aligned = mx.conv2d(x, w, padding=1)
+
+            # The same conv with an input channel count winograd declines.
+            xu = mx.pad(x, [(0, 0), (0, 0), (0, 0), (0, 16)])
+            wu = mx.pad(w, [(0, 0), (0, 0), (0, 0), (0, 16)])
+            unaligned = mx.conv2d(xu, wu, padding=1)
+
+            mx.eval(aligned, unaligned)
+            print(mx.abs(aligned - unaligned).max().item())
+            """)
+        # tf32 is off for the whole suite and enable_tf32() caches the read.
+        env = dict(os.environ, MLX_ENABLE_TF32="1")
+        out = subprocess.check_output(
+            [sys.executable, "-c", script], env=env, text=True
+        )
+        gap = float(out.strip())
+        self.assertLess(gap, 1e-2, f"winograd and gemm disagree by {gap}")
 
     def test_conv_1d_groups_flipped(self):
         x = mx.broadcast_to(mx.arange(5).astype(mx.float32), (2, 5)).T


### PR DESCRIPTION
A float32 conv2d on hardware with neural accelerators returns roughly float16 accuracy, but only
when the channel counts are multiples of 32.

`conv.cpp` sends 3x3 stride 1 convs to winograd when `C % 32 == 0` and `O % 32 == 0` (plus size
conditions). Winograd runs its batched gemm through `steel_matmul`, which takes the nax path for
float32 whenever `MLX_ENABLE_TF32` is set, and that is the default. The winograd transforms then
amplify what tf32 rounded away. The implicit gemm path never calls `steel_matmul`, so it is
unaffected, which is why the same conv is accurate at 336 channels and not at 352.

N=4, 64x64, 3x3, padding 1, C = O, error against a cpu float32 reference:

| dtype | implicit gemm | winograd | ratio |
|---|---:|---:|---:|
| float32 | 0.00085 | **4.15259** | 4859.7x |
| float16 | 0.14026 | 5.13802 | 36.6x |
| bfloat16 | 0.98453 | 42.59959 | 43.3x |

Setting `MLX_ENABLE_TF32=0` drops the float32 winograd error to 0.00693, a 600x change, and the
same shape on an M4 Pro, which has no neural accelerators, measures 0.00693 as well. Both point
at the same place, so this makes winograd ask for full float32 rather than depending on a global
that is about matmul.

`steel_matmul_axpby` decides `use_nax` from `env::enable_tf32()` internally, so this adds an
`allow_tf32` parameter defaulted to true and threads it to that decision. Every existing caller
is unchanged; winograd passes false. The flag only has an effect for float32 inputs, since the
condition it guards is already false for every other dtype.

The float16 and bfloat16 rows above are a separate problem and are not addressed here. Those come
from the winograd intermediates being allocated in the input dtype, and fixing them means
doubling the working set, which is the opposite of what #4102 is trying to do.

### Cost

N=8, 64x64, C = O = 352, calibrated, min of 7.

| | before | after |
|---|---:|---:|
| float32 winograd | 2.124 ms | 2.654 ms |
| float16 winograd | 1.349 ms | 1.333 ms |
| bfloat16 winograd | 1.324 ms | 1.328 ms |
| implicit gemm, C=336 | 5.312 ms | 5.313 ms |

25% on the float32 winograd path and nothing anywhere else. It stays about 2x faster than the
implicit gemm the same conv falls to with an unaligned channel count.

### Test

`mlx_tests` sets `MLX_ENABLE_TF32=0` for the whole suite and `enable_tf32()` reads the
environment once into a static, so a test in the suite cannot see this. The new test runs the
conv in a subprocess with tf32 on and compares an aligned conv against an unaligned one. It
reports 2.38 before this change and 0.0023 after.

`test_conv`, `test_blas`, `test_ops`, `test_autograd` and `test_nn` all pass, which is worth
saying because `matmul.h` has a lot of callers.

This touches the `steel_matmul` call that #4102 moves, so whichever lands second needs a one line
rebase.

