### PR TITLE
Reject complex in erf and erfinv

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -3428,6 +3428,9 @@ array sigmoid(const array& a, StreamOrDevice s /* = {} */) {
 }
 
 array erf(const array& a, StreamOrDevice s /* = {} */) {
+  if (a.dtype() == complex64) {
+    throw std::invalid_argument("[erf] Not supported for complex64.");
+  }
   auto dtype = at_least_float(a.dtype());
   return array(
       a.shape(),
@@ -3437,6 +3440,9 @@ array erf(const array& a, StreamOrDevice s /* = {} */) {
 }
 
 array erfinv(const array& a, StreamOrDevice s /* = {} */) {
+  if (a.dtype() == complex64) {
+    throw std::invalid_argument("[erfinv] Not supported for complex64.");
+  }
   auto dtype = at_least_float(a.dtype());
   return array(
       a.shape(),

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -1161,6 +1161,13 @@ class TestOps(mlx_tests.MLXTestCase):
         expected = np.array([math.erf(i) for i in inputs])
         self.assertTrue(np.allclose(mx.erf(x), expected))
 
+        # Complex is not supported and has to say so rather than abort
+        z = mx.array([1 + 2j], mx.complex64)
+        with self.assertRaises(ValueError):
+            mx.erf(z)
+        with self.assertRaises(ValueError):
+            mx.erfinv(z)
+
     def test_erfinv(self):
         inputs = [-5.0, -1.0, 0.5, 0.0, 0.5, 1.0, 5.0]
         x = mx.array(inputs)


### PR DESCRIPTION
## Proposed changes

`mx.erf` and `mx.erfinv` do not support complex, but instead of saying so they take the whole process down:

```python
>>> z = mx.array([1 + 2j], mx.complex64)
>>> mx.eval(mx.erf(z))
libc++abi: terminating due to uncaught exception of type std::runtime_error:
[unary_real] Does not support complex64
zsh: abort
```

The check exists, but it lives in the CPU kernel dispatch, which runs on the stream worker thread. Throwing there does not reach the caller, so `std::terminate` runs instead of a Python exception. There is no way to catch it and nothing else in the process survives.

The other unary ops that cannot take complex check at the op level and raise normally, for example:

```cpp
array floor(const array& a, StreamOrDevice s /* = {} */) {
  if (a.dtype() == complex64) {
    throw std::invalid_argument("[floor] Not supported for complex64.");
  }
```

`erf` and `erfinv` now do the same:

```python
>>> mx.erf(z)
ValueError: [erf] Not supported for complex64.
>>> mx.erfinv(z)
ValueError: [erfinv] Not supported for complex64.
```

Real inputs are untouched: `erf` still matches `math.erf` on the existing cases, `erfinv` still matches scipy, int32 still promotes to float32, float16 and bfloat16 keep their dtype, and the gradient is unchanged.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

CPU only build (`MLX_BUILD_METAL=OFF`) at 77a0c1e. `test_ops.py` and `test_nn.py` pass, and the C++ suite passes too (249 cases, 3346 assertions). On main the new assertions do not fail, they abort the interpreter, which is the bug.

---

freshman contributor, i work through these with Claude Code. found it running every unary op over a complex64 input and comparing against numpy: my script died mid sweep with no python traceback at all, which is what pointed at the worker thread rather than at the op.
