### PR TITLE
Widen list elements that do not fit in int32 to int64

### DIFF
--- a/python/src/convert.cpp
+++ b/python/src/convert.cpp
@@ -505,7 +505,8 @@ PyScalarT validate_shape(
     T list,
     const mx::Shape& shape,
     int idx,
-    bool& all_python_primitive_elements) {
+    bool& all_python_primitive_elements,
+    bool& has_wide_int) {
   if (idx >= shape.size()) {
     throw std::invalid_argument("Initialization encountered extra dimension.");
   }
@@ -524,13 +525,18 @@ PyScalarT validate_shape(
     PyScalarT t;
     if (nb::isinstance<nb::list>(l)) {
       t = validate_shape(
-          nb::cast<nb::list>(l), shape, idx + 1, all_python_primitive_elements);
+          nb::cast<nb::list>(l),
+          shape,
+          idx + 1,
+          all_python_primitive_elements,
+          has_wide_int);
     } else if (nb::isinstance<nb::tuple>(*list.begin())) {
       t = validate_shape(
           nb::cast<nb::tuple>(l),
           shape,
           idx + 1,
-          all_python_primitive_elements);
+          all_python_primitive_elements,
+          has_wide_int);
     } else if (nb::isinstance<mx::array>(l)) {
       all_python_primitive_elements = false;
       auto arr = nb::cast<mx::array>(l);
@@ -549,6 +555,13 @@ PyScalarT validate_shape(
         t = pybool;
       } else if (nb::isinstance<nb::int_>(l)) {
         t = pyint;
+        // Match the scalar path, which widens to int64 rather than failing
+        // when a python int does not fit in int32.
+        auto val = nb::cast<int64_t>(l);
+        if (val > std::numeric_limits<int>::max() ||
+            val < std::numeric_limits<int>::min()) {
+          has_wide_int = true;
+        }
       } else if (nb::isinstance<nb::float_>(l)) {
         t = pyfloat;
       } else if (PyComplex_Check(l.ptr())) {
@@ -594,7 +607,8 @@ mx::array array_from_list_impl(
     T pl,
     const PyScalarT& inferred_type,
     std::optional<mx::Dtype> specified_type,
-    const mx::Shape& shape) {
+    const mx::Shape& shape,
+    bool has_wide_int) {
   // Make the array
   switch (inferred_type) {
     case pybool: {
@@ -603,7 +617,8 @@ mx::array array_from_list_impl(
       return mx::array(vals.begin(), shape, specified_type.value_or(mx::bool_));
     }
     case pyint: {
-      auto dtype = specified_type.value_or(mx::int32);
+      auto dtype =
+          specified_type.value_or(has_wide_int ? mx::int64 : mx::int32);
       if (dtype == mx::int64) {
         std::vector<int64_t> vals;
         fill_vector(pl, vals);
@@ -663,11 +678,13 @@ mx::array array_from_list_impl(T pl, std::optional<mx::Dtype> dtype) {
 
   // Validate the shape and type
   bool all_python_primitive_elements = true;
-  auto type = validate_shape(pl, shape, 0, all_python_primitive_elements);
+  bool has_wide_int = false;
+  auto type =
+      validate_shape(pl, shape, 0, all_python_primitive_elements, has_wide_int);
 
   if (all_python_primitive_elements) {
     // `pl` does not contain mlx arrays
-    return array_from_list_impl(pl, type, dtype, shape);
+    return array_from_list_impl(pl, type, dtype, shape, has_wide_int);
   }
 
   // `pl` contains mlx arrays

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -523,6 +523,33 @@ class TestArray(mlx_tests.MLXTestCase):
         out = mx.array([x], dtype=mx.float64).item()
         self.assertEqual(out, x)
 
+    def test_construction_from_lists_wide_ints(self):
+        # A python int that does not fit in int32 widens to int64, the same
+        # rule the scalar path already uses. It used to raise std::bad_cast.
+        for value in (2**31, 2**40, -(2**31) - 1, -(2**40)):
+            for make in (
+                lambda v: [v],
+                lambda v: (v,),
+                lambda v: [[v]],
+                lambda v: [v, 1],
+            ):
+                x = mx.array(make(value))
+                self.assertEqual(x.dtype, mx.int64, msg=f"{value} {make(value)}")
+                self.assertEqual(x.flatten()[0].item(), value)
+                self.assertEqual(mx.array(value).dtype, mx.int64)
+
+        # Values that still fit keep int32, including both boundaries.
+        for value in (0, 1, 2**31 - 1, -(2**31)):
+            x = mx.array([value])
+            self.assertEqual(x.dtype, mx.int32, msg=str(value))
+            self.assertEqual(x[0].item(), value)
+
+        # An explicit dtype still wins.
+        self.assertEqual(mx.array([2**40], mx.int64).dtype, mx.int64)
+        self.assertEqual(mx.array([1, 2], mx.int64).dtype, mx.int64)
+        # A float in the list still makes it float, not int64.
+        self.assertEqual(mx.array([2**40, 1.5]).dtype, mx.float32)
+
     def test_construction_from_lists_of_mlx_arrays(self):
         dtypes = [
             mx.bool_,


### PR DESCRIPTION
`mx.array` infers `int64` for a python int that does not fit in `int32`, but only when it is passed on its own. The same value inside a list fails with a raw C++ error:

```python
>>> mx.array(2**40)
array(1099511627776, dtype=int64)
>>> mx.array([2**40])
RuntimeError: std::bad_cast
>>> mx.array([1, 2**40])
RuntimeError: std::bad_cast
>>> mx.array([2**31])
RuntimeError: std::bad_cast
```

Anything above `INT32_MAX` or below `INT32_MIN` hits it, in a list, a tuple or nested. numpy gives `int64` for all of these.

The scalar path in `convert.cpp` already has the rule:

```cpp
} else if (nb::isinstance<nb::int_>(v)) {
  auto val = nb::cast<int64_t>(v);
  auto default_type = (val > std::numeric_limits<int>::max() ||
                       val < std::numeric_limits<int>::min())
      ? mx::int64
      : mx::int32;
```

The list path does not. `validate_shape` only records the python type category, so every int list infers `int32`, and `array_from_list_impl` then fills a `std::vector<int>`, where `nb::cast<int>` on an out of range value throws `std::bad_cast`. That exception has nothing to do with the actual problem, which is why the message is unhelpable.

This tracks whether any element is out of `int32` range while the shape is being validated, and uses `int64` as the default when one is, so the list path lands on the same dtype the scalar path already picks.

Boundaries are exact, and lists that fit are untouched:

```
[2**31 - 1]      int32        [2**31]         int64
[-(2**31)]       int32        [-(2**31) - 1]  int64
[1, 2, 3]        int32        [2**40, 1]      int64
```

An explicit dtype still wins, and a float anywhere in the list still makes the result float rather than `int64`.

Deliberately left alone, since both are the same on the scalar path and so are not this inconsistency: `mx.array([2**63])` still fails, because the value does not fit `int64` either, and `mx.array([2**40], mx.int32)` still fails, because that is an explicit request rather than inference.

`test_array.py`, `test_ops.py`, `test_autograd.py`, `test_compile.py`, `test_vmap.py`, `test_nn.py` and `test_random.py` pass. The added test errors on main with `std::bad_cast`.

I am a freshman learning my way around this codebase, using Claude Code as I go. Every result quoted here came from a run here.
