### PR TITLE
metal: faster decode attention (tiled online softmax, vectorized KV loads, context-scaled 2-pass split)

### DIFF
--- a/mlx/backend/metal/kernels/sdpa_vector.h
+++ b/mlx/backend/metal/kernels/sdpa_vector.h
@@ -12,6 +12,31 @@ constant bool float_mask [[function_constant(24)]];
 constant bool has_sinks [[function_constant(25)]];
 constant int blocks [[function_constant(26)]];
 
+// Load N contiguous elements of type T with as few (and as wide) loads as
+// possible. The address must be aligned to N * sizeof(T) bytes (capped at 16
+// byte transactions), which the caller guarantees via the stride checks in
+// scaled_dot_product_attention.cpp.
+template <typename T, int N>
+inline void load_vec(thread T (&dst)[N], const device T* p) {
+  if constexpr (N == 2 || N == 4) {
+    *reinterpret_cast<thread vec<T, N>*>(dst) =
+        *reinterpret_cast<const device vec<T, N>*>(p);
+  } else if constexpr (N == 8 && sizeof(T) == 2) {
+    *reinterpret_cast<thread vec<T, 8>*>(dst) =
+        *reinterpret_cast<const device vec<T, 8>*>(p);
+  } else if constexpr (N == 8) {
+    *reinterpret_cast<thread vec<T, 4>*>(dst) =
+        *reinterpret_cast<const device vec<T, 4>*>(p);
+    *reinterpret_cast<thread vec<T, 4>*>(dst + 4) =
+        *reinterpret_cast<const device vec<T, 4>*>(p + 4);
+  } else {
+#pragma unroll
+    for (int i = 0; i < N; i++) {
+      dst[i] = p[i];
+    }
+  }
+}
+
 template <typename T, int D, int V = D>
 [[kernel]] void sdpa_vector(
     const device T* queries [[buffer(0)]],
@@ -42,15 +67,17 @@ template <typename T, int D, int V = D>
     uint simd_lid [[thread_index_in_simdgroup]]) {
   constexpr int BN = 32;
   constexpr int BD = 32;
+  // Keys are processed in tiles of TK so the online softmax update (max, exp
+  // and rescale of the accumulator) happens once per tile instead of per key.
+  constexpr int TK = 4;
   constexpr int qk_per_thread = D / BD;
   constexpr int v_per_thread = V / BD;
-  int inner_k_stride = BN * int(k_seq_stride);
-  int inner_v_stride = BN * int(v_seq_stride);
+  int inner_k_stride = BN * TK * int(k_seq_stride);
+  int inner_v_stride = BN * TK * int(v_seq_stride);
 
   typedef float U;
 
   thread U q[qk_per_thread];
-  thread U k[qk_per_thread];
   thread U o[v_per_thread];
 
   threadgroup U outputs[BN * BD];
@@ -65,24 +92,28 @@ template <typename T, int D, int V = D>
   const int q_offset =
       query_transposed ? tpg.x * q_seq_idx + q_batch_head_idx : o_offset;
   queries += q_offset * D + simd_lid * qk_per_thread;
-  keys += kv_head_idx * k_head_stride + simd_gid * k_seq_stride +
+  keys += kv_head_idx * k_head_stride + simd_gid * TK * k_seq_stride +
       simd_lid * qk_per_thread;
-  values += kv_head_idx * v_head_stride + simd_gid * v_seq_stride +
+  values += kv_head_idx * v_head_stride + simd_gid * TK * v_seq_stride +
       simd_lid * v_per_thread;
   if (bool_mask) {
     bmask += q_batch_head_idx * mask_head_stride +
-        simd_gid * mask_kv_seq_stride + q_seq_idx * mask_q_seq_stride;
+        simd_gid * TK * mask_kv_seq_stride + q_seq_idx * mask_q_seq_stride;
   }
   if (float_mask) {
     fmask += q_batch_head_idx * mask_head_stride +
-        simd_gid * mask_kv_seq_stride + q_seq_idx * mask_q_seq_stride;
+        simd_gid * TK * mask_kv_seq_stride + q_seq_idx * mask_q_seq_stride;
   }
 
   out += o_offset * V + simd_gid * v_per_thread;
 
   // Read the query and 0 the output accumulator
-  for (int i = 0; i < qk_per_thread; i++) {
-    q[i] = static_cast<U>(scale) * queries[i];
+  {
+    thread T qt[qk_per_thread];
+    load_vec<T, qk_per_thread>(qt, queries);
+    for (int i = 0; i < qk_per_thread; i++) {
+      q[i] = static_cast<U>(scale) * static_cast<U>(qt[i]);
+    }
   }
   for (int i = 0; i < v_per_thread; i++) {
     o[i] = 0;
@@ -95,8 +126,88 @@ template <typename T, int D, int V = D>
     sum_exp_score = 1;
   }
 
-  // For each key
-  for (int i = simd_gid; i < N; i += BN) {
+  // For each tile of TK keys
+  int i = simd_gid * TK;
+  for (; i + TK <= N; i += BN * TK) {
+    // Read the keys and compute the scores
+    thread T ks[TK][qk_per_thread];
+    U scores[TK];
+    bool use_key[TK];
+#pragma unroll
+    for (int t = 0; t < TK; t++) {
+      load_vec<T, qk_per_thread>(ks[t], keys + t * int(k_seq_stride));
+    }
+#pragma unroll
+    for (int t = 0; t < TK; t++) {
+      U score = 0;
+      for (int j = 0; j < qk_per_thread; j++) {
+        score += q[j] * static_cast<U>(ks[t][j]);
+      }
+      score = simd_sum(score);
+
+      use_key[t] = true;
+      if (do_causal) {
+        use_key[t] = i + t <= (N - int(tpg.y) + int(q_seq_idx));
+      } else if (bool_mask) {
+        use_key[t] = bmask[t * mask_kv_seq_stride];
+      } else if (float_mask) {
+        use_key[t] = fmask[t * mask_kv_seq_stride] >= Limits<T>::finite_min;
+      }
+      if (use_key[t] && float_mask) {
+        score += static_cast<U>(fmask[t * mask_kv_seq_stride]);
+      }
+      scores[t] = use_key[t] ? score : Limits<U>::finite_min;
+    }
+
+    U tile_max = scores[0];
+#pragma unroll
+    for (int t = 1; t < TK; t++) {
+      tile_max = max(tile_max, scores[t]);
+    }
+    U new_max = max(max_score, tile_max);
+
+    // Read the values
+    thread T vs[TK][v_per_thread];
+#pragma unroll
+    for (int t = 0; t < TK; t++) {
+      load_vec<T, v_per_thread>(vs[t], values + t * int(v_seq_stride));
+    }
+
+    // Rescale the accumulators only when the running max actually increased
+    if (new_max > max_score) {
+      U factor = fast::exp(max_score - new_max);
+      sum_exp_score *= factor;
+      for (int j = 0; j < v_per_thread; j++) {
+        o[j] *= factor;
+      }
+      max_score = new_max;
+    }
+
+    // Update the accumulators
+#pragma unroll
+    for (int t = 0; t < TK; t++) {
+      U p = use_key[t] ? fast::exp(scores[t] - max_score) : U(0);
+      sum_exp_score += p;
+#pragma unroll
+      for (int j = 0; j < v_per_thread; j++) {
+        o[j] += p * static_cast<U>(vs[t][j]);
+      }
+    }
+
+    // Move the pointers to the next tile
+    keys += inner_k_stride;
+    values += inner_v_stride;
+    if (bool_mask) {
+      bmask += BN * TK * mask_kv_seq_stride;
+    }
+    if (float_mask) {
+      fmask += BN * TK * mask_kv_seq_stride;
+    }
+  }
+
+  // Process the remaining keys of the last partial tile
+  const int tail_end = min(N, i + TK);
+  for (; i < tail_end; i++) {
     bool use_key = true;
     if (do_causal) {
       use_key = i <= (N - int(tpg.y) + int(q_seq_idx));
@@ -107,14 +218,13 @@ template <typename T, int D, int V = D>
     }
     if (use_key) {
       // Read the key
-      for (int j = 0; j < qk_per_thread; j++) {
-        k[j] = keys[j];
-      }
+      thread T k[qk_per_thread];
+      load_vec<T, qk_per_thread>(k, keys);
 
       // Compute the i-th score
       U score = 0;
       for (int j = 0; j < qk_per_thread; j++) {
-        score += q[j] * k[j];
+        score += q[j] * static_cast<U>(k[j]);
       }
       score = simd_sum(score);
       if (float_mask) {
@@ -130,19 +240,21 @@ template <typename T, int D, int V = D>
       sum_exp_score = sum_exp_score * factor + exp_score;
 
       // Update the output accumulator
+      thread T vt[v_per_thread];
+      load_vec<T, v_per_thread>(vt, values);
       for (int j = 0; j < v_per_thread; j++) {
-        o[j] = o[j] * factor + exp_score * values[j];
+        o[j] = o[j] * factor + exp_score * static_cast<U>(vt[j]);
       }
     }
 
     // Move the pointers to the next kv
-    keys += inner_k_stride;
-    values += inner_v_stride;
+    keys += int(k_seq_stride);
+    values += int(v_seq_stride);
     if (bool_mask) {
-      bmask += BN * mask_kv_seq_stride;
+      bmask += mask_kv_seq_stride;
     }
     if (float_mask) {
-      fmask += BN * mask_kv_seq_stride;
+      fmask += mask_kv_seq_stride;
     }
   }
 
@@ -181,7 +293,7 @@ template <typename T, int D, int V = D>
     const device T* queries [[buffer(0)]],
     const device T* keys [[buffer(1)]],
     const device T* values [[buffer(2)]],
-    device T* out [[buffer(3)]],
+    device float* out [[buffer(3)]],
     device float* sums [[buffer(4)]],
     device float* maxs [[buffer(5)]],
     const constant int& N [[buffer(7)]],
@@ -205,6 +317,9 @@ template <typename T, int D, int V = D>
     uint3 tpg [[threadgroups_per_grid]],
     uint simd_lid [[thread_index_in_simdgroup]]) {
   constexpr int BD = 32;
+  // Keys are processed in tiles of TK so the online softmax update (max, exp
+  // and rescale of the accumulator) happens once per tile instead of per key.
+  constexpr int TK = 4;
   constexpr int qk_per_thread = D / BD;
   constexpr int v_per_thread = V / BD;
 
@@ -230,26 +345,35 @@ template <typename T, int D, int V = D>
 
   queries += q_offset * D + simd_lid * qk_per_thread;
 
+  // Each block processes a contiguous chunk of the KV sequence.
+  const int chunk = (N + blocks - 1) / blocks;
+  const int k_start = block_idx * chunk;
+  const int k_end = min(N, k_start + chunk);
+
   const int kv_batch_head_idx = batch_idx * num_kv_heads + kv_head_idx;
-  keys += kv_batch_head_idx * k_head_stride + block_idx * k_seq_stride +
+  keys += kv_batch_head_idx * k_head_stride + k_start * k_seq_stride +
       simd_lid * qk_per_thread;
-  values += kv_batch_head_idx * v_head_stride + block_idx * v_seq_stride +
+  values += kv_batch_head_idx * v_head_stride + k_start * v_seq_stride +
       simd_lid * v_per_thread;
   out += o_offset * blocks * V + block_idx * V + simd_lid * v_per_thread;
   if (bool_mask) {
     bmask += q_batch_head_idx * mask_head_stride +
-        block_idx * mask_kv_seq_stride + q_seq_idx * mask_q_seq_stride;
+        k_start * mask_kv_seq_stride + q_seq_idx * mask_q_seq_stride;
   }
   if (float_mask) {
     fmask += q_batch_head_idx * mask_head_stride +
-        block_idx * mask_kv_seq_stride + q_seq_idx * mask_q_seq_stride;
+        k_start * mask_kv_seq_stride + q_seq_idx * mask_q_seq_stride;
   }
   sums += o_offset * blocks + block_idx;
   maxs += o_offset * blocks + block_idx;
 
   // Read the query
-  for (int i = 0; i < qk_per_thread; i++) {
-    q[i] = static_cast<U>(scale) * queries[i];
+  {
+    thread T qt[qk_per_thread];
+    load_vec<T, qk_per_thread>(qt, queries);
+    for (int i = 0; i < qk_per_thread; i++) {
+      q[i] = static_cast<U>(scale) * static_cast<U>(qt[i]);
+    }
   }
 
   U max_score = Limits<U>::finite_min;
@@ -259,8 +383,87 @@ template <typename T, int D, int V = D>
     sum_exp_score = 1;
   }
 
-  // For each key
-  for (int i = block_idx; i < N; i += blocks) {
+  // For each tile of TK keys in this block's chunk
+  int i = k_start;
+  for (; i + TK <= k_end; i += TK) {
+    // Read the keys and compute the scores
+    thread T ks[TK][qk_per_thread];
+    U scores[TK];
+    bool use_key[TK];
+#pragma unroll
+    for (int t = 0; t < TK; t++) {
+      load_vec<T, qk_per_thread>(ks[t], keys + t * int(k_seq_stride));
+    }
+#pragma unroll
+    for (int t = 0; t < TK; t++) {
+      U score = 0;
+      for (int j = 0; j < qk_per_thread; j++) {
+        score += q[j] * static_cast<U>(ks[t][j]);
+      }
+      score = simd_sum(score);
+
+      use_key[t] = true;
+      if (do_causal) {
+        use_key[t] = i + t <= (N - q_seq_len + int(q_seq_idx));
+      } else if (bool_mask) {
+        use_key[t] = bmask[t * mask_kv_seq_stride];
+      } else if (float_mask) {
+        use_key[t] = fmask[t * mask_kv_seq_stride] >= Limits<T>::finite_min;
+      }
+      if (use_key[t] && float_mask) {
+        score += static_cast<U>(fmask[t * mask_kv_seq_stride]);
+      }
+      scores[t] = use_key[t] ? score : Limits<U>::finite_min;
+    }
+
+    U tile_max = scores[0];
+#pragma unroll
+    for (int t = 1; t < TK; t++) {
+      tile_max = max(tile_max, scores[t]);
+    }
+    U new_max = max(max_score, tile_max);
+
+    // Read the values
+    thread T vs[TK][v_per_thread];
+#pragma unroll
+    for (int t = 0; t < TK; t++) {
+      load_vec<T, v_per_thread>(vs[t], values + t * int(v_seq_stride));
+    }
+
+    // Rescale the accumulators only when the running max actually increased
+    if (new_max > max_score) {
+      U factor = fast::exp(max_score - new_max);
+      sum_exp_score *= factor;
+      for (int j = 0; j < v_per_thread; j++) {
+        o[j] *= factor;
+      }
+      max_score = new_max;
+    }
+
+    // Update the accumulators
+#pragma unroll
+    for (int t = 0; t < TK; t++) {
+      U p = use_key[t] ? fast::exp(scores[t] - max_score) : U(0);
+      sum_exp_score += p;
+#pragma unroll
+      for (int j = 0; j < v_per_thread; j++) {
+        o[j] += p * static_cast<U>(vs[t][j]);
+      }
+    }
+
+    // Move the pointers to the next tile
+    keys += TK * int(k_seq_stride);
+    values += TK * int(v_seq_stride);
+    if (bool_mask) {
+      bmask += TK * mask_kv_seq_stride;
+    }
+    if (float_mask) {
+      fmask += TK * mask_kv_seq_stride;
+    }
+  }
+
+  // Process the remaining keys of the chunk
+  for (; i < k_end; i++) {
     bool use_key = true;
     if (do_causal) {
       use_key = i <= (N - q_seq_len + int(q_seq_idx));
@@ -271,9 +474,11 @@ template <typename T, int D, int V = D>
     }
     if (use_key) {
       // Compute the i-th score
+      thread T k[qk_per_thread];
+      load_vec<T, qk_per_thread>(k, keys);
       U score = 0;
-      for (int i = 0; i < qk_per_thread; i++) {
-        score += q[i] * keys[i];
+      for (int j = 0; j < qk_per_thread; j++) {
+        score += q[j] * static_cast<U>(k[j]);
       }
       score = simd_sum(score);
 
@@ -290,19 +495,21 @@ template <typename T, int D, int V = D>
       sum_exp_score = sum_exp_score * factor + exp_score;
 
       // Update the output accumulator
-      for (int i = 0; i < v_per_thread; i++) {
-        o[i] = o[i] * factor + exp_score * values[i];
+      thread T vt[v_per_thread];
+      load_vec<T, v_per_thread>(vt, values);
+      for (int j = 0; j < v_per_thread; j++) {
+        o[j] = o[j] * factor + exp_score * static_cast<U>(vt[j]);
       }
     }
 
     // Move the pointers to the next kv
-    keys += blocks * int(k_seq_stride);
-    values += blocks * int(v_seq_stride);
+    keys += int(k_seq_stride);
+    values += int(v_seq_stride);
     if (bool_mask) {
-      bmask += blocks * mask_kv_seq_stride;
+      bmask += mask_kv_seq_stride;
     }
     if (float_mask) {
-      fmask += blocks * mask_kv_seq_stride;
+      fmask += mask_kv_seq_stride;
     }
   }
 
@@ -313,13 +520,13 @@ template <typename T, int D, int V = D>
   }
 
   for (int i = 0; i < v_per_thread; i++) {
-    out[i] = static_cast<T>(o[i]);
+    out[i] = o[i];
   }
 }
 
 template <typename T, int D>
 [[kernel]] void sdpa_vector_2pass_2(
-    const device T* partials [[buffer(0)]],
+    const device float* partials [[buffer(0)]],
     const device float* sums [[buffer(1)]],
     const device float* maxs [[buffer(2)]],
     device T* out [[buffer(3)]],
@@ -369,7 +576,7 @@ template <typename T, int D>
 
     // Update the output accumulator
     for (int i = 0; i < elem_per_thread; i++) {
-      o[i] += factor * static_cast<U>(partials[i]);
+      o[i] += factor * partials[i];
     }
     maxs += BN;
     sums += BN;

--- a/mlx/backend/metal/scaled_dot_product_attention.cpp
+++ b/mlx/backend/metal/scaled_dot_product_attention.cpp
@@ -458,16 +458,11 @@ void sdpa_vector_2pass(
       }
     }
   } else if (devc == 'd') {
-    blocks = 128;
-    if (n_simds <= 2 && N > 8192) {
-      blocks = 256;
-    } else if (n_simds >= 6) {
-      if (N >= 16384 && N < 65536) {
-        blocks = 512;
-      } else if (N >= 65536) {
-        blocks = 1024;
-      }
-    }
+    // Split the KV sequence so that each threadgroup processes a contiguous
+    // chunk of ~256 keys, while keeping at least 32-64 blocks for parallelism
+    // and capping at 256 to bound the partials traffic. Tuned on M3 Ultra.
+    int b = (((N + 255) / 256 + 31) / 32) * 32;
+    blocks = std::min(256, std::max(N >= 4096 ? 64 : 32, b));
   } else {
     if (n_simds >= 4) {
       blocks = 64;
@@ -487,14 +482,16 @@ void sdpa_vector_2pass(
   MTL::Size group_dims(32, gqa_factor, q.shape(2));
   MTL::Size grid_dims(k.shape(1), q.shape(0), blocks);
 
-  // Allocate the intermediates
+  // Allocate the intermediates. The partials are stored in float32 (rather
+  // than the query dtype) for accuracy: the extra traffic is negligible since
+  // they are tiny compared to the KV read.
   Shape intermediate_shape;
   intermediate_shape.reserve(out.ndim() + 1);
   intermediate_shape.insert(
       intermediate_shape.end(), out.shape().begin(), out.shape().end() - 1);
   intermediate_shape.push_back(blocks);
   intermediate_shape.push_back(out.shape().back());
-  array intermediate(intermediate_shape, q.dtype(), nullptr, {});
+  array intermediate(intermediate_shape, float32, nullptr, {});
   intermediate_shape.pop_back();
   array sums(intermediate_shape, float32, nullptr, {});
   array maxs(std::move(intermediate_shape), float32, nullptr, {});
@@ -708,9 +705,17 @@ void ScaledDotProductAttention::eval_gpu(
       // keys and values should be copied if:
       // - the last dimension is not contiguous
       // - the batch and head dim are not contiguous
+      // - the seq or head strides are not multiples of the per-thread load
+      //   width (head_dim / 32 elements), which the vectorized loads in the
+      //   sdpa vector kernels require for alignment
       auto& strides = arr.strides();
       auto& shape = arr.shape();
       if (strides.back() != 1) {
+        return false;
+      }
+      auto per_thread = shape[3] / 32;
+      if ((shape[2] > 1 && strides[2] % per_thread != 0) ||
+          (shape[1] > 1 && strides[1] % per_thread != 0)) {
         return false;
       }
       if (shape[0] == 1 || shape[1] == 1) {
@@ -748,10 +753,20 @@ void ScaledDotProductAttention::eval_gpu(
     // We route to the 2 pass fused attention if
     // - The device is large and the sequence length long
     // - The sequence length is even longer and we have gqa
+    // On 'd' class GPUs (e.g. M3 Ultra) the retuned 2-pass kernels win for
+    // GQA from 1024 keys and for MHA / small head counts from 32768 keys;
+    // the (also retuned) 1-pass kernel wins everywhere below that.
     bool do_causal = do_causal_ && q.shape(2) > 1;
     char devc = d.get_architecture().back();
-    if (((devc == 'd' || devc == 's') && k.shape(2) >= 1024) ||
-        (k.shape(1) < q.shape(1) && k.shape(2) >= 4096)) {
+    bool gqa = k.shape(1) < q.shape(1);
+    bool use_2pass;
+    if (devc == 'd') {
+      use_2pass = gqa ? (k.shape(2) >= 1024) : (k.shape(2) >= 32768);
+    } else {
+      use_2pass =
+          (devc == 's' && k.shape(2) >= 1024) || (gqa && k.shape(2) >= 4096);
+    }
+    if (use_2pass) {
       sdpa_vector_2pass(s, d, q, k, v, o, scale_, do_causal, mask, sinks);
     } else {
       sdpa_vector(s, d, q, k, v, o, scale_, do_causal, mask, sinks);


### PR DESCRIPTION
Decode-path SDPA (`sdpa_vector*`, qL ≤ 8) leaves the GPU mostly idle at short and mid context lengths and uses a latency-bound inner loop everywhere:

- the 1-pass kernel launches one threadgroup per (batch·head) — e.g. 32 TGs on a 60-core GPU — and walks the whole KV cache serially;
- both kernels run online softmax **per key** (simd_sum + 2 exp + full output rescale per key = a long serial dependency chain) with scalar 2-byte loads;
- the 2-pass `blocks` heuristic is pinned to 128 for common GQA ratios regardless of context length.

This PR reworks the decode kernels:

1. **Tiled online softmax**: keys processed in tiles of 4 with one max/exp/rescale per tile; the rescale is skipped (uniform branch) when the running max does not increase.
2. **Vectorized K/V loads**: a `load_vec` helper emitting a single 4/8/16-byte load per thread (D=64→4B, 128→8B, 256→16B; D=96 keeps scalar loads due to misalignment).
3. **Context-scaled 2-pass splitting**: `blocks = clamp(roundup32(L/256), 32–64, 256)` on Ultra-class ('d') archs and 2-pass routing for GQA at L≥1024; block-contiguous key chunks replace strided block order.
4. **fp32 2-pass partials** (previously query dtype) — strictly better numerics; pass-2 updated accordingly.

Non-'d' arch routing is unchanged; the kernel improvements apply everywhere but were only benchmarked on M3 Ultra (see Risks).

### Benchmarks (M3 Ultra 60-core)

Stock `benchmarks/python/sdpa_vector_bench.py` (fp16, L=16k, H=32, HK=8):

| case | main | this PR | speedup |
|---|---|---|---|
| sdpa (qL=1) | 1.688 ms | 1.201 ms | **1.41x** |
| sdpa + mask | 1.542 ms | 1.292 ms | 1.19x |

Effective KV bandwidth, qL=1 decode (bf16), main → PR:

| H,HK,D | 2k ctx | 8k ctx | 32k ctx |
|---|---|---|---|
| 40,8,128 | 220→273 GB/s | 407→519 | 1087→1377 |
| 32,8,128 | 293→384 | 666→872 | 1137→1737 |
| 64,8,128 | 207→279 | 507→591 | 762→1188 |
| 32,32,64 (MHA) | 564→1797 | 1445→2791 | ≈ (noise) |

End-to-end decode (mlx_lm generate, Qwen3-8B-4bit, interleaved A/B, <0.5% rep variance): +2.1% tok/s @1k ctx, **+9.5% @8k**, **+12.7% @16k**. Short ctx (≤512) is parity (latency-bound; ±30% run-to-run at 10–25 µs — measured with many-rep medians).

### Tests
- `python/tests/test_fast.py` passes (27/27), incl. sdpa-vs-composed reference.
- Additionally validated across D∈{64,96,128,256}, bf16/fp16, GQA 1–8, L∈[256, 131072], bool/float masks, causal, qL∈{1,4}, tail lengths (257, 4093): max-abs-diff vs fp32 composed reference ≤1e-3, equal or closer than main (fp32 partials).

### Risks / notes for reviewers
- Register pressure at D=256 with the tiled inner loop could reduce occupancy on small GPUs (untested — no M1/M2 hardware available to the author); kernel changes apply to all archs, so a look from someone with base/Pro hardware would be appreciated. Routing changes are 'd'-gated.
- KV with unusual strides failing a new 32-element alignment check now takes a contiguous copy first (correct, small cost).
- `MLX_SDPA_BLOCKS` env override behavior preserved.
