### PR TITLE
Fix Log and Equal is_equivalent ignoring primitive state

### DIFF
--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -1941,6 +1941,11 @@ std::pair<std::vector<array>, std::vector<int>> Equal::vmap(
   return {{equal(a, b, stream())}, {to_ax}};
 }
 
+bool Equal::is_equivalent(const Primitive& other) const {
+  const Equal& e_other = static_cast<const Equal&>(other);
+  return equal_nan_ == e_other.equal_nan_;
+}
+
 std::vector<array> Equal::vjp(
     const std::vector<array>& primals,
     const std::vector<array>& cotangents,
@@ -2793,6 +2798,11 @@ std::pair<std::vector<array>, std::vector<int>> Log::vmap(
           std::make_shared<Log>(stream(), base_),
           {in})},
       axes};
+}
+
+bool Log::is_equivalent(const Primitive& other) const {
+  const Log& l_other = static_cast<const Log&>(other);
+  return base_ == l_other.base_;
 }
 
 std::vector<array> Log1p::vjp(

--- a/mlx/primitives.h
+++ b/mlx/primitives.h
@@ -975,8 +975,8 @@ class Equal : public UnaryPrimitive {
 
   DEFINE_VMAP()
   DEFINE_GRADS()
-  DEFINE_DEFAULT_IS_EQUIVALENT()
   DEFINE_INPUT_OUTPUT_SHAPE()
+  bool is_equivalent(const Primitive& other) const override;
 
   const char* name() const override {
     if (equal_nan_) {
@@ -1325,8 +1325,8 @@ class Log : public UnaryPrimitive {
 
   DEFINE_VMAP()
   DEFINE_GRADS()
-  DEFINE_DEFAULT_IS_EQUIVALENT()
   DEFINE_INPUT_OUTPUT_SHAPE()
+  bool is_equivalent(const Primitive& other) const override;
 
   Base state() const {
     return base_;

--- a/mlx/primitives.h
+++ b/mlx/primitives.h
@@ -976,8 +976,8 @@ class Equal : public UnaryPrimitive {
   DEFINE_VMAP()
   DEFINE_GRADS()
   DEFINE_INPUT_OUTPUT_SHAPE()
-  bool is_equivalent(const Primitive& other) const override;
 
+  bool is_equivalent(const Primitive& other) const override;
   const char* name() const override {
     if (equal_nan_) {
       return "NaNEqual";
@@ -1326,8 +1326,8 @@ class Log : public UnaryPrimitive {
   DEFINE_VMAP()
   DEFINE_GRADS()
   DEFINE_INPUT_OUTPUT_SHAPE()
-  bool is_equivalent(const Primitive& other) const override;
 
+  bool is_equivalent(const Primitive& other) const override;
   Base state() const {
     return base_;
   };

--- a/python/tests/test_compile.py
+++ b/python/tests/test_compile.py
@@ -1623,6 +1623,29 @@ class TestCompile(mlx_tests.MLXTestCase):
             x = mx.array([1, 2, 3], dtype)
             self.assertTrue(mx.array_equal(mx.compile(fun)(x), fun(x)))
 
+    def test_compile_different_log_bases(self):
+        # The logs are intermediates, since outputs are not simplified.
+        def entropies(p):
+            nats = -mx.sum(p * mx.log(p))
+            bits = -mx.sum(p * mx.log2(p))
+            return mx.stack([nats, bits])
+
+        p = np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float32)
+        expected = np.array(
+            [-(p * np.log(p)).sum(), -(p * np.log2(p)).sum()], dtype=np.float32
+        )
+        out = mx.compile(entropies)(mx.array(p))
+        self.assertTrue(np.allclose(out, expected, atol=1e-5))
+
+    def test_compile_equal_nan(self):
+        def fun(x):
+            return mx.stack(
+                [mx.array_equal(x, x), mx.array_equal(x, x, equal_nan=True)]
+            )
+
+        x = mx.array([1.0, float("nan"), 3.0])
+        self.assertTrue(mx.array_equal(mx.compile(fun)(x), mx.array([False, True])))
+
 
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner()

--- a/tests/compile_tests.cpp
+++ b/tests/compile_tests.cpp
@@ -212,37 +212,6 @@ TEST_CASE("test no simplify") {
   set_compile_mode(CompileMode::enabled);
 }
 
-auto log_bases(const std::vector<array>& inputs) {
-  auto a = inputs[0];
-  return std::vector<array>{log(a) + log2(a)};
-};
-
-auto equal_nan_variants(const std::vector<array>& inputs) {
-  auto a = inputs[0];
-  return std::vector<array>{
-      stack({array_equal(a, a), array_equal(a, a, true)})};
-};
-
-TEST_CASE("test no simplify different primitive state") {
-  set_compile_mode(CompileMode::no_fuse);
-  auto a = array({2.0f, 8.0f});
-  auto b = compile(log_bases)({a})[0];
-  CHECK(b.inputs()[0].id() != b.inputs()[1].id());
-  CHECK(allclose(b, log(a) + log2(a)).item<bool>());
-
-  auto c = array({1.0f, std::numeric_limits<float>::quiet_NaN()});
-  auto d = compile(equal_nan_variants)({c})[0];
-  CHECK(array_equal(d, array({false, true})).item<bool>());
-
-  // Matching state still simplifies.
-  auto same_base = [](const std::vector<array>& inputs) -> std::vector<array> {
-    return {log(inputs[0]) + log(inputs[0])};
-  };
-  auto e = compile(same_base)({a})[0];
-  CHECK(e.inputs()[0].id() == e.inputs()[1].id());
-  set_compile_mode(CompileMode::enabled);
-}
-
 auto multi_one(const std::vector<array>&) {
   auto a = array(1.0);
   auto b = array(2.0);

--- a/tests/compile_tests.cpp
+++ b/tests/compile_tests.cpp
@@ -212,6 +212,37 @@ TEST_CASE("test no simplify") {
   set_compile_mode(CompileMode::enabled);
 }
 
+auto log_bases(const std::vector<array>& inputs) {
+  auto a = inputs[0];
+  return std::vector<array>{log(a) + log2(a)};
+};
+
+auto equal_nan_variants(const std::vector<array>& inputs) {
+  auto a = inputs[0];
+  return std::vector<array>{
+      stack({array_equal(a, a), array_equal(a, a, true)})};
+};
+
+TEST_CASE("test no simplify different primitive state") {
+  set_compile_mode(CompileMode::no_fuse);
+  auto a = array({2.0f, 8.0f});
+  auto b = compile(log_bases)({a})[0];
+  CHECK(b.inputs()[0].id() != b.inputs()[1].id());
+  CHECK(allclose(b, log(a) + log2(a)).item<bool>());
+
+  auto c = array({1.0f, std::numeric_limits<float>::quiet_NaN()});
+  auto d = compile(equal_nan_variants)({c})[0];
+  CHECK(array_equal(d, array({false, true})).item<bool>());
+
+  // Matching state still simplifies.
+  auto same_base = [](const std::vector<array>& inputs) -> std::vector<array> {
+    return {log(inputs[0]) + log(inputs[0])};
+  };
+  auto e = compile(same_base)({a})[0];
+  CHECK(e.inputs()[0].id() == e.inputs()[1].id());
+  set_compile_mode(CompileMode::enabled);
+}
+
 auto multi_one(const std::vector<array>&) {
   auto a = array(1.0);
   auto b = array(2.0);


### PR DESCRIPTION
## Problem

`Log` carries `base_` for `log` / `log2` / `log10`, and `Equal` carries `equal_nan_` for `array_equal`, but both use `DEFINE_DEFAULT_IS_EQUIVALENT()`, which returns `true` unconditionally (mlx/primitives.h:35). The compile simplify pass merges two nodes when `array_equivalent` accepts them (mlx/compile.cpp:606, applied at :698), and that check delegates the final decision to `is_equivalent` (mlx/compile.cpp:629). Two logs of different bases over the same input therefore look identical and one of them is dropped.

Apple M3 Pro, macOS 26.6.1 (25G76). Before is main at 140faa8ae, after is this branch at 9bfa10227:

```python
import mlx.core as mx

def entropies(p):
    nats = -mx.sum(p * mx.log(p))
    bits = -mx.sum(p * mx.log2(p))
    return mx.stack([nats, bits])

p = mx.array([0.1, 0.2, 0.3, 0.4])
print(entropies(p))
print(mx.compile(entropies)(p))
```

Before, the entropy in bits silently returns the value in nats:

```
array([1.27985, 1.84644], dtype=float32)
array([1.27985, 1.27985], dtype=float32)
```

After, both lines agree:

```
array([1.27985, 1.84644], dtype=float32)
array([1.27985, 1.84644], dtype=float32)
```

Same on cpu and gpu, since the merge happens on the graph. `mx.array_equal(x, x)` and `mx.array_equal(x, x, equal_nan=True)` collapse the same way, as do `isclose` and `allclose` with and without `equal_nan`.

Present since 8ca7f9e8e (2023-11-29). Existing tests miss it because simplify exempts function outputs from merging (mlx/compile.cpp:699), so returning the two logs directly is correct and only intermediates are affected.

Same class as #2978, which fixed `RandomBits::is_equivalent` ignoring `width_`. These two are the only remaining primitives that declare `state()` while using the default equivalence.

## Testing

Both new tests fail on main and pass with the change. On main the C++ case reports `CHECK( 4335042088 != 4335042088 )`, the two `Log` nodes having been merged into one id.

With the change: C++ suite 277/277 on gpu and on `DEVICE=cpu`; python suite 841 passing on gpu, and on `DEVICE=cpu` the only failure is the pre-existing `test_fft_too_large`, which fails identically on main. A `MLX_METAL_JIT=ON` build matches, with the pre-existing 291 `test_quantized` errors unchanged. The new tests ran 200 times per device without a flake, and `pre-commit run --all-files` is clean.

Simplification is not weakened: same-base logs and same-`equal_nan` comparisons still merge, asserted in the C++ test, and compiled graph node counts are unchanged on five functions covering log-softmax, cross entropy, layer norm, RMS norm and attention.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
