### PR TITLE
Fix silent wrong results at gather_mm.

### DIFF
--- a/mlx/backend/metal/matmul.cpp
+++ b/mlx/backend/metal/matmul.cpp
@@ -2158,7 +2158,10 @@ void gather_mm_rhs(
   // lhs_indices.
   auto broadcast_with_indices = [&d, &s, &indices](const array& x) {
     if (x.size() / x.shape(-1) == indices.size()) {
-      return ensure_row_contiguous(x, d, s);
+      // Flatten to 2D so the kernel sees (M, K) not (M, 1, K)
+      std::vector<int> new_shape = {
+          static_cast<int>(indices.size()), x.shape(-1)};
+      return ensure_row_contiguous(reshape(x, new_shape, s), d, s);
     }
 
     auto x_shape = indices.shape();
@@ -2291,7 +2294,10 @@ void gather_mm_rhs_nax(
   // lhs_indices.
   auto broadcast_with_indices = [&d, &s, &indices](const array& x) {
     if (x.size() / x.shape(-1) == indices.size()) {
-      return ensure_row_contiguous(x, d, s);
+      // Flatten to 2D so the kernel sees (M, K) not (M, 1, K)
+      std::vector<int> new_shape = {
+          static_cast<int>(indices.size()), x.shape(-1)};
+      return ensure_row_contiguous(reshape(x, new_shape, s), d, s);
     }
 
     auto x_shape = indices.shape();

--- a/mlx/backend/metal/matmul.cpp
+++ b/mlx/backend/metal/matmul.cpp
@@ -2157,7 +2157,7 @@ void gather_mm_rhs(
   // with rhs_indices. We need only broadcast a and copy it as if applying the
   // lhs_indices.
   auto broadcast_with_indices = [&d, &s, &indices](const array& x) {
-    if (x.size() / x.shape(-2) / x.shape(-1) == indices.size()) {
+    if (x.size() / x.shape(-1) == indices.size()) {
       return ensure_row_contiguous(x, d, s);
     }
 
@@ -2290,7 +2290,7 @@ void gather_mm_rhs_nax(
   // with rhs_indices. We need only broadcast a and copy it as if applying the
   // lhs_indices.
   auto broadcast_with_indices = [&d, &s, &indices](const array& x) {
-    if (x.size() / x.shape(-2) / x.shape(-1) == indices.size()) {
+    if (x.size() / x.shape(-1) == indices.size()) {
       return ensure_row_contiguous(x, d, s);
     }
 

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -1470,7 +1470,7 @@ void gather_qmm_rhs_nax(
   // with rhs_indices. We need only broadcast x and copy it as if applying the
   // lhs_indices.
   auto broadcast_with_indices = [&d, &s, &indices](const array& x) {
-    if (x.size() / x.shape(-2) / x.shape(-1) == indices.size()) {
+    if (x.size() / x.shape(-1) == indices.size()) {
       return ensure_row_contiguous(x, d, s);
     }
 
@@ -1626,7 +1626,7 @@ void gather_qmm_rhs(
   // with rhs_indices. We need only broadcast x and copy it as if applying the
   // lhs_indices.
   auto broadcast_with_indices = [&d, &s, &indices](const array& x) {
-    if (x.size() / x.shape(-2) / x.shape(-1) == indices.size()) {
+    if (x.size() / x.shape(-1) == indices.size()) {
       return ensure_row_contiguous(x, d, s);
     }
 

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -1471,7 +1471,10 @@ void gather_qmm_rhs_nax(
   // lhs_indices.
   auto broadcast_with_indices = [&d, &s, &indices](const array& x) {
     if (x.size() / x.shape(-1) == indices.size()) {
-      return ensure_row_contiguous(x, d, s);
+      // Flatten to 2D so the kernel sees (M, K) not (M, 1, K)
+      std::vector<int> new_shape = {
+          static_cast<int>(indices.size()), x.shape(-1)};
+      return ensure_row_contiguous(reshape(x, new_shape, s), d, s);
     }
 
     auto x_shape = indices.shape();
@@ -1627,7 +1630,10 @@ void gather_qmm_rhs(
   // lhs_indices.
   auto broadcast_with_indices = [&d, &s, &indices](const array& x) {
     if (x.size() / x.shape(-1) == indices.size()) {
-      return ensure_row_contiguous(x, d, s);
+      // Flatten to 2D so the kernel sees (M, K) not (M, 1, K)
+      std::vector<int> new_shape = {
+          static_cast<int>(indices.size()), x.shape(-1)};
+      return ensure_row_contiguous(reshape(x, new_shape, s), d, s);
     }
 
     auto x_shape = indices.shape();


### PR DESCRIPTION
## Proposed changes

Fix [4253](https://github.com/ml-explore/mlx/issues/4253)
A minimal test case for this PR on CPU (Sry for I can't test it on GPU since my network keep crashing):
```python
import mlx.core as mx
import numpy as np

mx.set_default_device(mx.cpu)

E, ROWS, K, N = 4, 3, 256, 64
R = E * ROWS
idx = mx.array(np.repeat(np.arange(E, dtype=np.uint32), ROWS))

for tag, build in (
    ("3D direct", lambda: mx.random.normal((R, 1, K))),
    ("2D + [:, None, :]", lambda: mx.random.normal((R, K))[:, None, :]),
):
    mx.random.seed(0)
    W = mx.random.normal((E, K, N))
    x = build()
    ref = mx.stack([x[r, 0] @ W[int(idx[r])] for r in range(R)])
    y = mx.gather_mm(x, W, lhs_indices=None, rhs_indices=idx, sorted_indices=True)[:, 0, :]
    max_delta = mx.abs(y - ref).max().item()
    print(f"{max_delta:.4f}")
```


## Checklist

Put an `x` in the boxes that apply.

- [ ] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
