### PR TITLE
Add workflow to update pull request limit bypass list

### DIFF
--- a/.github/scripts/find-eligible-contributors.js
+++ b/.github/scripts/find-eligible-contributors.js
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+
+/**
+ * find-eligible-contributors.js
+ *
+ * Finds users who have opened pull requests on a GitHub repo,
+ * are NOT collaborators on that repo, and match:
+ *   - fewer than 5 currently open PRs
+ *   - more than 2 merged PRs
+ *   - merge rate (merged / closed) > 50%
+ *
+ * Usage:
+ *   GITHUB_TOKEN=xxxx node find-eligible-contributors.js <owner> <repo>
+ */
+
+const GITHUB_API = 'https://api.github.com';
+
+function authHeaders(token) {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'User-Agent': 'find-eligible-contributors-script',
+  };
+}
+
+async function fetchAllPages(url, token, { stopWhen } = {}) {
+  const results = [];
+  let page = 1;
+  const perPage = 100;
+  const concurrentRequests = 5;
+
+  while (true) {
+    const responses = await Promise.all(
+      Array.from({ length: concurrentRequests }, async (_, index) => {
+        const pageUrl = new URL(url);
+        pageUrl.searchParams.set('per_page', String(perPage));
+        pageUrl.searchParams.set('page', String(page + index));
+
+        const res = await fetch(pageUrl, { headers: authHeaders(token) });
+        if (!res.ok) {
+          const body = await res.text();
+          throw new Error(`GitHub API error ${res.status} for ${pageUrl}: ${body}`);
+        }
+        return res.json();
+      })
+    );
+
+    let end = false;
+    for (const data of responses) {
+      if (!Array.isArray(data) || data.length === 0) {
+        end = true;
+        continue;
+      }
+      if (data.length < perPage) {
+        end = true;
+      }
+
+      for (const item of data) {
+        if (stopWhen && stopWhen(item)) break;
+        results.push(item);
+      }
+    }
+
+    if (end) {
+      break;
+    }
+
+    page += concurrentRequests;
+  }
+
+  return results;
+}
+
+async function fetchPullRequests(owner, repo, token) {
+  const url = `${GITHUB_API}/repos/${owner}/${repo}/pulls?state=all&sort=created&direction=desc`;
+
+  const oneYearAgo = new Date();
+  oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+
+  return fetchAllPages(url, token, {
+    stopWhen: (pr) => new Date(pr.created_at) < oneYearAgo,
+  });
+}
+
+async function fetchCollaborators(owner, repo, token) {
+  const url = `${GITHUB_API}/repos/${owner}/${repo}/collaborators`;
+  const collaborators = await fetchAllPages(url, token);
+  return new Set(collaborators.map((c) => c.login));
+}
+
+/**
+ * Aggregate per-user PR stats from the list of PRs.
+ * Returns Map<login, {
+ *   open: number,
+ *   closed: number,
+ *   merged: number,
+ *   mostRecentCreatedAt: Date
+ * }>
+ */
+function aggregateUserStats(pullRequests) {
+  const stats = new Map();
+
+  for (const pr of pullRequests) {
+    const login = pr.user?.login;
+    if (!login) continue;
+
+    if (!stats.has(login)) {
+      stats.set(login, {
+        open: 0,
+        closed: 0,
+        merged: 0,
+        mostRecentCreatedAt: null,
+      });
+    }
+    const s = stats.get(login);
+
+    if (pr.state === 'open') {
+      s.open += 1;
+    } else if (pr.state === 'closed') {
+      s.closed += 1;
+      if (pr.merged_at) {
+        s.merged += 1;
+      }
+    }
+
+    const createdAt = new Date(pr.created_at);
+    if (!s.mostRecentCreatedAt || createdAt > s.mostRecentCreatedAt) {
+      s.mostRecentCreatedAt = createdAt;
+    }
+  }
+
+  return stats;
+}
+
+/**
+ * Apply eligibility filters:
+ *   - fewer than 5 currently open PRs
+ *   - more than 2 merged PRs
+ *   - merge rate (merged / closed) > 50%
+ *   - not a collaborator
+ *   - has an open PR or at least one PR within the past 6 weeks
+ */
+function filterEligibleUsers(stats, collaboratorLogins) {
+  const SIX_WEEKS_MS = 6 * 7 * 24 * 60 * 60 * 1000;
+  const cutoff = new Date((new Date).getTime() - SIX_WEEKS_MS);
+  const eligible = [];
+
+  for (const [login, s] of stats.entries()) {
+    if (s.open >= 5) continue;
+    if (s.merged <= 2) continue;
+    if (collaboratorLogins.has(login)) continue;
+    if (s.open == 0 && s.mostRecentCreatedAt < cutoff) continue;
+    if ((s.merged / s.closed) < 0.5) continue;
+
+    eligible.push(login);
+  }
+  return eligible;
+}
+
+/**
+ * Given a repo (owner/repo) and a GitHub token, returns the login names of
+ * eligible external contributors matching all filters.
+ *
+ * @param {Object} params
+ * @param {string} params.owner - Repo owner (user or org).
+ * @param {string} params.repo - Repo name.
+ * @param {string} params.token - GitHub token with repo read (and ideally push) access.
+ * @returns {Promise<string[]>}
+ */
+async function findEligibleContributors({ owner, repo, token } = {}) {
+  if (!owner || !repo) {
+    throw new Error('findEligibleContributors requires both "owner" and "repo".');
+  }
+  if (!token) {
+    throw new Error('findEligibleContributors requires a "token".');
+  }
+
+  const [pullRequests, collaboratorLogins] = await Promise.all([
+    fetchPullRequests(owner, repo, token),
+    fetchCollaborators(owner, repo, token),
+  ]);
+
+  const stats = aggregateUserStats(pullRequests);
+  return filterEligibleUsers(stats, collaboratorLogins);
+}
+
+// ---- CLI entry point ----
+
+function isRunAsCLI() {
+  return import.meta.url === `file://${process.argv[1]}`;
+}
+
+async function runCLI() {
+  const [, , owner, repo] = process.argv;
+  if (!owner || !repo) {
+    console.error('Usage: node find-eligible-contributors.js <owner> <repo>');
+    process.exit(1);
+  }
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    console.error('Error: set GITHUB_TOKEN environment variable with a valid GitHub token.');
+    process.exit(1);
+  }
+
+  console.error(`Fetching pull requests and collaborators for ${owner}/${repo} in parallel...`);
+  const eligibleLogins = await findEligibleContributors({ owner, repo, token });
+
+  console.log(JSON.stringify(eligibleLogins, null, 2));
+  console.error(`\n${eligibleLogins.length} user(s) match the criteria.`);
+}
+
+if (isRunAsCLI()) {
+  runCLI().catch((err) => {
+    console.error('Fatal error:', err);
+    process.exit(1);
+  });
+}
+
+export { findEligibleContributors };

--- a/.github/scripts/update-bypass-list.js
+++ b/.github/scripts/update-bypass-list.js
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+
+/**
+ * update-bypass-list.js
+ *
+ * Syncs a repo's PR interaction-limits bypass list with the current
+ * set of eligible external contributors.
+ *
+ * Usage:
+ *   GITHUB_TOKEN=xxxx node update-bypass-list.js <owner> <repo> [--dry-run]
+ */
+
+import { findEligibleContributors } from './find-eligible-contributors.js';
+
+const GITHUB_API = 'https://api.github.com';
+
+function authHeaders(token) {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2026-03-10',
+    'User-Agent': 'update-bypass-list-script',
+    'Content-Type': 'application/json',
+  };
+}
+
+function bypassListUrl(owner, repo) {
+  return `${GITHUB_API}/repos/${owner}/${repo}/interaction-limits/pulls/bypass-list`;
+}
+
+async function fetchBypassList(owner, repo, token) {
+  const url = bypassListUrl(owner, repo);
+  const res = await fetch(url, { headers: authHeaders(token) });
+
+  if (res.status === 404) {
+    return new Set();
+  }
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Failed to fetch bypass list (${res.status}): ${body}`);
+  }
+
+  const data = await res.json();
+  const logins = data.map((user) => user?.login).filter(Boolean);
+
+  return new Set(logins);
+}
+
+async function addUsersToBypassList(owner, repo, token, usernames) {
+  if (usernames.length === 0) return;
+
+  const res = await fetch(bypassListUrl(owner, repo), {
+    method: 'PUT',
+    headers: authHeaders(token),
+    body: JSON.stringify({ users: usernames }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Failed to add users [${usernames.join(', ')}] (${res.status}): ${body}`);
+  }
+}
+
+async function removeUsersFromBypassList(owner, repo, token, usernames) {
+  if (usernames.length === 0) return;
+
+  const res = await fetch(bypassListUrl(owner, repo), {
+    method: 'DELETE',
+    headers: authHeaders(token),
+    body: JSON.stringify({ users: usernames }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Failed to remove users [${usernames.join(', ')}] (${res.status}): ${body}`);
+  }
+}
+
+function diffLists(eligibleLogins, currentBypassLogins) {
+  const toAdd = [...eligibleLogins].filter((login) => !currentBypassLogins.has(login));
+  const toRemove = [...currentBypassLogins].filter((login) => !eligibleLogins.has(login));
+  return { toAdd, toRemove };
+}
+
+/**
+ * Update the bypass list to eligible contributors.
+ *
+ * @param {Object} params
+ * @param {string} params.owner
+ * @param {string} params.repo
+ * @param {string} params.token
+ * @param {boolean} [params.dryRun] - If true, only computes the diff, makes no API writes.
+ */
+async function updateBypassList({ owner, repo, token, dryRun = false }) {
+  console.error(`Getting eligible external contributors for ${owner}/${repo}...`);
+  const eligibleLogins = new Set(await findEligibleContributors({ owner, repo, token }));
+  console.error(`Found ${eligibleLogins.size} eligible user(s).`);
+
+  console.error(`Fetching current bypass list...`);
+  const currentBypassLogins = await fetchBypassList(owner, repo, token);
+  console.error(`Current bypass list has ${currentBypassLogins.size} user(s).`);
+
+  const { toAdd, toRemove } = diffLists(eligibleLogins, currentBypassLogins);
+
+  console.error(`\nUsers to add (${toAdd.length}): ${toAdd.join(', ') || '(none)'}`);
+  console.error(`Users to remove (${toRemove.length}): ${toRemove.join(', ') || '(none)'}`);
+
+  if (dryRun) {
+    console.error('\nDry run mode: no changes will be made.');
+    return;
+  }
+
+  try {
+    await addUsersToBypassList(owner, repo, token, toAdd);
+    if (toAdd.length > 0) console.error(`Added ${toAdd.length} user(s) to bypass list.`);
+  } catch (err) {
+    console.error(`Error adding users: ${err.message}`);
+  }
+
+  try {
+    await removeUsersFromBypassList(owner, repo, token, toRemove);
+    if (toRemove.length > 0) console.error(`Removed ${toRemove.length} user(s) from bypass list.`);
+  } catch (err) {
+    console.error(`Error removing users: ${err.message}`);
+  }
+}
+
+// ---- CLI entry point ----
+
+function isRunAsCLI() {
+  return import.meta.url === `file://${process.argv[1]}`;
+}
+
+async function runCLI() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--dry-run');
+  const [owner, repo] = args.filter((a) => !a.startsWith('--'));
+
+  if (!owner || !repo) {
+    console.error('Usage: node update-bypass-list.js <owner> <repo> [--dry-run]');
+    process.exit(1);
+  }
+
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    console.error('Error: set GITHUB_TOKEN environment variable with a valid GitHub token.');
+    process.exit(1);
+  }
+
+  await updateBypassList({ owner, repo, token, dryRun });
+}
+
+if (isRunAsCLI()) {
+  runCLI().catch((err) => {
+    console.error('Fatal error:', err);
+    process.exit(1);
+  });
+}
+
+export { updateBypassList };

--- a/.github/workflows/update_bypass_list.yml
+++ b/.github/workflows/update_bypass_list.yml
@@ -1,0 +1,21 @@
+name: 'Update bypass list'
+description: 'Update interaction-limits bypass list with eligible contributors'
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 * * * *
+
+permissions:
+  contents: write
+
+jobs:
+  update_bypass_list:
+    name: 'Update bypass list'
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v7
+      - env:
+          # Can only use PAT with permissions: admin:org_hook, public_repo
+          GITHUB_TOKEN: ${{ secrets.ZCBENZ_TOKEN_UPDATE_BYPASS_LIST }}
+        run: node .github/scripts/update-bypass-list.js ml-explore mlx

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
     rev: v21.1.8
     hooks:
     -   id: clang-format
+        files: \.(h|cpp)$
 # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
 -   repo: https://github.com/psf/black-pre-commit-mirror
     rev: 26.1.0

--- a/python/tests/test_load.py
+++ b/python/tests/test_load.py
@@ -115,13 +115,12 @@ class TestLoad(mlx_tests.MLXTestCase):
         )
         with self.assertRaises(RuntimeError):
             mx.eval(out)
-        # The error should propagate on both streams, but the Event impl of
-        # CUDA backend signals via gpu stream which adds a Fence wait which
-        # does a synchronous wait, so error surfaced early in producer_stream
-        # before poisoning the producer_stream.
-        if not mx.cuda.is_available():
-            with self.assertRaises(RuntimeError):
-                mx.synchronize(producer_stream)
+        # Depending on backend the error might be caught early before poisoning
+        # the producer_stream, but still sync to clear the errors.
+        try:
+            mx.synchronize(producer_stream)
+        except Exception:
+            pass
 
     def test_save_and_load_safetensors(self):
         test_file = os.path.join(self.test_dir, "test.safetensors")


### PR DESCRIPTION
We are going to set the [pull request limit](https://github.blog/open-source/maintainers/how-pull-request-limits-are-cutting-down-the-noise/) to 1 for this repo, with a script that automatically updates the bypass list to external contributors that fulfill following conditions:

- fewer than 5 currently open PRs
- more than 2 merged PRs
- merge rate (merged / closed) > 50%

The purpose is to discourage contributors from opening excessive PRs which burden the team too much. 

The script for updating bypass list is written by Claude and fully reviewed by myself.