### PR TITLE
Fix Metal row reductions on negative-stride views

### DIFF
--- a/mlx/backend/metal/kernels/reduction/reduce_row.h
+++ b/mlx/backend/metal/kernels/reduction/reduce_row.h
@@ -337,7 +337,8 @@ template <
 
   // lid.x * N_READS breaks the per_thread_row_reduce interface a bit. Maybe it
   // needs a small refactor.
-  in += elem_to_loc<IdxT>(out_idx, shape, strides, ndim) + lid.x * N_READS;
+  in +=
+      elem_to_loc<IdxT>(out_idx, shape, strides, ndim) + IdxT(lid.x) * N_READS;
 
   LoopedElemToLoc<NDIMS, IdxT, (NDIMS > 2)> loop(reduce_ndim);
   const device T* row;

--- a/python/tests/test_reduce.py
+++ b/python/tests/test_reduce.py
@@ -47,6 +47,17 @@ class TestReduce(mlx_tests.MLXTestCase):
                                     np.allclose(z_npy, np.array(z_mlx), atol=1e-4)
                                 )
 
+    @unittest.skipIf(not mx.metal.is_available(), "Metal is not available")
+    def test_row_reduce_negative_stride(self):
+        x_npy = np.arange(1, 131).reshape(2, 65)[::-1]
+        x_mlx = mx.arange(1, 131).reshape(2, 65)[::-1]
+
+        for op in ["sum", "max", "min", "mean", "var"]:
+            with self.subTest(op=op):
+                expected = getattr(np, op)(x_npy, axis=-1)
+                actual = getattr(mx, op)(x_mlx, axis=-1, stream=mx.gpu)
+                self.assertTrue(np.allclose(expected, actual))
+
     def test_dtypes(self):
         int_dtypes = [
             "int8",

--- a/python/tests/test_reduce.py
+++ b/python/tests/test_reduce.py
@@ -1,6 +1,5 @@
 # Copyright © 2023 Apple Inc.
 
-import unittest
 from itertools import combinations, permutations
 
 import mlx.core as mx
@@ -47,7 +46,6 @@ class TestReduce(mlx_tests.MLXTestCase):
                                     np.allclose(z_npy, np.array(z_mlx), atol=1e-4)
                                 )
 
-    @unittest.skipIf(not mx.metal.is_available(), "Metal is not available")
     def test_row_reduce_negative_stride(self):
         x_npy = np.arange(1, 131).reshape(2, 65)[::-1]
         x_mlx = mx.arange(1, 131).reshape(2, 65)[::-1]
@@ -55,7 +53,7 @@ class TestReduce(mlx_tests.MLXTestCase):
         for op in ["sum", "max", "min", "mean", "var"]:
             with self.subTest(op=op):
                 expected = getattr(np, op)(x_npy, axis=-1)
-                actual = getattr(mx, op)(x_mlx, axis=-1, stream=mx.gpu)
+                actual = getattr(mx, op)(x_mlx, axis=-1)
                 self.assertTrue(np.allclose(expected, actual))
 
     def test_dtypes(self):


### PR DESCRIPTION
## Proposed changes

Metal row reductions return incorrect values when a non-reduced dimension has a negative stride and the reduced row contains more than 64 elements. For example:

```python
x = mx.arange(1, 131).reshape(2, 65)[::-1]
mx.sum(x, axis=-1, stream=mx.gpu)
```

NumPy and the MLX CPU backend return `[6370, 2145]`; current Metal returns `[6370, 0]`. The same pointer error affects `max`, `min`, `mean`, and `var`.

`row_reduce_looped` combines the signed offset returned by `elem_to_loc<IdxT>` with the unsigned expression `lid.x * N_READS`. For the ordinary `IdxT=int` specialization, a negative outer-dimension offset is therefore promoted to `uint` and wraps before pointer arithmetic. Casting `lid.x` to `IdxT` keeps this addition signed. The large precompiled `IdxT=int64_t` specialization is unchanged semantically.

This adds an explicit Metal regression test for five row reductions on a 65-element negative-stride view. This is adjacent to the signed-indexing issue addressed for sort kernels in #4252, but affects the separate row-reduction kernel.

### Validation

- Current `main` (`140faa8a`) / development Metal wheel: the new regression test fails for all five operations.
- Patched source, CPU-only build: `python -m unittest test_reduce` — 13 passed; the Metal-only regression is skipped as intended.
- `pre-commit run --all-files` — passed.
- `git diff --check` — passed.

This machine has the Command Line Tools but not the standalone Xcode Metal compiler, so the patched metallib has not been rebuilt locally. The repository's macOS CI must compile and validate the Metal change before merge.

Disclosure: Codex assisted with differential testing and review. I verified the reproduction, root cause, focused diff, and local checks before submission.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (not needed; no API change)
