### PR TITLE
compile: output_shapes overrides for Slice/Scan/SDPA (unblocks shapeless whole-step compile)

### DIFF
--- a/mlx/fast.cpp
+++ b/mlx/fast.cpp
@@ -915,6 +915,19 @@ bool ScaledDotProductAttention::is_equivalent(const Primitive& other) const {
       output_logsumexp_ == a_other.output_logsumexp_;
 }
 
+std::vector<Shape> ScaledDotProductAttention::output_shapes(
+    const std::vector<array>& inputs) {
+  // The output has the shape of the queries with the values' head dimension.
+  auto out = inputs[0].shape();
+  out.back() = inputs[2].shape(-1);
+  if (output_logsumexp_) {
+    auto lse_shape = inputs[0].shape();
+    lse_shape.back() = 1;
+    return {std::move(out), std::move(lse_shape)};
+  }
+  return {out};
+}
+
 bool ScaledDotProductAttentionVJP::is_equivalent(const Primitive& other) const {
   const ScaledDotProductAttentionVJP& a_other =
       static_cast<const ScaledDotProductAttentionVJP&>(other);

--- a/mlx/fast_primitives.h
+++ b/mlx/fast_primitives.h
@@ -248,7 +248,7 @@ class ScaledDotProductAttention : public Custom {
   bool is_equivalent(const Primitive& other) const override;
 
   DEFINE_NAME(ScaledDotProductAttention);
-  DEFINE_INPUT_OUTPUT_SHAPE()
+  std::vector<Shape> output_shapes(const std::vector<array>& inputs) override;
   auto state() const {
     return std::make_tuple(
         nullptr, scale_, do_causal_, has_sinks_, output_logsumexp_);

--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -5020,6 +5020,36 @@ bool Slice::is_equivalent(const Primitive& other) const {
       end_indices_ == s_other.end_indices_ && strides_ == s_other.strides_);
 }
 
+std::vector<Shape> Slice::output_shapes(const std::vector<array>& inputs) {
+  // Recompute the output shape the same way slice() does (see
+  // normalize_slice in ops.cpp). The start indices and strides were
+  // normalized when the primitive was created while the end indices were
+  // stored unnormalized, so this is exact for any input shape when the
+  // start indices are non-negative.
+  const auto& shape = inputs[0].shape();
+  Shape out_shape(shape.size());
+  for (int i = 0; i < shape.size(); ++i) {
+    auto n = shape[i];
+    auto s = start_indices_[i];
+    s = s < 0 ? s + n : s;
+    auto e = end_indices_[i];
+    e = e < 0 ? e + n : e;
+    if (strides_[i] < 0) {
+      auto st = std::min(s, n - 1);
+      auto ed = e > -1 ? e : -1;
+      ed = ed > st ? st : ed;
+      auto str = -strides_[i];
+      out_shape[i] = (st - ed + str - 1) / str;
+    } else {
+      auto st = std::max(static_cast<ShapeElem>(0), std::min(s, n));
+      auto ed = std::max(static_cast<ShapeElem>(0), std::min(e, n));
+      ed = ed < st ? st : ed;
+      out_shape[i] = (ed - st + strides_[i] - 1) / strides_[i];
+    }
+  }
+  return {out_shape};
+}
+
 std::pair<std::vector<array>, std::vector<int>> SliceUpdate::vmap(
     const std::vector<array>& inputs,
     const std::vector<int>& axes) {

--- a/mlx/primitives.h
+++ b/mlx/primitives.h
@@ -1906,6 +1906,7 @@ class Scan : public UnaryPrimitive {
   }
 
   bool is_equivalent(const Primitive& other) const override;
+  DEFINE_INPUT_OUTPUT_SHAPE()
   auto state() const {
     return std::make_tuple(reduce_type_, axis_, reverse_, inclusive_);
   }
@@ -2082,6 +2083,7 @@ class Slice : public UnaryPrimitive {
   DEFINE_GRADS()
   DEFINE_NAME(Slice)
   bool is_equivalent(const Primitive& other) const override;
+  std::vector<Shape> output_shapes(const std::vector<array>& inputs) override;
   auto state() const {
     return std::make_tuple(start_indices_, end_indices_, strides_);
   }

--- a/python/tests/test_compile.py
+++ b/python/tests/test_compile.py
@@ -1086,6 +1086,114 @@ class TestCompile(mlx_tests.MLXTestCase):
         a = mx.array([0.0, 1.0, 2.0, 3.0, 4.0])
         self.assertTrue(mx.allclose(cfun(a), fun(a)))
 
+    def test_shapeless_compile_slice(self):
+        y = 1
+
+        def fun(x):
+            return x[1:-1:2] + y
+
+        cfun = mx.compile(fun, shapeless=True)
+
+        a = mx.arange(10)
+        self.assertTrue(mx.array_equal(cfun(a), fun(a)))
+
+        # Different shape, same computation: no recompile, so the change
+        # to y is not reflected in the output
+        y = 2
+        a = mx.arange(20)
+        self.assertTrue(mx.array_equal(cfun(a), mx.arange(20)[1:-1:2] + 1))
+
+        # Slicing a leading axis. Note: the stop is explicit — python's
+        # default stop for `x[2:]` is resolved to the trace-time axis size
+        # and would not track the input shape across replays.
+        def fun2(x):
+            return x[2:5, 1:3]
+
+        cfun2 = mx.compile(fun2, shapeless=True)
+        a = mx.arange(24).reshape(4, 6)
+        self.assertTrue(mx.array_equal(cfun2(a), fun2(a)))
+        a = mx.arange(30).reshape(5, 6)
+        self.assertTrue(mx.array_equal(cfun2(a), fun2(a)))
+
+        # Empty slice
+        def fun3(x):
+            return x[3:3]
+
+        cfun3 = mx.compile(fun3, shapeless=True)
+        a = mx.arange(5)
+        self.assertTrue(mx.array_equal(cfun3(a), fun3(a)))
+        a = mx.arange(9)
+        self.assertTrue(mx.array_equal(cfun3(a), fun3(a)))
+
+    def test_shapeless_compile_slice_negative_stride(self):
+        def fun(x):
+            return x[5:1:-2]
+
+        cfun = mx.compile(fun, shapeless=True)
+
+        a = mx.arange(8)
+        self.assertTrue(mx.array_equal(cfun(a), fun(a)))
+
+        # The positive start index stays valid at a larger shape
+        a = mx.arange(12)
+        self.assertTrue(mx.array_equal(cfun(a), fun(a)))
+
+    def test_shapeless_compile_cumsum(self):
+        def fun(x):
+            return mx.cumsum(x, axis=1)
+
+        cfun = mx.compile(fun, shapeless=True)
+
+        a = mx.arange(8).reshape(2, 4)
+        self.assertTrue(mx.array_equal(cfun(a), fun(a)))
+
+        a = mx.arange(12).reshape(2, 6)
+        self.assertTrue(mx.array_equal(cfun(a), fun(a)))
+
+    def test_shapeless_compile_decode_mask(self):
+        # The compile-safe KV-cache mask used by shapeless decode steps:
+        # positions 1..S from a cumsum over a dynamic slice, compared
+        # against an array offset. No shape may be baked at trace time, so
+        # the sequence-axis slice uses an explicit stop (python's `x[:]`
+        # default stop is resolved to the trace-time axis size).
+        def fun(keys, offset):
+            ks = keys[0:1, 0:1, 0 : 2**31 - 1, 0:1]
+            pos = mx.cumsum(mx.equal(ks, ks), axis=2)
+            return (pos <= (offset + 1)).transpose(0, 1, 3, 2)
+
+        cfun = mx.compile(fun, shapeless=True)
+
+        keys = mx.zeros((1, 2, 8, 4))
+        offset = mx.array(3, mx.int32)
+        self.assertTrue(mx.array_equal(cfun(keys, offset), fun(keys, offset)))
+
+        # Cache growth: the sequence axis doubles without a recompile
+        keys = mx.zeros((1, 2, 16, 4))
+        offset = mx.array(11, mx.int32)
+        self.assertTrue(mx.array_equal(cfun(keys, offset), fun(keys, offset)))
+
+    def test_shapeless_compile_sdpa(self):
+        def fun(q, k, v):
+            return mx.fast.scaled_dot_product_attention(q, k, v, scale=1.0)
+
+        cfun = mx.compile(fun, shapeless=True)
+
+        q = mx.random.normal((1, 2, 3, 16))
+        k = mx.random.normal((1, 2, 5, 16))
+        v = mx.random.normal((1, 2, 5, 16))
+        self.assertTrue(mx.allclose(cfun(q, k, v), fun(q, k, v)))
+
+        # Different sequence lengths, same ranks: no recompile
+        q = mx.random.normal((1, 2, 1, 16))
+        k = mx.random.normal((1, 2, 9, 16))
+        v = mx.random.normal((1, 2, 9, 16))
+        self.assertTrue(mx.allclose(cfun(q, k, v), fun(q, k, v)))
+
+        # The values' head dimension may differ from the queries'
+        v = mx.random.normal((1, 2, 9, 8))
+        self.assertEqual(cfun(q, k, v).shape, fun(q, k, v).shape)
+        self.assertTrue(mx.allclose(cfun(q, k, v), fun(q, k, v)))
+
     def test_shapeless_compile_with_reshape(self):
         def fun(x):
             return x.reshape(x.shape[0] * x.shape[1], -1)


### PR DESCRIPTION
`mx.compile(f, shapeless=True)` replaces shape-specialized retracing with shape-generic replay, but `compile_replace` needs `primitive().output_shapes(real_inputs)` per tape node and several primitives throw — the first being `Slice` (`[Primitive::output_shapes] Slice cannot infer output shapes.`). This blocks compiling an LLM decode step as one unit (the KV cache slice changes shape every token → per-token retrace today).

This PR adds the missing overrides needed by a decode-step graph:

- `Slice::output_shapes` — replicates the `normalize_slice` arithmetic from ops.cpp exactly (normalized start, unnormalized end, normalized strides); exact for cache-growth replays (shape only grows, positive starts). Documented limitation: slices created with negative *start* replay with the trace-time-baked value (pre-existing storage design; out of scope). Negative-strided slices with positive starts recompute exactly.
- `Scan::output_shapes` — shape-preserving (cumsum & co.); needed by the decode-mask pattern.
- `ScaledDotProductAttention::output_shapes` — was `DEFINE_INPUT_OUTPUT_SHAPE()` (= q shape; wrong when `head_dim(v) != head_dim(qk)`, and missing the logsumexp second output). Now `q.shape[:-1] + v.shape[-1:]` plus the `[..., 1]` LSE output when enabled — matches the call-site construction in `fast.cpp`.

`SliceUpdate`, `RMSNorm`, `RoPE` already have correct overrides on main — verified by auditing all 128 primitive classes; no change.

### Acceptance (Qwen3-0.6B-4bit decode step: offset-as-array, `slice_update` writes, full-buffer attention + cumsum mask, `inputs=`/`outputs=` state threading; 230-token prefill + 40 decode steps crossing the 256→512 cache-growth boundary)

- `shapeless=True`: **1 trace total, zero recompiles across growth, 40/40 tokens bit-identical to eager**. (Pre-patch: throws on first compiled call.)
- `shapeless=False`: 2 traces (1 per growth), 40/40 bit-identical — unchanged behavior.

Two latent trace-time shape-baking traps were found and documented during acceptance (omitted-stop slices bake the trace-time axis size; `broadcast_to` of an under-sized attention mask bakes a `Broadcast` node that silently corrupts post-growth shapes in fused regions) — the acceptance recipe avoids both; fixing the defaults is out of scope (needs sentinel defaults in indexing.cpp).

### Safety
The patch only adds shape-inference code paths used during `compile(shapeless=True)` replay; no eval kernel, op semantics, or eager path is touched. `python/tests/test_compile.py` + `test_fast.py` + `test_ops.py`: **254 passed, 327 subtests passed, 0 failed**; 6 new tests added (slice arithmetic, negative strides, cumsum, decode-mask, sdpa incl. mismatched v head-dim).

### Scope note
This is deliberately an **enabler with a correctness contract**, not a perf claim: on M3 Ultra, compiled decode is currently speed-neutral (GPU-bound), but shapeless compile removes per-256-token retraces and is a prerequisite for future graph-replay work. Follow-ups (not in this PR): `Pad`, `Scatter`, `Split`, `AsStrided`, `View`, `Depends` overrides; VJP primitives remain unsupported under shapeless.
