### PR TITLE
fix: support 64-bit eye on GPU

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -408,6 +408,11 @@ array eye(int n, int m, int k, Dtype dtype, StreamOrDevice s /* = {} */) {
   if (n < 0 || m < 0) {
     throw std::invalid_argument("[eye] N and M must be positive integers.");
   }
+
+  if (dtype.size() == 8) {
+    return astype(eye(n, m, k, float32, s), dtype, s);
+  }
+
   array result = zeros({n, m}, dtype, s);
 
   if (n == 0 || m == 0) {

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -2931,6 +2931,10 @@ class TestOps(mlx_tests.MLXTestCase):
         # Test with negative k parameter
         self.assertCmpNumpy([5, 6], mx.eye, np.eye, k=-2)
 
+        # Test with 64 bit dtype
+        self.assertEqual(mx.eye(3, dtype=mx.int64).dtype, mx.int64)
+        self.assertEqual(mx.eye(3, dtype=mx.uint64).dtype, mx.uint64)
+
     def test_stack(self):
         a = mx.ones((2,))
         np_a = np.ones((2,))


### PR DESCRIPTION
## Proposed changes

Please include a description of the problem or feature this PR is addressing. If there is a corresponding issue, include the issue #.
This pull request updates the `eye` function to improve support for 64-bit data types and adds corresponding tests to ensure correct behavior. The main changes include handling for 64-bit integer types in the implementation and new test cases for these types.

### Enhanced dtype support:
* Updated the `eye` function in `mlx/ops.cpp` to handle 64-bit data types by constructing the eye matrix as `float32` and then converting it to the requested 64-bit type. This ensures compatibility with `int64` and `uint64` dtypes.

### Testing improvements:
* Added test cases in `python/tests/test_ops.py` to verify that `mx.eye` correctly returns arrays of `int64` and `uint64` dtypes.

closes #4300 
## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
