### PR TITLE
Fix vmap of scatter placing the batch axis wrongly in the updates

### DIFF
--- a/mlx/primitives.cpp
+++ b/mlx/primitives.cpp
@@ -4591,15 +4591,25 @@ std::pair<std::vector<array>, std::vector<int>> Scatter::vmap(
 
     // Clone updates along the vmap dimension so they can be applied to each
     // source tensor in the vmap.
+    //
+    // The updates are laid out as the index dimensions followed by one
+    // dimension per source axis. The vmap axis becomes an extra scattered
+    // source axis at position src_ax, so the singleton for it has to be
+    // inserted at src_ax *within the source part*, not at its front.
     auto& updates = inputs.back();
+    int idx_ndim = static_cast<int>(inputs[1].ndim());
+    int upd_src_ax = idx_ndim + src_ax;
     if (vmap_axes.back() < 0) {
-      updates = expand_dims(
-          updates, {0, static_cast<int>(inputs[1].ndim())}, stream());
+      updates = expand_dims(updates, {0, upd_src_ax}, stream());
       updates = repeat(updates, vmap_size, 0, stream());
     } else {
-      updates =
-          expand_dims(updates, static_cast<int>(inputs[1].ndim()), stream());
-      updates = moveaxis(updates, vmap_axes.back(), 0, stream());
+      int upd_vmap_ax = vmap_axes.back();
+      // expand_dims shifts any axis at or after the insertion point
+      if (upd_vmap_ax >= upd_src_ax) {
+        upd_vmap_ax++;
+      }
+      updates = expand_dims(updates, upd_src_ax, stream());
+      updates = moveaxis(updates, upd_vmap_ax, 0, stream());
     }
   }
 

--- a/python/tests/test_vmap.py
+++ b/python/tests/test_vmap.py
@@ -547,6 +547,41 @@ class TestVmap(mlx_tests.MLXTestCase):
         expected = mx.array([[2.0, 3.0, 4.0], [2.0, 3.0, 4.0]])
         self.assertTrue(mx.allclose(out, expected))
 
+    def test_vmap_scatter_higher_rank(self):
+        # The vmap axis becomes an extra scattered source axis, so the
+        # singleton added to the updates has to land at that axis rather than
+        # at the front of the source dims. Only shows up for a vmap axis >= 2,
+        # where the misplaced singleton actually reorders a non-unit dim.
+        def unstack(x, axis):
+            return [s.squeeze(axis) for s in mx.split(x, x.shape[axis], axis=axis)]
+
+        for shape in [(2, 3), (2, 3, 4), (2, 3, 4, 5)]:
+            n = 1
+            for d in shape:
+                n *= d
+            a = mx.arange(n, dtype=mx.float32).reshape(shape)
+
+            fns = {
+                "add_derived": lambda x: x.at[mx.array([0])].add(x[:1]),
+                "add_const": lambda x: x.at[mx.array([0])].add(
+                    mx.ones((1,) + tuple(x.shape[1:]), dtype=x.dtype)
+                ),
+                "add_dup": lambda x: x.at[mx.array([0, 0])].add(
+                    mx.ones((2,) + tuple(x.shape[1:]), dtype=x.dtype)
+                ),
+                "maximum": lambda x: x.at[mx.array([0])].maximum(x[:1] + 1.0),
+            }
+            for name, fn in fns.items():
+                for ax in range(len(shape)):
+                    out = mx.vmap(fn, in_axes=ax, out_axes=ax)(a)
+                    expected = mx.stack([fn(s) for s in unstack(a, ax)], axis=ax)
+                    self.assertEqual(
+                        out.shape, expected.shape, f"{name} ax{ax} {shape}"
+                    )
+                    self.assertTrue(
+                        mx.array_equal(out, expected), f"{name} ax{ax} {shape}"
+                    )
+
         # Multiple indices
         def scatter(a):
             a[mx.array([0, 1]), mx.array([0, 1])] = mx.array((1.0, 1.0))


### PR DESCRIPTION
Fixes #4321.

### Proposed changes

Under `vmap` the batch dimension becomes an extra scattered source axis at position `src_ax`, so the updates need a matching singleton dimension. The updates are laid out as the index dimensions followed by one dimension per source axis, but the singleton was inserted at the front of the source part rather than at `src_ax`:

```cpp
updates = expand_dims(updates, {0, static_cast<int>(inputs[1].ndim())}, stream());
```

For a source of shape `(2, 3, 4)` batched on axis 2, the source part of the updates has to be `(1, 3, 1)` but came out `(1, 1, 3)`, so the scatter wrote with the last two source dimensions transposed and silently produced wrong values.

That is also why it stayed hidden. For axis 0 the intended position and the front coincide. For axis 1 the misplaced singleton lands next to the scattered axis, which is itself size 1, so the shape is unchanged by luck. Only from axis 2 on does the singleton displace a real dimension:

| source shape | axis 0 | axis 1 | axis 2 | axis 3 |
| --- | --- | --- | --- | --- |
| `(2,3)` | ok | ok | – | – |
| `(2,3,4)` | ok | ok | **wrong** | – |
| `(2,3,4,5)` | ok | ok | **wrong** | **wrong** |

The fix inserts the singleton at `src_ax` within the source part. In the branch where the updates are themselves batched, that insertion shifts their vmap axis, so the index is adjusted before the `moveaxis`.

Affects every scatter reduction and plain indexed assignment (`add`, `subtract`, `multiply`, `maximum`, `minimum`, `a[idx] = v`). `take`, `take_along_axis` and `put_along_axis` were never affected — they go through `Gather` / `GatherAxis` / `ScatterAxis` rather than the general `Scatter`.

Before / after on the repro from the issue, where `out[0] = 2 * a[0]` makes the expected values checkable by hand:

```
before:  [ 0,  6, 17, 21]
after:   [ 0,  2,  4,  6]     # matches the per-slice loop
```

### Tests

Added `test_vmap_scatter_higher_rank` to `python/tests/test_vmap.py`. It sweeps shapes `(2,3)`, `(2,3,4)` and `(2,3,4,5)` over every vmap axis and several scatter forms (update derived from the vmapped array, constant update, duplicate indices, and a non-sum reduction), comparing against the equivalent per-slice loop.

I confirmed the test is a real regression test rather than a tautology: with the `primitives.cpp` change stashed and the extension rebuilt, it fails with

```
AssertionError: array(False, dtype=bool) is not true : add_derived ax2 (2, 3, 4)
```

and passes with the change applied.

The existing `test_vmap_scatter` only covered a 2-D source with `in_axes` 0 and 1, i.e. exactly the two cases that already worked, which is how the gap survived.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (not needed, no API change)
- [x] I have run `pre-commit run --all-files` to format my code and installed pre-commit prior to committing changes

Verified with a CPU-only build (`-DMLX_BUILD_METAL=OFF`):

- C++ suite: 247 test cases, 3326 assertions, all pass
- Python: `test_vmap`, `test_ops`, `test_array`, `test_autograd`, `test_einsum`, `test_linalg`, `test_blas`, `test_nn`, `test_reduce`, `test_fft` (481 tests) pass
