### PR TITLE
Add support for the __array_namespace_info__ 

### DIFF
--- a/python/mlx/__array_api_info.py
+++ b/python/mlx/__array_api_info.py
@@ -29,7 +29,7 @@ class ArrayNamespaceInfo:
             }
         return {
             "real floating": mx.float64,
-            "complex floating": mx.complex128,
+            "complex floating": mx.complex64,
             "integral": mx.int64,
             "indexing": mx.uint64,
         }

--- a/python/mlx/__array_api_info.py
+++ b/python/mlx/__array_api_info.py
@@ -3,16 +3,46 @@ class ArrayNamespaceInfo:
         pass
 
     def capabilities(self):
-        pass
+        return {
+            "boolean indexing": False,
+            "data-dependent shapes": False,
+            "max dimensions": None,
+        }
 
     def default_device(self):
-        pass
+        import mlx.core as mx
 
-    def default_dtype(self):
-        pass
+        return mx.default_device()
+
+    def default_dtypes(self, *, device=None):
+        import mlx.core as mx
+
+        if device is not None and not isinstance(device, mx.Device):
+            raise TypeError("Expected a mlx Device")
+        device = device if device is not None else self.default_device()
+        if device.type == mx.gpu:
+            return {
+                "real floating": mx.float32,
+                "complex floating": mx.complex64,
+                "integral": mx.int32,
+                "indexing": mx.uint32,
+            }
+        return {
+            "real floating": mx.float64,
+            "complex floating": mx.complex128,
+            "integral": mx.int64,
+            "indexing": mx.uint64,
+        }
 
     def devices(self):
-        pass
+        import mlx.core as mx
+
+        devices = [
+            mx.Device(dev_type, i)
+            for dev_type in (mx.cpu, mx.gpu)
+            for i in range(mx.device_count(dev_type))
+        ]
+        return tuple(devices)
 
     def dtypes(self, *, device=None, kind=None):
         pass

--- a/python/mlx/__array_api_info.py
+++ b/python/mlx/__array_api_info.py
@@ -1,12 +1,9 @@
 class ArrayNamespaceInfo:
-    def __init__(self):
-        pass
-
     def capabilities(self):
         return {
             "boolean indexing": False,
             "data-dependent shapes": False,
-            "max dimensions": None,
+            "max dimensions": 10,
         }
 
     def default_device(self):
@@ -19,19 +16,11 @@ class ArrayNamespaceInfo:
 
         if device is not None and not isinstance(device, mx.Device):
             raise TypeError("Expected a mlx Device")
-        device = device if device is not None else self.default_device()
-        if device.type == mx.gpu:
-            return {
-                "real floating": mx.float32,
-                "complex floating": mx.complex64,
-                "integral": mx.int32,
-                "indexing": mx.uint32,
-            }
         return {
-            "real floating": mx.float64,
+            "real floating": mx.float32,
             "complex floating": mx.complex64,
-            "integral": mx.int64,
-            "indexing": mx.uint64,
+            "integral": mx.int32,
+            "indexing": mx.int32,
         }
 
     def devices(self):
@@ -45,7 +34,48 @@ class ArrayNamespaceInfo:
         return tuple(devices)
 
     def dtypes(self, *, device=None, kind=None):
-        pass
+        import mlx.core as mx
+
+        if device is not None and not isinstance(device, mx.Device):
+            raise TypeError("Expected a mlx Device")
+        device = device if device is not None else self.default_device()
+
+        dtypes = {
+            "bool": mx.bool_,
+            "int8": mx.int8,
+            "int16": mx.int16,
+            "int32": mx.int32,
+            "int64": mx.int64,
+            "uint8": mx.uint8,
+            "uint16": mx.uint16,
+            "uint32": mx.uint32,
+            "uint64": mx.uint64,
+            "float32": mx.float32,
+            "complex64": mx.complex64,
+        }
+        if device.type == mx.cpu:
+            dtypes["float64"] = mx.float64
+        if kind is None:
+            return dtypes
+
+        signed = {"int8", "int16", "int32", "int64"}
+        unsigned = {"uint8", "uint16", "uint32", "uint64"}
+        real = {"float32", "float64"}
+        complex_ = {"complex64"}
+        kinds = {
+            "bool": {"bool"},
+            "signed integer": signed,
+            "unsigned integer": unsigned,
+            "integral": signed | unsigned,
+            "real floating": real,
+            "complex floating": complex_,
+            "numeric": signed | unsigned | real | complex_,
+        }
+        kind = (kind,) if isinstance(kind, str) else kind
+        if not isinstance(kind, tuple) or any(k not in kinds for k in kind):
+            raise ValueError(f"Unsupported dtype kind: {kind!r}")
+        names = {name for k in kind for name in kinds[k]}
+        return {name: dtype for name, dtype in dtypes.items() if name in names}
 
 
 def __array_namespace_info__():

--- a/python/mlx/__array_api_info.py
+++ b/python/mlx/__array_api_info.py
@@ -1,0 +1,22 @@
+class ArrayNamespaceInfo:
+    def __init__(self):
+        pass
+
+    def capabilities(self):
+        pass
+
+    def default_device(self):
+        pass
+
+    def default_dtype(self):
+        pass
+
+    def devices(self):
+        pass
+
+    def dtypes(self, *, device=None, kind=None):
+        pass
+
+
+def __array_namespace_info__():
+    return ArrayNamespaceInfo()

--- a/python/src/mlx.cpp
+++ b/python/src/mlx.cpp
@@ -31,6 +31,10 @@ NB_MODULE(core, m) {
   auto reprlib_fix = nb::module_::import_("mlx._reprlib_fix");
   nb::set_leak_warnings(false);
 
+  auto array_namespace_info = nb::module_::import_("mlx.__array_api_info");
+  m.attr("__array_namespace_info__") =
+      array_namespace_info.attr("__array_namespace_info__");
+
   init_mlx_func(m);
   init_device(m);
   init_stream(m);

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -49,6 +49,11 @@ class TestVersion(mlx_tests.MLXTestCase):
         self.assertEqual(v, mx.__version__[: len(v)])
 
 
+class TestArrayNamespsceInfo(mlx_tests.MLXTestCase):
+    def test(self):
+        namespace = mx.__array_namespace_info__()
+
+
 class TestDtypes(mlx_tests.MLXTestCase):
     def test_dtypes(self):
         self.assertEqual(mx.bool_.size, 1)

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -53,6 +53,32 @@ class TestArrayNamespsceInfo(mlx_tests.MLXTestCase):
     def test(self):
         namespace = mx.__array_namespace_info__()
 
+        self.assertEqual(namespace.default_device(), mx.default_device())
+        self.assertEqual(
+            namespace.default_dtypes(),
+            {
+                "real floating": mx.float32,
+                "complex floating": mx.complex64,
+                "integral": mx.int32,
+                "indexing": mx.int32,
+            },
+        )
+        self.assertEqual(
+            namespace.dtypes(device=mx.Device(mx.cpu), kind="real floating"),
+            {"float32": mx.float32, "float64": mx.float64},
+        )
+        if mx.is_available(mx.gpu):
+            self.assertEqual(
+                namespace.dtypes(device=mx.Device(mx.gpu), kind="real floating"),
+                {"float32": mx.float32},
+            )
+        self.assertEqual(
+            namespace.dtypes(kind=("bool", "complex floating")),
+            {"bool": mx.bool_, "complex64": mx.complex64},
+        )
+        with self.assertRaises(ValueError):
+            namespace.dtypes(kind="invalid")
+
 
 class TestDtypes(mlx_tests.MLXTestCase):
     def test_dtypes(self):


### PR DESCRIPTION
## Proposed changes

Please include a description of the problem or feature this PR is addressing. If there is a corresponding issue, include the issue #.
This pull request adds support for the `__array_namespace_info__ ` to make it complaint with the array api spec 
https://data-apis.org/array-api/latest/API_specification/generated/array_api.info.__array_namespace_info__.html#array-namespace-info

Ai was used for writing test :)
closes #4239 

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
