### PR TITLE
Fix int32 overflow in concatenate/repeat/kron

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -1330,7 +1330,6 @@ array concatenate(
   };
 
   auto shape = arrays[0].shape();
-  shape[ax] = 0;
   // Accumulate the concatenation axis in 64 bits so a total that does not fit
   // in a shape dimension is reported rather than silently wrapping.
   int64_t concat_size = 0;

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -1430,7 +1430,8 @@ array repeat(const array& arr, int repeats, int axis, StreamOrDevice s) {
 
   // Reshape back into a contiguous array where S_axis is now S_axis * repeats
   shape.erase(shape.begin() + axis + 1);
-  shape[axis] *= repeats;
+  shape[axis] =
+      safe_cast(static_cast<int64_t>(shape[axis]) * repeats, "repeat");
   out = reshape(out, shape, s);
 
   return out;
@@ -3688,11 +3689,13 @@ array kron(const array& a, const array& b, StreamOrDevice s /* = {} */) {
 
   for (int i = ndim - 1, j = a.ndim() - 1; j >= 0; j--, i--) {
     a_shape[2 * i] = a.shape(j);
-    out_shape[i] *= a.shape(j);
+    out_shape[i] =
+        safe_cast(static_cast<int64_t>(out_shape[i]) * a.shape(j), "kron");
   }
   for (int i = ndim - 1, j = b.ndim() - 1; j >= 0; j--, i--) {
     b_shape[2 * i + 1] = b.shape(j);
-    out_shape[i] *= b.shape(j);
+    out_shape[i] =
+        safe_cast(static_cast<int64_t>(out_shape[i]) * b.shape(j), "kron");
   }
 
   return reshape(

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -1331,6 +1331,9 @@ array concatenate(
 
   auto shape = arrays[0].shape();
   shape[ax] = 0;
+  // Accumulate the concatenation axis in 64 bits so a total that does not fit
+  // in a shape dimension is reported rather than silently wrapping.
+  int64_t concat_size = 0;
   // Make the output shape and validate that all arrays have the same shape
   // except for the concatenation axis.
   for (auto& a : arrays) {
@@ -1349,8 +1352,9 @@ array concatenate(
         throw_invalid_shapes();
       }
     }
-    shape[ax] += a.shape(ax);
+    concat_size += a.shape(ax);
   }
+  shape[ax] = safe_cast(concat_size, "concatenate");
 
   // Promote all the arrays to the same type
   auto dtype = result_type(arrays);

--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -1187,9 +1187,11 @@ bool Concatenate::is_equivalent(const Primitive& other) const {
 std::vector<Shape> Concatenate::output_shapes(
     const std::vector<array>& inputs) {
   auto shape = inputs[0].shape();
+  int64_t concat_size = shape[axis_];
   for (int i = 1; i < inputs.size(); ++i) {
-    shape[axis_] += inputs[i].shape(axis_);
+    concat_size += inputs[i].shape(axis_);
   }
+  shape[axis_] = safe_cast(concat_size, "concatenate");
   return {std::move(shape)};
 }
 

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -135,6 +135,18 @@ class TestOps(mlx_tests.MLXTestCase):
                 mx.concatenate([big] * parts)
             self.assertIn(str(2**30 * parts), str(cm.exception))
 
+        # repeat and kron multiply a dimension, and used to wrap into a
+        # negative or zero one that only surfaced later as a confusing reshape
+        # error naming a shape the caller never asked for.
+        for parts in (2, 3, 4):
+            with self.assertRaises(OverflowError) as cm:
+                mx.repeat(big, parts)
+            self.assertIn(str(2**30 * parts), str(cm.exception))
+
+        with self.assertRaises(OverflowError) as cm:
+            mx.kron(mx.zeros(2**16), mx.zeros(2**16))
+        self.assertIn(str(2**32), str(cm.exception))
+
         # Negative overflow (< int32 min) is caught too.
         too_negative = -(2**31) - 1
         with self.assertRaises(OverflowError) as cm:

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -126,6 +126,15 @@ class TestOps(mlx_tests.MLXTestCase):
             mx.broadcast_to(a, [too_big, 1])
         self.assertIn(str(too_big), str(cm.exception))
 
+        # A concatenation axis that does not fit is computed rather than given,
+        # so it has to be reported instead of wrapping into a bogus dimension.
+        # These stay lazy, so nothing near this size is allocated.
+        big = mx.zeros(2**30)
+        for parts in (3, 4, 5):
+            with self.assertRaises(OverflowError) as cm:
+                mx.concatenate([big] * parts)
+            self.assertIn(str(2**30 * parts), str(cm.exception))
+
         # Negative overflow (< int32 min) is caught too.
         too_negative = -(2**31) - 1
         with self.assertRaises(OverflowError) as cm:


### PR DESCRIPTION
Three ops compute an output dimension by adding or multiplying existing ones, and all three wrap when the result does not fit in a shape dimension.

`concatenate` is the bad one, because it returns an array and says nothing:

```python
>>> big = mx.zeros(2**30)
>>> mx.concatenate([big] * 4).shape
(0,)
>>> mx.concatenate([big] * 3).shape
(-1073741824,)
>>> mx.concatenate([big] * 5).shape
(1073741824,)
```

A negative dimension is the worst of those. The array is lazy, so nothing is allocated and nothing complains until something downstream trips over the shape.

`repeat` and `kron` wrap the same way, but the wrapped value happens to reach `reshape`, which rejects it with a message naming a shape the caller never asked for:

```python
>>> mx.repeat(big, 4)
ValueError: [reshape] Cannot reshape array of size 4294967296 into shape (0).
>>> mx.kron(mx.zeros(2**16), mx.zeros(2**16))
ValueError: [reshape] Cannot reshape array of size 4294967296 into shape (0).
```

The arithmetic is all on `ShapeElem`, which is `int32_t`:

```cpp
shape[ax] += a.shape(ax);   // concatenate, ops.cpp
shape[axis] *= repeats;     // repeat, ops.cpp
out_shape[i] *= a.shape(j); // kron, ops.cpp
```

Neighbouring ops already guard exactly this. `tile` does `safe_cast(static_cast<int64_t>(reps[i]) * shape[i], "tile")`, and `pad`, `flatten` and `reshape` do the same, which is why `mx.tile(big, 4)` reports cleanly while `mx.repeat(big, 4)` does not. These three were just missed.

Each now accumulates in `int64_t` and goes through `safe_cast`, so they report instead of wrapping:

```
OverflowError: [concatenate] Shape dimension 4294967296 is outside the supported range [-2147483648, 2147483647]. MLX currently uses 32-bit integers for shape dimensions.
OverflowError: [repeat] Shape dimension 4294967296 is outside the supported range ...
OverflowError: [kron] Shape dimension 4294967296 is outside the supported range ...
```

`Concatenate::output_shapes` in `mlx/primitives.cpp` had the identical accumulation and is fixed the same way, so the shapeless and vmap paths agree with the eager one.

Totals that do fit are untouched. The added cases fail on main with `AssertionError: OverflowError not raised` for `concatenate`, and with the misleading reshape `ValueError` for `repeat` and `kron`. Everything stays lazy, so the test allocates nothing near these sizes.

`test_ops.py`, `test_array.py`, `test_compile.py`, `test_vmap.py`, `test_autograd.py`, `test_nn.py`, `test_reduce.py` and the C++ suite (250 cases, 3351 assertions) pass.

I am a freshman working through this codebase and I leaned on Claude Code while doing it. Every output above came from a run on this machine.
