### PR TITLE
Reject complex in expm1, sigmoid and arctan2

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -3322,6 +3322,9 @@ array arctan(const array& a, StreamOrDevice s /* = {} */) {
 }
 
 array arctan2(const array& a, const array& b, StreamOrDevice s /* = {} */) {
+  if (a.dtype() == complex64 || b.dtype() == complex64) {
+    throw std::invalid_argument("[arctan2] Not supported for complex64.");
+  }
   auto dtype = at_least_float(promote_types(a.dtype(), b.dtype()));
   auto inputs = broadcast_arrays({astype(a, dtype, s), astype(b, dtype, s)}, s);
   auto shape = inputs[0].shape();

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -3273,6 +3273,9 @@ array exp(const array& a, StreamOrDevice s /* = {} */) {
 }
 
 array expm1(const array& a, StreamOrDevice s /* = {} */) {
+  if (a.dtype() == complex64) {
+    throw std::invalid_argument("[expm1] Not supported for complex64.");
+  }
   auto dtype = at_least_float(a.dtype());
   auto input = astype(a, dtype, s);
   return array(
@@ -3426,6 +3429,9 @@ array logaddexp(const array& a, const array& b, StreamOrDevice s /* = {} */) {
 }
 
 array sigmoid(const array& a, StreamOrDevice s /* = {} */) {
+  if (a.dtype() == complex64) {
+    throw std::invalid_argument("[sigmoid] Not supported for complex64.");
+  }
   auto dtype = at_least_float(a.dtype());
   auto input = astype(a, dtype, s);
   return array(

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -1162,6 +1162,8 @@ class TestOps(mlx_tests.MLXTestCase):
             mx.expm1(z)
         with self.assertRaises(ValueError):
             mx.sigmoid(z)
+        with self.assertRaises(ValueError):
+            mx.arctan2(z, z)
 
     def test_erf(self):
         inputs = [-5, 0.0, 0.5, 1.0, 2.0, 10.0]

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -1155,6 +1155,14 @@ class TestOps(mlx_tests.MLXTestCase):
         np.seterr(over=errs["over"])
         self.assertTrue(np.allclose(result, expected, rtol=1e-3, atol=1e-4))
 
+        # Complex is not supported and has to say so rather than quietly
+        # computing on the real part
+        z = mx.array([1 + 2j], mx.complex64)
+        with self.assertRaises(ValueError):
+            mx.expm1(z)
+        with self.assertRaises(ValueError):
+            mx.sigmoid(z)
+
     def test_erf(self):
         inputs = [-5, 0.0, 0.5, 1.0, 2.0, 10.0]
         x = mx.array(inputs)


### PR DESCRIPTION
## Proposed changes

`mx.expm1`, `mx.sigmoid` and `mx.arctan2` accept complex64 and quietly return an answer computed from the real part only:

```python
>>> z = mx.array([1 + 2j], mx.complex64)
>>> mx.expm1(z).item()
(1.718281865119934+0j)      # numpy and pytorch: -2.1312044+2.4717267j
>>> mx.sigmoid(z).item()
(0.9034420251846313+0j)     # 1/(1+exp(-z)) is 1.0214154+0.4034387j
>>> mx.arctan2(z, mx.array([2 - 1j], mx.complex64)).item()
(0.46364760398864746+0j)    # exactly atan2(1, 2)
```

`1.7182818` is `expm1(1)`, so the imaginary part is simply dropped. That happens because `complex64_t` converts to `float` by returning its real component, so `std::expm1` and the `abs` and `< 0` inside `Sigmoid` all silently take that conversion instead of failing to compile.

This is CPU only. The Metal kernels are instantiated with `instantiate_unary_float(Expm1)`, `instantiate_unary_float(Sigmoid)` and `instantiate_binary_float(ArcTan2)`, which cover float16, float32 and bfloat16 and not complex, so the GPU never had complex support for any of the three. The CPU was the odd one out, giving a wrong number where the GPU gives nothing.

Both now reject complex at the op level, the same way `floor`, `ceil`, `trunc`, `erf` and `erfinv` already do:

```python
>>> mx.expm1(z)
ValueError: [expm1] Not supported for complex64.
>>> mx.sigmoid(z)
ValueError: [sigmoid] Not supported for complex64.
>>> mx.arctan2(z, z)
ValueError: [arctan2] Not supported for complex64.
```

`arctan2` is the clear cut one, since numpy raises `TypeError` and pytorch raises `NotImplementedError` for complex there, so returning a number was never right.

`expm1` and `sigmoid` are the arguable ones: numpy and pytorch do support those on complex, so rejecting is the smaller of the two honest options rather than the better one. Implementing them properly is not a one liner either, since `exp(z) - 1` is not good enough for a small argument (for `1e-8 + 1e-8j` numpy returns the input while `exp(z) - 1` loses the real part entirely), and it would need matching Metal and CUDA kernels. Happy to attempt that instead if you would rather have the feature than the guard.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

CPU only build (`MLX_BUILD_METAL=OFF`) at 3d23f7d. Real inputs are untouched: `expm1`, `sigmoid` and `arctan2` still match numpy across the existing ranges, int32 promotes to float32, float16 and bfloat16 keep their dtype, gradients are unchanged and `nn.sigmoid` still behaves. `test_ops.py`, `test_nn.py`, `test_losses.py` and `test_autograd.py` pass, and the C++ suite passes (249 cases, 3350 assertions).

---

freshman contributor, i use Claude Code while digging. this came out of running every unary op over complex64 and diffing against numpy. the giveaway was the value itself: seeing exactly `expm1(1)` come back for an input of `1+2j` made it obvious the imaginary half was being thrown away rather than mishandled.
