### PR TITLE
Support 8-byte dtypes in assignment scatter on Metal

### DIFF
--- a/mlx/backend/metal/indexing.cpp
+++ b/mlx/backend/metal/indexing.cpp
@@ -230,10 +230,12 @@ void Gather::eval_gpu(const std::vector<array>& inputs, array& out) {
 }
 
 void Scatter::eval_gpu(const std::vector<array>& inputs, array& out) {
-  if (size_of(out.dtype()) == 8 &&
+  // Assignment is dispatched non-atomically below and has no size limit.
+  if (size_of(out.dtype()) == 8 && reduce_type_ != Scatter::None &&
       !(out.dtype() == complex64 && reduce_type_ == Scatter::Sum)) {
     std::ostringstream msg;
-    msg << "[Scatter::eval_gpu] Does not support " << out.dtype();
+    msg << "[Scatter::eval_gpu] Does not support " << out.dtype()
+        << " with a reducing scatter";
     throw std::invalid_argument(msg.str());
   }
 
@@ -328,6 +330,10 @@ void Scatter::eval_gpu(const std::vector<array>& inputs, array& out) {
         nidx ? get_type_string(inputs[1].dtype()) : "bool";
     std::string op_type = make_op<Scatter>(reduce_type_, out_type_str);
     auto [idx_args, idx_arr] = make_index_args(idx_type_str, nidx);
+    // Kernel names carry the op, so the two pointer forms cannot collide.
+    std::string out_ptr_type = reduce_type_ == Scatter::None
+        ? out_type_str
+        : "mlx_atomic<" + out_type_str + ">";
 
     kernel_source += fmt::format(
         scatter_kernels,
@@ -340,7 +346,8 @@ void Scatter::eval_gpu(const std::vector<array>& inputs, array& out) {
         idx_arr,
         upd_contig,
         nwork,
-        large ? "int64_t" : "int");
+        large ? "int64_t" : "int",
+        out_ptr_type);
     return kernel_source;
   });
 
@@ -520,10 +527,11 @@ void GatherAxis::eval_gpu(const std::vector<array>& inputs, array& out) {
 }
 
 void ScatterAxis::eval_gpu(const std::vector<array>& inputs, array& out) {
-  if (size_of(out.dtype()) == 8 &&
+  if (size_of(out.dtype()) == 8 && reduce_type_ != ScatterAxis::None &&
       !(out.dtype() == complex64 && reduce_type_ == ScatterAxis::Sum)) {
     std::ostringstream msg;
-    msg << "[ScatterAxis::eval_gpu] Does not support " << out.dtype();
+    msg << "[ScatterAxis::eval_gpu] Does not support " << out.dtype()
+        << " with a reducing scatter";
     throw std::invalid_argument(msg.str());
   }
 
@@ -590,6 +598,10 @@ void ScatterAxis::eval_gpu(const std::vector<array>& inputs, array& out) {
         break;
     }
 
+    std::string out_ptr_type = reduce_type_ == ScatterAxis::None
+        ? out_type_str
+        : "mlx_atomic<" + out_type_str + ">";
+
     for (int i = 0; i < 4; ++i) {
       bool uc = i & 1;
       bool ic = i & 2;
@@ -601,7 +613,8 @@ void ScatterAxis::eval_gpu(const std::vector<array>& inputs, array& out) {
           large ? "int64_t" : "int",
           op_type,
           uc ? "true" : "false",
-          ic ? "true" : "false");
+          ic ? "true" : "false",
+          out_ptr_type);
     }
     return kernel_source;
   });

--- a/mlx/backend/metal/jit/indexing.h
+++ b/mlx/backend/metal/jit/indexing.h
@@ -36,7 +36,7 @@ constexpr std::string_view gather_kernels = R"(
 constexpr std::string_view scatter_kernels = R"(
 [[kernel]] void scatter{0}_{4}_updc_{7}_nwork{8}_{9}(
     const device {1}* updates [[buffer(1)]],
-    device mlx_atomic<{1}>* out [[buffer(2)]],
+    device {10}* out [[buffer(2)]],
     const constant int* upd_shape [[buffer(3)]],
     const constant int64_t* upd_strides [[buffer(4)]],
     const constant size_t& upd_ndim [[buffer(5)]],

--- a/mlx/backend/metal/kernels/indexing/scatter.h
+++ b/mlx/backend/metal/kernels/indexing/scatter.h
@@ -11,10 +11,11 @@ template <
     int NIDX,
     bool UPD_ROW_CONTIG,
     int NWORK,
-    typename LocT>
+    typename LocT,
+    typename OutT>
 METAL_FUNC void scatter_impl(
     const device T* updates,
-    device mlx_atomic<T>* out,
+    device OutT* out,
     const constant int* upd_shape,
     const constant int64_t* upd_strides,
     const constant size_t& upd_ndim,

--- a/mlx/backend/metal/kernels/indexing/scatter_axis.h
+++ b/mlx/backend/metal/kernels/indexing/scatter_axis.h
@@ -8,11 +8,12 @@ template <
     typename LocT,
     typename Op,
     bool UpdC,
-    bool IdxC>
+    bool IdxC,
+    typename OutT>
 [[kernel]] void scatter_axis(
     const device T* upd [[buffer(0)]],
     const device IdxT* indices [[buffer(1)]],
-    device mlx_atomic<T>* out [[buffer(2)]],
+    device OutT* out [[buffer(2)]],
     const constant int* shape [[buffer(3)]],
     const constant int64_t* upd_strides [[buffer(4)]],
     const constant int64_t* idx_strides [[buffer(5)]],

--- a/mlx/backend/metal/kernels/reduction/ops.h
+++ b/mlx/backend/metal/kernels/reduction/ops.h
@@ -32,6 +32,14 @@ struct None {
       thread {
     mlx_atomic_store_explicit(out, val, offset);
   }
+
+  // Non-atomic overload, used for types with no atomic representation such as
+  // the 8-byte ones. Duplicate indices already race under assignment and the
+  // last write wins, which is what a plain store does.
+  template <typename T>
+  void atomic_update(device T* out, T val, size_t offset = 0) thread {
+    out[offset] = val;
+  }
 };
 
 template <typename U = bool>

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -3909,12 +3909,13 @@ array scatter(
     idx = astype(idx, dtype, s);
   }
 
-  // TODO, remove when scatter supports 64-bit outputs
+  // Only the reducing modes need an atomic, which the GPU lacks at 8 bytes.
   if (to_stream(s).device == Device::gpu && size_of(a.dtype()) == 8 &&
+      mode != Scatter::None &&
       !(a.dtype() == complex64 && mode == Scatter::Sum)) {
     std::ostringstream msg;
-    msg << "[scatter] GPU scatter does not yet support " << a.dtype()
-        << " for the input or updates.";
+    msg << "[scatter] GPU scatter does not support " << a.dtype()
+        << " for a reducing scatter.";
     throw std::invalid_argument(msg.str());
   }
 

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -1538,19 +1538,20 @@ class TestOps(mlx_tests.MLXTestCase):
         self.assertEqual(b.size, 0)
         self.assertEqual(b.shape, a.shape)
 
-        # 64-bit outputs are not supported by the Metal scatter and should
-        # raise a clean error rather than failing the Metal JIT build. The CPU
-        # and CUDA backends handle them fine.
+        # Assignment needs no atomic, so 8-byte outputs work on every backend.
         idx = mx.array([[0], [1], [2], [3]])
+        expected = np.zeros((4, 8))
+        expected[np.arange(4), np.arange(4)] = 1
         for dt in (mx.int64, mx.uint64):
             x = mx.zeros((4, 8), dtype=dt)
             upd = mx.ones((4, 1), dtype=dt)
-            if mx.metal.is_available():
-                with self.assertRaises(ValueError):
-                    mx.eval(mx.put_along_axis(x, idx, upd, axis=1, stream=mx.gpu))
-            out = mx.put_along_axis(x, idx, upd, axis=1, stream=mx.cpu)
-            self.assertEqual(out.dtype, dt)
-            mx.eval(out)
+            for stream in (mx.cpu, mx.gpu):
+                if stream == mx.gpu and not mx.metal.is_available():
+                    continue
+                out = mx.put_along_axis(x, idx, upd, axis=1, stream=stream)
+                self.assertEqual(out.dtype, dt)
+                mx.eval(out)
+                self.assertTrue(np.array_equal(np.array(out), expected))
 
     def test_split(self):
         a = mx.array([1, 2, 3])
@@ -2930,6 +2931,43 @@ class TestOps(mlx_tests.MLXTestCase):
         self.assertCmpNumpy([3, 4], mx.eye, np.eye, k=1)
         # Test with negative k parameter
         self.assertCmpNumpy([5, 6], mx.eye, np.eye, k=-2)
+
+    def test_scatter_8_byte_types(self):
+        # eye and diag build their result with an assignment scatter, which used
+        # to reject 8-byte output types on the GPU.
+        for dt in (mx.int64, mx.uint64, mx.complex64):
+            for stream in (mx.cpu, mx.gpu):
+                if stream == mx.gpu and not mx.metal.is_available():
+                    continue
+                d = mx.diag(mx.arange(5).astype(dt), stream=stream)
+                mx.eval(d)
+                self.assertEqual(d.dtype, dt)
+                self.assertTrue(np.array_equal(np.array(d), np.diag(np.arange(5))))
+
+                if dt != mx.complex64:
+                    e = mx.eye(4, dtype=dt, stream=stream)
+                    mx.eval(e)
+                    self.assertEqual(e.dtype, dt)
+                    self.assertTrue(np.array_equal(np.array(e), np.eye(4)))
+
+                # Unique indices: a repeated one is a race by definition, so
+                # the GPU and the CPU need not agree.
+                base = mx.zeros((10,), dtype=dt)
+                idx = mx.array([7, 1, 4])
+                upd = mx.array([30, 10, 20]).astype(dt)
+                out = base
+                out[idx] = upd
+                mx.eval(out)
+                want = np.zeros(10)
+                want[[7, 1, 4]] = [30, 10, 20]
+                self.assertTrue(np.array_equal(np.array(out), want))
+
+        # The reducing scatters still have no atomic to use.
+        if mx.metal.is_available():
+            for dt in (mx.int64, mx.uint64):
+                x = mx.zeros((8,), dtype=dt, stream=mx.gpu)
+                with self.assertRaises(ValueError):
+                    mx.eval(x.at[mx.array([0, 1, 1])].add(mx.ones((3,), dtype=dt)))
 
     def test_stack(self):
         a = mx.ones((2,))


### PR DESCRIPTION
## Proposed changes

Root cause identified: fixes #4300, supersedes the two closed workarounds, #4301 (eye) and #4309 (diag)

`mx.eye` and `mx.diag` fail on the GPU for `int64`, `uint64` and `complex64`
because Metal scatter rejects every 8-byte output type. Both build their result
with an assignment scatter, so fixing the scatter fixes them, and `put_along_axis`
and anything else assigning 8-byte data with it.

**Why they were rejected.** Every scatter writes through
`device mlx_atomic<T>* out`. For a type with no native Metal atomic,
`mlx_atomic<T>` packs several values into a single `atomic<uint>`, which cannot
represent an 8-byte value, so `Scatter::eval_gpu` and the `scatter` op refused
them outright.

**That is real for the reducing scatters and was never real for assignment.**
Metal has no 8-byte atomic, so `Sum`, `Prod`, `Max` and `Min` do need
read-modify-write. Scattering duplicate indices under `Scatter::None` is
a race and the result is whichever thread writes last; a plain store has those
semantics.

**The change.** The output pointer type is chosen by the op: `mlx_atomic<T>` for
the reducing scatters, plain `T` for assignment. `None` gains a non-atomic
overload, `scatter_impl` deduces the pointer type, `scatter_axis` takes it as a
template parameter, and the JIT signature takes it as a placeholder. Three type
gates now reject only the reducing case: `Scatter::eval_gpu`,
`ScatterAxis::eval_gpu`, and the one in `ops.cpp` carrying
`// TODO, remove when scatter supports 64-bit outputs`. Kernel names already
encode the op, so the two pointer forms cannot collide in the library cache.

CUDA and CPU are unaffected; both already handled these dtypes, which is why the
old gate was GPU-only. `complex64 + Sum` keeps its existing path.

### Verified

macOS 26.2, M5 Max. `mx.eye` and `mx.diag` for `int64`, `uint64` and `complex64`
on both streams. Assignment scatter against the CPU across those three plus seven
control dtypes over four shapes. Duplicate indices land a valid candidate and
leave other slots untouched. Reducing scatter still raises for `int64` and
`uint64`.

`test_put_along_axis` asserted the old limitation and now checks the result on
both streams. `test_scatter_8_byte_types` covers the reported ops and keeps the
invariant that a reducing scatter raises rather than returning something
plausible. Its indices are unique on purpose: assignment with a repeated index is
a race by definition, so the GPU and CPU need not agree.

Full python suite 839 passed, 11,814 subtests, 5 skipped.
