### PR TITLE
Fix scan and sort for a zero-size axis

### DIFF
--- a/mlx/backend/cpu/scan.cpp
+++ b/mlx/backend/cpu/scan.cpp
@@ -269,6 +269,11 @@ void scan_dispatch(
 void Scan::eval_cpu(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 1);
 
+  if (out.size() == 0) {
+    out.set_data(allocator::malloc(0));
+    return;
+  }
+
   auto& encoder = cpu::get_command_encoder(stream());
 
   // Ensure contiguity

--- a/mlx/backend/cpu/sort.cpp
+++ b/mlx/backend/cpu/sort.cpp
@@ -357,6 +357,10 @@ void ArgSort::eval_cpu(const std::vector<array>& inputs, array& out) {
   // Allocate output
   out.set_data(allocator::malloc(out.nbytes()));
 
+  if (out.size() == 0) {
+    return;
+  }
+
   auto& encoder = cpu::get_command_encoder(stream());
   encoder.set_input_array(in);
   encoder.set_input_array(out);
@@ -383,6 +387,10 @@ void Sort::eval_cpu(const std::vector<array>& inputs, array& out) {
       ? CopyType::Vector
       : CopyType::General;
   copy_cpu(in, out, ctype, stream());
+
+  if (out.size() == 0) {
+    return;
+  }
 
   auto& encoder = cpu::get_command_encoder(stream());
   encoder.set_output_array(out);

--- a/mlx/backend/cuda/scan.cu
+++ b/mlx/backend/cuda/scan.cu
@@ -458,6 +458,11 @@ void Scan::eval_gpu(const std::vector<array>& inputs, array& out) {
   auto& s = stream();
   auto& encoder = cu::get_command_encoder(s);
 
+  if (out.size() == 0) {
+    out.set_data(cu::malloc_async(out.nbytes(), encoder));
+    return;
+  }
+
   if (in.flags().contiguous && in.strides()[axis_] != 0) {
     if (in.is_donatable() && in.itemsize() == out.itemsize()) {
       out.copy_shared_buffer(in);

--- a/mlx/backend/cuda/sort.cu
+++ b/mlx/backend/cuda/sort.cu
@@ -1084,6 +1084,10 @@ void gpu_sort(
     int axis,
     bool argsort) {
   auto& encoder = cu::get_command_encoder(s);
+  if (out.size() == 0) {
+    out.set_data(cu::malloc_async(out.nbytes(), encoder));
+    return;
+  }
   gpu_merge_sort(s, in, out, axis, argsort);
 }
 

--- a/mlx/backend/metal/scan.cpp
+++ b/mlx/backend/metal/scan.cpp
@@ -116,6 +116,11 @@ void scan_gpu_inplace(
 void Scan::eval_gpu(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 1);
 
+  if (out.size() == 0) {
+    out.set_data(allocator::malloc(0));
+    return;
+  }
+
   auto in = inputs[0];
   if (in.flags().contiguous && in.strides()[axis_] != 0) {
     if (in.is_donatable() && in.itemsize() == out.itemsize()) {

--- a/mlx/backend/metal/sort.cpp
+++ b/mlx/backend/metal/sort.cpp
@@ -278,6 +278,10 @@ void gpu_merge_sort(
     array& out,
     int axis_,
     bool argsort) {
+  if (out.size() == 0) {
+    return;
+  }
+
   // Get size info
   int axis = axis_ < 0 ? axis_ + in.ndim() : axis_;
   int size_sorted_axis = in.shape(axis);

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -2677,6 +2677,14 @@ class TestOps(mlx_tests.MLXTestCase):
         mem4 = mx.get_peak_memory()
         self.assertEqual(mem2, mem4)
 
+        # Scanning an empty axis is a no-op
+        for a in (mx.array([]), mx.zeros((2, 0)), mx.zeros((0, 2))):
+            for op in ("cumsum", "cumprod", "cummax", "cummin", "logcumsumexp"):
+                for axis in range(a.ndim):
+                    out = getattr(mx, op)(a, axis=axis)
+                    mx.eval(out)
+                    self.assertEqual(out.shape, a.shape)
+
     def test_scan_size_one_axis(self):
         # A size one axis can carry any stride and still be row contiguous, so
         # the scan must not take its row count from that stride.
@@ -2935,6 +2943,16 @@ class TestOps(mlx_tests.MLXTestCase):
 
                     b_mx = mx.partition(a_mx, 1, axis=-1)
                     self.assertTrue(np.array_equal(b_np[:, 1], np.array(b_mx)[:, 1]))
+
+        # Sorting an empty axis is a no-op
+        for a in (mx.array([]), mx.zeros((2, 0)), mx.zeros((0, 2))):
+            for axis in range(a.ndim):
+                out = mx.sort(a, axis=axis)
+                mx.eval(out)
+                self.assertEqual(out.shape, a.shape)
+                out = mx.argsort(a, axis=axis)
+                mx.eval(out)
+                self.assertEqual(out.shape, a.shape)
 
     def test_partition(self):
         shape = (3, 4, 5)

--- a/tests/ops_tests.cpp
+++ b/tests/ops_tests.cpp
@@ -2949,6 +2949,40 @@ TEST_CASE("test scan op") {
   y = vmap(fun, 1, 1)(x);
   expected = array({1.0f, 2.0f, 4.0f, 6.0f, 9.0f, 12.0f, 16.0f, 20.0f}, {4, 2});
   CHECK(array_equal(y, expected).item<bool>());
+
+  // Scanning an empty axis is a no-op
+  x = zeros({2, 0});
+  y = cumsum(x, 1);
+  eval(y);
+  CHECK_EQ(y.shape(), Shape{2, 0});
+  y = cummax(x, 1);
+  eval(y);
+  CHECK_EQ(y.shape(), Shape{2, 0});
+  x = zeros({0, 2});
+  y = cumsum(x, 0);
+  eval(y);
+  CHECK_EQ(y.shape(), Shape{0, 2});
+  y = cummin(x, 0);
+  eval(y);
+  CHECK_EQ(y.shape(), Shape{0, 2});
+}
+
+TEST_CASE("test sort op") {
+  // Sorting an empty axis is a no-op
+  auto x = zeros({2, 0});
+  auto y = sort(x, 1);
+  eval(y);
+  CHECK_EQ(y.shape(), Shape{2, 0});
+  y = argsort(x, 1);
+  eval(y);
+  CHECK_EQ(y.shape(), Shape{2, 0});
+  x = zeros({0, 2});
+  y = sort(x, 0);
+  eval(y);
+  CHECK_EQ(y.shape(), Shape{0, 2});
+  y = argsort(x, 0);
+  eval(y);
+  CHECK_EQ(y.shape(), Shape{0, 2});
 }
 
 TEST_CASE("test pad") {


### PR DESCRIPTION
## Proposed changes

`Scan` and `Sort` work out the row count on the host with `in.size() / in.shape(axis)`.
When the scanned or sorted axis has length zero, both operands are zero.
On x86-64 the `DIV` instruction raises `#DE`, so `mx.cumsum(mx.array([]), axis=0)` kills the process with `SIGFPE`.

Apple silicon never sees it.
AArch64 integer division by zero returns 0 and raises nothing, so the loop bound comes out zero and the empty result is right by accident.

I built `main` for linux/amd64 in a container and ran `cumsum` on a shape `(0,)` array.
It dies with a floating point exception, exit 136.
The same build with the guard exits 0 and prints the empty result.

A `USE_UBSAN` build on macOS reports the division at `mlx/backend/cpu/scan.cpp:170` and `mlx/backend/cpu/sort.cpp:124` before the change, and nothing after it.

The fix returns early when the output is empty, in the scan and sort entry points of all three backends.
It is the same `out.size() == 0` check `SearchSorted` already carries.
Eight files is one guard landing in three backends across two ops, plus the two test files.

`Partition` and `ArgPartition` divide the same way on CPU and are left alone.
`mlx/ops.cpp` rejects every `kth` on a zero-length axis, so those primitives are never built.
On Metal and CUDA they route through the shared sort helper and pick up the guard anyway.

I have no NVIDIA hardware here.
Both `.cu` files compile clean under `nvcc` 12.9 for sm_80, but running them needs a real GPU, so that part rides on CI.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)