### PR TITLE
Fix mx.arange dtype inference overflow regression

### DIFF
--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -1517,8 +1517,7 @@ void init_ops(nb::module_& m) {
           start (float or int, optional): Starting value which defaults to ``0``.
           stop (float or int, optional): Stopping value.
           step (float or int, optional): Increment which defaults to ``1``.
-          dtype (Dtype, optional): Specifies the data type of the output. If unspecified will default to ``float32`` if any of ``start``, ``stop``, or ``step`` are ``float``. Otherwise will default to ``int32``, or ``int64``
-            when any of them does not fit in ``int32``.
+          dtype (Dtype, optional): Specifies the data type of the output. If unspecified will default to ``float32`` if any of ``start``, ``stop``, or ``step`` are ``float``. Otherwise will default to ``int32``, or ``int64`` if any of ``start``, ``stop``, or ``step`` does not fit in ``int32``.
 
       Returns:
           array: The range of values.

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -1,5 +1,6 @@
 // Copyright © 2023-2024 Apple Inc.
 
+#include <limits>
 #include <numeric>
 #include <ostream>
 #include <variant>
@@ -27,8 +28,11 @@ using namespace nb::literals;
 using Scalar = std::variant<bool, int64_t, double>;
 
 mx::Dtype scalar_to_dtype(Scalar s) {
-  if (std::holds_alternative<int64_t>(s)) {
-    return mx::int32;
+  if (auto pv = std::get_if<int64_t>(&s); pv) {
+    return (*pv > std::numeric_limits<int>::max() ||
+            *pv < std::numeric_limits<int>::min())
+        ? mx::int64
+        : mx::int32;
   } else if (std::holds_alternative<double>(s)) {
     return mx::float32;
   } else {
@@ -1513,7 +1517,8 @@ void init_ops(nb::module_& m) {
           start (float or int, optional): Starting value which defaults to ``0``.
           stop (float or int, optional): Stopping value.
           step (float or int, optional): Increment which defaults to ``1``.
-          dtype (Dtype, optional): Specifies the data type of the output. If unspecified will default to ``float32`` if any of ``start``, ``stop``, or ``step`` are ``float``. Otherwise will default to ``int32``.
+          dtype (Dtype, optional): Specifies the data type of the output. If unspecified will default to ``float32`` if any of ``start``, ``stop``, or ``step`` are ``float``. Otherwise will default to ``int32``, or ``int64``
+            when any of them does not fit in ``int32``.
 
       Returns:
           array: The range of values.

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -1644,6 +1644,8 @@ class TestOps(mlx_tests.MLXTestCase):
         with self.assertRaises(ValueError):
             INT_MAX = 2147483647
             a = mx.arange(0, INT_MAX + 1, 1)
+        with self.assertRaises(ValueError):
+            a = mx.arange(0, 2**40)
 
         a = mx.arange(5)
         expected = [0, 1, 2, 3, 4]
@@ -1707,6 +1709,57 @@ class TestOps(mlx_tests.MLXTestCase):
         a = mx.arange(1.0, 3.0, 0.2, dtype=mx.int32)
         self.assertEqual(a.dtype, mx.int32)
 
+        # Integers that do not fit in int32 widen the inferred dtype to int64,
+        # matching the scalar inference of mx.array and numpy.
+        a = mx.arange(2**40, 2**40 + 3)
+        self.assertEqual(a.dtype, mx.int64)
+        self.assertListEqual(a.tolist(), [2**40, 2**40 + 1, 2**40 + 2])
+
+        a = mx.arange(-(2**40), -(2**40) + 3)
+        self.assertEqual(a.dtype, mx.int64)
+        self.assertListEqual(a.tolist(), [-(2**40), -(2**40) + 1, -(2**40) + 2])
+
+        # int32 boundaries themselves still infer int32.
+        a = mx.arange(2**31 - 3, 2**31 - 1)
+        self.assertEqual(a.dtype, mx.int32)
+        self.assertListEqual(a.tolist(), [2**31 - 3, 2**31 - 2])
+
+        a = mx.arange(-(2**31), -(2**31) + 2)
+        self.assertEqual(a.dtype, mx.int32)
+        self.assertListEqual(a.tolist(), [-(2**31), -(2**31) + 1])
+
+        # The first values that no longer fit widen as well.
+        a = mx.arange(-(2**31) - 1, -(2**31) + 1)
+        self.assertEqual(a.dtype, mx.int64)
+        self.assertListEqual(a.tolist(), [-(2**31) - 1, -(2**31)])
+
+        # A large step also widens the inferred dtype.
+        a = mx.arange(2**40, 2**40 + 3, 2**40)
+        self.assertEqual(a.dtype, mx.int64)
+        self.assertListEqual(a.tolist(), [2**40])
+
+        a = mx.arange(stop=2, step=2**40)
+        self.assertEqual(a.dtype, mx.int64)
+        self.assertListEqual(a.tolist(), [0])
+
+        # A negative step with widened values.
+        a = mx.arange(2**40 + 3, 2**40, -1)
+        self.assertEqual(a.dtype, mx.int64)
+        self.assertListEqual(a.tolist(), [2**40 + 3, 2**40 + 2, 2**40 + 1])
+
+        # The stop-only overload widens too, even for an empty result.
+        a = mx.arange(stop=2**40, step=-1)
+        self.assertEqual(a.dtype, mx.int64)
+        self.assertEqual(a.shape, (0,))
+
+        # An explicit dtype takes precedence over the widened inference.
+        a = mx.arange(2**40, 2**40 + 3, dtype=mx.int32)
+        self.assertEqual(a.dtype, mx.int32)
+
+        # A float in the mix still infers float32.
+        a = mx.arange(0.5, 2**40, 2**39)
+        self.assertEqual(a.dtype, mx.float32)
+
     def test_arange_corner_cases_cast(self):
         a = mx.arange(0, 3, 0.2, dtype=mx.int32)
         expected = [0] * 15
@@ -1761,8 +1814,16 @@ class TestOps(mlx_tests.MLXTestCase):
         expected = [0]
         self.assertListEqual(a.tolist(), expected)
 
+        # The range crossing the int32 limit widens the dtype to int64 instead
+        # of saturating or wrapping.
         n = mx.iinfo(mx.int32).max
         result = mx.arange(n - 1, n + 3)
+        self.assertEqual(result.shape, (4,))
+        self.assertEqual(result.dtype, mx.int64)
+        self.assertEqual(result.tolist(), [n - 1, n, n + 1, n + 2])
+
+        # An explicit dtype keeps the previous wrapping behaviour.
+        result = mx.arange(n - 1, n + 3, dtype=mx.int32)
         self.assertEqual(result.shape, (4,))
         self.assertEqual(result.dtype, mx.int32)
         self.assertEqual(result.tolist(), [n - 1, n, -2147483648, -2147483647])


### PR DESCRIPTION
Fixes #4306.

## Summary

#4255 moved the `Scalar` variant in `python/src/ops.cpp` from `std::variant<bool, int, double>` to `std::variant<bool, int64_t, double>`, but `scalar_to_dtype` still returned `int32` for every integer. Out-of-`int32` arguments therefore stopped raising and `mx.arange` now silently computes in `int32`, where the `double` -> `int32` cast saturates or wraps depending on the backend:

```python
>>> mx.arange(2**40, 2**40 + 3)      # before, and on main today
array([2147483647, 2147483647, 2147483647], dtype=int32)
```

This PR widens the inferred dtype to `int64` when an integer argument does not fit in `int32` (option 1 from the issue), matching numpy and the existing scalar inference in `python/src/convert.cpp` (`mx.array(2**40)` is already `int64`):

```python
>>> mx.arange(2**40, 2**40 + 3)      # after
array([1099511627776, 1099511627777, 1099511627778], dtype=int64)
>>> np.arange(2**40, 2**40 + 3)
array([1099511627776, 1099511627777, 1099511627778])
```

I picked widening over the issue's option 2 (keep wrapping, raise when `start` itself does not fit) because option 2 still leaves cases like `mx.arange(0, 2**40)` silently saturating where numpy widens. Explicit `dtype=` is untouched, and ranges within `int32` keep inferring `int32`.

## Changes

- `python/src/ops.cpp`: `scalar_to_dtype` returns `int64` for integers outside the `int32` range; `arange` docstring mentions the widening.
- `python/tests/test_ops.py`:
  - `test_arange_inferred_dtype` gains positive/negative out-of-range ranges, `int32` boundary values, large and negative steps, the stop-only overload, explicit `dtype=` override, and a float mix.
  - The boundary case added in #4255 now expects `int64` for `mx.arange(n - 1, n + 3)`; the wrapping it used to pin is kept under an explicit `dtype=mx.int32`.
  - `test_arange_overload_dispatch` covers `mx.arange(0, 2**40)` still raising `ValueError` (size limit).

## Test

Built from source on Linux (CPU backend) and ran:

```
pytest python/tests/test_ops.py        # 156 passed, 1 skipped
pytest python/tests                    # passes except test_fft.py::TestFFT::test_fft_grads,
                                       # which fails identically on unmodified main in this
                                       # environment (torch interop, unrelated)
```

Note: arguments still travel to the core `arange` as doubles, so integer arguments beyond 2**53 can lose precision — e.g. `mx.arange(2**53 + 1, 2**53 + 3, dtype=mx.int64)` behaves the same way before and after this change. That is a pre-existing property of the double-based core `arange` and left untouched here.