### PR TITLE
Reject complex in remainder

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -3183,6 +3183,9 @@ array floor_divide(
 
 array remainder(const array& a, const array& b, StreamOrDevice s /* = {} */) {
   auto dtype = promote_types(a.dtype(), b.dtype());
+  if (issubdtype(dtype, complexfloating)) {
+    throw std::invalid_argument("[remainder] Complex type not supported.");
+  }
   auto inputs = broadcast_arrays(
       {astype(a, dtype, s), astype(b, dtype, to_stream(s))}, s);
   auto shape = inputs[0].shape();

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -344,6 +344,14 @@ class TestOps(mlx_tests.MLXTestCase):
         self.assertEqual(z.item(), 2)
 
     def test_remainder(self):
+        # Complex is not supported and has to say so rather than quietly
+        # computing a componentwise remainder, which no other library defines
+        z = mx.array([7 + 3j], mx.complex64)
+        with self.assertRaises(ValueError):
+            mx.remainder(z, z)
+        with self.assertRaises(ValueError):
+            z % z
+
         for dt in [mx.int32, mx.float32, mx.float16, mx.bfloat16]:
             x = mx.array(2, dtype=dt)
             y = mx.array(4, dtype=dt)


### PR DESCRIPTION
`mx.remainder` is the only member of its family that accepts complex input:

```python
>>> z = mx.array([7+3j], mx.complex64)
>>> mx.floor(z)         # ValueError: [floor] Not supported for complex64.
>>> mx.floor_divide(z, z)  # ValueError: [floor] Not supported for complex64.
>>> mx.divmod(z, z)     # ValueError: [divmod] Complex type not supported.
>>> mx.remainder(z, z)  # array([1+0j], dtype=complex64)
>>> z % z               # array([1+0j], dtype=complex64)
```

numpy raises `TypeError`, pytorch raises `NotImplementedError: "remainder_cpu" not implemented for 'ComplexFloat'`, and python says `TypeError: can't mod complex numbers`. There is no accepted definition of a remainder on the complex field, since there is no ordering to floor toward.

What mlx returns instead is a componentwise remainder, real against real and imaginary against imaginary, from `operator%` in `mlx/types/complex.h`. That operator also casts the quotient to `int64_t`:

```cpp
auto real = a.real() - (b.real() * static_cast<int64_t>(a.real() / b.real()));
```

so once the quotient leaves the `int64_t` range the cast is undefined and the answer silently degrades:

```python
>>> mx.remainder(mx.array([1e10+1e10j]), mx.array([3+2j]))   # array([1+0j])
>>> mx.remainder(mx.array([9e18+9e18j]), mx.array([3+2j]))   # array([-1+0j])
>>> mx.remainder(mx.array([1e19+1e19j]), mx.array([3+2j]))   # array([0+0j])
>>> mx.remainder(mx.array([1e30+1e30j]), mx.array([3+2j]))   # array([0+0j])
```

This adds the same guard `divmod` already has a few lines below, so the whole family now rejects complex consistently instead of one member handing back a number nobody asked for. Same shape as #4243 and #4257.

The kernels are untouched. `Remainder` is still instantiated for `complex64` through `instantiate_binary_types` on Metal and CUDA, so nothing there needs to change; the op simply stops reaching them.

`remainder` has two internal callers and neither can hit the new path: `Remainder::vmap` only runs once a `Remainder` primitive exists, and `linalg.cpp:834` passes `int32`. `floor_divide` sends inexact dtypes to `floor`, which already rejected complex.

`python/tests/test_ops.py`, `test_nn.py`, `test_autograd.py`, `test_compile.py`, `test_vmap.py`, `test_linalg.py`, `test_fft.py` and the C++ suite (249 cases, 3350 assertions) pass. The added test fails on main with `AssertionError: ValueError not raised`.

I am a freshman working through this codebase, and I used Claude Code alongside it. Everything above I ran and checked myself.
