### PR TITLE
Raise cpu stream errors from synchronize

### DIFF
--- a/mlx/scheduler.cpp
+++ b/mlx/scheduler.cpp
@@ -17,8 +17,6 @@ void synchronize(Stream s) {
     std::future<void> f = p->get_future();
     scheduler::enqueue(s, [p = std::move(p)]() { p->set_value(); });
     f.wait();
-    // enqueue() checks the error before the queued work runs, so an error from
-    // the work waited on above is only visible here.
     scheduler::check_error(s);
   } else {
     gpu::synchronize(s);

--- a/mlx/scheduler.cpp
+++ b/mlx/scheduler.cpp
@@ -17,6 +17,9 @@ void synchronize(Stream s) {
     std::future<void> f = p->get_future();
     scheduler::enqueue(s, [p = std::move(p)]() { p->set_value(); });
     f.wait();
+    // enqueue() checks the error before the queued work runs, so an error from
+    // the work waited on above is only visible here.
+    scheduler::check_error(s);
   } else {
     gpu::synchronize(s);
   }
@@ -138,6 +141,10 @@ void Scheduler::signal_event(
     }
     task(event);
   });
+}
+
+void Scheduler::check_error(Stream s) {
+  get_thread(s).error.check();
 }
 
 StreamThread& Scheduler::get_thread(Stream s) {

--- a/mlx/scheduler.h
+++ b/mlx/scheduler.h
@@ -31,6 +31,7 @@ class MLX_API Scheduler {
   void enqueue(Stream s, std::function<void()> task);
   void wait_event(Stream s, Event event, std::function<void(Event&)> task);
   void signal_event(Stream s, Event event, std::function<void(Event&)> task);
+  void check_error(Stream s);
 
   void notify_new_task(const Stream& stream) {
     {
@@ -90,6 +91,11 @@ inline void wait_event(Stream s, Event event, F&& f) {
 template <typename F>
 inline void signal_event(Stream s, Event event, F&& f) {
   scheduler().signal_event(s, std::move(event), std::forward<F>(f));
+}
+
+// Throw and clear the error stored in the stream, if any.
+inline void check_error(Stream s) {
+  scheduler().check_error(s);
 }
 
 inline int n_active_tasks() {

--- a/python/tests/test_eval.py
+++ b/python/tests/test_eval.py
@@ -227,6 +227,12 @@ class TestEval(mlx_tests.MLXTestCase):
         x = mx.full((512,), 2.0)
         self.assertEqual((x + 1.0).sum().item(), 512.0 * 3.0)
 
+    def test_async_eval_error_in_synchronize(self):
+        a = mx.linalg.inv(mx.array([[1.0, 2.0], [2.0, 4.0]]), stream=mx.cpu)
+        mx.async_eval(a)
+        with self.assertRaises(RuntimeError):
+            mx.synchronize(mx.cpu)
+
 
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner()

--- a/python/tests/test_eval.py
+++ b/python/tests/test_eval.py
@@ -227,6 +227,9 @@ class TestEval(mlx_tests.MLXTestCase):
         x = mx.full((512,), 2.0)
         self.assertEqual((x + 1.0).sum().item(), 512.0 * 3.0)
 
+    @unittest.skipIf(
+        mx.cuda.is_available(), "CUDA backend waits cpu stream synchronously"
+    )
     def test_async_eval_error_in_synchronize(self):
         a = mx.linalg.inv(mx.array([[1.0, 2.0], [2.0, 4.0]]), stream=mx.cpu)
         mx.async_eval(a)


### PR DESCRIPTION
## Proposed changes

Addresses the first half of #4329. The reporter diagnosed the ordering; this is their option 1.

A cpu stream error is stored on the stream and checked only by the next main-thread `enqueue`, or by an event poisoned at signal time - never by `synchronize`, which enqueues a task then waits, so its check runs before that work has run:

```python
a = mx.linalg.inv(mx.array([[1.0, 2.0], [2.0, 4.0]]), stream=mx.cpu)  # singular
mx.async_eval(a)
mx.synchronize(mx.cpu)   # returns cleanly, the error never surfaces
```

The gpu branch already waits then checks (`CommandEncoder::synchronize`, `mlx/backend/metal/device.cpp:564`), so this restores symmetry; the promise task is queued behind the failing one, so the check is deterministic. Like the gpu path and unlike the enqueue-time check, it is deliberately not gated on the main thread. Only the cpu branch changes, so with a gpu default device the no-argument `mx.synchronize()` is unaffected. `python/tests/test_load.py:121` already syncs a poisoned stream "to clear the errors"; this makes that reliable.

Not addressed: the uncatchable abort on read (`getbuffer` in `python/src/buffer.h` is a CPython slot with no exception translation; it reproduces without `async_eval`).

New test `test_async_eval_error_in_synchronize`: 20 failures at base, 20 passes with the fix. Suites: `python/tests` 827 passed / 22 skipped, C++ 277 cases / 3714 assertions.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)

---
AI assistance was used in developing this change. I reviewed and tested every line.
