### PR TITLE
Clamp out of range shift amounts

### DIFF
--- a/mlx/backend/cpu/binary_ops.h
+++ b/mlx/backend/cpu/binary_ops.h
@@ -33,8 +33,46 @@ DEFAULT_BINARY_OP(LogicalOr, operator||)
 DEFAULT_BINARY_OP(BitwiseAnd, operator&)
 DEFAULT_BINARY_OP(BitwiseOr, operator|)
 DEFAULT_BINARY_OP(BitwiseXor, operator^)
-DEFAULT_BINARY_OP(LeftShift, operator<<)
-DEFAULT_BINARY_OP(RightShift, operator>>)
+// A shift amount that is negative or at least the operand width is undefined
+// in C++, so the scalar and vectorized paths disagreed about it and the answer
+// depended on the array length. Clamp the amount instead, which gives what
+// numpy and pytorch return: zero for a left shift, and the sign bit for a
+// right shift.
+template <int N, typename T>
+Simd<bool, N> shift_in_range(Simd<T, N> y) {
+  auto in_range = y < Simd<T, N>(sizeof(T) * 8);
+  if constexpr (std::is_signed_v<T>) {
+    in_range = in_range && y >= Simd<T, N>(0);
+  }
+  return in_range;
+}
+
+struct LeftShift {
+  template <int N, typename T>
+  Simd<T, N> operator()(Simd<T, N> x, Simd<T, N> y) {
+    Simd<T, N> amount = y & Simd<T, N>(sizeof(T) * 8 - 1);
+    Simd<T, N> shifted = x << amount;
+    return select(shift_in_range(y), shifted, Simd<T, N>(0));
+  }
+  BINARY_SINGLE()
+};
+
+struct RightShift {
+  template <int N, typename T>
+  Simd<T, N> operator()(Simd<T, N> x, Simd<T, N> y) {
+    auto in_range = shift_in_range(y);
+    Simd<T, N> amount = select(in_range, y, Simd<T, N>(sizeof(T) * 8 - 1));
+    Simd<T, N> shifted = x >> amount;
+    if constexpr (std::is_signed_v<T>) {
+      // Shifting a negative value past the width leaves the sign bit behind.
+      return shifted;
+    } else {
+      return select(in_range, shifted, Simd<T, N>(0));
+    }
+  }
+  BINARY_SINGLE()
+};
+
 DEFAULT_BINARY_OP(Remainder, remainder)
 DEFAULT_BINARY_OP(Maximum, maximum)
 DEFAULT_BINARY_OP(Minimum, minimum)

--- a/mlx/backend/cuda/device/binary_ops.cuh
+++ b/mlx/backend/cuda/device/binary_ops.cuh
@@ -269,17 +269,38 @@ struct BitwiseXor {
   };
 };
 
+// A shift amount that is negative or at least the operand width is undefined,
+// so clamp it to what numpy and pytorch return: zero for a left shift, and the
+// sign bit for a right shift.
+template <typename T>
+__device__ bool shift_in_range(T y) {
+  bool in_range = y < static_cast<T>(sizeof(T) * 8);
+  if constexpr (cuda::std::is_signed_v<T>) {
+    in_range = in_range && y >= 0;
+  }
+  return in_range;
+}
+
 struct LeftShift {
   template <typename T>
   __device__ T operator()(T x, T y) {
-    return x << y;
+    T amount = y & static_cast<T>(sizeof(T) * 8 - 1);
+    return shift_in_range(y) ? static_cast<T>(x << amount) : static_cast<T>(0);
   };
 };
 
 struct RightShift {
   template <typename T>
   __device__ T operator()(T x, T y) {
-    return x >> y;
+    bool in_range = shift_in_range(y);
+    T amount = in_range ? y : static_cast<T>(sizeof(T) * 8 - 1);
+    T shifted = x >> amount;
+    if constexpr (cuda::std::is_signed_v<T>) {
+      // Shifting a negative value past the width leaves the sign bit behind.
+      return shifted;
+    } else {
+      return in_range ? shifted : static_cast<T>(0);
+    }
   };
 };
 

--- a/mlx/backend/metal/kernels/binary_ops.h
+++ b/mlx/backend/metal/kernels/binary_ops.h
@@ -303,17 +303,38 @@ struct BitwiseXor {
   };
 };
 
+// A shift amount that is negative or at least the operand width is undefined,
+// so clamp it to what numpy and pytorch return: zero for a left shift, and the
+// sign bit for a right shift.
+template <typename T>
+inline bool shift_in_range(T y) {
+  bool in_range = y < static_cast<T>(sizeof(T) * 8);
+  if constexpr (metal::is_signed_v<T>) {
+    in_range = in_range && y >= 0;
+  }
+  return in_range;
+}
+
 struct LeftShift {
   template <typename T>
   T operator()(T x, T y) thread {
-    return x << y;
+    T amount = y & static_cast<T>(sizeof(T) * 8 - 1);
+    return shift_in_range(y) ? static_cast<T>(x << amount) : static_cast<T>(0);
   };
 };
 
 struct RightShift {
   template <typename T>
   T operator()(T x, T y) thread {
-    return x >> y;
+    bool in_range = shift_in_range(y);
+    T amount = in_range ? y : static_cast<T>(sizeof(T) * 8 - 1);
+    T shifted = x >> amount;
+    if constexpr (metal::is_signed_v<T>) {
+      // Shifting a negative value past the width leaves the sign bit behind.
+      return shifted;
+    } else {
+      return in_range ? shifted : static_cast<T>(0);
+    }
   };
 };
 

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -3448,6 +3448,34 @@ class TestOps(mlx_tests.MLXTestCase):
                 out_np = getattr(np, op)(a_np, b_np)
                 self.assertTrue(np.array_equal(np.array(out_mlx), out_np))
 
+        # A shift amount that is negative or at least the operand width is
+        # undefined in C++, so the scalar and vectorized paths disagreed and
+        # the answer depended on the length of the array.
+        for t in types:
+            nt = np.array(mx.zeros(1, dtype=t)).dtype
+            info = np.iinfo(nt)
+            width = t.size * 8
+            amounts = [0, 1, width - 1, width, width + 3]
+            values = [1, 16, info.max]
+            if info.min < 0:
+                amounts += [-1, -width]
+                values += [-16, info.min]
+            for n in (1, 7, 8, 100):
+                for v in values:
+                    for sh in amounts:
+                        a_np = np.full(n, v, nt)
+                        b_np = np.full(n, sh, nt)
+                        a_mlx = mx.array(a_np)
+                        b_mlx = mx.array(b_np)
+                        for op in ("left_shift", "right_shift"):
+                            self.assertTrue(
+                                np.array_equal(
+                                    np.array(getattr(mx, op)(a_mlx, b_mlx)),
+                                    getattr(np, op)(a_np, b_np),
+                                ),
+                                msg=f"{op} {t} n={n} {v} by {sh}",
+                            )
+
         for t in types:
             a_mlx = a.astype(t)
             a_np = np.array(a_mlx)


### PR DESCRIPTION
On the CPU, `left_shift` returns a different answer for the same values depending on how long the array is:

```python
>>> for n in (1, 2, 3, 4, 7, 8, 1000):
...     x = mx.ones(n, mx.int32)
...     print(n, mx.left_shift(x, mx.full((n,), 32, mx.int32)).tolist()[:8])
1    [1]
2    [1, 1]
3    [1, 1, 1]
4    [0, 0, 0, 0]
7    [0, 0, 0, 0, 1, 1, 1]
8    [0, 0, 0, 0, 0, 0, 0, 0]
1000 [0, 0, 0, ...]
```

At n=7 a single array contains both answers: the vectorized body produces 0 and the scalar tail produces 1. A strided view takes the scalar path too, so `mx.left_shift(x[::2], 32)` disagrees with `mx.left_shift(x, 32)`.

The cause is that a shift amount that is negative or at least the operand width is undefined in C++, and the two paths landed on different answers for it. `binary_ops.h` maps both ops straight onto the built in operators:

```cpp
DEFAULT_BINARY_OP(LeftShift, operator<<)
DEFAULT_BINARY_OP(RightShift, operator>>)
```

The scalar overload gets the hardware behaviour, which on arm64 and x86 masks the count against the width, so `1 << 32` becomes `1 << 0`. The vectorized overload goes through the Accelerate vector types, which saturate to 0 instead.

numpy and pytorch agree with each other on every case, and mlx's vectorized path already matches them:

```
   x     sh      numpy <<   torch <<      numpy >>   torch >>
   1     32             0          0             0          0
  16     32             0          0             0          0
 -16     32             0          0            -1         -1
   1     -1             0          0             0          0
 -16     -1             0          0            -1         -1
```

So the rule is: out of range means zero for a left shift, and the sign bit for a right shift. This clamps the amount to make that true on both paths. The mask keeps the shift itself in range so the operation is no longer undefined, and the `select` picks the out of range answer.

Verified against numpy over all 8 integer dtypes, array lengths 1, 3, 5, 7, 8, 16, 33, 64 and 257, every shift amount from 0 to width+2 plus `2*width` and `8*width` and the negative amounts, and the type min, max, and assorted values. That is 39744 combinations, all matching, where main misses 2697 of them. Also checked 9999 element arrays of randomly mixed amounts, which exercises the vector body and the scalar tail in a single call.

The extra select is not free but it is small, 8M elements on an M4:

```
            main     this
int32  <<   1.045    1.206 ms
int32  >>   1.007    1.271 ms
uint8  <<   0.254    0.274 ms
uint8  >>   0.228    0.292 ms
int64  <<   2.126    2.240 ms
int64  >>   2.388    2.249 ms
```

This started as a CPU only change, because Metal and CUDA also use a bare `x << y` and I have no GPU here to see what they actually returned. CI answered that: the macOS run failed on the new test with `left_shift mlx.core.uint32 n=1 1 by 32`, which is the GPU masking the count against the width exactly like the CPU scalar path did. So the same clamp is now in `metal/kernels/binary_ops.h` and `cuda/device/binary_ops.cuh`, and all three backends agree with numpy and pytorch.

The GPU side is the same shape as the CPU one, with the signed check behind `if constexpr` so the unsigned instantiations do not emit a tautological comparison under `-DCMAKE_COMPILE_WARNING_AS_ERROR=ON`. Shifts are only instantiated for the eight integer types, so there is no bool, float or complex path to worry about. I still cannot build Metal or CUDA locally, so CI is the check on those two.

`test_ops.py`, `test_array.py`, `test_reduce.py`, `test_nn.py`, `test_linalg.py`, `test_fft.py`, `test_compile.py`, `test_vmap.py`, `test_autograd.py`, `test_random.py`, `test_double.py` and the C++ suite (249 cases, 3350 assertions) pass. The added test fails on main with `left_shift mlx.core.uint32 n=1 1 by 32`.

I am a freshman working through this codebase and I used Claude Code alongside it. Every number above came from a run on this machine.


