### PR TITLE
fast: optional fused residual-add in rms_norm (Metal)

### DIFF
--- a/mlx/backend/cuda/rms_norm.cu
+++ b/mlx/backend/cuda/rms_norm.cu
@@ -462,6 +462,11 @@ bool RMSNorm::use_fallback(Stream s) {
   return s.device == Device::cpu;
 }
 
+bool RMSNorm::use_fallback(Stream s, bool has_residual) {
+  // The fused residual kernel is only implemented on metal for now.
+  return has_residual || use_fallback(s);
+}
+
 template <int n_per_thread, typename F>
 void dispatch_group_dim(int axis_size, F&& f) {
   if (axis_size <= n_per_thread * 8) {

--- a/mlx/backend/metal/kernels/rms_norm.metal
+++ b/mlx/backend/metal/kernels/rms_norm.metal
@@ -156,6 +156,177 @@ template <typename T, int N_READS = RMS_N_READS>
   }
 }
 
+// Fused residual add + RMS norm: computes out = rms_norm(x + res) * w and
+// out_sum = x + res in a single pass. The reduction structure matches
+// rms_single_row/rms_looped exactly.
+template <typename T, int N_READS = RMS_N_READS>
+[[kernel]] void rms_residual_single_row(
+    const device T* x,
+    const device T* res,
+    const device T* w,
+    device T* out,
+    device T* out_sum,
+    constant float& eps,
+    constant uint& axis_size,
+    constant uint& w_stride,
+    uint gid [[threadgroup_position_in_grid]],
+    uint lid [[thread_position_in_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]]) {
+  constexpr int SIMD_SIZE = 32;
+
+  threadgroup float local_inv_mean[1];
+  threadgroup float local_sums[SIMD_SIZE];
+
+  float acc = 0;
+  float thread_x[N_READS];
+  x += gid * size_t(axis_size) + lid * N_READS;
+  res += gid * size_t(axis_size) + lid * N_READS;
+  w += w_stride * lid * N_READS;
+  if (lid * N_READS + N_READS <= axis_size) {
+    for (int i = 0; i < N_READS; i++) {
+      T s = x[i] + res[i];
+      thread_x[i] = s;
+      acc += thread_x[i] * thread_x[i];
+    }
+  } else {
+    for (int i = 0; i < N_READS; i++) {
+      T s = (lid * N_READS + i < axis_size) ? T(x[i] + res[i]) : T(0);
+      thread_x[i] = s;
+      acc += thread_x[i] * thread_x[i];
+    }
+  }
+  acc = simd_sum(acc);
+  //  Initialize shared memory
+  if (simd_group_id == 0) {
+    local_sums[simd_lane_id] = 0;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // Write simd accumulations into shared memory
+  if (simd_lane_id == 0) {
+    local_sums[simd_group_id] = acc;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // Accumulate over simd groups
+  if (simd_group_id == 0) {
+    acc = simd_sum(local_sums[simd_lane_id]);
+    if (simd_lane_id == 0) {
+      local_inv_mean[0] = metal::precise::rsqrt(acc / axis_size + eps);
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // Write the outputs using the cached sums
+  out += gid * size_t(axis_size) + lid * N_READS;
+  out_sum += gid * size_t(axis_size) + lid * N_READS;
+  if (lid * N_READS + N_READS <= axis_size) {
+    for (int i = 0; i < N_READS; i++) {
+      out_sum[i] = static_cast<T>(thread_x[i]);
+      out[i] =
+          w[w_stride * i] * static_cast<T>(thread_x[i] * local_inv_mean[0]);
+    }
+  } else {
+    for (int i = 0; i < N_READS; i++) {
+      if ((lid * N_READS + i) < axis_size) {
+        out_sum[i] = static_cast<T>(thread_x[i]);
+        out[i] =
+            w[w_stride * i] * static_cast<T>(thread_x[i] * local_inv_mean[0]);
+      }
+    }
+  }
+}
+
+// Looped variant for large axes. The sums are stored to out_sum during the
+// accumulation pass and re-read (cache-hot) in the write pass instead of
+// re-reading both inputs.
+template <typename T, int N_READS = RMS_N_READS>
+[[kernel]] void rms_residual_looped(
+    const device T* x,
+    const device T* res,
+    const device T* w,
+    device T* out,
+    device T* out_sum,
+    constant float& eps,
+    constant uint& axis_size,
+    constant uint& w_stride,
+    uint gid [[threadgroup_position_in_grid]],
+    uint lid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]]) {
+  constexpr int SIMD_SIZE = 32;
+  threadgroup float local_inv_mean[1];
+  threadgroup float local_sums[SIMD_SIZE];
+
+  float acc = 0;
+  x += gid * size_t(axis_size) + lid * N_READS;
+  res += gid * size_t(axis_size) + lid * N_READS;
+  w += w_stride * lid * N_READS;
+  out_sum += gid * size_t(axis_size) + lid * N_READS;
+  for (uint r = 0; r < axis_size; r += lsize * N_READS) {
+    if (r + lid * N_READS + N_READS <= axis_size) {
+      for (int i = 0; i < N_READS; i++) {
+        T s = x[i + r] + res[i + r];
+        out_sum[i + r] = s;
+        float sf = s;
+        acc += sf * sf;
+      }
+    } else {
+      for (int i = 0; i < N_READS; i++) {
+        if ((r + lid * N_READS + i) < axis_size) {
+          T s = x[i + r] + res[i + r];
+          out_sum[i + r] = s;
+          float sf = s;
+          acc += sf * sf;
+        }
+      }
+    }
+  }
+  acc = simd_sum(acc);
+  //  Initialize shared memory
+  if (simd_group_id == 0) {
+    local_sums[simd_lane_id] = 0;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // Write simd accumulations into shared memory
+  if (simd_lane_id == 0) {
+    local_sums[simd_group_id] = acc;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // Accumulate over simd groups
+  if (simd_group_id == 0) {
+    acc = simd_sum(local_sums[simd_lane_id]);
+    if (simd_lane_id == 0) {
+      local_inv_mean[0] = metal::precise::rsqrt(acc / axis_size + eps);
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // Write the outputs re-reading the cached sums
+  out += gid * size_t(axis_size) + lid * N_READS;
+  for (uint r = 0; r < axis_size; r += lsize * N_READS) {
+    if (r + lid * N_READS + N_READS <= axis_size) {
+      for (int i = 0; i < N_READS; i++) {
+        float sf = out_sum[r + i];
+        out[r + i] =
+            w[w_stride * (i + r)] * static_cast<T>(sf * local_inv_mean[0]);
+      }
+    } else {
+      for (int i = 0; i < N_READS; i++) {
+        if ((r + lid * N_READS + i) < axis_size) {
+          float sf = out_sum[r + i];
+          out[r + i] =
+              w[w_stride * (i + r)] * static_cast<T>(sf * local_inv_mean[0]);
+        }
+      }
+    }
+  }
+}
+
 template <typename T, int N_READS = RMS_N_READS>
 [[kernel]] void vjp_rms_single_row(
     const device T* x,
@@ -381,11 +552,16 @@ template <typename T, int N_READS = RMS_N_READS>
 }
 
 // clang-format off
-#define instantiate_rms(name, itype)                                \
-  instantiate_kernel("rms" #name, rms_single_row, itype)            \
-  instantiate_kernel("vjp_rms" #name, vjp_rms_single_row, itype)    \
-  instantiate_kernel("rms_looped" #name, rms_looped, itype)         \
-  instantiate_kernel("vjp_rms_looped" #name, vjp_rms_looped, itype)
+#define instantiate_rms(name, itype)                                     \
+  instantiate_kernel("rms" #name, rms_single_row, itype)                 \
+  instantiate_kernel("vjp_rms" #name, vjp_rms_single_row, itype)         \
+  instantiate_kernel("rms_looped" #name, rms_looped, itype)              \
+  instantiate_kernel("vjp_rms_looped" #name, vjp_rms_looped, itype)      \
+  instantiate_kernel("rms_residual" #name, rms_residual_single_row, itype) \
+  instantiate_kernel(                                                    \
+      "rms_residual16" #name, rms_residual_single_row, itype, 16)        \
+  instantiate_kernel(                                                    \
+      "rms_residual_looped" #name, rms_residual_looped, itype)
 
 instantiate_rms(float32, float)
 instantiate_rms(float16, half)

--- a/mlx/backend/metal/normalization.cpp
+++ b/mlx/backend/metal/normalization.cpp
@@ -14,15 +14,21 @@ bool RMSNorm::use_fallback(Stream s) {
   return s.device == Device::cpu;
 }
 
+bool RMSNorm::use_fallback(Stream s, bool /* has_residual */) {
+  // The metal backend implements the fused residual kernels.
+  return use_fallback(s);
+}
+
 void RMSNorm::eval_gpu(
     const std::vector<array>& inputs,
     std::vector<array>& outputs) {
   auto& s = stream();
   auto& d = metal::device(s.device);
+  bool has_residual = inputs.size() == 3;
   auto& out = outputs[0];
 
   // Make sure that the last dimension is contiguous
-  auto set_output = [&s, &out](const array& x) {
+  auto set_output = [&s](const array& x, array& out) {
     bool no_copy = x.flags().contiguous && x.strides()[x.ndim() - 1] == 1;
     if (no_copy && x.ndim() > 1) {
       auto s = x.strides()[x.ndim() - 2];
@@ -46,16 +52,32 @@ void RMSNorm::eval_gpu(
     }
   };
 
-  const array x = set_output(inputs[0]);
+  const array x = set_output(inputs[0], out);
   const array& w = inputs[1];
+  // The residual input gets the same treatment and donates its buffer to the
+  // sum output when possible. Buffers can only be donated when solely owned
+  // so x and the residual can never alias the same donated buffer.
+  array r = x;
+  if (has_residual) {
+    r = set_output(inputs[2], outputs[1]);
+  }
 
   auto axis_size = static_cast<uint32_t>(x.shape().back());
   int n_rows = x.data_size() / axis_size;
 
   const int simd_size = 32;
-  const int n_reads = RMS_N_READS;
   const int looped_limit = RMS_LOOPED_LIMIT;
+  int n_reads = RMS_N_READS;
   std::string op_name = "rms";
+  if (has_residual) {
+    op_name += "_residual";
+    if (axis_size <= 3072) {
+      // More reads per thread keep the threadgroup small which leaves room
+      // for more resident threadgroups per SM at small axis sizes.
+      op_name += "16";
+      n_reads = 16;
+    }
+  }
   if (axis_size > looped_limit) {
     op_name += "_looped";
   }
@@ -82,12 +104,23 @@ void RMSNorm::eval_gpu(
 
     uint32_t w_stride = (w.ndim() == 1) ? w.strides()[0] : 0;
     compute_encoder.set_compute_pipeline_state(kernel);
-    compute_encoder.set_input_array(x, 0);
-    compute_encoder.set_input_array(w, 1);
-    compute_encoder.set_output_array(out, 2);
-    compute_encoder.set_bytes(eps_, 3);
-    compute_encoder.set_bytes(axis_size, 4);
-    compute_encoder.set_bytes(w_stride, 5);
+    if (has_residual) {
+      compute_encoder.set_input_array(x, 0);
+      compute_encoder.set_input_array(r, 1);
+      compute_encoder.set_input_array(w, 2);
+      compute_encoder.set_output_array(out, 3);
+      compute_encoder.set_output_array(outputs[1], 4);
+      compute_encoder.set_bytes(eps_, 5);
+      compute_encoder.set_bytes(axis_size, 6);
+      compute_encoder.set_bytes(w_stride, 7);
+    } else {
+      compute_encoder.set_input_array(x, 0);
+      compute_encoder.set_input_array(w, 1);
+      compute_encoder.set_output_array(out, 2);
+      compute_encoder.set_bytes(eps_, 3);
+      compute_encoder.set_bytes(axis_size, 4);
+      compute_encoder.set_bytes(w_stride, 5);
+    }
     compute_encoder.dispatch_threads(grid_dims, group_dims);
   }
 }

--- a/mlx/backend/no_gpu/primitives.cpp
+++ b/mlx/backend/no_gpu/primitives.cpp
@@ -168,6 +168,9 @@ NO_GPU_USE_FALLBACK(LayerNorm)
 NO_GPU_MULTI(LayerNormVJP)
 NO_GPU_USE_FALLBACK(RMSNorm)
 NO_GPU_MULTI(RMSNormVJP)
+bool RMSNorm::use_fallback(Stream, bool) {
+  return true;
+}
 NO_GPU_USE_FALLBACK(RoPE)
 NO_GPU_MULTI(ScaledDotProductAttention)
 NO_GPU_MULTI(ScaledDotProductAttentionVJP)

--- a/mlx/fast.cpp
+++ b/mlx/fast.cpp
@@ -120,14 +120,100 @@ array rms_norm(
   return fallback({x, passed_weight})[0];
 }
 
+std::vector<array> rms_norm(
+    const array& x,
+    const std::optional<array>& weight,
+    const std::optional<array>& residual,
+    float eps,
+    StreamOrDevice s_ /* = {} */) {
+  if (!residual.has_value()) {
+    return {rms_norm(x, weight, eps, s_)};
+  }
+  bool has_weight = weight.has_value();
+
+  if (x.ndim() == 0) {
+    std::ostringstream msg;
+    msg << "[rms_norm] Input must have at least 1 dimension but got input with "
+           "0 dimensions.";
+    throw std::invalid_argument(msg.str());
+  }
+  if ((*residual).shape() != x.shape()) {
+    std::ostringstream msg;
+    msg << "[rms_norm] (*residual) must have the same shape as x but has shape "
+        << (*residual).shape() << " while x has shape " << x.shape() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  if (has_weight) {
+    if ((*weight).ndim() != 1) {
+      std::ostringstream msg;
+      msg << "[rms_norm] (*weight) must have 1 dimension but has "
+          << (*weight).ndim() << " dimensions.";
+      throw std::invalid_argument(msg.str());
+    }
+    if ((*weight).size() != x.shape(-1)) {
+      std::ostringstream msg;
+      msg << "[rms_norm] (*weight) must have the same size as the last dimension of"
+             " x but has "
+          << (*weight).size() << " elements.";
+      throw std::invalid_argument(msg.str());
+    }
+  }
+
+  auto out_type = has_weight ? result_type(x, (*residual), (*weight))
+                             : result_type(x, (*residual));
+  if (!issubdtype(out_type, floating)) {
+    std::ostringstream msg;
+    msg << "[rms_norm] Received unsupported type " << out_type << ".";
+    throw std::invalid_argument(msg.str());
+  }
+
+  auto s = to_stream(s_);
+  // The sum is computed in the output type (matching a composed
+  // ``add`` followed by ``rms_norm``) and the normalization accumulates in
+  // float32.
+  auto fallback =
+      [has_weight, eps, out_type, s](const std::vector<array>& inputs) {
+        auto summed = add(inputs[0], inputs[2], s);
+        auto xf = astype(summed, float32, s);
+        auto out = multiply(
+            xf,
+            rsqrt(
+                add(mean(square(xf, s), -1, /* keepdims */ true, s),
+                    array(eps, float32),
+                    s),
+                s),
+            s);
+        out = astype(out, out_type, s);
+        if (has_weight) {
+          out = multiply(out, inputs[1], s);
+        }
+        return std::vector<array>{out, summed};
+      };
+
+  auto passed_weight =
+      (has_weight) ? astype(*weight, out_type, s) : array(1, out_type);
+
+  if (!RMSNorm::use_fallback(s, /* has_residual */ true)) {
+    return array::make_arrays(
+        {x.shape(), x.shape()},
+        {out_type, out_type},
+        std::make_shared<RMSNorm>(s, fallback, eps),
+        {astype(x, out_type, s),
+         passed_weight,
+         astype(*residual, out_type, s)});
+  }
+  return fallback({x, passed_weight, *residual});
+}
+
 std::vector<array> RMSNorm::vjp(
     const std::vector<array>& primals,
     const std::vector<array>& cotangents,
     const std::vector<int>& argnums,
     const std::vector<array>& outputs) {
-  assert(primals.size() == 2);
-  assert(outputs.size() == 1);
-  assert(cotangents.size() == 1);
+  bool has_residual = primals.size() == 3;
+  assert(primals.size() == 2 || has_residual);
+  assert(outputs.size() == (has_residual ? 2 : 1));
+  assert(cotangents.size() == outputs.size());
 
   auto s = stream();
   auto fallback = [eps = eps_, s](const std::vector<array>& inputs) {
@@ -162,6 +248,25 @@ std::vector<array> RMSNorm::vjp(
 
     return vjps;
   };
+
+  if (has_residual) {
+    // The forward is out = rms_norm(summed) * w, out_sum = summed with
+    // summed = x + residual. The gradient w.r.t. both x and residual is the
+    // norm's vjp w.r.t. summed plus the cotangent of the sum output.
+    auto vjps = array::make_arrays(
+        {primals[0].shape(), primals[1].shape()},
+        {primals[0].dtype(), primals[1].dtype()},
+        std::make_shared<RMSNormVJP>(s, fallback, eps_),
+        {outputs[1], primals[1], cotangents[0]});
+    auto gx = add(vjps[0], cotangents[1], s);
+    std::vector<array> all_vjps{gx, vjps[1], gx};
+
+    std::vector<array> returned_vjps;
+    for (auto& arg : argnums) {
+      returned_vjps.push_back(all_vjps[arg]);
+    }
+    return returned_vjps;
+  }
 
   auto vjps = array::make_arrays(
       {primals[0].shape(), primals[1].shape()},

--- a/mlx/fast.h
+++ b/mlx/fast.h
@@ -17,6 +17,15 @@ MLX_API array rms_norm(
     float eps,
     StreamOrDevice s = {});
 
+/** Fused residual add + RMS norm: returns {rms_norm(x + residual) * weight,
+ * x + residual}. Without a residual this is equivalent to the above. */
+MLX_API std::vector<array> rms_norm(
+    const array& x,
+    const std::optional<array>& weight,
+    const std::optional<array>& residual,
+    float eps,
+    StreamOrDevice s = {});
+
 MLX_API array layer_norm(
     const array& x,
     const std::optional<array>& weight,

--- a/mlx/fast_primitives.h
+++ b/mlx/fast_primitives.h
@@ -46,6 +46,9 @@ class RMSNorm : public Custom {
       : Custom(stream, std::move(fallback)), eps_(eps) {}
 
   static bool use_fallback(Stream stream);
+  // Whether the primitive falls back to composed ops when a residual input
+  // is provided. Backends without a fused kernel fall back.
+  static bool use_fallback(Stream stream, bool has_residual);
 
   void eval_cpu(const std::vector<array>& inputs, std::vector<array>& outputs)
       override {
@@ -62,7 +65,11 @@ class RMSNorm : public Custom {
 
   DEFINE_NAME(RMSNorm)
   bool is_equivalent(const Primitive& other) const override;
-  DEFINE_INPUT_OUTPUT_SHAPE()
+  // The primitive takes {x, w} or {x, w, residual} and produces one output
+  // per non-weight input, each with the shape of x.
+  std::vector<Shape> output_shapes(const std::vector<array>& inputs) override {
+    return std::vector<Shape>(inputs.size() - 1, inputs[0].shape());
+  }
 
   auto state() const {
     return std::make_pair(nullptr, eps_);

--- a/python/src/fast.cpp
+++ b/python/src/fast.cpp
@@ -120,14 +120,25 @@ void init_fast(nb::module_& parent_module) {
 
   m.def(
       "rms_norm",
-      &mx::fast::rms_norm,
+      [](const mx::array& x,
+         std::optional<mx::array> weight,
+         float eps,
+         const std::optional<mx::array>& residual,
+         mx::StreamOrDevice s) -> nb::object {
+        if (residual.has_value()) {
+          auto out = mx::fast::rms_norm(x, weight, residual, eps, s);
+          return nb::make_tuple(nb::cast(out[0]), nb::cast(out[1]));
+        }
+        return nb::cast(mx::fast::rms_norm(x, weight, eps, s));
+      },
       "x"_a,
       "weight"_a.none(),
       "eps"_a,
       nb::kw_only(),
+      "residual"_a = nb::none(),
       "stream"_a = nb::none(),
       nb::sig(
-          "def rms_norm(x: array, weight: array | None, eps: float, *, stream: StreamOrDevice = None) -> array"),
+          "def rms_norm(x: array, weight: array | None, eps: float, *, residual: array | None = None, stream: StreamOrDevice = None) -> array | tuple[array, array]"),
       R"pbdoc(
         Root Mean Square normalization (RMS norm).
 
@@ -139,9 +150,14 @@ void init_fast(nb::module_& parent_module) {
               The ``weight`` should be one-dimensional with the same size
               as the last axis of ``x``. If set to ``None`` then no scaling happens.
             eps (float): A small additive constant for numerical stability.
+            residual (array, optional): An optional residual to add to ``x``
+              before normalizing. When given, the normalized output and the sum
+              ``x + residual`` are computed with a single fused kernel.
 
         Returns:
-            array: The output array.
+            array or tuple(array, array): The normalized output, or when
+              ``residual`` is provided a tuple ``(normed, summed)`` with the
+              normalized output and the sum ``x + residual``.
       )pbdoc");
 
   m.def(

--- a/python/tests/test_fast.py
+++ b/python/tests/test_fast.py
@@ -525,6 +525,90 @@ class TestFast(mlx_tests.MLXTestCase):
         self.assertLess(mx.abs(gx1 - gx2).max(), 1e-5)
         self.assertLess(mx.abs(gw1 - gw2).max() / mx.abs(gw1).mean(), 1e-5)
 
+    def test_rms_norm_residual(self):
+        # Per dtype absolute tolerance. The fused kernel uses 16 reads per
+        # thread for axis sizes <= 3072 which regroups the fp32 reduction, so
+        # unlike plain rms_norm the output can differ from the composed ops by
+        # an ulp; the sum output is always exact.
+        tolerances = {mx.float32: 1e-6, mx.float16: 2e-3, mx.bfloat16: 2e-2}
+
+        eps = 1e-5
+        dimss = [31, 256, 512, 2560, 4099, 5120, 8192]
+        for dtype in [mx.float32, mx.float16, mx.bfloat16]:
+            for dims in dimss:
+                for shape in [(dims,), (1, 1, dims), (1, 8, dims), (4, 32, dims)]:
+                    x = mx.random.uniform(shape=shape).astype(dtype)
+                    r = mx.random.uniform(shape=shape).astype(dtype)
+                    weight = mx.random.uniform(shape=(dims,)).astype(dtype)
+                    for w in (weight, None):
+                        out, summed = mx.fast.rms_norm(x, w, eps, residual=r)
+                        expected_sum = x + r
+                        expected_out = mx.fast.rms_norm(expected_sum, w, eps)
+                        self.assertLess(
+                            mx.abs(out - expected_out).max(), tolerances[dtype]
+                        )
+                        # The sum output must be exact
+                        self.assertEqual(
+                            mx.abs(summed - expected_sum).max().item(), 0.0
+                        )
+
+        # Non-contiguous inputs
+        dims = 128
+        x = mx.random.uniform(shape=(4, 64, dims)).transpose(0, 2, 1)
+        r = mx.random.uniform(shape=(4, 64, dims)).transpose(0, 2, 1)
+        weight = mx.random.uniform(shape=(64,))
+        out, summed = mx.fast.rms_norm(x, weight, eps, residual=r)
+        expected_sum = x + r
+        expected_out = mx.fast.rms_norm(expected_sum, weight, eps)
+        self.assertLess(mx.abs(out - expected_out).max(), 1e-6)
+        self.assertEqual(mx.abs(summed - expected_sum).max().item(), 0.0)
+
+        # Shape mismatch raises
+        with self.assertRaises(ValueError):
+            x = mx.random.uniform(shape=(1, 5))
+            mx.fast.rms_norm(x, None, 1e-5, residual=mx.ones((1, 4)))
+
+        # vmap
+        x = mx.random.uniform(shape=(4, 256))
+        r = mx.random.uniform(shape=(4, 256))
+        weight = mx.random.uniform(shape=(256,))
+        vf = mx.vmap(lambda a, b: mx.fast.rms_norm(a, weight, eps, residual=b))
+        out, summed = vf(x, r)
+        self.assertLess(mx.abs(summed - (x + r)).max().item(), 1e-6)
+        self.assertLess(
+            mx.abs(out - mx.fast.rms_norm(x + r, weight, eps)).max(), 1e-6
+        )
+
+    def test_rms_norm_residual_grad(self):
+        eps = 1e-5
+
+        def f_comp(x, r, w, y, z):
+            s = x + r
+            return (mx.fast.rms_norm(s, w, eps) * y).sum() + (s * z).sum()
+
+        def f_fused(x, r, w, y, z):
+            out, s = mx.fast.rms_norm(x, w, eps, residual=r)
+            return (out * y).sum() + (s * z).sum()
+
+        for D in [256, 2560, 8192]:
+            x = mx.random.uniform(shape=(4, 32, D))
+            r = mx.random.uniform(shape=(4, 32, D))
+            w = mx.random.uniform(shape=(D,))
+            y = mx.random.uniform(shape=(4, 32, D))
+            z = mx.random.uniform(shape=(4, 32, D))
+            g_comp = mx.grad(f_comp, argnums=(0, 1, 2))(x, r, w, y, z)
+            g_fused = mx.grad(f_fused, argnums=(0, 1, 2))(x, r, w, y, z)
+            for gc, gf in zip(g_comp, g_fused):
+                self.assertLess(
+                    mx.abs(gc - gf).max() / mx.abs(gc).mean(), 1e-5
+                )
+            # Partial argnums
+            gr_comp = mx.grad(f_comp, argnums=(1,))(x, r, w, y, z)
+            gr_fused = mx.grad(f_fused, argnums=(1,))(x, r, w, y, z)
+            self.assertLess(
+                mx.abs(gr_comp - gr_fused).max() / mx.abs(gr_comp).mean(), 1e-5
+            )
+
     def test_layer_norm_dim_check(self):
         with self.assertRaises(ValueError):
             weight = mx.ones((129,))


### PR DESCRIPTION
Every decoder layer runs `h = x + sublayer_out; normed = rms_norm(h)` twice — two kernel launches and an extra full-width read/write of the stream per boundary (72 boundaries per token at 36 layers). This PR adds an optional `residual` argument to `mx.fast.rms_norm`:

```python
normed, h = mx.fast.rms_norm(x, weight, eps, residual=r)
# normed == rms_norm(x + r) * weight ; h == x + r
```

- `residual=None` (default) → unchanged behavior, single array out. Fully backward compatible.
- Metal: two fused kernels (register-cached single-row for H≤3072, looped for larger H) reusing the existing threadgroup reduction structure.
- VJP implemented (`RMSNormVJP` on the sum + add for the sum cotangent); verified against composed autograd (<1e-5 rel).
- CUDA/no-GPU: composed fallback (correct, unfused); a fused CUDA kernel is a straightforward follow-up.

### Numerics
`out_sum` bit-identical to `x + r`. `out` bit-identical for H>3072; ≤1 ulp (fp16/bf16) for H≤3072 (reduction regrouping; documented in tests). Model-level: Qwen3-8B logits **bit-identical** fused vs unfused.

### Benchmarks (M3 Ultra)
- Micro, GPU-bound shapes (4,512,H): 1.13–1.38x for H≥5120, all dtypes. Decode shapes (1,1)/(1,8) are submission-bound: parity to 1.14x.
- E2E decode (mlx_lm, Qwen3-8B-4bit with call sites adopted, interleaved A/B): this PR contributes ~+1.1–2.6% decode tok/s on top of the numbers below, more at longer context.
- Honest losses in micro at small-H batched cells (harness cross-iteration overlap artifacts; convert to wins in serialized dependent chains) are documented in the test comments.

### Tests
- `test_rms_norm_residual` / `test_rms_norm_residual_grad` added (54 dtype/shape configs); full `test_fast.py` 29/29 pass (standalone build, this branch).

### Companion adoption
An mlx-lm PR adopting `residual=` at decoder-layer boundaries (feature-detected so older mlx keeps working) will follow; it is deliberately held until this API lands in a release.
