### PR TITLE
Stop an out of range optional shape from aborting the process

### DIFF
--- a/python/src/small_vector.h
+++ b/python/src/small_vector.h
@@ -9,7 +9,10 @@
 
 #include "mlx/small_vector.h"
 
+#include <optional>
+
 #include <nanobind/stl/detail/nb_list.h>
+#include <nanobind/stl/detail/nb_optional.h>
 
 NAMESPACE_BEGIN(NB_NAMESPACE)
 NAMESPACE_BEGIN(detail)
@@ -102,6 +105,32 @@ struct type_caster<::mlx::core::SmallVector<Type, Size, Alloc>> {
     }
 
     return ret.release();
+  }
+};
+
+// nanobind's optional caster is noexcept, so the OverflowError the caster above
+// raises for an out of range dimension would terminate the process instead of
+// reaching the dispatcher. Forward to the same caster from a context that is
+// allowed to throw, so an optional shape reports the error like a plain one.
+template <typename Type, size_t Size, typename Alloc>
+struct type_caster<std::optional<::mlx::core::SmallVector<Type, Size, Alloc>>>
+    : optional_caster<
+          std::optional<::mlx::core::SmallVector<Type, Size, Alloc>>> {
+  using List = ::mlx::core::SmallVector<Type, Size, Alloc>;
+
+  bool from_python(handle src, uint8_t flags, cleanup_list* cleanup) {
+    if (src.is_none()) {
+      this->value.reset();
+      return true;
+    }
+    make_caster<List> caster;
+    if (!caster.from_python(
+            src, flags_for_local_caster<List>(flags), cleanup) ||
+        !caster.template can_cast<List>()) {
+      return false;
+    }
+    this->value.emplace(caster.operator cast_t<List>());
+    return true;
   }
 };
 

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -126,6 +126,21 @@ class TestOps(mlx_tests.MLXTestCase):
             mx.broadcast_to(a, [too_big, 1])
         self.assertIn(str(too_big), str(cm.exception))
 
+        # Ops that take the shape as an optional go through nanobind's
+        # optional caster, which is noexcept, so the overflow used to abort the
+        # process instead of raising. See issue #2681 for the original report.
+        with self.assertRaises(OverflowError) as cm:
+            mx.as_strided(a, [too_big], [0])
+        self.assertIn(str(too_big), str(cm.exception))
+
+        with self.assertRaises(OverflowError) as cm:
+            mx.fft.fftn(a, s=[too_big], axes=[0])
+        self.assertIn(str(too_big), str(cm.exception))
+
+        with self.assertRaises(OverflowError) as cm:
+            mx.random.bernoulli(0.5, [too_big])
+        self.assertIn(str(too_big), str(cm.exception))
+
         # Negative overflow (< int32 min) is caught too.
         too_negative = -(2**31) - 1
         with self.assertRaises(OverflowError) as cm:


### PR DESCRIPTION
A shape dimension that does not fit in `int32` kills the interpreter instead of raising, whenever the op takes the shape as an optional:

```
$ python -c "import mlx.core as mx; mx.as_strided(mx.zeros(4), (2**31,), (0,))"
libc++abi: terminating due to uncaught exception of type nanobind::python_error:
OverflowError: Integer value 2147483648 is outside the supported range [-2147483648, 2147483647].
Abort trap: 6
```

Exit code 134. It cannot be caught, so a `try`/`except OverflowError` around it does not help.

The same call with the shape as a plain parameter is fine, which is what makes this easy to miss:

```python
>>> mx.zeros((2**31,))          # OverflowError, as intended
>>> mx.reshape(a, (2**31,))     # OverflowError
>>> mx.random.uniform(0, 1, (2**31,))   # OverflowError, shape is mx::Shape
>>> mx.random.bernoulli(0.5, (2**31,))  # abort, shape is std::optional<mx::Shape>
```

The caster added for #2681 raises on overflow, and the comment on it says so:

```cpp
// Not noexcept: on overflow of a narrow integer element we raise
// OverflowError so nanobind surfaces a clean error to the user.
bool from_python(handle src, uint8_t flags, cleanup_list* cleanup) {
```

That holds when nanobind calls the caster for the parameter directly. It does not hold through `std::optional`, because nanobind's `optional_caster::from_python` is declared `noexcept` (`nanobind/stl/detail/nb_optional.h`), so the raise crosses a `noexcept` boundary and calls `std::terminate`.

Affected today: `mx.as_strided` (the `shape` argument), every `mx.fft.*` taking `s`, and `mx.random.bernoulli`. `as_strided`'s `strides` is a `Strides`, whose element type is already 64 bit, so it does not go through the narrow integer path and does not abort.

This adds an optional caster for the same container that forwards to the existing one from a context that is allowed to throw, so an optional shape now reports exactly what a plain one does:

```
OverflowError: Integer value 2147483648 is outside the supported range [-2147483648, 2147483647].
```

I kept the raise rather than switching the caster to return `false`, since returning `false` would fall back to nanobind's generic "incompatible function arguments" `TypeError` and lose the message that #2681 asked for.

Checked that ordinary use of all three is unchanged: `as_strided` with no shape, with a shape, and with both; `fft.fftn` with and without `s`; `fft2`, `rfftn`, `irfftn`; `bernoulli` with and without a shape. The added cases abort the interpreter on main, so the proof is the exit code: `EXIT=134` before, `OK` after.

`test_ops.py`, `test_fft.py`, `test_random.py`, `test_array.py`, `test_compile.py`, `test_vmap.py`, `test_autograd.py`, `test_nn.py` and `test_linalg.py` pass.

I am a freshman finding my way around this codebase, with Claude Code alongside. Everything quoted here is from a run on this machine.
