### PR TITLE
Support head dimension 72 in Metal full attention

### DIFF
--- a/benchmarks/python/sdpa_bench.py
+++ b/benchmarks/python/sdpa_bench.py
@@ -180,6 +180,15 @@ if __name__ == "__main__":
           (  1,  2048,  32121,      64,   32,     8),
     )
 
+    shapes_72 = (
+        # (  B,   qsl,   ksl, head_dim, n_qh, n_kvh)
+          (  1,  1024,  1024,       72,   32,     8),
+          (  1,  2048,  2048,       72,   32,     8),
+          (  1,  4096,  4096,       72,   32,     8),
+          (  1,  4096,  5000,       72,   32,     8),
+          (  1,  2048,  32121,      72,   32,     8),
+    )
+
     shapes_80 = (
         # (  B,   qsl,   ksl, head_dim, n_qh, n_kvh)
           (  1,  1024,  1024,       80,   32,     8),
@@ -208,7 +217,7 @@ if __name__ == "__main__":
     )
     # fmt: on
 
-    shapes = shapes_64 + shapes_80 + shapes_96 + shapes_128
+    shapes = shapes_64 + shapes_72 + shapes_80 + shapes_96 + shapes_128
 
     masks = [None, "bool", "causal"]
 

--- a/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention.metal
+++ b/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention.metal
@@ -15,6 +15,7 @@
     instantiate_attn(iname, itype, 32, 16, 128, 4, 1, mname, mtype) \
     instantiate_attn(iname, itype, 32, 32,  96, 4, 1, mname, mtype) \
     instantiate_attn(iname, itype, 32, 32,  80, 4, 1, mname, mtype) \
+    instantiate_attn(iname, itype, 32, 32,  72, 4, 1, mname, mtype) \
     instantiate_attn(iname, itype, 32, 32,  64, 4, 1, mname, mtype)
 
 #define instantiate_attn_mask_helper(iname, itype) \

--- a/mlx/backend/metal/scaled_dot_product_attention.cpp
+++ b/mlx/backend/metal/scaled_dot_product_attention.cpp
@@ -174,7 +174,9 @@ void sdpa_full_self_attention_metal(
     bool do_causal_,
     const std::optional<array>& mask,
     const std::optional<array>& sinks) {
-  if (metal::is_nax_available() && q.shape(3) != 80 &&
+  // NAX tiles the head dim in units of kU=16 and steps TD by 2, so it needs
+  // a multiple of 32; 72 and 80 take the classic steel kernel.
+  if (metal::is_nax_available() && q.shape(3) != 80 && q.shape(3) != 72 &&
       (env::enable_tf32() || q.dtype() != float32)) {
     return sdpa_full_self_attention_nax(
         /* const Stream& s = */ s,
@@ -627,8 +629,8 @@ bool ScaledDotProductAttention::use_fallback(
         query_head_dim == 256)) ||
       (query_head_dim == 192 && value_head_dim == 128);
   const bool sdpa_full_supported_head_dim = query_head_dim == value_head_dim &&
-      (query_head_dim == 64 || query_head_dim == 80 || query_head_dim == 96 ||
-       query_head_dim == 128);
+      (query_head_dim == 64 || query_head_dim == 72 || query_head_dim == 80 ||
+       query_head_dim == 96 || query_head_dim == 128);
 
   const bool sdpa_full_supported_mask = !has_mask || has_arr_mask ||
       (query_sequence_length <= key_sequence_length && do_causal);

--- a/python/tests/test_fast_sdpa.py
+++ b/python/tests/test_fast_sdpa.py
@@ -118,6 +118,33 @@ def mlx_primitives_sdpa(q, k, v, scale, mask=None):
 
 class TestFastSDPA(mlx_tests.MLXTestCase):
     @unittest.skipIf(not mx.is_available(mx.gpu), "GPU kernel path only")
+    def test_sdpa_head_dim_72(self):
+        B, D, qH, kH = (1, 72, 8, 2)
+        for qL, kL, dtype, mask_str in product(
+            (64, 65),
+            (128, 127),
+            (mx.float16, mx.bfloat16, mx.float32),
+            (None, "additive", "bool", "causal"),
+        ):
+            with self.subTest(qL=qL, kL=kL, dtype=dtype, mask=mask_str):
+                q, k, v, scale, mask = prepare_inputs(
+                    B, qL, kL, D, qH, kH, mask_str, False, dtype
+                )
+                ref = mlx_ref_attn(q, k, v, scale, mask)
+                out = mx.fast.scaled_dot_product_attention(
+                    q, k, v, scale=scale, mask=mask
+                )
+
+                if dtype == mx.float32:
+                    atol = 1e-5
+                elif dtype == mx.bfloat16:
+                    atol = 5e-3
+                else:
+                    atol = 3e-4
+                diff = mx.abs(out - ref) - atol * mx.abs(ref)
+                self.assertLessEqual(mx.max(diff).item(), atol)
+
+    @unittest.skipIf(not mx.is_available(mx.gpu), "GPU kernel path only")
     def test_sdpa_head_dim_96(self):
         B, D, qH, kH = (1, 96, 8, 2)
         for qL, kL, dtype, mask_str in product(


### PR DESCRIPTION

## Proposed changes

Instantiate the head dimension 72 variant of the Steel full-attention kernel and allow scaled dot product attention to select it. This avoids the unfused fallback for full-attention workloads with that head dimension.

Head dim 72 is the vision tower shape of the Qwen3-VL family (`hidden_size 1152 / num_heads 16`), shared by the public 8B, 30B-A3B, 32B and 235B-A22B versions. The unfused path materializes the full `[B, H, N, N]` score tensor, and `N` is the patch count, so its memory is quadratic in image resolution: a 24MP image needs a single ~125GiB allocation and fails outright (ollama/ollama#17804).

NAX tiles the head dimension in units of 16 and steps `TD` by 2, so it needs a multiple of 32. Head dim 72 therefore joins the existing 80 carve-out and takes the classic Steel kernel.

Add aligned and unaligned correctness coverage across float16, bfloat16, and float32, including unmasked, additive, boolean, and causal masks. Add head dimension 72 cases to the existing SDPA benchmark.

## Benchmarks

M3 Ultra, bfloat16, batch 1, 16 heads, sequence 8192, head dimension 72, no mask:

| Path | Median latency | Peak allocation |
|---|---:|---:|
| Unfused fallback | 27.13 ms | 2.09 GiB |
| Fused kernel from this PR | 14.30 ms | 72.00 MiB |
| Improvement | **1.90x faster** | **29.7x lower** |

Head dimensions this PR does not touch move by at most 0.12% in the same runs (64, 80, 96, 128).

On NAX hardware peak allocation improves 12x to 58x over sequence 4096-16384, but the isolated kernel is 6-11% slower: head dim 72 lands on the classic Steel kernel, while the fallback's two GEMMs dispatch to NAX. That does not carry through end to end — on the Qwen3-VL-8B vision tower the patched build is 12% faster overall, because across 27 layers the score-tensor traffic saved outweighs the GEMM advantage. Bringing head dim 72 onto NAX would recover the isolated difference too, but that needs a more involved change to the NAX tiling and seems better as a follow-up.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
