### PR TITLE
Compare the macOS SDK version as a version when gating JACCL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,7 +363,7 @@ target_include_directories(
 if(MLX_BUILD_CPU
    AND ${CMAKE_SYSTEM_NAME} MATCHES "Darwin"
    AND DEFINED MACOS_SDK_VERSION
-   AND MACOS_SDK_VERSION GREATER_EQUAL 26.2)
+   AND MACOS_SDK_VERSION VERSION_GREATER_EQUAL 26.2)
   add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/mlx/distributed/jaccl/lib
                    ${CMAKE_BINARY_DIR}/jaccl)
 endif()


### PR DESCRIPTION
`CMakeLists.txt` gates the JACCL subdirectory on `MACOS_SDK_VERSION GREATER_EQUAL 26.2`.
That is a numeric comparison, so an SDK reporting `26.10` is read as 26.1 and compares
less than 26.2:

```
SDK 26.5:   GREATER_EQUAL=TRUE    VERSION_GREATER_EQUAL=TRUE
SDK 26.10:  GREATER_EQUAL=FALSE   VERSION_GREATER_EQUAL=TRUE
```

JACCL would then not be built and nothing would say so: `is_available()` false, and a
correctly configured multi-node setup falling back with no explanation.

`VERSION_GREATER_EQUAL` compares component by component and matches how the same
variable is already tested at `CMakeLists.txt:199` and in the NAX gate at
`mlx/backend/metal/kernels/CMakeLists.txt:162`.

No behaviour change on current SDKs: configuring the patched and unpatched trees on
26.5 builds JACCL in both.
