### PR TITLE
Normalize negative axes in sort and argsort

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -2794,17 +2794,9 @@ array sort(const array& a, StreamOrDevice s /* = {} */) {
 
 /** Returns a sorted copy of the array along a given axis. */
 array sort(const array& a, int axis, StreamOrDevice s /* = {} */) {
-  // Check for valid axis
-  if (axis + static_cast<int>(a.ndim()) < 0 ||
-      axis >= static_cast<int>(a.ndim())) {
-    std::ostringstream msg;
-    msg << "[sort] Received invalid axis " << axis << " for array with "
-        << a.ndim() << " dimensions.";
-    throw std::invalid_argument(msg.str());
-  }
-
+  auto ax = normalize_axis_index(axis, a.ndim(), "[sort] ");
   return array(
-      a.shape(), a.dtype(), std::make_shared<Sort>(to_stream(s), axis), {a});
+      a.shape(), a.dtype(), std::make_shared<Sort>(to_stream(s), ax), {a});
 }
 
 /** Returns indices that sort the flattened array. */
@@ -2815,17 +2807,9 @@ array argsort(const array& a, StreamOrDevice s /* = {} */) {
 
 /** Returns indices that sort the array along a given axis. */
 array argsort(const array& a, int axis, StreamOrDevice s /* = {} */) {
-  // Check for valid axis
-  if (axis + static_cast<int>(a.ndim()) < 0 ||
-      axis >= static_cast<int>(a.ndim())) {
-    std::ostringstream msg;
-    msg << "[argsort] Received invalid axis " << axis << " for array with "
-        << a.ndim() << " dimensions.";
-    throw std::invalid_argument(msg.str());
-  }
-
+  auto ax = normalize_axis_index(axis, a.ndim(), "[argsort] ");
   return array(
-      a.shape(), uint32, std::make_shared<ArgSort>(to_stream(s), axis), {a});
+      a.shape(), uint32, std::make_shared<ArgSort>(to_stream(s), ax), {a});
 }
 
 /**

--- a/python/tests/test_vmap.py
+++ b/python/tests/test_vmap.py
@@ -1023,6 +1023,20 @@ class TestVmap(mlx_tests.MLXTestCase):
         self.assertTrue(mx.array_equal(expected, out))
         self.assertEqual(6, counter[0])
 
+    def test_vmap_sort(self):
+        a = mx.random.uniform(shape=(3, 5))
+        expected = mx.stack([mx.sort(a[:, i]) for i in range(a.shape[1])], axis=1)
+        for axis in (0, -1):
+            out = mx.vmap(lambda x: mx.sort(x, axis=axis), in_axes=1, out_axes=1)(a)
+            self.assertTrue(mx.array_equal(out, expected))
+
+    def test_vmap_argsort(self):
+        a = mx.random.uniform(shape=(3, 5))
+        expected = mx.stack([mx.argsort(a[:, i]) for i in range(a.shape[1])], axis=1)
+        for axis in (0, -1):
+            out = mx.vmap(lambda x: mx.argsort(x, axis=axis), in_axes=1, out_axes=1)(a)
+            self.assertTrue(mx.array_equal(out, expected))
+
 
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner()


### PR DESCRIPTION
## Summary

`sort` and `argsort` don't normalize the axis before storing it on the primitive, so `axis=-1` stays `-1`. `Sort::vmap` and `ArgSort::vmap` then compute

```cpp
int axis_left = axes[0] >= 0 && axes[0] <= axis_;
```

which is `0` for any negative axis, and the sort runs on the batch axis instead of the data axis.

`axis=-1` is the default, so this is easy to hit:

```python
>>> x = mx.array([[3.0, 1.0], [2.0, 4.0], [0.0, 5.0]])
>>> mx.vmap(lambda a: mx.sort(a, axis=-1), in_axes=1, out_axes=1)(x)
array([[1, 3],
       [2, 4],
       [0, 5]], dtype=float32)          # main: each row sorted

>>> mx.stack([mx.sort(x[:, i]) for i in range(2)], axis=1)
array([[0, 1],
       [2, 4],
       [3, 5]], dtype=float32)          # expected: each column sorted
```

No error, correct shape and dtype, wrong values.

The fix is to use `normalize_axis_index`, the same thing #4288 did for `split`, `unstack`, `partition` and `topk`. `Partition`, `ArgPartition` and `Scan` already normalize; `Sort` and `ArgSort` were the last two that didn't.

## Changes

- `mlx/ops.cpp`: `sort` and `argsort` normalize the axis. This also replaces the hand-written bounds check in both.
- `python/tests/test_vmap.py`: adds `test_vmap_sort` and `test_vmap_argsort`. The file had no sort coverage, which is why this went unnoticed. Both check `axis=0` and `axis=-1` against a loop.

## Test

Built from source on macOS (Metal, M3 Pro):

```
python python/tests/test_vmap.py    # 30 tests, OK
python python/tests/test_ops.py     # 157 tests, OK
pre-commit run --all-files          # pass
```

One behavior change: the invalid-axis error now reads `[sort] Axis 3 is out of bounds for array with 2 dimensions` instead of `[sort] Received invalid axis 3 for array with 2 dimensions`. No test checks either string, and #4288 changed it the same way.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
