### PR TITLE
Update nanobind to 2.15.0

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -68,6 +68,14 @@ jobs:
           cmake-args: ${{ steps.setup.outputs.cmake-args }}
           # For MSVC, Ninja/Release is the only config supported by ccache.
           debug: ${{ matrix.os != 'Windows' }}
+      - name: Check generated Python stubs with Ruff
+        if: matrix.os == 'Linux' && matrix.arch == 'x86_64' && matrix.toolkit == 'cpu'
+        continue-on-error: true
+        run: uvx ruff check --select E4,E7,F python/mlx/core
+      - name: Check generated Python stubs with ty
+        if: matrix.os == 'Linux' && matrix.arch == 'x86_64' && matrix.toolkit == 'cpu'
+        continue-on-error: true
+        run: uvx ty check python/mlx/core
       - uses: ./.github/actions/test-linux
         if: matrix.os == 'Linux' && (matrix.toolkit == 'cpu' || matrix.arch == 'x86_64')
       - uses: ./.github/actions/test-windows

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -68,13 +68,8 @@ jobs:
           cmake-args: ${{ steps.setup.outputs.cmake-args }}
           # For MSVC, Ninja/Release is the only config supported by ccache.
           debug: ${{ matrix.os != 'Windows' }}
-      - name: Check generated Python stubs with Ruff
-        if: matrix.os == 'Linux' && matrix.arch == 'x86_64' && matrix.toolkit == 'cpu'
-        continue-on-error: true
-        run: uvx ruff check --select E4,E7,F python/mlx/core
       - name: Check generated Python stubs with ty
         if: matrix.os == 'Linux' && matrix.arch == 'x86_64' && matrix.toolkit == 'cpu'
-        continue-on-error: true
         run: uvx ty check python/mlx/core
       - uses: ./.github/actions/test-linux
         if: matrix.os == 'Linux' && (matrix.toolkit == 'cpu' || matrix.arch == 'x86_64')

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,7 +395,7 @@ if(MLX_BUILD_PYTHON_BINDINGS)
   FetchContent_Declare(
     nanobind
     GIT_REPOSITORY https://github.com/wjakob/nanobind.git
-    GIT_TAG v2.13.0
+    GIT_TAG v2.15.0
     GIT_SHALLOW TRUE
     EXCLUDE_FROM_ALL)
   FetchContent_MakeAvailable(nanobind)

--- a/examples/extensions/pyproject.toml
+++ b/examples/extensions/pyproject.toml
@@ -3,6 +3,6 @@ requires = [
   "setuptools>=42",
   "cmake>=3.25",
   "mlx>=0.18.0",
-  "nanobind==2.13.0",
+  "nanobind==2.15.0",
 ]
 build-backend = "setuptools.build_meta"

--- a/examples/extensions/requirements.txt
+++ b/examples/extensions/requirements.txt
@@ -1,4 +1,4 @@
 setuptools>=42
 cmake>=3.25
 mlx>=0.31.2
-nanobind==2.13.0
+nanobind==2.15.0

--- a/python/mlx/_stub_patterns.txt
+++ b/python/mlx/_stub_patterns.txt
@@ -1,5 +1,5 @@
 mlx.core.__prefix__:
-  from typing import Any, ParamSpec, Protocol, TypeAlias, TypeVar
+  from typing import Any, BinaryIO as file, Literal, ParamSpec, Protocol, TypeAlias, TypeVar
   P = ParamSpec("P")
   R = TypeVar("R")
   class DLPackCompatible(Protocol):
@@ -12,21 +12,32 @@ mlx.core.__suffix__:
   StreamOrDevice: TypeAlias = Stream | ThreadLocalStream | Device | DeviceType | None
   bool_: Dtype = ...
 
+mlx.core.matrix_norm:
+  matrix_norm = linalg.norm
+
+mlx.core.array.__(eq|ne)__:
+  @overload
+  def __\1__(self, other: bool | int | float | array | Annotated[NDArray, dict(writable=False)] | complex) -> array: ...
+  @overload
+  def __\1__(self, other: ArrayLike) -> array | bool: ...
+  @overload
+  def __\1__(self, other: object) -> Any: ...
+
+mlx.core._PrintOptionsContext:
+  class _PrintOptionsContext:
+    def __init__(self, arg: PrintOptions, /) -> None: ...
+    def __enter__(self) -> _PrintOptionsContext: ...
+    def __exit__(self, *args) -> None: ...
+
 mlx.core.distributed.__prefix__:
-  from mlx.core import array, Dtype, StreamOrDevice, scalar
-  from mlx.core.distributed import Group
-  from collections.abc import Sequence
+  from mlx.core import array, Dtype, StreamOrDevice
+  from collections.abc import Callable, Sequence
 
 mlx.core.fast.__prefix__:
-  from mlx.core import array, Dtype, StreamOrDevice, scalar
+  from mlx.core import array, StreamOrDevice
 
 mlx.core.linalg.__prefix__:
-  from mlx.core import array, Dtype, StreamOrDevice, scalar
-  from collections.abc import Sequence
-
-mlx.core.metal.__prefix__:
-  from mlx.core import array, Dtype, Device, Stream, scalar
-  from collections.abc import Sequence
+  from mlx.core import array, StreamOrDevice
 
 mlx.core.random.__prefix__:
   from mlx.core import array, Dtype, StreamOrDevice, scalar, float32, int32

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -159,6 +159,20 @@ class TestOps(mlx_tests.MLXTestCase):
         self.assertEqual(mx.ones([2, 3]).shape, (2, 3))
         self.assertEqual(mx.full((2, 3), 1.5).tolist(), [[1.5] * 3] * 2)
 
+    def test_integer_index_protocol(self):
+        a = mx.arange(4)
+
+        index = np.int32(2)
+        self.assertEqual(mx.topk(a, index).shape, (2,))
+        self.assertEqual(mx.reshape(a, [index, 2]).shape, (2, 2))
+
+        for value in (np.float32(2), "2"):
+            with self.subTest(value=value):
+                with self.assertRaises(TypeError):
+                    mx.topk(a, value)
+                with self.assertRaises(TypeError):
+                    mx.reshape(a, [value, 2])
+
     def test_scalar_inputs(self):
         # Check combinations of python types
         a = mx.add(False, True)


### PR DESCRIPTION
## Proposed changes

Update nanobind from 2.13.0 to 2.15.0 for the MLX Python bindings and extension examples.

This change also:

- adds coverage for the updated nanobind integer conversion semantics, accepting objects that implement `__index__` while rejecting floating-point and string inputs
- updates the stub generation patterns for nanobind 2.15, including generated imports, aliases, comparison return types, and context manager signatures
- adds non-blocking Ruff and ty checks for generated `mlx.core` stubs in the Linux CPU CI job

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
