### PR TITLE
Fix/speculative shape invariance

### DIFF
--- a/docs/src/usage/environment_variables.rst
+++ b/docs/src/usage/environment_variables.rst
@@ -94,12 +94,14 @@ Metal
 
 .. envvar:: MLX_METAL_BATCH_INVARIANT_LIMIT
 
-   Select Metal kernels whose reductions are invariant to leading matrix and
-   attention query dimensions up to this limit. This makes token-by-token and
-   short-block inference use the same reduction order, which is useful for
+   Select canonical reduction plans for supported short-block Metal inference
+   kernels up to this limit. This covers dense matmul, transposed-weight
+   quantized matmul, and vector SDPA queries up to length eight; it does not
+   make every MLX operation batch invariant. The setting is process-wide and
+   should remain stable while concurrent work is executing. It is useful for
    greedy speculative decoding and reproducibility. The default is ``0``
-   (disabled). Increasing the limit can reduce performance. The setting can
-   also be changed at runtime with
+   (disabled), and increasing the limit can reduce performance. The setting
+   can also be changed at runtime with
    :func:`mlx.core.metal.set_batch_invariant_limit`.
 
 Advanced tuning

--- a/docs/src/usage/environment_variables.rst
+++ b/docs/src/usage/environment_variables.rst
@@ -92,6 +92,16 @@ Metal
    Enable the faster Metal CPU/GPU synchronization path. The default is ``0``.
    This requires Metal 3.2 or later (macOS 15 or later, or iOS 18 or later).
 
+.. envvar:: MLX_METAL_BATCH_INVARIANT_LIMIT
+
+   Select Metal kernels whose reductions are invariant to leading matrix and
+   attention query dimensions up to this limit. This makes token-by-token and
+   short-block inference use the same reduction order, which is useful for
+   greedy speculative decoding and reproducibility. The default is ``0``
+   (disabled). Increasing the limit can reduce performance. The setting can
+   also be changed at runtime with
+   :func:`mlx.core.metal.set_batch_invariant_limit`.
+
 Advanced tuning
 ---------------
 

--- a/docs/src/usage/environment_variables.rst
+++ b/docs/src/usage/environment_variables.rst
@@ -95,13 +95,13 @@ Metal
 .. envvar:: MLX_METAL_BATCH_INVARIANT_LIMIT
 
    Select canonical reduction plans for supported short-block Metal inference
-   kernels up to this limit. This covers dense matmul, transposed-weight
-   quantized matmul, and vector SDPA queries up to length eight; it does not
-   make every MLX operation batch invariant. The setting is process-wide and
-   should remain stable while concurrent work is executing. It is useful for
-   greedy speculative decoding and reproducibility. The default is ``0``
-   (disabled), and increasing the limit can reduce performance. The setting
-   can also be changed at runtime with
+   kernels up to this limit. This covers dense matmul and addmm,
+   transposed-weight quantized matmul, and vector SDPA queries up to length
+   eight; it does not make every MLX operation batch invariant. The setting is
+   process-wide and should remain stable while concurrent work is executing.
+   It is useful for greedy speculative decoding and reproducibility. The
+   default is ``0`` (disabled), and increasing the limit can reduce
+   performance. The setting can also be changed at runtime with
    :func:`mlx.core.metal.set_batch_invariant_limit`.
 
 Advanced tuning

--- a/mlx/backend/metal/matmul.cpp
+++ b/mlx/backend/metal/matmul.cpp
@@ -1490,6 +1490,50 @@ void Matmul::eval_gpu(const std::vector<array>& inputs, array& out) {
 
   auto batch_size_out = out.size() / (size_t(M) * size_t(N));
 
+  // In batch-invariant mode, expose every short matrix row as an independent
+  // GEMV batch item. Preserve outer batch addressing, and materialize unusual
+  // activation layouts so each row matches token-by-token inference.
+  if (M > 1 && M <= metal::get_batch_invariant_limit()) {
+    array invariant_a = a;
+    int invariant_lda = a_cols;
+    if (a_transposed) {
+      invariant_a = contiguous_copy_gpu(a, s);
+      copies.push_back(invariant_a);
+      invariant_lda = K;
+      std::tie(batch_shape, A_batch_stride, B_batch_stride) =
+          collapse_batches(invariant_a, b);
+    }
+
+    if (batch_size_out == 1) {
+      batch_shape = {M};
+      A_batch_stride = {invariant_lda};
+      B_batch_stride = {0};
+    } else {
+      batch_shape.push_back(M);
+      A_batch_stride.push_back(invariant_lda);
+      B_batch_stride.push_back(0);
+    }
+
+    return gemv(
+        /* const Stream& s = */ s,
+        /* metal::Device& d = */ d,
+        /* const array& a = */ invariant_a,
+        /* const array& b = */ b,
+        /* array& out = */ out,
+        /* int M = */ 1,
+        /* int N = */ N,
+        /* int K = */ K,
+        /* int batch_size_out = */ static_cast<int>(batch_size_out * M),
+        /* int lda = */ invariant_lda,
+        /* int ldb = */ b_cols,
+        /* bool transpose_a = */ false,
+        /* bool transpose_b = */ b_transposed,
+        /* std::vector<array>& copies = */ copies,
+        /* Shape batch_shape = */ std::move(batch_shape),
+        /* Strides A_batch_stride = */ std::move(A_batch_stride),
+        /* Strides B_batch_stride = */ std::move(B_batch_stride));
+  }
+
   // Collapse batches into M if needed
   if (batch_size_out > 1 && !a_transposed && batch_shape.size() == 1 &&
       a.strides()[a.ndim() - 2] == K && A_batch_stride.back() == M * K &&
@@ -1506,7 +1550,8 @@ void Matmul::eval_gpu(const std::vector<array>& inputs, array& out) {
   // Gemv specialization
 
   if (M == 1 && N == 1 && batch_size_out == 1 && a.flags().row_contiguous &&
-      b.flags().row_contiguous && a.dtype() != complex64) {
+      b.flags().row_contiguous && a.dtype() != complex64 &&
+      metal::get_batch_invariant_limit() == 0) {
     return dot_product(
         /* const Stream& s = */ s,
         /* metal::Device& d = */ d,
@@ -1515,30 +1560,6 @@ void Matmul::eval_gpu(const std::vector<array>& inputs, array& out) {
         /* array& out = */ out,
         /* int K = */ K,
         /* std::vector<array>& copies = */ copies);
-  }
-  // In batch-invariant mode, treat each short matrix row as a batch of
-  // single-row GEMVs. The rows still execute in parallel, but use the same
-  // reduction kernel and order as token-by-token inference.
-  if (M > 1 && M <= metal::get_batch_invariant_limit() && batch_size_out == 1 &&
-      !a_transposed) {
-    return gemv(
-        /* const Stream& s = */ s,
-        /* metal::Device& d = */ d,
-        /* const array& a = */ a,
-        /* const array& b = */ b,
-        /* array& out = */ out,
-        /* int M = */ 1,
-        /* int N = */ N,
-        /* int K = */ K,
-        /* int batch_size_out = */ M,
-        /* int lda = */ a_cols,
-        /* int ldb = */ b_cols,
-        /* bool transpose_a = */ false,
-        /* bool transpose_b = */ b_transposed,
-        /* std::vector<array>& copies = */ copies,
-        /* Shape batch_shape = */ {M},
-        /* Strides A_batch_stride = */ {a_cols},
-        /* Strides B_batch_stride = */ {0});
   }
   // The wide gemv route streams the weight matrix once per <= 5 input
   // vectors instead of running a row-padded GEMM tile.
@@ -1680,6 +1701,56 @@ void AddMM::eval_gpu(const std::vector<array>& inputs, array& out) {
 
   int64_t matrix_stride_out = M * static_cast<int64_t>(N);
   auto batch_size_out = out.size() / (matrix_stride_out);
+
+  // Match the single-row GEMV and epilogue for short matrices in
+  // batch-invariant mode. Preserve outer batch addressing; the broadcasted C
+  // row either advances with each matrix row or has a zero stride.
+  if (M > 1 && M <= metal::get_batch_invariant_limit()) {
+    array invariant_a = a;
+    int invariant_lda = lda;
+    if (transpose_a) {
+      invariant_a = contiguous_copy_gpu(a, s);
+      copies.push_back(invariant_a);
+      invariant_lda = K;
+      std::tie(batch_shape, A_batch_stride, B_batch_stride, C_batch_stride) =
+          collapse_batches(invariant_a, b, c);
+    }
+
+    if (batch_size_out == 1) {
+      batch_shape = {M};
+      A_batch_stride = {invariant_lda};
+      B_batch_stride = {0};
+      C_batch_stride = {c.strides()[c.ndim() - 2]};
+    } else {
+      batch_shape.push_back(M);
+      A_batch_stride.push_back(invariant_lda);
+      B_batch_stride.push_back(0);
+      C_batch_stride.push_back(c.strides()[c.ndim() - 2]);
+    }
+
+    return gemv_axbpy(
+        /* const Stream& s = */ s,
+        /* metal::Device& d = */ d,
+        /* const array& a = */ invariant_a,
+        /* const array& b = */ b,
+        /* const array& c = */ c,
+        /* array& out = */ out,
+        /* int M = */ 1,
+        /* int N = */ N,
+        /* int K = */ K,
+        /* int batch_size_out = */ static_cast<int>(batch_size_out * M),
+        /* int lda = */ invariant_lda,
+        /* int ldb = */ ldb,
+        /* bool transpose_a = */ false,
+        /* bool transpose_b = */ transpose_b,
+        /* std::vector<array>& copies = */ copies,
+        /* Shape batch_shape = */ std::move(batch_shape),
+        /* Strides A_batch_stride = */ std::move(A_batch_stride),
+        /* Strides B_batch_stride = */ std::move(B_batch_stride),
+        /* Strides C_batch_stride = */ std::move(C_batch_stride),
+        /* float alpha = */ alpha_,
+        /* float beta = */ beta_);
+  }
 
   // Collapse batches into M if needed
   if (batch_size_out > 1 && !transpose_a && batch_shape.size() == 1 &&

--- a/mlx/backend/metal/matmul.cpp
+++ b/mlx/backend/metal/matmul.cpp
@@ -13,9 +13,9 @@
 #include "mlx/backend/metal/device.h"
 #include "mlx/backend/metal/kernels.h"
 #include "mlx/backend/metal/kernels/defines.h"
-#include "mlx/backend/metal/metal.h"
 #include "mlx/backend/metal/kernels/steel/gemm/params.h"
 #include "mlx/backend/metal/matmul.h"
+#include "mlx/backend/metal/metal.h"
 #include "mlx/backend/metal/reduce.h"
 #include "mlx/backend/metal/utils.h"
 #include "mlx/primitives.h"
@@ -1519,8 +1519,8 @@ void Matmul::eval_gpu(const std::vector<array>& inputs, array& out) {
   // In batch-invariant mode, treat each short matrix row as a batch of
   // single-row GEMVs. The rows still execute in parallel, but use the same
   // reduction kernel and order as token-by-token inference.
-  if (M > 1 && M <= metal::get_batch_invariant_limit() &&
-      batch_size_out == 1 && !a_transposed && b_transposed) {
+  if (M > 1 && M <= metal::get_batch_invariant_limit() && batch_size_out == 1 &&
+      !a_transposed && b_transposed) {
     return gemv(
         /* const Stream& s = */ s,
         /* metal::Device& d = */ d,

--- a/mlx/backend/metal/matmul.cpp
+++ b/mlx/backend/metal/matmul.cpp
@@ -13,6 +13,7 @@
 #include "mlx/backend/metal/device.h"
 #include "mlx/backend/metal/kernels.h"
 #include "mlx/backend/metal/kernels/defines.h"
+#include "mlx/backend/metal/metal.h"
 #include "mlx/backend/metal/kernels/steel/gemm/params.h"
 #include "mlx/backend/metal/matmul.h"
 #include "mlx/backend/metal/reduce.h"
@@ -1514,6 +1515,30 @@ void Matmul::eval_gpu(const std::vector<array>& inputs, array& out) {
         /* array& out = */ out,
         /* int K = */ K,
         /* std::vector<array>& copies = */ copies);
+  }
+  // In batch-invariant mode, treat each short matrix row as a batch of
+  // single-row GEMVs. The rows still execute in parallel, but use the same
+  // reduction kernel and order as token-by-token inference.
+  if (M > 1 && M <= metal::get_batch_invariant_limit() &&
+      batch_size_out == 1 && !a_transposed && b_transposed) {
+    return gemv(
+        /* const Stream& s = */ s,
+        /* metal::Device& d = */ d,
+        /* const array& a = */ a,
+        /* const array& b = */ b,
+        /* array& out = */ out,
+        /* int M = */ 1,
+        /* int N = */ N,
+        /* int K = */ K,
+        /* int batch_size_out = */ M,
+        /* int lda = */ a_cols,
+        /* int ldb = */ b_cols,
+        /* bool transpose_a = */ false,
+        /* bool transpose_b = */ true,
+        /* std::vector<array>& copies = */ copies,
+        /* Shape batch_shape = */ {M},
+        /* Strides A_batch_stride = */ {a_cols},
+        /* Strides B_batch_stride = */ {0});
   }
   // The wide gemv route streams the weight matrix once per <= 5 input
   // vectors instead of running a row-padded GEMM tile.

--- a/mlx/backend/metal/matmul.cpp
+++ b/mlx/backend/metal/matmul.cpp
@@ -1520,7 +1520,7 @@ void Matmul::eval_gpu(const std::vector<array>& inputs, array& out) {
   // single-row GEMVs. The rows still execute in parallel, but use the same
   // reduction kernel and order as token-by-token inference.
   if (M > 1 && M <= metal::get_batch_invariant_limit() && batch_size_out == 1 &&
-      !a_transposed && b_transposed) {
+      !a_transposed) {
     return gemv(
         /* const Stream& s = */ s,
         /* metal::Device& d = */ d,
@@ -1534,7 +1534,7 @@ void Matmul::eval_gpu(const std::vector<array>& inputs, array& out) {
         /* int lda = */ a_cols,
         /* int ldb = */ b_cols,
         /* bool transpose_a = */ false,
-        /* bool transpose_b = */ true,
+        /* bool transpose_b = */ b_transposed,
         /* std::vector<array>& copies = */ copies,
         /* Shape batch_shape = */ {M},
         /* Strides A_batch_stride = */ {a_cols},

--- a/mlx/backend/metal/metal.cpp
+++ b/mlx/backend/metal/metal.cpp
@@ -1,9 +1,11 @@
 // Copyright © 2023-2024 Apple Inc.
+#include <atomic>
 #include <memory>
 
 #include "mlx/backend/metal/device.h"
 #include "mlx/backend/metal/metal.h"
 #include "mlx/backend/metal/utils.h"
+#include "mlx/utils.h"
 
 namespace mlx::core::metal {
 
@@ -11,10 +13,26 @@ namespace {
 
 std::string g_metallib_path;
 
+int initial_batch_invariant_limit() {
+  int limit = env::get_var("MLX_METAL_BATCH_INVARIANT_LIMIT", 0);
+  return limit > 0 ? limit : 0;
+}
+
+std::atomic<int> g_batch_invariant_limit{initial_batch_invariant_limit()};
+
 } // namespace
 
 bool is_available() {
   return true;
+}
+
+void set_batch_invariant_limit(int limit) {
+  g_batch_invariant_limit.store(
+      limit > 0 ? limit : 0, std::memory_order_relaxed);
+}
+
+int get_batch_invariant_limit() {
+  return g_batch_invariant_limit.load(std::memory_order_relaxed);
 }
 
 void start_capture(std::string path, NS::Object* object) {

--- a/mlx/backend/metal/metal.h
+++ b/mlx/backend/metal/metal.h
@@ -13,6 +13,19 @@ namespace mlx::core::metal {
 /* Check if the Metal backend is available. */
 MLX_API bool is_available();
 
+/**
+ * Select kernels whose reductions are invariant to leading matrix and
+ * attention query dimensions up to `limit`. This is useful when an application
+ * requires token-by-token and short-block inference to produce identical
+ * results. Set to zero to disable.
+ *
+ * Increasing the limit can reduce performance. The default is controlled by
+ * the ``MLX_METAL_BATCH_INVARIANT_LIMIT`` environment variable and is zero
+ * when the variable is unset.
+ */
+MLX_API void set_batch_invariant_limit(int limit);
+MLX_API int get_batch_invariant_limit();
+
 /** Capture a GPU trace, saving it to an absolute file `path` */
 MLX_API void start_capture(std::string path = "");
 MLX_API void stop_capture();

--- a/mlx/backend/metal/metal.h
+++ b/mlx/backend/metal/metal.h
@@ -14,14 +14,15 @@ namespace mlx::core::metal {
 MLX_API bool is_available();
 
 /**
- * Select kernels whose reductions are invariant to leading matrix and
- * attention query dimensions up to `limit`. This is useful when an application
- * requires token-by-token and short-block inference to produce identical
- * results. Set to zero to disable.
+ * Select canonical reduction plans for supported short-block Metal inference
+ * kernels up to `limit`. This covers dense matmul, transposed-weight quantized
+ * matmul, and the vector SDPA path (whose query-length cap is eight). It does
+ * not make every MLX operation batch invariant. Set to zero to disable.
  *
- * Increasing the limit can reduce performance. The default is controlled by
- * the ``MLX_METAL_BATCH_INVARIANT_LIMIT`` environment variable and is zero
- * when the variable is unset.
+ * The setting is process-wide and should remain stable while concurrent work
+ * is executing. Increasing the limit can reduce performance. The default is
+ * controlled by the ``MLX_METAL_BATCH_INVARIANT_LIMIT`` environment variable
+ * and is zero when the variable is unset.
  */
 MLX_API void set_batch_invariant_limit(int limit);
 MLX_API int get_batch_invariant_limit();

--- a/mlx/backend/metal/metal.h
+++ b/mlx/backend/metal/metal.h
@@ -15,9 +15,10 @@ MLX_API bool is_available();
 
 /**
  * Select canonical reduction plans for supported short-block Metal inference
- * kernels up to `limit`. This covers dense matmul, transposed-weight quantized
- * matmul, and the vector SDPA path (whose query-length cap is eight). It does
- * not make every MLX operation batch invariant. Set to zero to disable.
+ * kernels up to `limit`. This covers dense matmul and addmm,
+ * transposed-weight quantized matmul, and the vector SDPA path (whose
+ * query-length cap is eight). It does not make every MLX operation batch
+ * invariant. Set to zero to disable.
  *
  * The setting is process-wide and should remain stable while concurrent work
  * is executing. Increasing the limit can reduce performance. The default is

--- a/mlx/backend/metal/no_metal.cpp
+++ b/mlx/backend/metal/no_metal.cpp
@@ -12,6 +12,12 @@ bool is_available() {
   return false;
 }
 
+void set_batch_invariant_limit(int) {}
+
+int get_batch_invariant_limit() {
+  return 0;
+}
+
 void start_capture(std::string) {}
 void stop_capture() {}
 

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -6,6 +6,7 @@
 #include "mlx/backend/gpu/copy.h"
 #include "mlx/backend/metal/device.h"
 #include "mlx/backend/metal/kernels.h"
+#include "mlx/backend/metal/metal.h"
 #include "mlx/backend/metal/reduce.h"
 #include "mlx/backend/metal/unary.h"
 #include "mlx/backend/metal/utils.h"
@@ -1758,7 +1759,8 @@ void dispatch_qmv(
 
   // Small batch so route to qmv_wide, which reuses each weight group across the
   // M vectors.
-  if (M >= 2 && use_qmv_wide(mode, d) && !global_scale) {
+  int invariant_limit = metal::get_batch_invariant_limit();
+  if (M >= 2 && M > invariant_limit && use_qmv_wide(mode, d) && !global_scale) {
     qmv_wide(x, w, scales, biases, out, group_size, bits, M, N, K, d, s, mode);
     return;
   }
@@ -1802,8 +1804,10 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
 
   int vector_limit = transpose_ ? get_qmv_batch_limit(K, N, d) : 4;
   auto mode = quantization_mode_to_string(mode_);
+  bool invariant_qmv =
+      transpose_ && M > 1 && M <= metal::get_batch_invariant_limit();
   // It is a matrix matrix product.
-  if (M >= vector_limit) {
+  if (M >= vector_limit && !invariant_qmv) {
     // Use split-K qmm for small M with transposed weights (non-batched only)
     int B = out.size() / M / N;
     if (transpose_ && B == 1) {

--- a/mlx/backend/metal/scaled_dot_product_attention.cpp
+++ b/mlx/backend/metal/scaled_dot_product_attention.cpp
@@ -6,8 +6,8 @@
 #include "mlx/backend/metal/device.h"
 #include "mlx/backend/metal/kernels.h"
 #include "mlx/backend/metal/kernels/defines.h"
-#include "mlx/backend/metal/metal.h"
 #include "mlx/backend/metal/kernels/steel/attn/params.h"
+#include "mlx/backend/metal/metal.h"
 #include "mlx/backend/metal/utils.h"
 #include "mlx/fast_primitives.h"
 #include "mlx/utils.h"
@@ -445,8 +445,7 @@ void sdpa_vector_2pass(
   // single-query decode so a row produces the same result alone or inside a
   // short causal verification block.
   int invariant_limit = metal::get_batch_invariant_limit();
-  int n_simds =
-      gqa_factor * (q.shape(2) <= invariant_limit ? 1 : q.shape(2));
+  int n_simds = gqa_factor * (q.shape(2) <= invariant_limit ? 1 : q.shape(2));
 
   char devc = d.get_architecture().back();
   int N = k.shape(2);

--- a/mlx/backend/metal/scaled_dot_product_attention.cpp
+++ b/mlx/backend/metal/scaled_dot_product_attention.cpp
@@ -6,6 +6,7 @@
 #include "mlx/backend/metal/device.h"
 #include "mlx/backend/metal/kernels.h"
 #include "mlx/backend/metal/kernels/defines.h"
+#include "mlx/backend/metal/metal.h"
 #include "mlx/backend/metal/kernels/steel/attn/params.h"
 #include "mlx/backend/metal/utils.h"
 #include "mlx/fast_primitives.h"
@@ -439,7 +440,13 @@ void sdpa_vector_2pass(
 
   // Compute the necessary sizes
   int gqa_factor = q.shape(1) / k.shape(1);
-  int n_simds = gqa_factor * q.shape(2);
+  // A query-length-dependent split count changes the order of the two-pass
+  // softmax reduction. In batch-invariant mode, tune as if this were a
+  // single-query decode so a row produces the same result alone or inside a
+  // short causal verification block.
+  int invariant_limit = metal::get_batch_invariant_limit();
+  int n_simds =
+      gqa_factor * (q.shape(2) <= invariant_limit ? 1 : q.shape(2));
 
   char devc = d.get_architecture().back();
   int N = k.shape(2);

--- a/mlx/backend/metal/scaled_dot_product_attention.cpp
+++ b/mlx/backend/metal/scaled_dot_product_attention.cpp
@@ -445,12 +445,26 @@ void sdpa_vector_2pass(
   // single-query decode so a row produces the same result alone or inside a
   // short causal verification block.
   int invariant_limit = metal::get_batch_invariant_limit();
-  int n_simds = gqa_factor * (q.shape(2) <= invariant_limit ? 1 : q.shape(2));
+  bool invariant = q.shape(2) <= invariant_limit;
+  int n_simds = gqa_factor * (invariant ? 1 : q.shape(2));
 
   char devc = d.get_architecture().back();
   int N = k.shape(2);
   int blocks;
-  if (devc == 's') {
+  // The causal block contains more physical K/V rows than its early queries
+  // can see. A split count selected from that full length can therefore differ
+  // from singleton decoding at the effective prefix length. Use an
+  // N-independent canonical plan in invariant mode so valid keys keep the same
+  // modulo partition for every query row.
+  if (invariant) {
+    if (devc == 's') {
+      blocks = 64;
+    } else if (devc == 'd') {
+      blocks = 128;
+    } else {
+      blocks = gqa_factor >= 4 ? 64 : 32;
+    }
+  } else if (devc == 's') {
     blocks = 64;
     if (N > 1024 && n_simds > 4) {
       if (N <= 8192) {
@@ -756,7 +770,8 @@ void ScaledDotProductAttention::eval_gpu(
     // - The sequence length is even longer and we have gqa
     bool do_causal = do_causal_ && q.shape(2) > 1;
     char devc = d.get_architecture().back();
-    if (((devc == 'd' || devc == 's') && k.shape(2) >= 1024) ||
+    bool invariant = q.shape(2) <= metal::get_batch_invariant_limit();
+    if (invariant || ((devc == 'd' || devc == 's') && k.shape(2) >= 1024) ||
         (k.shape(1) < q.shape(1) && k.shape(2) >= 4096)) {
       sdpa_vector_2pass(s, d, q, k, v, o, scale_, do_causal, mask, sinks);
     } else {

--- a/python/src/metal.cpp
+++ b/python/src/metal.cpp
@@ -33,6 +33,25 @@ void init_metal(nb::module_& m) {
       R"pbdoc(
       Check if the Metal back-end is available.
       )pbdoc");
+  metal.def(
+      "set_batch_invariant_limit",
+      &mx::metal::set_batch_invariant_limit,
+      "limit"_a,
+      R"pbdoc(
+      Select Metal kernels whose reductions are invariant to leading matrix
+      and attention query dimensions up to ``limit``. Set to zero to disable.
+
+      This is useful when token-by-token and short-block inference must
+      produce identical results, for example during greedy speculative
+      decoding. Increasing the limit can reduce performance.
+      )pbdoc");
+  metal.def(
+      "get_batch_invariant_limit",
+      &mx::metal::get_batch_invariant_limit,
+      R"pbdoc(
+      Return the maximum leading dimension covered by batch-invariant Metal
+      inference kernels, or zero when disabled.
+      )pbdoc");
   metal.def("get_active_memory", []() {
     DEPRECATE("mx.metal.get_active_memory", "mx.get_active_memory");
     return mx::get_active_memory();

--- a/python/src/metal.cpp
+++ b/python/src/metal.cpp
@@ -39,7 +39,7 @@ void init_metal(nb::module_& m) {
       "limit"_a,
       R"pbdoc(
       Select canonical reduction plans for supported short-block Metal
-      inference kernels up to ``limit``. This covers dense matmul,
+      inference kernels up to ``limit``. This covers dense matmul and addmm,
       transposed-weight quantized matmul, and vector SDPA queries up to length
       eight; it does not make every MLX operation batch invariant. Set to zero
       to disable.

--- a/python/src/metal.cpp
+++ b/python/src/metal.cpp
@@ -38,18 +38,23 @@ void init_metal(nb::module_& m) {
       &mx::metal::set_batch_invariant_limit,
       "limit"_a,
       R"pbdoc(
-      Select Metal kernels whose reductions are invariant to leading matrix
-      and attention query dimensions up to ``limit``. Set to zero to disable.
+      Select canonical reduction plans for supported short-block Metal
+      inference kernels up to ``limit``. This covers dense matmul,
+      transposed-weight quantized matmul, and vector SDPA queries up to length
+      eight; it does not make every MLX operation batch invariant. Set to zero
+      to disable.
 
       This is useful when token-by-token and short-block inference must
       produce identical results, for example during greedy speculative
-      decoding. Increasing the limit can reduce performance.
+      decoding. The setting is process-wide and should remain stable while
+      concurrent work is executing. Increasing the limit can reduce
+      performance.
       )pbdoc");
   metal.def(
       "get_batch_invariant_limit",
       &mx::metal::get_batch_invariant_limit,
       R"pbdoc(
-      Return the maximum leading dimension covered by batch-invariant Metal
+      Return the configured short-block limit for supported canonical Metal
       inference kernels, or zero when disabled.
       )pbdoc");
   metal.def("get_active_memory", []() {

--- a/tests/gpu_tests.cpp
+++ b/tests/gpu_tests.cpp
@@ -77,10 +77,10 @@ TEST_CASE("test gpu batch invariant sdpa") {
     }
   }
 
-  auto q_block = astype(
-      array(q_block_data.data(), {B, Hq, Lq, D}), bfloat16, Device::gpu);
-  auto q_single = astype(
-      array(q_single_data.data(), {B, Hq, 1, D}), bfloat16, Device::gpu);
+  auto q_block =
+      astype(array(q_block_data.data(), {B, Hq, Lq, D}), bfloat16, Device::gpu);
+  auto q_single =
+      astype(array(q_single_data.data(), {B, Hq, 1, D}), bfloat16, Device::gpu);
   auto k = astype(array(k_data.data(), {B, Hkv, Lk, D}), bfloat16, Device::gpu);
   auto v = astype(array(v_data.data(), {B, Hkv, Lk, D}), bfloat16, Device::gpu);
 
@@ -90,11 +90,10 @@ TEST_CASE("test gpu batch invariant sdpa") {
       q_single, k, v, 1.0f / std::sqrt(D), "", {}, {}, Device::gpu);
   auto block_last = slice(block, {0, 0, Lq - 1, 0}, {B, Hq, Lq, D});
 
-  auto max_diff = max(
-      abs(
-          astype(block_last, float32, Device::gpu) -
-          astype(single, float32, Device::gpu)),
-      Device::gpu);
+  auto max_diff =
+      max(abs(astype(block_last, float32, Device::gpu) -
+              astype(single, float32, Device::gpu)),
+          Device::gpu);
   MESSAGE("max SDPA query-shape difference: ", max_diff.item<float>());
   CHECK(array_equal(block_last, single, Device::cpu).item<bool>());
 }
@@ -123,20 +122,19 @@ TEST_CASE("test gpu batch invariant matmul") {
     }
   }
 
-  auto x_block = astype(
-      array(x_block_data.data(), {M, K}), bfloat16, Device::gpu);
-  auto x_single = astype(
-      array(x_single_data.data(), {1, K}), bfloat16, Device::gpu);
+  auto x_block =
+      astype(array(x_block_data.data(), {M, K}), bfloat16, Device::gpu);
+  auto x_single =
+      astype(array(x_single_data.data(), {1, K}), bfloat16, Device::gpu);
   auto w = astype(array(w_data.data(), {N, K}), bfloat16, Device::gpu);
 
   auto block = matmul(x_block, transpose(w), Device::gpu);
   auto single = matmul(x_single, transpose(w), Device::gpu);
   auto block_last = slice(block, {M - 1, 0}, {M, N});
-  auto max_diff = max(
-      abs(
-          astype(block_last, float32, Device::gpu) -
-          astype(single, float32, Device::gpu)),
-      Device::gpu);
+  auto max_diff =
+      max(abs(astype(block_last, float32, Device::gpu) -
+              astype(single, float32, Device::gpu)),
+          Device::gpu);
   MESSAGE("max matmul row-shape difference: ", max_diff.item<float>());
   CHECK(array_equal(block_last, single, Device::cpu).item<bool>());
 }

--- a/tests/gpu_tests.cpp
+++ b/tests/gpu_tests.cpp
@@ -30,8 +30,9 @@ TEST_CASE("test gpu arange") {
 
 class BatchInvariantGuard {
  public:
-  BatchInvariantGuard() : previous_(metal::get_batch_invariant_limit()) {
-    metal::set_batch_invariant_limit(4);
+  explicit BatchInvariantGuard(int limit = 4)
+      : previous_(metal::get_batch_invariant_limit()) {
+    metal::set_batch_invariant_limit(limit);
   }
 
   ~BatchInvariantGuard() {
@@ -43,77 +44,72 @@ class BatchInvariantGuard {
 };
 
 TEST_CASE("test gpu batch invariant sdpa") {
-  BatchInvariantGuard guard;
+  BatchInvariantGuard guard(8);
   constexpr int B = 1;
-  constexpr int Hq = 8;
-  constexpr int Hkv = 4;
-  constexpr int Lq = 4;
-  constexpr int Lk = 16384;
-  constexpr int D = 128;
+  constexpr int Hq = 2;
+  constexpr int Hkv = 1;
+  constexpr int Lq = 8;
+  constexpr int D = 64;
 
-  std::vector<float> q_block_data(B * Hq * Lq * D);
-  std::vector<float> q_single_data(B * Hq * D);
-  std::vector<float> k_data(B * Hkv * Lk * D);
-  std::vector<float> v_data(B * Hkv * Lk * D);
+  auto q_block = astype(
+      reshape(
+          sin(arange(B * Hq * Lq * D, float32, Device::gpu) * 0.017f),
+          {B, Hq, Lq, D}),
+      bfloat16,
+      Device::gpu);
 
-  for (int h = 0; h < Hq; ++h) {
-    for (int l = 0; l < Lq; ++l) {
-      for (int d = 0; d < D; ++d) {
-        auto value = std::sin(0.017f * (h * D + d) + 0.13f * l);
-        q_block_data[(h * Lq + l) * D + d] = value;
-        if (l == Lq - 1) {
-          q_single_data[h * D + d] = value;
-        }
-      }
-    }
-  }
-  for (int h = 0; h < Hkv; ++h) {
-    for (int l = 0; l < Lk; ++l) {
-      for (int d = 0; d < D; ++d) {
-        auto offset = (h * Lk + l) * D + d;
-        k_data[offset] = std::cos(0.011f * d + 0.003f * l + 0.2f * h);
-        v_data[offset] = std::sin(0.007f * d - 0.002f * l + 0.3f * h);
-      }
-    }
-  }
+  // Full K/V lengths are selected so the effective causal prefixes span each
+  // dispatch boundary: threshold - 3 through threshold + 4.
+  for (int Lk : {1028, 8196, 16388, 65540}) {
+    auto k = astype(
+        reshape(
+            cos(arange(B * Hkv * Lk * D, float32, Device::gpu) * 0.011f),
+            {B, Hkv, Lk, D}),
+        bfloat16,
+        Device::gpu);
+    auto v = astype(
+        reshape(
+            sin(arange(B * Hkv * Lk * D, float32, Device::gpu) * 0.007f),
+            {B, Hkv, Lk, D}),
+        bfloat16,
+        Device::gpu);
+    auto block = fast::scaled_dot_product_attention(
+        q_block, k, v, 1.0f / std::sqrt(D), "causal", {}, {}, Device::gpu);
 
-  auto q_block =
-      astype(array(q_block_data.data(), {B, Hq, Lq, D}), bfloat16, Device::gpu);
-  auto q_single =
-      astype(array(q_single_data.data(), {B, Hq, 1, D}), bfloat16, Device::gpu);
-  auto k = astype(array(k_data.data(), {B, Hkv, Lk, D}), bfloat16, Device::gpu);
-  auto v = astype(array(v_data.data(), {B, Hkv, Lk, D}), bfloat16, Device::gpu);
-
-  auto block = fast::scaled_dot_product_attention(
-      q_block, k, v, 1.0f / std::sqrt(D), "causal", {}, {}, Device::gpu);
-  auto single = fast::scaled_dot_product_attention(
-      q_single, k, v, 1.0f / std::sqrt(D), "", {}, {}, Device::gpu);
-  auto block_last = slice(block, {0, 0, Lq - 1, 0}, {B, Hq, Lq, D});
-
-  auto max_diff =
-      max(abs(astype(block_last, float32, Device::gpu) -
-              astype(single, float32, Device::gpu)),
+    for (int row = 0; row < Lq; ++row) {
+      int prefix = Lk - Lq + row + 1;
+      auto q_single = slice(q_block, {0, 0, row, 0}, {B, Hq, row + 1, D});
+      auto k_prefix = slice(k, {0, 0, 0, 0}, {B, Hkv, prefix, D});
+      auto v_prefix = slice(v, {0, 0, 0, 0}, {B, Hkv, prefix, D});
+      auto single = fast::scaled_dot_product_attention(
+          q_single,
+          k_prefix,
+          v_prefix,
+          1.0f / std::sqrt(D),
+          "",
+          {},
+          {},
           Device::gpu);
-  MESSAGE("max SDPA query-shape difference: ", max_diff.item<float>());
-  CHECK(array_equal(block_last, single, Device::cpu).item<bool>());
+      auto block_row = slice(block, {0, 0, row, 0}, {B, Hq, row + 1, D});
+      CAPTURE(Lk);
+      CAPTURE(row);
+      CAPTURE(prefix);
+      CHECK(array_equal(block_row, single, Device::cpu).item<bool>());
+    }
+  }
 }
 
 TEST_CASE("test gpu batch invariant matmul") {
   BatchInvariantGuard guard;
   constexpr int M = 4;
   constexpr int K = 4096;
-  constexpr int N = 4096;
+  constexpr int N = 512;
 
   std::vector<float> x_block_data(M * K);
-  std::vector<float> x_single_data(K);
   std::vector<float> w_data(N * K);
   for (int m = 0; m < M; ++m) {
     for (int k = 0; k < K; ++k) {
-      auto value = std::sin(0.013f * k + 0.17f * m);
-      x_block_data[m * K + k] = value;
-      if (m == M - 1) {
-        x_single_data[k] = value;
-      }
+      x_block_data[m * K + k] = std::sin(0.013f * k + 0.17f * m);
     }
   }
   for (int n = 0; n < N; ++n) {
@@ -122,21 +118,110 @@ TEST_CASE("test gpu batch invariant matmul") {
     }
   }
 
-  auto x_block =
-      astype(array(x_block_data.data(), {M, K}), bfloat16, Device::gpu);
-  auto x_single =
-      astype(array(x_single_data.data(), {1, K}), bfloat16, Device::gpu);
-  auto w = astype(array(w_data.data(), {N, K}), bfloat16, Device::gpu);
+  for (auto dtype : {float16, bfloat16, float32, complex64}) {
+    auto x_block =
+        astype(array(x_block_data.data(), {M, K}), dtype, Device::gpu);
+    auto w = astype(array(w_data.data(), {N, K}), dtype, Device::gpu);
+    auto block = matmul(x_block, transpose(w), Device::gpu);
 
-  auto block = matmul(x_block, transpose(w), Device::gpu);
-  auto single = matmul(x_single, transpose(w), Device::gpu);
-  auto block_last = slice(block, {M - 1, 0}, {M, N});
-  auto max_diff =
-      max(abs(astype(block_last, float32, Device::gpu) -
-              astype(single, float32, Device::gpu)),
+    for (int row = 0; row < M; ++row) {
+      auto x_single = slice(x_block, {row, 0}, {row + 1, K});
+      auto single = matmul(x_single, transpose(w), Device::gpu);
+      auto block_row = slice(block, {row, 0}, {row + 1, N});
+      CAPTURE(dtype);
+      CAPTURE(row);
+      CHECK(array_equal(block_row, single, Device::cpu).item<bool>());
+    }
+  }
+}
+
+TEST_CASE("test gpu batch invariant quantized matmul") {
+  BatchInvariantGuard guard;
+  constexpr int limit = 4;
+  constexpr int K = 4096;
+  constexpr int N = 512;
+
+  auto x_base = reshape(
+      sin(arange((limit + 1) * K, float32, Device::gpu) * 0.013f),
+      {limit + 1, K});
+  auto w_base =
+      reshape(cos(arange(N * K, float32, Device::gpu) * 0.009f), {N, K});
+
+  struct QuantizationConfig {
+    int group_size;
+    int bits;
+    const char* mode;
+  };
+  const QuantizationConfig configs[] = {
+      {32, 4, "affine"},
+      {64, 4, "affine"},
+      {128, 4, "affine"},
+      {32, 4, "mxfp4"},
+      {32, 8, "mxfp8"},
+      {16, 4, "nvfp4"},
+  };
+
+  for (auto dtype : {float32, bfloat16}) {
+    auto x = astype(x_base, dtype, Device::gpu);
+    auto w = astype(w_base, dtype, Device::gpu);
+    for (const auto& config : configs) {
+      std::string mode(config.mode);
+      auto quantized = quantize(
+          w, config.group_size, config.bits, mode, std::nullopt, Device::gpu);
+      std::optional<array> biases =
+          mode == "affine" ? std::optional<array>{quantized[2]} : std::nullopt;
+
+      for (int M = 1; M <= limit; ++M) {
+        auto x_block = slice(x, {0, 0}, {M, K});
+        auto block = quantized_matmul(
+            x_block,
+            quantized[0],
+            quantized[1],
+            biases,
+            true,
+            config.group_size,
+            config.bits,
+            mode,
+            Device::gpu);
+        for (int row = 0; row < M; ++row) {
+          auto x_single = slice(x, {row, 0}, {row + 1, K});
+          auto single = quantized_matmul(
+              x_single,
+              quantized[0],
+              quantized[1],
+              biases,
+              true,
+              config.group_size,
+              config.bits,
+              mode,
+              Device::gpu);
+          auto block_row = slice(block, {row, 0}, {row + 1, N});
+          CAPTURE(dtype);
+          CAPTURE(mode);
+          CAPTURE(config.group_size);
+          CAPTURE(config.bits);
+          CAPTURE(M);
+          CAPTURE(row);
+          CHECK(array_equal(block_row, single, Device::cpu).item<bool>());
+        }
+      }
+
+      // The first shape above the configured limit remains on the normal fast
+      // dispatch path.
+      auto above_limit = quantized_matmul(
+          x,
+          quantized[0],
+          quantized[1],
+          biases,
+          true,
+          config.group_size,
+          config.bits,
+          mode,
           Device::gpu);
-  MESSAGE("max matmul row-shape difference: ", max_diff.item<float>());
-  CHECK(array_equal(block_last, single, Device::cpu).item<bool>());
+      CHECK_EQ(above_limit.shape(), Shape{limit + 1, N});
+      eval(above_limit);
+    }
+  }
 }
 
 TEST_CASE("test gpu full") {

--- a/tests/gpu_tests.cpp
+++ b/tests/gpu_tests.cpp
@@ -100,14 +100,14 @@ TEST_CASE("test gpu batch invariant sdpa") {
 }
 
 TEST_CASE("test gpu batch invariant matmul") {
-  BatchInvariantGuard guard;
-  constexpr int M = 4;
+  constexpr int limit = 8;
+  BatchInvariantGuard guard(limit);
   constexpr int K = 4096;
   constexpr int N = 512;
 
-  std::vector<float> x_block_data(M * K);
+  std::vector<float> x_block_data(limit * K);
   std::vector<float> w_data(N * K);
-  for (int m = 0; m < M; ++m) {
+  for (int m = 0; m < limit; ++m) {
     for (int k = 0; k < K; ++k) {
       x_block_data[m * K + k] = std::sin(0.013f * k + 0.17f * m);
     }
@@ -119,18 +119,28 @@ TEST_CASE("test gpu batch invariant matmul") {
   }
 
   for (auto dtype : {float16, bfloat16, float32, complex64}) {
-    auto x_block =
-        astype(array(x_block_data.data(), {M, K}), dtype, Device::gpu);
+    auto x = astype(array(x_block_data.data(), {limit, K}), dtype, Device::gpu);
     auto w = astype(array(w_data.data(), {N, K}), dtype, Device::gpu);
-    auto block = matmul(x_block, transpose(w), Device::gpu);
+    auto b_transposed = transpose(w);
+    auto b_natural = contiguous(b_transposed, false, Device::gpu);
 
-    for (int row = 0; row < M; ++row) {
-      auto x_single = slice(x_block, {row, 0}, {row + 1, K});
-      auto single = matmul(x_single, transpose(w), Device::gpu);
-      auto block_row = slice(block, {row, 0}, {row + 1, N});
-      CAPTURE(dtype);
-      CAPTURE(row);
-      CHECK(array_equal(block_row, single, Device::cpu).item<bool>());
+    for (int M = 2; M <= limit; ++M) {
+      auto x_block = slice(x, {0, 0}, {M, K});
+      auto check_layout = [&](const std::string& layout, const array& b) {
+        auto block = matmul(x_block, b, Device::gpu);
+        for (int row = 0; row < M; ++row) {
+          auto x_single = slice(x_block, {row, 0}, {row + 1, K});
+          auto single = matmul(x_single, b, Device::gpu);
+          auto block_row = slice(block, {row, 0}, {row + 1, N});
+          CAPTURE(dtype);
+          CAPTURE(layout);
+          CAPTURE(M);
+          CAPTURE(row);
+          CHECK(array_equal(block_row, single, Device::cpu).item<bool>());
+        }
+      };
+      check_layout("transposed", b_transposed);
+      check_layout("natural", b_natural);
     }
   }
 }

--- a/tests/gpu_tests.cpp
+++ b/tests/gpu_tests.cpp
@@ -28,6 +28,119 @@ TEST_CASE("test gpu arange") {
   }
 }
 
+class BatchInvariantGuard {
+ public:
+  BatchInvariantGuard() : previous_(metal::get_batch_invariant_limit()) {
+    metal::set_batch_invariant_limit(4);
+  }
+
+  ~BatchInvariantGuard() {
+    metal::set_batch_invariant_limit(previous_);
+  }
+
+ private:
+  int previous_;
+};
+
+TEST_CASE("test gpu batch invariant sdpa") {
+  BatchInvariantGuard guard;
+  constexpr int B = 1;
+  constexpr int Hq = 8;
+  constexpr int Hkv = 4;
+  constexpr int Lq = 4;
+  constexpr int Lk = 16384;
+  constexpr int D = 128;
+
+  std::vector<float> q_block_data(B * Hq * Lq * D);
+  std::vector<float> q_single_data(B * Hq * D);
+  std::vector<float> k_data(B * Hkv * Lk * D);
+  std::vector<float> v_data(B * Hkv * Lk * D);
+
+  for (int h = 0; h < Hq; ++h) {
+    for (int l = 0; l < Lq; ++l) {
+      for (int d = 0; d < D; ++d) {
+        auto value = std::sin(0.017f * (h * D + d) + 0.13f * l);
+        q_block_data[(h * Lq + l) * D + d] = value;
+        if (l == Lq - 1) {
+          q_single_data[h * D + d] = value;
+        }
+      }
+    }
+  }
+  for (int h = 0; h < Hkv; ++h) {
+    for (int l = 0; l < Lk; ++l) {
+      for (int d = 0; d < D; ++d) {
+        auto offset = (h * Lk + l) * D + d;
+        k_data[offset] = std::cos(0.011f * d + 0.003f * l + 0.2f * h);
+        v_data[offset] = std::sin(0.007f * d - 0.002f * l + 0.3f * h);
+      }
+    }
+  }
+
+  auto q_block = astype(
+      array(q_block_data.data(), {B, Hq, Lq, D}), bfloat16, Device::gpu);
+  auto q_single = astype(
+      array(q_single_data.data(), {B, Hq, 1, D}), bfloat16, Device::gpu);
+  auto k = astype(array(k_data.data(), {B, Hkv, Lk, D}), bfloat16, Device::gpu);
+  auto v = astype(array(v_data.data(), {B, Hkv, Lk, D}), bfloat16, Device::gpu);
+
+  auto block = fast::scaled_dot_product_attention(
+      q_block, k, v, 1.0f / std::sqrt(D), "causal", {}, {}, Device::gpu);
+  auto single = fast::scaled_dot_product_attention(
+      q_single, k, v, 1.0f / std::sqrt(D), "", {}, {}, Device::gpu);
+  auto block_last = slice(block, {0, 0, Lq - 1, 0}, {B, Hq, Lq, D});
+
+  auto max_diff = max(
+      abs(
+          astype(block_last, float32, Device::gpu) -
+          astype(single, float32, Device::gpu)),
+      Device::gpu);
+  MESSAGE("max SDPA query-shape difference: ", max_diff.item<float>());
+  CHECK(array_equal(block_last, single, Device::cpu).item<bool>());
+}
+
+TEST_CASE("test gpu batch invariant matmul") {
+  BatchInvariantGuard guard;
+  constexpr int M = 4;
+  constexpr int K = 4096;
+  constexpr int N = 4096;
+
+  std::vector<float> x_block_data(M * K);
+  std::vector<float> x_single_data(K);
+  std::vector<float> w_data(N * K);
+  for (int m = 0; m < M; ++m) {
+    for (int k = 0; k < K; ++k) {
+      auto value = std::sin(0.013f * k + 0.17f * m);
+      x_block_data[m * K + k] = value;
+      if (m == M - 1) {
+        x_single_data[k] = value;
+      }
+    }
+  }
+  for (int n = 0; n < N; ++n) {
+    for (int k = 0; k < K; ++k) {
+      w_data[n * K + k] = std::cos(0.009f * k - 0.015f * n);
+    }
+  }
+
+  auto x_block = astype(
+      array(x_block_data.data(), {M, K}), bfloat16, Device::gpu);
+  auto x_single = astype(
+      array(x_single_data.data(), {1, K}), bfloat16, Device::gpu);
+  auto w = astype(array(w_data.data(), {N, K}), bfloat16, Device::gpu);
+
+  auto block = matmul(x_block, transpose(w), Device::gpu);
+  auto single = matmul(x_single, transpose(w), Device::gpu);
+  auto block_last = slice(block, {M - 1, 0}, {M, N});
+  auto max_diff = max(
+      abs(
+          astype(block_last, float32, Device::gpu) -
+          astype(single, float32, Device::gpu)),
+      Device::gpu);
+  MESSAGE("max matmul row-shape difference: ", max_diff.item<float>());
+  CHECK(array_equal(block_last, single, Device::cpu).item<bool>());
+}
+
 TEST_CASE("test gpu full") {
   for (auto t : types) {
     auto out_cpu = full({4, 4}, 2, t, Device::cpu);

--- a/tests/gpu_tests.cpp
+++ b/tests/gpu_tests.cpp
@@ -145,6 +145,136 @@ TEST_CASE("test gpu batch invariant matmul") {
   }
 }
 
+TEST_CASE("test gpu batch invariant addmm") {
+  constexpr int limit = 8;
+  constexpr int K = 4096;
+  constexpr int N = 512;
+  BatchInvariantGuard guard(limit);
+
+  auto x_base = reshape(
+      sin(arange(limit * K, float32, Device::gpu) * 0.013f), {limit, K});
+  auto w_base =
+      reshape(cos(arange(N * K, float32, Device::gpu) * 0.009f), {N, K});
+  auto bias_base = sin(arange(N, float32, Device::gpu) * 0.021f);
+  auto rows_base = reshape(
+      sin(arange(limit * N, float32, Device::gpu) * 0.017f), {limit, N});
+  auto columns_base =
+      reshape(cos(arange(limit, float32, Device::gpu) * 0.019f), {limit, 1});
+
+  for (auto dtype : {float16, bfloat16, float32}) {
+    auto x = astype(x_base, dtype, Device::gpu);
+    auto w = astype(w_base, dtype, Device::gpu);
+    auto bias = astype(bias_base, dtype, Device::gpu);
+    auto rows = astype(rows_base, dtype, Device::gpu);
+    auto columns = astype(columns_base, dtype, Device::gpu);
+    auto b_transposed = transpose(w);
+    auto b_natural = contiguous(b_transposed, false, Device::gpu);
+
+    for (int M = 2; M <= limit; ++M) {
+      auto x_block = slice(x, {0, 0}, {M, K});
+      auto c_rows = slice(rows, {0, 0}, {M, N});
+      auto c_columns = slice(columns, {0, 0}, {M, 1});
+      for (auto& [layout, b] : std::vector<std::pair<std::string, array>>{
+               {"transposed", b_transposed}, {"natural", b_natural}}) {
+        for (auto& [c_layout, c] : std::vector<std::pair<std::string, array>>{
+                 {"bias", bias}, {"rows", c_rows}, {"columns", c_columns}}) {
+          auto c_expanded = broadcast_to(c, {M, N}, Device::gpu);
+          for (auto [alpha, beta] :
+               {std::pair{1.0f, 1.0f}, std::pair{0.5f, 2.0f}}) {
+            auto block = addmm(c, x_block, b, alpha, beta, Device::gpu);
+            for (int row = 0; row < M; ++row) {
+              auto x_single = slice(x_block, {row, 0}, {row + 1, K});
+              auto c_single = slice(c_expanded, {row, 0}, {row + 1, N});
+              auto single =
+                  addmm(c_single, x_single, b, alpha, beta, Device::gpu);
+              auto block_row = slice(block, {row, 0}, {row + 1, N});
+              CAPTURE(dtype);
+              CAPTURE(layout);
+              CAPTURE(c_layout);
+              CAPTURE(alpha);
+              CAPTURE(beta);
+              CAPTURE(M);
+              CAPTURE(row);
+              CHECK(array_equal(block_row, single, Device::cpu).item<bool>());
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+TEST_CASE("test gpu batch invariant dense boundaries") {
+  constexpr int B = 3;
+  constexpr int M = 4;
+  constexpr int K = 4096;
+  constexpr int N = 512;
+  BatchInvariantGuard guard(M);
+
+  auto w = reshape(cos(arange(N * K, float32, Device::gpu) * 0.009f), {N, K});
+  auto b = transpose(w);
+  auto bias = sin(arange(N, float32, Device::gpu) * 0.021f);
+
+  SUBCASE("outer batch") {
+    auto x = reshape(
+        sin(arange(B * M * K, float32, Device::gpu) * 0.013f), {B, M, K});
+    // Keep B explicitly batched so the backend sees the logical verification
+    // width M rather than the frontend's common-weight B*M flattening.
+    auto b_batched = broadcast_to(b, {B, K, N}, Device::gpu);
+    auto block = matmul(x, b_batched, Device::gpu);
+    auto block_bias = addmm(bias, x, b_batched, 1.0f, 1.0f, Device::gpu);
+    for (int batch = 0; batch < B; ++batch) {
+      for (int row = 0; row < M; ++row) {
+        auto x_single =
+            reshape(slice(x, {batch, row, 0}, {batch + 1, row + 1, K}), {1, K});
+        auto single = matmul(x_single, b, Device::gpu);
+        auto single_bias = addmm(bias, x_single, b, 1.0f, 1.0f, Device::gpu);
+        auto block_row = reshape(
+            slice(block, {batch, row, 0}, {batch + 1, row + 1, N}), {1, N});
+        auto block_bias_row = reshape(
+            slice(block_bias, {batch, row, 0}, {batch + 1, row + 1, N}),
+            {1, N});
+        CAPTURE(batch);
+        CAPTURE(row);
+        CHECK(array_equal(block_row, single, Device::cpu).item<bool>());
+        CHECK(
+            array_equal(block_bias_row, single_bias, Device::cpu).item<bool>());
+      }
+    }
+  }
+
+  SUBCASE("transposed activation") {
+    auto x = transpose(
+        reshape(sin(arange(M * K, float32, Device::gpu) * 0.013f), {K, M}));
+    auto block = matmul(x, b, Device::gpu);
+    auto block_bias = addmm(bias, x, b, 1.0f, 1.0f, Device::gpu);
+    for (int row = 0; row < M; ++row) {
+      auto x_single = slice(x, {row, 0}, {row + 1, K});
+      auto single = matmul(x_single, b, Device::gpu);
+      auto single_bias = addmm(bias, x_single, b, 1.0f, 1.0f, Device::gpu);
+      auto block_row = slice(block, {row, 0}, {row + 1, N});
+      auto block_bias_row = slice(block_bias, {row, 0}, {row + 1, N});
+      CAPTURE(row);
+      CHECK(array_equal(block_row, single, Device::cpu).item<bool>());
+      CHECK(array_equal(block_bias_row, single_bias, Device::cpu).item<bool>());
+    }
+  }
+
+  SUBCASE("single output") {
+    auto x = reshape(sin(arange(M * K, float32, Device::gpu) * 0.013f), {M, K});
+    auto b_single =
+        reshape(cos(arange(K, float32, Device::gpu) * 0.009f), {K, 1});
+    auto block = matmul(x, b_single, Device::gpu);
+    for (int row = 0; row < M; ++row) {
+      auto x_single = slice(x, {row, 0}, {row + 1, K});
+      auto single = matmul(x_single, b_single, Device::gpu);
+      auto block_row = slice(block, {row, 0}, {row + 1, 1});
+      CAPTURE(row);
+      CHECK(array_equal(block_row, single, Device::cpu).item<bool>());
+    }
+  }
+}
+
 TEST_CASE("test gpu batch invariant quantized matmul") {
   BatchInvariantGuard guard;
   constexpr int limit = 4;


### PR DESCRIPTION
## Proposed changes

Related issue: [ml-explore/mlx-swift-lm#542](https://github.com/ml-explore/mlx-swift-lm/issues/542)

Opt-in batch-invariant execution mode for selected Metal inference kernels. It is intended for workloads such as greedy speculative decoding, where evaluating a token independently and evaluating the same token inside a short verification block must produce identical results.

### Problem

Autoregressive decoding normally evaluates one token at a time, while speculative decoding verifies several tokens in one target-model invocation.

Although these computations are mathematically equivalent, their shapes currently select different Metal execution paths:

- A single matrix row uses GEMV, while a short matrix can use `gemv_wide` or GEMM.
- Two-pass SDPA derives its split count from the query length, changing the softmax reduction tree between single-query decoding and multi-query verification.

Floating-point reductions are not associative. Consequently, the different kernels can produce slightly different BF16 results for the same logical token. Across many transformer layers and decoding rounds, these differences can eventually change the ordering of two close logits and cause greedy `argmax` decoding to diverge.

This is especially visible with quantized models and long contexts, but the underlying problem is shape-dependent floating-point reduction order rather than quantized matrix multiplication itself.

### Changes

This PR introduces `MLX_METAL_BATCH_INVARIANT_LIMIT`, with matching runtime APIs:

```python
mx.metal.set_batch_invariant_limit(limit)
mx.metal.get_batch_invariant_limit()
```

When the relevant leading/query dimension is within the configured limit:

- Short matrix rows are executed as a parallel batch of canonical single-row GEMVs. Rows remain parallel, but each row uses the same reduction kernel and order as token-by-token inference.
- Two-pass SDPA uses the single-query split configuration, preserving the same softmax reduction layout for a query evaluated alone or inside a short causal block.

The setting is process-wide and stored atomically. It defaults to `0`, meaning disabled, so existing execution and performance are unchanged unless an application explicitly opts in. Long prefills and dimensions above the configured limit continue using the existing optimized paths.

The mode is intentionally opt-in because selecting canonical reduction kernels can reduce performance. Applications only need to cover their maximum speculative verification width.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [[CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md)](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)