### PR TITLE
Support assigning through a bare Ellipsis index

### DIFF
--- a/python/src/indexing.cpp
+++ b/python/src/indexing.cpp
@@ -778,6 +778,8 @@ mlx_compute_scatter_args(
     return mlx_scatter_args_int(src, obj, vals);
   } else if (nb::isinstance<nb::tuple>(obj)) {
     return mlx_scatter_args_nd(src, nb::cast<nb::tuple>(obj), vals);
+  } else if (nb::isinstance<nb::ellipsis>(obj)) {
+    return {{}, broadcast_to(vals, src.shape()), {}};
   } else if (obj.is_none()) {
     return {{}, broadcast_to(vals, src.shape()), {}};
   } else if (nb::isinstance<nb::list>(obj)) {

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -1243,6 +1243,28 @@ class TestArray(mlx_tests.MLXTestCase):
         a[0:2] = 3
         self.assertEqual(a.tolist(), [3, 3, 1])
 
+        # Assigning through a bare Ellipsis, like a[:] and a[None]
+        e = mx.zeros((2, 3), mx.int32)
+        e[...] = 5
+        self.assertEqual(e.tolist(), [[5, 5, 5], [5, 5, 5]])
+
+        # Broadcasting an array update through Ellipsis
+        e[...] = mx.array([1, 2, 3])
+        self.assertEqual(e.tolist(), [[1, 2, 3], [1, 2, 3]])
+
+        e[...] = mx.zeros((2, 3), mx.int32)
+        self.assertEqual(e.tolist(), [[0, 0, 0], [0, 0, 0]])
+
+        # Scalar array
+        e = mx.array(0)
+        e[...] = 7
+        self.assertEqual(e.item(), 7)
+
+        # Shapes that cannot broadcast are still rejected
+        e = mx.zeros((2, 3), mx.int32)
+        with self.assertRaises(ValueError):
+            e[...] = mx.array([1, 2])
+
         a[0:3] = 4
         self.assertEqual(a.tolist(), [4, 4, 4])
 


### PR DESCRIPTION
Fixes #4313.

### Proposed changes

`mlx_get_item` handles a bare `Ellipsis`:

```cpp
} else if (nb::isinstance<nb::ellipsis>(obj)) {
    return src;
```

`mlx_compute_scatter_args` had no matching branch, so the object fell through the slice / array / int / tuple / None / list cases to the final `throw`. Reads worked, assignment did not:

```python
a = mx.zeros((2, 3))
a[...]        # fine
a[...] = 5    # ValueError: Cannot index mlx array using the given type.
```

Only the bare form was affected. `a[..., 0] = v`, `a[0, ...] = v` and `a[..., :] = v` all go through `mlx_scatter_args_nd` and already worked, as do `a[:] = v` and `a[None] = v`. That asymmetry, plus `docs/src/usage/indexing.rst` saying the `...` syntax "works as in NumPy" and listing only two deviations (no bounds checking, boolean-mask assignment only), is why I read this as an omission rather than an intended restriction.

This handles `Ellipsis` the same way `None` is handled, broadcasting the update to the full shape. The slice-update fast path already declines anything that is not a slice, tuple or int, so a bare ellipsis routes here as before.

Updates that cannot broadcast still raise:

```python
a = mx.zeros((2, 3))
a[...] = mx.array([1, 2])   # ValueError, unchanged
```

### Tests

Extended `test_setitem` in `python/tests/test_array.py` with the bare-Ellipsis form: scalar fill, broadcasting an array update, assigning a full-shape array, a 0-d array target, and the non-broadcastable case still raising. Existing coverage only exercised `Ellipsis` inside a tuple via `check_slices` and a bare `[...]` read, which is how the gap survived.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (not needed, this restores documented NumPy parity)
- [x] I have run `pre-commit run --all-files` to format my code and installed pre-commit prior to committing changes

Verified with a CPU-only build (`-DMLX_BUILD_METAL=OFF`):

- C++ suite: 247 test cases, 3326 assertions, all pass
- Python: `test_array`, `test_ops`, `test_autograd`, `test_vmap`, `test_einsum`, `test_linalg`, `test_blas`, `test_nn`, `test_reduce` (463 tests) pass
