### PR TITLE
Clamp ring socket transfers so a payload of 2 GiB or more can be sent

### DIFF
--- a/mlx/distributed/ring/ring.cpp
+++ b/mlx/distributed/ring/ring.cpp
@@ -39,9 +39,7 @@ constexpr const int CONN_WAIT = 1000;
 constexpr const char* RING_TAG = "[ring]";
 // send(2) and recv(2) reject a length above INT_MAX with EINVAL, so a single
 // transfer of 2 GiB or more fails outright rather than being carried in
-// pieces. Clamping every syscall keeps each one well inside that limit; the
-// loop below already advances the buffer and shrinks the remaining size on a
-// short transfer, so nothing else has to change.
+// pieces.
 constexpr const size_t MAX_IO_BYTES = 1024 * 1024 * 1024;
 
 using GroupImpl = mlx::core::distributed::detail::GroupImpl;

--- a/mlx/distributed/ring/ring.cpp
+++ b/mlx/distributed/ring/ring.cpp
@@ -5,6 +5,7 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <chrono>
 #include <fstream>
 #include <future>
@@ -36,6 +37,12 @@ constexpr const size_t ALL_SUM_BUFFERS = 2;
 constexpr const int CONN_ATTEMPTS = 5;
 constexpr const int CONN_WAIT = 1000;
 constexpr const char* RING_TAG = "[ring]";
+// send(2) and recv(2) reject a length above INT_MAX with EINVAL, so a single
+// transfer of 2 GiB or more fails outright rather than being carried in
+// pieces. Clamping every syscall keeps each one well inside that limit; the
+// loop below already advances the buffer and shrinks the remaining size on a
+// short transfer, so nothing else has to change.
+constexpr const size_t MAX_IO_BYTES = 1024 * 1024 * 1024;
 
 using GroupImpl = mlx::core::distributed::detail::GroupImpl;
 using json = nlohmann::json;
@@ -174,7 +181,8 @@ class SocketThread {
 
       if (!recvs_.empty()) {
         auto& task = recvs_.front();
-        ssize_t r = ::recv(fd_, task.buffer, task.size, 0);
+        ssize_t r =
+            ::recv(fd_, task.buffer, std::min(task.size, MAX_IO_BYTES), 0);
         if (r > 0) {
           task.buffer = static_cast<char*>(task.buffer) + r;
           task.size -= r;
@@ -191,7 +199,8 @@ class SocketThread {
       }
       if (!sends_.empty()) {
         auto& task = sends_.front();
-        ssize_t r = ::send(fd_, task.buffer, task.size, 0);
+        ssize_t r =
+            ::send(fd_, task.buffer, std::min(task.size, MAX_IO_BYTES), 0);
         if (r > 0) {
           task.buffer = static_cast<char*>(task.buffer) + r;
           task.size -= r;


### PR DESCRIPTION
Fixes #4280.

`send(2)` and `recv(2)` reject a length above `INT_MAX` with EINVAL, and the ring
backend hands the whole remaining size of a task to the syscall, so a single transfer
of 2 GiB or more fails outright. Measured boundary is exactly `INT_MAX`:
2,147,483,640 bytes goes through, 2,147,483,648 does not.

The loop already advances the buffer and shrinks the remaining size after a short
transfer, which is the same path a large payload takes on a busy socket, so clamping
each individual call is all that's needed. 1 GiB leaves plenty of headroom.

Verified on two M4 Pro minis over a direct Thunderbolt link:

- every size from `INT_MAX - 4099` to `INT_MAX + 1048577` now succeeds, where the
  last three aborted
- a dtype sweep of float32, float16, bfloat16, uint32 and int8 up to 2.24 GiB passes
- `all_sum` bus bandwidth at 16, 64 and 256 MB is unchanged: 4.16, 5.55, 5.55 GB/s
