### PR TITLE
Deduplicate fftshift and ifftshift

### DIFF
--- a/mlx/fft.cpp
+++ b/mlx/fft.cpp
@@ -240,10 +240,16 @@ array irfftn(
   return fft_impl(a, true, true, norm, s);
 }
 
-array fftshift(
+namespace {
+
+// Shared implementation for fftshift/ifftshift: validates axes and computes
+// the per-axis roll amount, differing only in shift sign and error prefix.
+array fftshift_impl(
+    const char* name,
     const array& a,
     const std::vector<int>& axes,
-    StreamOrDevice s /* = {} */) {
+    bool inverse,
+    StreamOrDevice s) {
   if (axes.empty()) {
     return a;
   }
@@ -254,41 +260,32 @@ array fftshift(
     int axis = ax < 0 ? ax + a.ndim() : ax;
     if (axis < 0 || axis >= a.ndim()) {
       std::ostringstream msg;
-      msg << "[fftshift] Invalid axis " << ax << " for array with " << a.ndim()
-          << " dimensions.";
+      msg << "[" << name << "] Invalid axis " << ax << " for array with "
+          << a.ndim() << " dimensions.";
       throw std::invalid_argument(msg.str());
     }
     // Match NumPy's implementation
-    shifts.push_back(a.shape(axis) / 2);
+    int shift = a.shape(axis) / 2;
+    shifts.push_back(inverse ? -shift : shift);
   }
 
   return roll(a, shifts, axes, s);
+}
+
+} // namespace
+
+array fftshift(
+    const array& a,
+    const std::vector<int>& axes,
+    StreamOrDevice s /* = {} */) {
+  return fftshift_impl("fftshift", a, axes, false, s);
 }
 
 array ifftshift(
     const array& a,
     const std::vector<int>& axes,
     StreamOrDevice s /* = {} */) {
-  if (axes.empty()) {
-    return a;
-  }
-
-  Shape shifts;
-  for (int ax : axes) {
-    // Convert negative axes to positive
-    int axis = ax < 0 ? ax + a.ndim() : ax;
-    if (axis < 0 || axis >= a.ndim()) {
-      std::ostringstream msg;
-      msg << "[ifftshift] Invalid axis " << ax << " for array with " << a.ndim()
-          << " dimensions.";
-      throw std::invalid_argument(msg.str());
-    }
-    // Match NumPy's implementation
-    int size = a.shape(axis);
-    shifts.push_back(-(size / 2));
-  }
-
-  return roll(a, shifts, axes, s);
+  return fftshift_impl("ifftshift", a, axes, true, s);
 }
 
 // Default versions that operate on all axes


### PR DESCRIPTION
### Proposed changes

Pure refactor, no behaviour change.

`fftshift` and `ifftshift` in `mlx/fft.cpp` were near-identical. Both early-return on empty axes, normalize and validate each axis identically, and roll by `shape(axis) / 2`. The only two differences were the sign of the shift and the name in the error message.

This factors the shared body into a file-local `fftshift_impl(name, a, axes, inverse, s)` and leaves the two public entry points as one-line wrappers. Net −25/+22.

Equivalence, stated precisely so it is easy to check:

- shift magnitude is still `a.shape(axis) / 2`, computed with the same integer truncation, so odd sizes behave as before
- `ifftshift` still negates it — previously `-(size / 2)`, now `inverse ? -shift : shift` where `shift = size / 2`, which is the same value
- the empty-axes early return is preserved
- the negative-axis normalization and bounds check are unchanged
- error strings are unchanged: `[fftshift] Invalid axis ...` and `[ifftshift] Invalid axis ...` are produced via the `name` parameter

### Tests

No test changes. That is deliberate — the point of a pure refactor is that the existing suite proves equivalence. Current coverage already exercises both functions across default axes, a single int axis, axis lists, negative axes, odd sizes and complex input, and `test_fftshift_errors` asserts the error messages, which is what pins the parameterized prefix.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have added tests that prove my fix is effective or that my feature works (no new tests — behaviour is unchanged and existing tests cover both functions)
- [ ] I have updated the necessary documentation (not needed, no API change)
- [x] I have run `pre-commit run --all-files` to format my code and installed pre-commit prior to committing changes

Verified with a CPU-only build (`-DMLX_BUILD_METAL=OFF`):

- C++ suite: 247 test cases, 3326 assertions, all pass
- Python: `test_fft`, `test_ops`, `test_array`, `test_autograd`, `test_vmap`, `test_einsum`, `test_linalg`, `test_blas`, `test_nn`, `test_reduce` (480 tests) pass

Happy to close this if you would rather not take churn in `fft.cpp` — it is cleanup rather than a fix, and I would rather ask than assume.
