### PR TITLE
Mirror the depth axis in the decomposed 3D conv when flipped

### DIFF
--- a/mlx/backend/metal/conv.cpp
+++ b/mlx/backend/metal/conv.cpp
@@ -790,6 +790,10 @@ void small_kd_conv_3D_gpu(
         static_cast<size_t>(OD) * H * W * C,
         static_cast<int64_t>(kd) * H * W * C);
 
+    // The 2D conv only flips the last two kernel axes, so mirror the depth
+    // axis here when the convolution is flipped.
+    const int kd_wt = conv_params.flip ? KD - 1 - kd : kd;
+
     array wt_2d({O, KH, KW, C}, wt.dtype(), nullptr, {});
     wt_2d.copy_shared_buffer(
         wt,
@@ -800,7 +804,7 @@ void small_kd_conv_3D_gpu(
         {false, false, false},
         static_cast<size_t>(O - 1) * KD * KH * KW * C +
             static_cast<size_t>(KH) * KW * C,
-        static_cast<int64_t>(kd) * KH * KW * C);
+        static_cast<int64_t>(kd_wt) * KH * KW * C);
 
     array conv_out({OD, OH, OW, O}, out.dtype(), nullptr, {});
     conv_2D_gpu(

--- a/python/tests/test_conv.py
+++ b/python/tests/test_conv.py
@@ -1235,13 +1235,18 @@ class TestConv(mlx_tests.MLXTestCase):
         ]:
             x = mx.random.normal((1, T, H, W, Cin))
             w = mx.random.normal((Cout, kd, kh, kw, Cin))
-            y_gpu = mx.conv_general(x, w, stride=(1, 1, 1))
-            y_cpu = mx.conv_general(x, w, stride=(1, 1, 1), stream=mx.cpu)
-            mx.eval(y_gpu, y_cpu)
-            self.assertTrue(
-                mx.allclose(y_gpu, y_cpu, rtol=1e-4, atol=1e-4),
-                f"3D small-kd mismatch T{T} H{H} W{W} C{Cin}->{Cout} k{kd}{kh}{kw}",
-            )
+            # flip mirrors every kernel axis, including the decomposed depth
+            for flip in (False, True):
+                y_gpu = mx.conv_general(x, w, stride=(1, 1, 1), flip=flip)
+                y_cpu = mx.conv_general(
+                    x, w, stride=(1, 1, 1), flip=flip, stream=mx.cpu
+                )
+                mx.eval(y_gpu, y_cpu)
+                self.assertTrue(
+                    mx.allclose(y_gpu, y_cpu, rtol=1e-4, atol=1e-4),
+                    f"3D small-kd mismatch T{T} H{H} W{W} "
+                    f"C{Cin}->{Cout} k{kd}{kh}{kw} flip={flip}",
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The small kernel-depth 3D decomposition added in #3785 returns the wrong result when the convolution is flipped.

`small_kd_conv_3D_gpu` walks the kernel depth and, for each `kd`, pairs input frame `od + kd` with weight depth `kd`:

```cpp
static_cast<int64_t>(kd) * H * W * C);     // in_2d  -> in[od + kd]
...
static_cast<int64_t>(kd) * KH * KW * C);   // wt_2d  -> wt[o, kd]
```

then hands `conv_params.flip` to `conv_2D_gpu`, which only mirrors the last two kernel axes. A flipped convolution has to mirror every kernel axis, so for a given input frame `od + kd` it must read the weight at `KD - 1 - kd`. Nothing does that today, so the depth axis stays unflipped while the height and width axes flip.

`flip` reaches this branch unguarded: `conv_3D_gpu` copies it straight into `conv_params`, and the new condition in `dispatch_conv_3D_gpu` does not exclude it. `mx.conv_general(x, w, flip=True)` with the default stride and padding satisfies every part of that condition, so it is a plain public call.

I have no Metal machine, so rather than guess I reproduced the decomposition itself with mlx ops on the CPU stream and compared it against `mx.conv_general`, which takes a different code path. `current` is what the merged code computes, `fixed` is the same loop reading the weight at `KD - 1 - kd`:

```
case                        current maxdiff   fixed maxdiff
T5 k333 C32->32                  1.5374e+02      1.2589e-04
T4 k333 C16->48                  1.0423e+02      5.3406e-05
T6 k133 C32->32                  0.0000e+00      0.0000e+00
T5 k511 C16->16                  3.9660e+01      1.1444e-05
T4 k233 C32->16                  1.1368e+02      4.9591e-05
T8 k722 C16->16                  8.6852e+01      4.9591e-05
```

Those are the shapes from the test #3785 added, plus one more. `KD = 1` is unaffected, since there is no depth axis to mirror, and every `KD > 1` case is badly wrong and becomes exact with the mirrored index.

The fix is the index. The test that #3785 added already compares the GPU stream against the CPU stream, which is the right harness, so this just runs it for both `flip` settings.

If you would rather not carry a flipped path through the decomposition at all, adding `&& !conv_params.flip` to the dispatch condition also fixes it and falls back to the implicit gemm. I went with the index because it keeps the optimization and the arithmetic checks out above, but the conservative version is yours to prefer.

To be explicit about what I did not verify: this is Metal code and my build here is CPU only, so I could not compile the kernel path or run the new test against a real GPU. The evidence is the code and the CPU reproduction of the algorithm. `test_conv.py` passes here, but on a CPU only build both sides of that comparison run on the CPU, so it cannot fail locally either way.

I am a freshman working through this codebase and I used Claude Code alongside it. The numbers above are from a run on this machine.
