### PR TITLE
Propagate NaN in arg reductions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -88,8 +88,7 @@ runs:
         max-size: |-
           ${{ case(inputs.ccache-key == 'release',
                    case(startsWith(inputs.toolkit, 'cuda'),
-                        case(runner.os == 'Linux', '300MB',
-                             '160MB'),
+                        '300MB',
                         '60MB'),
                    case(startsWith(inputs.toolkit, 'cuda'),
                         case(runner.os == 'Linux' && runner.arch == 'x64', '600MB',

--- a/mlx/CMakeLists.txt
+++ b/mlx/CMakeLists.txt
@@ -54,6 +54,10 @@ endif()
 if(WIN32)
   # windows.h defines min/max macros that conflict with std::min/std::max.
   target_compile_definitions(mlx PRIVATE NOMINMAX WIN32_LEAN_AND_MEAN)
+  # TODO: Remove after removing std::atomic_store/load.
+  target_compile_definitions(
+    mlx
+    PRIVATE _SILENCE_CXX20_OLD_SHARED_PTR_ATOMIC_SUPPORT_DEPRECATION_WARNING)
 endif()
 if(MSVC)
   # Unicode support in fmt does not compile in .cu files.

--- a/mlx/CMakeLists.txt
+++ b/mlx/CMakeLists.txt
@@ -56,8 +56,7 @@ if(WIN32)
   target_compile_definitions(mlx PRIVATE NOMINMAX WIN32_LEAN_AND_MEAN)
   # TODO: Remove after removing std::atomic_store/load.
   target_compile_definitions(
-    mlx
-    PRIVATE _SILENCE_CXX20_OLD_SHARED_PTR_ATOMIC_SUPPORT_DEPRECATION_WARNING)
+    mlx PUBLIC _SILENCE_CXX20_OLD_SHARED_PTR_ATOMIC_SUPPORT_DEPRECATION_WARNING)
 endif()
 if(MSVC)
   # Unicode support in fmt does not compile in .cu files.

--- a/mlx/backend/cpu/arg_reduce.cpp
+++ b/mlx/backend/cpu/arg_reduce.cpp
@@ -1,7 +1,6 @@
 // Copyright © 2023 Apple Inc.
 
 #include <cassert>
-#include <cmath>
 
 #include "mlx/backend/common/utils.h"
 #include "mlx/backend/cpu/encoder.h"
@@ -42,7 +41,7 @@ void arg_reduce_dispatch(
   switch (rtype) {
     case ArgReduce::ArgMin: {
       auto op = [](auto ind_x, auto x, auto ind_y, auto y) {
-        if ((!std::isnan(*y) && std::isnan(x)) || x < (*y)) {
+        if ((*y == *y && x != x) || x < (*y)) {
           (*y) = x;
           (*ind_y) = ind_x;
         }
@@ -52,7 +51,7 @@ void arg_reduce_dispatch(
     }
     case ArgReduce::ArgMax: {
       auto op = [](auto ind_x, auto x, auto ind_y, auto y) {
-        if ((!std::isnan(*y) && std::isnan(x)) || x > (*y)) {
+        if ((*y == *y && x != x) || x > (*y)) {
           (*y) = x;
           (*ind_y) = ind_x;
         }

--- a/mlx/backend/cpu/arg_reduce.cpp
+++ b/mlx/backend/cpu/arg_reduce.cpp
@@ -41,7 +41,7 @@ void arg_reduce_dispatch(
   switch (rtype) {
     case ArgReduce::ArgMin: {
       auto op = [](auto ind_x, auto x, auto ind_y, auto y) {
-        if ((!isnan(*y) && isnan(x)) || x < (*y)) {
+        if ((!mlx::core::isnan(*y) && mlx::core::isnan(x)) || x < (*y)) {
           (*y) = x;
           (*ind_y) = ind_x;
         }
@@ -51,7 +51,7 @@ void arg_reduce_dispatch(
     }
     case ArgReduce::ArgMax: {
       auto op = [](auto ind_x, auto x, auto ind_y, auto y) {
-        if ((!isnan(*y) && isnan(x)) || x > (*y)) {
+        if ((!mlx::core::isnan(*y) && mlx::core::isnan(x)) || x > (*y)) {
           (*y) = x;
           (*ind_y) = ind_x;
         }

--- a/mlx/backend/cpu/arg_reduce.cpp
+++ b/mlx/backend/cpu/arg_reduce.cpp
@@ -12,14 +12,6 @@ namespace mlx::core {
 
 namespace {
 
-template <typename T>
-bool is_nan(T x) {
-  if constexpr (is_floating_point_v<T>) {
-    return std::isnan(x);
-  }
-  return false;
-}
-
 template <typename InT, typename OpT>
 void arg_reduce(const array& in, array& out, const OpT& op, int axis) {
   auto axis_size = in.shape()[axis];
@@ -50,7 +42,7 @@ void arg_reduce_dispatch(
   switch (rtype) {
     case ArgReduce::ArgMin: {
       auto op = [](auto ind_x, auto x, auto ind_y, auto y) {
-        if ((!is_nan(*y) && is_nan(x)) || x < (*y)) {
+        if ((!std::isnan(*y) && std::isnan(x)) || x < (*y)) {
           (*y) = x;
           (*ind_y) = ind_x;
         }
@@ -60,7 +52,7 @@ void arg_reduce_dispatch(
     }
     case ArgReduce::ArgMax: {
       auto op = [](auto ind_x, auto x, auto ind_y, auto y) {
-        if ((!is_nan(*y) && is_nan(x)) || x > (*y)) {
+        if ((!std::isnan(*y) && std::isnan(x)) || x > (*y)) {
           (*y) = x;
           (*ind_y) = ind_x;
         }

--- a/mlx/backend/cpu/arg_reduce.cpp
+++ b/mlx/backend/cpu/arg_reduce.cpp
@@ -1,6 +1,7 @@
 // Copyright © 2023 Apple Inc.
 
 #include <cassert>
+#include <cmath>
 
 #include "mlx/backend/common/utils.h"
 #include "mlx/backend/cpu/encoder.h"
@@ -10,6 +11,14 @@
 namespace mlx::core {
 
 namespace {
+
+template <typename T>
+bool is_nan(T x) {
+  if constexpr (is_floating_point_v<T>) {
+    return std::isnan(x);
+  }
+  return false;
+}
 
 template <typename InT, typename OpT>
 void arg_reduce(const array& in, array& out, const OpT& op, int axis) {
@@ -41,7 +50,7 @@ void arg_reduce_dispatch(
   switch (rtype) {
     case ArgReduce::ArgMin: {
       auto op = [](auto ind_x, auto x, auto ind_y, auto y) {
-        if (x < (*y)) {
+        if ((!is_nan(*y) && is_nan(x)) || x < (*y)) {
           (*y) = x;
           (*ind_y) = ind_x;
         }
@@ -51,7 +60,7 @@ void arg_reduce_dispatch(
     }
     case ArgReduce::ArgMax: {
       auto op = [](auto ind_x, auto x, auto ind_y, auto y) {
-        if (x > (*y)) {
+        if ((!is_nan(*y) && is_nan(x)) || x > (*y)) {
           (*y) = x;
           (*ind_y) = ind_x;
         }

--- a/mlx/backend/cpu/arg_reduce.cpp
+++ b/mlx/backend/cpu/arg_reduce.cpp
@@ -41,7 +41,7 @@ void arg_reduce_dispatch(
   switch (rtype) {
     case ArgReduce::ArgMin: {
       auto op = [](auto ind_x, auto x, auto ind_y, auto y) {
-        if ((*y == *y && x != x) || x < (*y)) {
+        if ((!isnan(*y) && isnan(x)) || x < (*y)) {
           (*y) = x;
           (*ind_y) = ind_x;
         }
@@ -51,7 +51,7 @@ void arg_reduce_dispatch(
     }
     case ArgReduce::ArgMax: {
       auto op = [](auto ind_x, auto x, auto ind_y, auto y) {
-        if ((*y == *y && x != x) || x > (*y)) {
+        if ((!isnan(*y) && isnan(x)) || x > (*y)) {
           (*y) = x;
           (*ind_y) = ind_x;
         }

--- a/mlx/backend/cpu/simd/base_simd.h
+++ b/mlx/backend/cpu/simd/base_simd.h
@@ -13,6 +13,7 @@
 #include <intrin.h> // For _BitScanReverse
 #endif
 
+#include "mlx/types/complex.h"
 #include "mlx/types/half_types.h"
 
 namespace mlx::core::simd {

--- a/mlx/backend/cpu/simd/base_simd.h
+++ b/mlx/backend/cpu/simd/base_simd.h
@@ -160,7 +160,7 @@ auto imag(Simd<T, 1> in) -> Simd<decltype(std::imag(in.value)), 1> {
 }
 template <typename T>
 Simd<bool, 1> isnan(Simd<T, 1> in) {
-  return std::isnan(in.value);
+  return mlx::core::isnan(in.value);
 }
 
 #define DEFAULT_BINARY(OP)                                                 \

--- a/mlx/backend/cuda/arg_reduce.cu
+++ b/mlx/backend/cuda/arg_reduce.cu
@@ -27,14 +27,6 @@ struct IndexValPair {
 };
 
 template <typename T>
-__device__ bool is_nan(T x) {
-  if constexpr (is_floating_v<T>) {
-    return cuda::std::isnan(x);
-  }
-  return false;
-}
-
-template <typename T>
 struct ArgMin {
   constexpr __device__ T init() {
     return Limits<T>::max();
@@ -43,9 +35,9 @@ struct ArgMin {
   __device__ IndexValPair<T> operator()(
       const IndexValPair<T>& best,
       const IndexValPair<T>& current) {
-    if ((is_nan(current.val) &&
-         (!is_nan(best.val) || best.index > current.index)) ||
-        (!is_nan(best.val) &&
+    if ((cuda::std::isnan(current.val) &&
+         (!cuda::std::isnan(best.val) || best.index > current.index)) ||
+        (!cuda::std::isnan(best.val) &&
          (best.val > current.val ||
           (best.val == current.val && best.index > current.index)))) {
       return current;
@@ -61,7 +53,8 @@ struct ArgMin {
       uint32_t offset) {
 #pragma unroll
     for (int i = 0; i < N; i++) {
-      if ((!is_nan(best.val) && is_nan(vals[i])) || vals[i] < best.val) {
+      if ((!cuda::std::isnan(best.val) && cuda::std::isnan(vals[i])) ||
+          vals[i] < best.val) {
         best.val = vals[i];
         best.index = offset + i;
       }
@@ -79,9 +72,9 @@ struct ArgMax {
   __device__ IndexValPair<T> operator()(
       const IndexValPair<T>& best,
       const IndexValPair<T>& current) {
-    if ((is_nan(current.val) &&
-         (!is_nan(best.val) || best.index > current.index)) ||
-        (!is_nan(best.val) &&
+    if ((cuda::std::isnan(current.val) &&
+         (!cuda::std::isnan(best.val) || best.index > current.index)) ||
+        (!cuda::std::isnan(best.val) &&
          (best.val < current.val ||
           (best.val == current.val && best.index > current.index)))) {
       return current;
@@ -97,7 +90,8 @@ struct ArgMax {
       uint32_t offset) {
 #pragma unroll
     for (int i = 0; i < N; i++) {
-      if ((!is_nan(best.val) && is_nan(vals[i])) || vals[i] > best.val) {
+      if ((!cuda::std::isnan(best.val) && cuda::std::isnan(vals[i])) ||
+          vals[i] > best.val) {
         best.val = vals[i];
         best.index = offset + i;
       }

--- a/mlx/backend/cuda/arg_reduce.cu
+++ b/mlx/backend/cuda/arg_reduce.cu
@@ -61,8 +61,7 @@ struct ArgMin {
       uint32_t offset) {
 #pragma unroll
     for (int i = 0; i < N; i++) {
-      if ((!is_nan(best.val) && is_nan(vals[i])) ||
-          vals[i] < best.val) {
+      if ((!is_nan(best.val) && is_nan(vals[i])) || vals[i] < best.val) {
         best.val = vals[i];
         best.index = offset + i;
       }
@@ -98,8 +97,7 @@ struct ArgMax {
       uint32_t offset) {
 #pragma unroll
     for (int i = 0; i < N; i++) {
-      if ((!is_nan(best.val) && is_nan(vals[i])) ||
-          vals[i] > best.val) {
+      if ((!is_nan(best.val) && is_nan(vals[i])) || vals[i] > best.val) {
         best.val = vals[i];
         best.index = offset + i;
       }

--- a/mlx/backend/cuda/arg_reduce.cu
+++ b/mlx/backend/cuda/arg_reduce.cu
@@ -27,6 +27,14 @@ struct IndexValPair {
 };
 
 template <typename T>
+__device__ bool is_nan(T x) {
+  if constexpr (is_floating_v<T>) {
+    return cuda::std::isnan(x);
+  }
+  return false;
+}
+
+template <typename T>
 struct ArgMin {
   constexpr __device__ T init() {
     return Limits<T>::max();
@@ -35,8 +43,11 @@ struct ArgMin {
   __device__ IndexValPair<T> operator()(
       const IndexValPair<T>& best,
       const IndexValPair<T>& current) {
-    if (best.val > current.val ||
-        (best.val == current.val && best.index > current.index)) {
+    if ((is_nan(current.val) &&
+         (!is_nan(best.val) || best.index > current.index)) ||
+        (!is_nan(best.val) &&
+         (best.val > current.val ||
+          (best.val == current.val && best.index > current.index)))) {
       return current;
     } else {
       return best;
@@ -50,7 +61,8 @@ struct ArgMin {
       uint32_t offset) {
 #pragma unroll
     for (int i = 0; i < N; i++) {
-      if (vals[i] < best.val) {
+      if ((!is_nan(best.val) && is_nan(vals[i])) ||
+          vals[i] < best.val) {
         best.val = vals[i];
         best.index = offset + i;
       }
@@ -68,8 +80,11 @@ struct ArgMax {
   __device__ IndexValPair<T> operator()(
       const IndexValPair<T>& best,
       const IndexValPair<T>& current) {
-    if (best.val < current.val ||
-        (best.val == current.val && best.index > current.index)) {
+    if ((is_nan(current.val) &&
+         (!is_nan(best.val) || best.index > current.index)) ||
+        (!is_nan(best.val) &&
+         (best.val < current.val ||
+          (best.val == current.val && best.index > current.index)))) {
       return current;
     } else {
       return best;
@@ -83,7 +98,8 @@ struct ArgMax {
       uint32_t offset) {
 #pragma unroll
     for (int i = 0; i < N; i++) {
-      if (vals[i] > best.val) {
+      if ((!is_nan(best.val) && is_nan(vals[i])) ||
+          vals[i] > best.val) {
         best.val = vals[i];
         best.index = offset + i;
       }

--- a/mlx/backend/metal/kernels/arg_reduce.metal
+++ b/mlx/backend/metal/kernels/arg_reduce.metal
@@ -13,12 +13,23 @@ struct IndexValPair {
 };
 
 template <typename U>
+bool is_nan(U x) {
+  if constexpr (metal::is_floating_point_v<U>) {
+    return isnan(x);
+  }
+  return false;
+}
+
+template <typename U>
 struct ArgMin {
   static constexpr constant U init = Limits<U>::max;
 
   IndexValPair<U> reduce(IndexValPair<U> best, IndexValPair<U> current) thread {
-    if (best.val > current.val ||
-        (best.val == current.val && best.index > current.index)) {
+    if ((is_nan(current.val) &&
+         (!is_nan(best.val) || best.index > current.index)) ||
+        (!is_nan(best.val) &&
+         (best.val > current.val ||
+          (best.val == current.val && best.index > current.index)))) {
       return current;
     } else {
       return best;
@@ -29,7 +40,7 @@ struct ArgMin {
   IndexValPair<U>
   reduce_many(IndexValPair<U> best, thread U* vals, uint32_t offset) thread {
     for (int i = 0; i < N; i++) {
-      if (vals[i] < best.val) {
+      if ((!is_nan(best.val) && is_nan(vals[i])) || vals[i] < best.val) {
         best.val = vals[i];
         best.index = offset + i;
       }
@@ -43,8 +54,11 @@ struct ArgMax {
   static constexpr constant U init = Limits<U>::min;
 
   IndexValPair<U> reduce(IndexValPair<U> best, IndexValPair<U> current) thread {
-    if (best.val < current.val ||
-        (best.val == current.val && best.index > current.index)) {
+    if ((is_nan(current.val) &&
+         (!is_nan(best.val) || best.index > current.index)) ||
+        (!is_nan(best.val) &&
+         (best.val < current.val ||
+          (best.val == current.val && best.index > current.index)))) {
       return current;
     } else {
       return best;
@@ -55,7 +69,7 @@ struct ArgMax {
   IndexValPair<U>
   reduce_many(IndexValPair<U> best, thread U* vals, uint32_t offset) thread {
     for (int i = 0; i < N; i++) {
-      if (vals[i] > best.val) {
+      if ((!is_nan(best.val) && is_nan(vals[i])) || vals[i] > best.val) {
         best.val = vals[i];
         best.index = offset + i;
       }

--- a/mlx/backend/metal/kernels/arg_reduce.metal
+++ b/mlx/backend/metal/kernels/arg_reduce.metal
@@ -1,10 +1,16 @@
 // Copyright © 2023 Apple Inc.
 
+#include <metal_integer>
 #include <metal_simdgroup>
 
 #include "mlx/backend/metal/kernels/utils.h"
 
 using namespace metal;
+
+template <typename T, metal::enable_if_t<metal::is_integral_v<T>, bool> = true>
+bool isnan(T) {
+  return false;
+}
 
 template <typename U>
 struct IndexValPair {
@@ -13,21 +19,13 @@ struct IndexValPair {
 };
 
 template <typename U>
-bool is_nan(U x) {
-  if constexpr (metal::is_floating_point_v<U>) {
-    return isnan(x);
-  }
-  return false;
-}
-
-template <typename U>
 struct ArgMin {
   static constexpr constant U init = Limits<U>::max;
 
   IndexValPair<U> reduce(IndexValPair<U> best, IndexValPair<U> current) thread {
-    if ((is_nan(current.val) &&
-         (!is_nan(best.val) || best.index > current.index)) ||
-        (!is_nan(best.val) &&
+    if ((isnan(current.val) &&
+         (!isnan(best.val) || best.index > current.index)) ||
+        (!isnan(best.val) &&
          (best.val > current.val ||
           (best.val == current.val && best.index > current.index)))) {
       return current;
@@ -40,7 +38,7 @@ struct ArgMin {
   IndexValPair<U>
   reduce_many(IndexValPair<U> best, thread U* vals, uint32_t offset) thread {
     for (int i = 0; i < N; i++) {
-      if ((!is_nan(best.val) && is_nan(vals[i])) || vals[i] < best.val) {
+      if ((!isnan(best.val) && isnan(vals[i])) || vals[i] < best.val) {
         best.val = vals[i];
         best.index = offset + i;
       }
@@ -54,9 +52,9 @@ struct ArgMax {
   static constexpr constant U init = Limits<U>::min;
 
   IndexValPair<U> reduce(IndexValPair<U> best, IndexValPair<U> current) thread {
-    if ((is_nan(current.val) &&
-         (!is_nan(best.val) || best.index > current.index)) ||
-        (!is_nan(best.val) &&
+    if ((isnan(current.val) &&
+         (!isnan(best.val) || best.index > current.index)) ||
+        (!isnan(best.val) &&
          (best.val < current.val ||
           (best.val == current.val && best.index > current.index)))) {
       return current;
@@ -69,7 +67,7 @@ struct ArgMax {
   IndexValPair<U>
   reduce_many(IndexValPair<U> best, thread U* vals, uint32_t offset) thread {
     for (int i = 0; i < N; i++) {
-      if ((!is_nan(best.val) && is_nan(vals[i])) || vals[i] > best.val) {
+      if ((!isnan(best.val) && isnan(vals[i])) || vals[i] > best.val) {
         best.val = vals[i];
         best.index = offset + i;
       }

--- a/mlx/backend/metal/kernels/arg_reduce.metal
+++ b/mlx/backend/metal/kernels/arg_reduce.metal
@@ -8,7 +8,7 @@
 using namespace metal;
 
 template <typename T, metal::enable_if_t<metal::is_integral_v<T>, bool> = true>
-bool isnan(T) {
+inline bool isnan(T) {
   return false;
 }
 

--- a/mlx/types/complex.h
+++ b/mlx/types/complex.h
@@ -106,8 +106,23 @@ inline complex64_t operator-(const complex64_t& v) {
   complex_binop_helper(_op_, _operator_, float16_t)                                   \
   complex_binop_helper(_op_, _operator_, bfloat16_t)                                  \
   complex_binop_helper(_op_, _operator_, float)
-// clang-format on
 
 complex_binop(+, operator+)
+
+template <typename, typename = void>
+constexpr bool is_complex = false;
+
+template <typename T>
+constexpr bool is_complex<T, std::void_t<decltype(std::declval<T>().real())>> = true;
+// clang-format on
+
+template <typename T>
+inline bool isnan(T v) {
+  if constexpr (is_complex<T>) {
+    return std::isnan(std::real(v)) || std::isnan(std::imag(v));
+  } else {
+    return std::isnan(v);
+  }
+}
 
 } // namespace mlx::core

--- a/mlx/types/half_types.h
+++ b/mlx/types/half_types.h
@@ -56,13 +56,6 @@ fp16_bf16_binop_helper(/, operator/)
 
 #endif
 
-template <typename, typename = void>
-constexpr bool is_complex = false;
-
-template <typename T>
-constexpr bool is_complex<T, std::void_t<decltype(std::declval<T>().real())>> =
-    true;
-
 template <typename T>
 constexpr bool is_signed_v = std::is_signed_v<T> ||
     std::is_same_v<T, float16_t> || std::is_same_v<T, bfloat16_t>;

--- a/tests/arg_reduce_tests.cpp
+++ b/tests/arg_reduce_tests.cpp
@@ -1,5 +1,7 @@
 // Copyright © 2023 Apple Inc.
 
+#include <limits>
+
 #include "doctest/doctest.h"
 
 #include "mlx/mlx.h"
@@ -185,6 +187,31 @@ TEST_CASE("test arg reduce edge cases") {
   CHECK_EQ(b.item<uint32_t>(), 0);
   CHECK_THROWS(argmin(array({})));
   CHECK_THROWS(argmax(array({})));
+}
+
+TEST_CASE("test arg reduce NaN") {
+  auto nan = std::numeric_limits<float>::quiet_NaN();
+  auto x = array({3.0f, nan, 1.0f, 5.0f, nan, -1.0f}, {2, 3});
+
+  test_arg_reduce_small(Device::cpu, x, ArgReduce::ArgMin, {2}, 1, {1, 1});
+  test_arg_reduce_small(Device::cpu, x, ArgReduce::ArgMax, {2}, 1, {1, 1});
+
+  if (!metal::is_available()) {
+    INFO("Skipping arg reduction gpu tests");
+    return;
+  }
+
+  test_arg_reduce_small(Device::gpu, x, ArgReduce::ArgMin, {2}, 1, {1, 1});
+  test_arg_reduce_small(Device::gpu, x, ArgReduce::ArgMax, {2}, 1, {1, 1});
+
+  std::vector<float> wide(1024, 0.0f);
+  wide[17] = nan;
+  wide[529] = nan;
+  x = array(wide.data(), {1024});
+  test_arg_reduce_small(Device::cpu, x, ArgReduce::ArgMin, {}, 0, {17});
+  test_arg_reduce_small(Device::cpu, x, ArgReduce::ArgMax, {}, 0, {17});
+  test_arg_reduce_small(Device::gpu, x, ArgReduce::ArgMin, {}, 0, {17});
+  test_arg_reduce_small(Device::gpu, x, ArgReduce::ArgMax, {}, 0, {17});
 }
 
 TEST_CASE("test arg reduce irregular strides") {

--- a/tests/arg_reduce_tests.cpp
+++ b/tests/arg_reduce_tests.cpp
@@ -190,32 +190,24 @@ TEST_CASE("test arg reduce edge cases") {
 }
 
 TEST_CASE("test arg reduce NaN") {
+  auto d = default_device();
   auto nan = std::numeric_limits<float>::quiet_NaN();
   auto x = array({3.0f, nan, 1.0f, 5.0f, nan, -1.0f}, {2, 3});
-
-  test_arg_reduce_small(Device::cpu, x, ArgReduce::ArgMin, {2}, 1, {1, 1});
-  test_arg_reduce_small(Device::cpu, x, ArgReduce::ArgMax, {2}, 1, {1, 1});
-
-  auto z = array({complex64_t{1.0f, 0.0f}, complex64_t{1.0f, nan}}, {2});
-  test_arg_reduce_small(Device::cpu, z, ArgReduce::ArgMin, {}, 0, {1});
-  test_arg_reduce_small(Device::cpu, z, ArgReduce::ArgMax, {}, 0, {1});
-
-  if (!metal::is_available()) {
-    INFO("Skipping arg reduction gpu tests");
-    return;
-  }
-
-  test_arg_reduce_small(Device::gpu, x, ArgReduce::ArgMin, {2}, 1, {1, 1});
-  test_arg_reduce_small(Device::gpu, x, ArgReduce::ArgMax, {2}, 1, {1, 1});
+  test_arg_reduce_small(d, x, ArgReduce::ArgMin, {2}, 1, {1, 1});
+  test_arg_reduce_small(d, x, ArgReduce::ArgMax, {2}, 1, {1, 1});
 
   std::vector<float> wide(1024, 0.0f);
   wide[17] = nan;
   wide[529] = nan;
   x = array(wide.data(), {1024});
-  test_arg_reduce_small(Device::cpu, x, ArgReduce::ArgMin, {}, 0, {17});
-  test_arg_reduce_small(Device::cpu, x, ArgReduce::ArgMax, {}, 0, {17});
-  test_arg_reduce_small(Device::gpu, x, ArgReduce::ArgMin, {}, 0, {17});
-  test_arg_reduce_small(Device::gpu, x, ArgReduce::ArgMax, {}, 0, {17});
+  test_arg_reduce_small(d, x, ArgReduce::ArgMin, {}, 0, {17});
+  test_arg_reduce_small(d, x, ArgReduce::ArgMax, {}, 0, {17});
+
+  if (!(metal::is_available() && d == Device::gpu)) {
+    auto z = array({complex64_t{1.0f, 0.0f}, complex64_t{1.0f, nan}}, {2});
+    test_arg_reduce_small(d, z, ArgReduce::ArgMin, {}, 0, {1});
+    test_arg_reduce_small(d, z, ArgReduce::ArgMax, {}, 0, {1});
+  }
 }
 
 TEST_CASE("test arg reduce irregular strides") {

--- a/tests/arg_reduce_tests.cpp
+++ b/tests/arg_reduce_tests.cpp
@@ -196,6 +196,10 @@ TEST_CASE("test arg reduce NaN") {
   test_arg_reduce_small(Device::cpu, x, ArgReduce::ArgMin, {2}, 1, {1, 1});
   test_arg_reduce_small(Device::cpu, x, ArgReduce::ArgMax, {2}, 1, {1, 1});
 
+  auto z = array({complex64_t{1.0f, 0.0f}, complex64_t{1.0f, nan}}, {2});
+  test_arg_reduce_small(Device::cpu, z, ArgReduce::ArgMin, {}, 0, {1});
+  test_arg_reduce_small(Device::cpu, z, ArgReduce::ArgMax, {}, 0, {1});
+
   if (!metal::is_available()) {
     INFO("Skipping arg reduction gpu tests");
     return;

--- a/tests/arg_reduce_tests.cpp
+++ b/tests/arg_reduce_tests.cpp
@@ -203,7 +203,7 @@ TEST_CASE("test arg reduce NaN") {
   test_arg_reduce_small(d, x, ArgReduce::ArgMin, {}, 0, {17});
   test_arg_reduce_small(d, x, ArgReduce::ArgMax, {}, 0, {17});
 
-  if (!(metal::is_available() && d == Device::gpu)) {
+  if (d == Device::cpu) {
     auto z = array({complex64_t{1.0f, 0.0f}, complex64_t{1.0f, nan}}, {2});
     test_arg_reduce_small(d, z, ArgReduce::ArgMin, {}, 0, {1});
     test_arg_reduce_small(d, z, ArgReduce::ArgMax, {}, 0, {1});


### PR DESCRIPTION
## Proposed changes

Fixes #4274 by making `argmin` and `argmax` select the first `NaN`, matching MLX min/max propagation and NumPy/PyTorch behavior. The implementation covers CPU, Metal, and CUDA reduction paths, including pairwise GPU reductions where separate partials contain NaNs.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes (passed on the formatting commit; see 03694f5)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)

## Tests

- `cmake --build build-metal --target tests -j2`
- `./build-metal/tests/tests --test-case='test arg reduce NaN'` (14 assertions)
- `./build-metal/tests/tests --test-case='test arg reduce*'` (190 assertions)



