### PR TITLE
Replace hand-rolled axis normalization with normalize_axis_index in split/unstack/partition/topk

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -1143,13 +1143,7 @@ std::vector<array> split(
     const Shape& indices,
     int axis,
     StreamOrDevice s /* = {} */) {
-  auto ax = axis < 0 ? axis + a.ndim() : axis;
-  if (ax < 0 || ax >= a.ndim()) {
-    std::ostringstream msg;
-    msg << "Invalid axis (" << axis << ") passed to split"
-        << " for array with shape " << a.shape() << ".";
-    throw std::invalid_argument(msg.str());
-  }
+  auto ax = normalize_axis_index(axis, a.ndim(), "[split] ");
 
   if (indices.empty()) {
     return {a};
@@ -1191,20 +1185,14 @@ split(const array& a, const Shape& indices, StreamOrDevice s /* = {} */) {
 
 std::vector<array>
 split(const array& a, int num_splits, int axis, StreamOrDevice s /* = {} */) {
-  auto ax = axis < 0 ? axis + a.ndim() : axis;
-  if (ax < 0 || ax >= a.ndim()) {
-    std::ostringstream msg;
-    msg << "Invalid axis " << axis << " passed to split"
-        << " for array with shape " << a.shape() << ".";
-    throw std::invalid_argument(msg.str());
-  }
+  auto ax = normalize_axis_index(axis, a.ndim(), "[split] ");
   if (num_splits <= 0) {
     std::ostringstream msg;
     msg << "[split] num_splits must be positive and non-zero but got "
         << num_splits << ".";
     throw std::invalid_argument(msg.str());
   }
-  auto q_and_r = std::ldiv(a.shape(axis), num_splits);
+  auto q_and_r = std::ldiv(a.shape(ax), num_splits);
   if (q_and_r.rem) {
     std::ostringstream msg;
     msg << "Array split does not result in sub arrays with equal size:"
@@ -1217,7 +1205,7 @@ split(const array& a, int num_splits, int axis, StreamOrDevice s /* = {} */) {
   for (int i = 0; i < indices.size(); ++i) {
     indices[i] = (i + 1) * split_size;
   }
-  return split(a, indices, axis, s);
+  return split(a, indices, ax, s);
 }
 
 std::vector<array>
@@ -1228,13 +1216,7 @@ split(const array& a, int num_splits, StreamOrDevice s /* = {} */) {
 std::vector<array>
 unstack(const array& a, int axis, StreamOrDevice s /* = {} */) {
   auto ndim = static_cast<int>(a.ndim());
-  auto ax = axis < 0 ? axis + ndim : axis;
-  if (ax < 0 || ax >= ndim) {
-    std::ostringstream msg;
-    msg << "[unstack] Invalid axis " << axis << " for array with " << ndim
-        << " dimensions.";
-    throw std::invalid_argument(msg.str());
-  }
+  auto ax = normalize_axis_index(axis, ndim, "[unstack] ");
   auto n = a.shape(ax);
   std::vector<array> res;
   res.reserve(n);
@@ -2838,14 +2820,7 @@ array partition(
     int axis,
     StreamOrDevice s /* = {} */) {
   // Check for valid axis
-  if (axis + static_cast<int>(a.ndim()) < 0 ||
-      axis >= static_cast<int>(a.ndim())) {
-    std::ostringstream msg;
-    msg << "[partition] Received invalid axis " << axis << " for array with "
-        << a.ndim() << " dimensions.";
-    throw std::invalid_argument(msg.str());
-  }
-  int axis_ = axis < 0 ? axis + a.ndim() : axis;
+  int axis_ = normalize_axis_index(axis, a.ndim(), "[partition] ");
   int kth_ = kth < 0 ? kth + a.shape(axis) : kth;
   if (kth_ < 0 || kth_ >= a.shape(axis_)) {
     std::ostringstream msg;
@@ -2879,14 +2854,7 @@ array argpartition(
     int axis,
     StreamOrDevice s /* = {} */) {
   // Check for valid axis
-  if (axis + static_cast<int>(a.ndim()) < 0 ||
-      axis >= static_cast<int>(a.ndim())) {
-    std::ostringstream msg;
-    msg << "[argpartition] Received invalid axis " << axis << " for array with "
-        << a.ndim() << " dimensions.";
-    throw std::invalid_argument(msg.str());
-  }
-  int axis_ = axis < 0 ? axis + a.ndim() : axis;
+  int axis_ = normalize_axis_index(axis, a.ndim(), "[argpartition] ");
   int kth_ = kth < 0 ? kth + a.shape(axis) : kth;
   if (kth_ < 0 || kth_ >= a.shape(axis_)) {
     std::ostringstream msg;
@@ -2941,13 +2909,7 @@ array topk(const array& a, int k, StreamOrDevice s /* = {}*/) {
 /** Returns topk elements of the array along a given axis. */
 array topk(const array& a, int k, int axis, StreamOrDevice s /* = {}*/) {
   // Check for valid axis
-  int axis_ = axis < 0 ? axis + a.ndim() : axis;
-  if (axis_ < 0 || axis_ >= static_cast<int>(a.ndim())) {
-    std::ostringstream msg;
-    msg << "[topk] Received invalid axis " << axis << " for array with "
-        << a.ndim() << " dimensions.";
-    throw std::invalid_argument(msg.str());
-  }
+  int axis_ = normalize_axis_index(axis, a.ndim(), "[topk] ");
   if (k < 0 || k > a.shape(axis_)) {
     std::ostringstream msg;
     msg << "[topk] Received invalid k=" << k << " along axis " << axis


### PR DESCRIPTION
Fixes #4287.

### Proposed changes

`split`, `unstack`, `partition`, `argpartition` and `topk` each duplicated the same axis normalization pattern:

```cpp
auto ax = axis < 0 ? axis + a.ndim() : axis;
if (ax < 0 || ax >= a.ndim()) {
  std::ostringstream msg;
  msg << "...";
  throw std::invalid_argument(msg.str());
}
```

with slightly different bounds-check expressions at each site. `normalize_axis_index` already does this — normalize and validate in one call — and is already used for exactly this purpose elsewhere in `ops.cpp` (`squeeze`, `expand_dims`, `flip`, `concatenate`, `stack`, `repeat`). #4118 fixed the same duplication in `take_along_axis`/`scatter_axis`/`linalg::cross`; this covers the remaining call sites in `ops.cpp`.

This is a pure refactor, not a behavior change:
- Valid axes, including negative ones, normalize to the same value as before.
- Out-of-range axes still raise `std::invalid_argument` (`ValueError` in Python).
- Only the exact wording of the error message changes (e.g. `[topk] Axis -100 is out of bounds for array with 3 dimensions.` instead of `[topk] Received invalid axis -100 for array with 3 dimensions.`); no test in the tree asserts on that text, only that the correct exception type is raised.

In `split(a, num_splits, axis, s)` the normalized axis is now also reused for the subsequent `a.shape(...)` lookup and the recursive `split(a, indices, ax, s)` call instead of re-deriving it, avoiding the redundant re-normalization that happened implicitly through `array::shape(int)`.

Net diff removes more than it adds (54 lines changed, 8 added / 46 removed).

### Tests

No behavior change, so no new tests were added. Verified with a build of `libmlx.a` (`cmake --build cmake_build --target mlx`) and the full C++ test suite (`cmake --build cmake_build --target tests && ./cmake_build/tests/tests`): 263 test cases / 3578 assertions, all passing, including `ops_tests.cpp` coverage of `split`, `unstack`, `partition`, `argpartition` and `topk`.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have added tests that prove my fix is effective or that my feature works (n/a — pure refactor, existing tests cover behavior)
- [ ] I have updated the necessary documentation (not needed, no API or behavior change)
- [x] I have run `pre-commit run --all-files` to format my code and installed pre-commit prior to committing changes