### PR TITLE
[CUDA] Fix custom kernel cache collision for same name, different source

### DIFF
--- a/mlx/backend/cuda/custom_kernel.cpp
+++ b/mlx/backend/cuda/custom_kernel.cpp
@@ -310,9 +310,14 @@ void CustomKernel::eval_gpu(
   // Compile the custom kernel
   std::string kernel_name =
       (is_precompiled_) ? name_ : "mlx::core::cu::" + name_;
+  // The module cache is keyed on this name, so it has to include the source:
+  // two kernels sharing a name but not a body would otherwise both run
+  // whichever was compiled first. Same fix as #3833 on the Metal side.
+  std::string module_name =
+      fmt::format("{}_{:x}", name_, std::hash<std::string>{}(source_));
   cu::JitModule& mod = cu::get_jit_module(
       encoder.device(),
-      name_,
+      module_name,
       [&]() {
         return std::make_tuple(
             is_precompiled_, source_, std::vector{kernel_name});

--- a/mlx/backend/cuda/custom_kernel.cpp
+++ b/mlx/backend/cuda/custom_kernel.cpp
@@ -310,9 +310,6 @@ void CustomKernel::eval_gpu(
   // Compile the custom kernel
   std::string kernel_name =
       (is_precompiled_) ? name_ : "mlx::core::cu::" + name_;
-  // The module cache is keyed on this name, so it has to include the source:
-  // two kernels sharing a name but not a body would otherwise both run
-  // whichever was compiled first. Same fix as #3833 on the Metal side.
   std::string module_name =
       fmt::format("{}_{:x}", name_, std::hash<std::string>{}(source_));
   cu::JitModule& mod = cu::get_jit_module(

--- a/python/tests/test_fast.py
+++ b/python/tests/test_fast.py
@@ -1058,6 +1058,35 @@ class TestFast(mlx_tests.MLXTestCase):
         self.assertTrue(mx.array_equal(out_a, a * 2.0))
         self.assertTrue(mx.array_equal(out_b, a + 100.0))
 
+    @unittest.skipIf(not mx.cuda.is_available(), "CUDA is not available")
+    def test_cuda_kernel_same_name_different_source(self):
+        # The CUDA module cache was keyed on the kernel name alone, so the
+        # second kernel here silently ran the first one's code. Metal had the
+        # same bug, fixed in #3833.
+        def call_kernel(a, source):
+            kernel = mx.fast.cuda_kernel(
+                name="dup_name",
+                input_names=["inp"],
+                output_names=["out"],
+                source=source,
+            )
+            return kernel(
+                inputs=[a],
+                grid=(a.size, 1, 1),
+                threadgroup=(a.size, 1, 1),
+                output_shapes=[a.shape],
+                output_dtypes=[a.dtype],
+                stream=mx.gpu,
+            )[0]
+
+        a = mx.arange(32, dtype=mx.float32)
+        elem = "auto e = cooperative_groups::this_grid().thread_rank();"
+        out_a = call_kernel(a, f"{elem} out[e] = inp[e] * 2.0f;")
+        out_b = call_kernel(a, f"{elem} out[e] = inp[e] + 100.0f;")
+        mx.eval(out_a, out_b)
+        self.assertTrue(mx.array_equal(out_a, a * 2.0))
+        self.assertTrue(mx.array_equal(out_b, a + 100.0))
+
     @unittest.skipIf(not mx.metal.is_available(), "Metal is not available")
     def test_custom_metal_kernel_math_mode(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Fixes #4275.

`get_jit_module` keys the module cache on the kernel name alone (`jit_module.cpp:471-485`), so a second custom kernel sharing a name silently runs the first one's compiled code — no error, wrong results.

This is the CUDA counterpart of #3832, fixed for Metal in #3833. It is worse here: on Metal the stale-source invalidation worked across `eval` boundaries and only failed within a single batch, whereas `get_jit_module` has no invalidation at all, so the collision persists for the lifetime of the process.

The fix hashes the source into the module name, the same way #3833 did. The kernel name passed to `get_kernel()` is unchanged, so lookup inside the module still works.

It also covers a second path with the same root cause: `read_cached_ptx()` runs unconditionally (`jit_module.cpp:407`) even when `use_disk_cache` is false, so a stale on-disk PTX under the same name could be picked up too.

### Testing

`test_cuda_kernel_same_name_different_source` mirrors the Metal regression test from #3833. Verified on an L40S (sm_89) with CUDA 12.6 — two kernels sharing an entry name but differing in body, with a separate `mx.eval` between them:

| | before | after |
|---|---|---|
| first source (`x * 2`) | `[0, 2, 4]` correct | correct |
| second source (`x + 100`) | `[0, 2, 4]` — kernel A's code | `[100, 101, 102]` correct |

The rest of `test_fast.py` is unaffected: 24 passed / 4 skipped on CUDA, 27 passed / 1 skipped on Metal.

I ran into this through `mx.fast.precompiled_cuda_kernel` with Triton output, where it is easy to hit by accident since Triton names kernels after the Python function.