### PR TITLE
Fix Metal sort of a view with a negative stride

### DIFF
--- a/mlx/backend/metal/kernels/sort.h
+++ b/mlx/backend/metal/kernels/sort.h
@@ -388,8 +388,11 @@ template <
   using ValT = typename sort_kernel::ValT;
   using IdxT = typename sort_kernel::IdxT;
 
-  auto in_block_idx = elem_to_loc(tid.y, nc_shape, in_nc_strides, nc_dim);
-  auto out_block_idx = elem_to_loc(tid.y, nc_shape, out_nc_strides, nc_dim);
+  // Signed offsets: a non-sorted axis may have a negative stride.
+  auto in_block_idx =
+      elem_to_loc<int64_t>(tid.y, nc_shape, in_nc_strides, nc_dim);
+  auto out_block_idx =
+      elem_to_loc<int64_t>(tid.y, nc_shape, out_nc_strides, nc_dim);
   inp += in_block_idx;
   out += out_block_idx;
 
@@ -532,7 +535,8 @@ template <
       BLOCK_THREADS,
       N_PER_THREAD>;
 
-  auto block_idx = elem_to_loc(tid.y, nc_shape, nc_strides, nc_dim);
+  // Signed offset: a non-sorted axis may have a negative stride.
+  auto block_idx = elem_to_loc<int64_t>(tid.y, nc_shape, nc_strides, nc_dim);
   inp += block_idx;
   out_vals += tid.y * size_sorted_axis;
   out_idxs += tid.y * size_sorted_axis;

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -2675,6 +2675,27 @@ class TestOps(mlx_tests.MLXTestCase):
         y_np = np.sort(np.array(a), axis=-1)
         self.assertTrue(np.array_equal(y_np, y_mx))
 
+        # Negative stride on an axis that is not sorted, single and multi block
+        np.random.seed(0)
+        for dtype in ("int32", "float32"):
+            for size in (4, 32769):
+                with self.subTest(dtype=dtype, size=size):
+                    a_np = np.random.uniform(0, 100, size=(3, size))
+                    a_np = a_np.astype(getattr(np, dtype))
+                    a_mx = mx.array(a_np)[::-1, :]
+                    a_np = a_np[::-1, :]
+
+                    b_np = np.sort(a_np, axis=-1)
+                    self.assertTrue(np.array_equal(b_np, mx.sort(a_mx, axis=-1)))
+
+                    idx = mx.argsort(a_mx, axis=-1)
+                    self.assertTrue(
+                        np.array_equal(b_np, mx.take_along_axis(a_mx, idx, axis=-1))
+                    )
+
+                    b_mx = mx.partition(a_mx, 1, axis=-1)
+                    self.assertTrue(np.array_equal(b_np[:, 1], np.array(b_mx)[:, 1]))
+
     def test_partition(self):
         shape = (3, 4, 5)
         for dtype in ("int32", "float32"):


### PR DESCRIPTION
## Proposed changes

Fixes #4225. #4226 addresses the same bug by copying negative-stride inputs to a contiguous buffer
before the sort; the review there asks for the root cause instead, which is what this does. On Metal,
`mx.sort` / `mx.argsort` / `mx.partition` / `mx.topk` return zeros for every segment but the first
when the input is a view with a negative stride on an axis that is not being sorted:

```python
a = mx.array(np.arange(12, dtype=np.int32).reshape(3, 4))[::-1, :]
mx.sort(a, axis=-1)   # [[8, 9, 10, 11], [0, 0, 0, 0], [0, 0, 0, 0]]
```

`block_sort_nc` and `mb_block_sort` get each segment's base offset from `elem_to_loc(tid.y, ...)`.
`elem_to_loc` deduces `IdxT` from its first argument, so `tid.y` makes it `uint`: a negative stride
wraps to ~4.29e9 instead of stepping backwards, the segment reads out of bounds, and Metal returns
zeros. Asking for `int64_t` matches what the CUDA kernels already do with `int64_t(blockIdx.y)`.

`block_sort` has the same signedness issue at `sort.h:283-284`, left unpatched here: slicing and
`as_strided` clear `flags().contiguous` for a negative stride, so the only producer that reaches it is
an independent `Split` mis-flagging bug whose CPU path is wrong for the same input. Happy to add the
two lines if you would rather have all three sites consistent.

```
                 before                                after
sort      [[8,9,10,11],[0,0,0,0],[0,0,0,0]]   [[8,9,10,11],[4,5,6,7],[0,1,2,3]]
topk      [[10,11],[0,0],[0,0]]               [[10,11],[6,7],[2,3]]
partition [[8,9,10,11],[0,0,0,0],[0,0,0,0]]   [[8,9,10,11],[4,5,6,7],[0,1,2,3]]
```

Added to `test_sort`, covering `int32` and `float32` at both the single-block and multi-block sizes;
all four subtests fail on the unpatched kernel. On an M3 Pro `python/tests` is 810 passed / 21 skipped
and the C++ suite 266 cases / 3600 assertions.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)

---
AI assistance was used in developing this change. I reviewed and tested every line.
