### PR TITLE
Select diag's diagonal out of a broadcast for 8-byte types

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -6362,9 +6362,26 @@ array diag(const array& a, int k /* = 0 */, StreamOrDevice s /* = {} */) {
       return res;
     }
 
-    std::vector<array> indices;
     auto s1 = std::max(0, -k);
     auto s2 = std::max(0, k);
+
+    if (size_of(a.dtype()) == 8) {
+      // The Metal scatter has no 8-byte output path, so placing the values
+      // with one refuses int64, uint64 and complex64. eye can sidestep that by
+      // building in a narrower type and casting, because the only values it
+      // writes are 0 and 1. These are the caller's values, and an int64 past
+      // float32's exact range would come back changed, so instead of casting
+      // the diagonal is selected out of a broadcast, which never leaves the
+      // dtype. Only the types that currently throw take this path.
+      auto vals =
+          pad(a, {s1, n - s1 - a_size}, array(0, a.dtype()), "constant", s);
+      auto rows = expand_dims(arange(n, s), 1, s);
+      auto cols = expand_dims(arange(n, s), 0, s);
+      auto on_diagonal = equal(cols, add(rows, array(k), s), s);
+      return where(on_diagonal, expand_dims(vals, 1, s), res, s);
+    }
+
+    std::vector<array> indices;
     indices.push_back(arange(s1, a_size + s1, uint32, s));
     indices.push_back(arange(s2, a_size + s2, uint32, s));
 

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -2931,6 +2931,31 @@ class TestOps(mlx_tests.MLXTestCase):
         # Test with negative k parameter
         self.assertCmpNumpy([5, 6], mx.eye, np.eye, k=-2)
 
+    def test_diag_8_byte_dtypes(self):
+        # diag places its values with a scatter, and the Metal scatter has no
+        # 8-byte output path, so a 1-D int64, uint64 or complex64 input failed
+        # on the GPU while working on the CPU.
+        for dtype, np_dtype in (
+            (mx.int64, np.int64),
+            (mx.uint64, np.uint64),
+            (mx.complex64, np.complex64),
+        ):
+            for k in (0, 2, -3):
+                vals = np.array([1, 2, 3], dtype=np_dtype)
+                out = mx.diag(mx.array(vals, dtype=dtype), k)
+                self.assertEqual(out.dtype, dtype)
+                self.assertTrue(np.array_equal(np.array(out), np.diag(vals, k)))
+
+        # These values are not representable in float32, so a fix that built
+        # the diagonal in a narrower type and cast would return them changed.
+        big = np.array([(1 << 53) + 1, (1 << 62) - 1], dtype=np.int64)
+        out = mx.diag(mx.array(big, dtype=mx.int64))
+        self.assertTrue(np.array_equal(np.array(out).diagonal(), big))
+
+        top = np.array([(1 << 64) - 1, (1 << 63) + 5], dtype=np.uint64)
+        out = mx.diag(mx.array(top, dtype=mx.uint64))
+        self.assertTrue(np.array_equal(np.array(out).diagonal(), top))
+
     def test_stack(self):
         a = mx.ones((2,))
         np_a = np.ones((2,))


### PR DESCRIPTION
Fixes #4308.

`diag` places a 1-D input on the diagonal with a `scatter`, and `Scatter::eval_gpu` refuses
any 8-byte output that is not a `complex64` sum, so `int64`, `uint64` and `complex64` fail
on the GPU and work on the CPU.

`eye` reached the same guard and #4301 fixes it by building in a narrower type and casting.
That works there because the only values `eye` writes are 0 and 1, exact in every type it
can return. It does not work here: these are the caller's values, and float32 has 24 bits
of mantissa.

```
in                  9007199254740993   4611686018427387903
via float32         9007199254740992   4611686018427387904
```

So the 8-byte types select the diagonal out of a broadcast rather than scattering into it,
which never leaves the dtype. Only those three take that path: the mask is an n x n
allocation the scatter does not need, and there is no reason to spend it on the types that
already work.

### Verified

M5 Max, cpu and gpu streams. 180 cases over int64, uint64, complex64, int32, float32 and
uint8, offsets -3 to 2, and lengths 1, 3 and 6, values checked against numpy: all pass.
`2^53 + 1`, `2^62 - 1` and `2^64 - 1` round trip exactly, which is the case a cast would
have changed. The empty input and the 2-D extraction path are unchanged.

`test_ops`, `test_autograd` and `test_array` pass. Fork CI green on all 22 jobs, including
metal and jit on macOS 14, 15 and 26.2, and the cuda 12.6, 12.9 and 13.0 legs.
