### PR TITLE
Floor integer floor_divide to match python and numpy

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -3154,10 +3154,23 @@ array floor_divide(
     return floor(divide(a, b, s), s);
   }
 
+  // Integer division truncates toward zero, so take that quotient and step it
+  // down when the result was negative and did not divide evenly. Deriving the
+  // quotient from a - remainder(a, b) instead would leave the dtype range: for
+  // int8 that numerator is 135 when a is 120 and b is -27.
   auto inputs = broadcast_arrays({astype(a, dtype, s), astype(b, dtype, s)}, s);
   auto shape = inputs[0].shape();
-  return array(
-      shape, dtype, std::make_shared<Divide>(to_stream(s)), std::move(inputs));
+  auto quotient =
+      array(shape, dtype, std::make_shared<Divide>(to_stream(s)), inputs);
+  // quotient * b has the sign of a and is no larger in magnitude, so this
+  // truncated remainder is exact for every input the division itself accepts.
+  auto zero = array(0, dtype);
+  auto rem = subtract(inputs[0], multiply(quotient, inputs[1], s), s);
+  auto step = logical_and(
+      not_equal(rem, zero, s),
+      not_equal(less(rem, zero, s), less(inputs[1], zero, s), s),
+      s);
+  return subtract(quotient, astype(step, dtype, s), s);
 }
 
 array remainder(const array& a, const array& b, StreamOrDevice s /* = {} */) {

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -330,6 +330,50 @@ class TestOps(mlx_tests.MLXTestCase):
         self.assertEqual(z.dtype, mx.float32)
         self.assertEqual(z.item(), 6.0)
 
+    def test_floor_divide_integers_floor(self):
+        # Integer // truncated toward zero, so it disagreed with python and
+        # numpy whenever the operands had opposite signs.
+        av = [-7, 7, -7, 7, -1, 1, -5, 5, 6, -6]
+        bv = [2, 2, -2, -2, 3, -3, 3, -3, 3, 3]
+        got = mx.floor_divide(mx.array(av), mx.array(bv))
+        self.assertEqual(got.tolist(), [x // y for x, y in zip(av, bv)])
+
+        # The quotient comes from the truncating one plus a correction rather
+        # than from a - remainder(a, b), which can leave the dtype range: for
+        # int8 that numerator is 135 when a is 120 and b is -27.
+        for np_dtype in (np.int8, np.int16):
+            info = np.iinfo(np_dtype)
+            values = [info.min, info.min + 1, -1, 0, 1, 2, info.max - 1, info.max]
+            pairs = [
+                (x, y)
+                for x in values
+                for y in values
+                if y != 0 and not (x == info.min and y == -1)
+            ]
+            a_np = np.array([p[0] for p in pairs], np_dtype)
+            b_np = np.array([p[1] for p in pairs], np_dtype)
+            want = np.floor_divide(a_np.astype(np.int64), b_np.astype(np.int64)).astype(
+                np_dtype
+            )
+            got = mx.floor_divide(mx.array(a_np), mx.array(b_np))
+            self.assertEqual(got.tolist(), want.tolist(), msg=str(np_dtype))
+
+        # Unsigned division already floors and is unchanged.
+        au = np.array([0, 1, 7, 255], np.uint8)
+        bu = np.array([1, 2, 3, 7], np.uint8)
+        self.assertEqual(
+            mx.floor_divide(mx.array(au), mx.array(bu)).tolist(),
+            np.floor_divide(au, bu).tolist(),
+        )
+
+        # Floats keep going through floor(a / b).
+        af = np.array([7.5, -7.5, 7.5, -7.5], np.float32)
+        bf = np.array([2.0, 2.0, -2.0, -2.0], np.float32)
+        self.assertEqual(
+            mx.floor_divide(mx.array(af), mx.array(bf)).tolist(),
+            np.floor_divide(af, bf).tolist(),
+        )
+
     def test_divide(self):
         x = mx.array(2.0)
         y = mx.array(4.0)


### PR DESCRIPTION
Follow up to #4108, split out at your request there.

Integer division truncates toward zero, so `mx.floor_divide` disagrees with python and numpy whenever the operands have opposite signs:

```python
>>> av = [-7, 7, -7, 7, -1, 1, -5, 5]
>>> bv = [ 2, 2, -2, -2, 3, -3, 3, -3]
>>> mx.floor_divide(mx.array(av), mx.array(bv)).tolist()
[-3, 3, 3, -3, 0, 0, -1, -1]
>>> [x // y for x, y in zip(av, bv)]        # python
[-4, 3, 3, -4, -1, -1, -2, -2]
>>> np.floor_divide(av, bv).tolist()        # numpy
[-4, 3, 3, -4, -1, -1, -2, -2]
```

`mx.remainder` already floors, so today `//` and `%` describe different divisions, and the `divmod` docstring's claim that it is equivalent to `(a // b, a % b)` cannot hold for either.

The fix takes the truncating quotient and steps it down when the operands have opposite signs and the division was not exact. The reason it is written that way rather than as the shorter `(a - remainder(a, b)) / b` is that the shorter form overflows: for `int8` with `a = 120` and `b = -27` the numerator is 135, which wraps to -121, and `-121 / -27` is 4 instead of -5. `quotient * b` has the sign of `a` and is never larger in magnitude, so the truncated remainder here is exact for every input the division itself accepts.

Verified over **all 65279 int8 pairs** with a non zero divisor, skipping only `INT_MIN / -1` which overflows before any of this, with zero mismatches against numpy. Also the boundary values (`min`, `min+1`, -1, 0, 1, 2, `max-1`, `max`) for int16, int32, int64 and all four unsigned widths, again zero mismatches. Unsigned division already floored and is unchanged, floats still go through `floor(a / b)` untouched, and `vmap` and `compile` of `//` both match numpy, which matters because `Divide::vmap` rewrites integer division to `floor_divide`.

`test_ops.py`, `test_vmap.py`, `test_compile.py`, `test_autograd.py` and `test_array.py` pass, along with the C++ suite (250 cases, 3351 assertions). The added test fails on main.

One consequence worth stating: with this and #4108 both in, `mx.divmod(a, b)` and `(a // b, a % b)` agree for integers and the docstring becomes true. Either one alone leaves them disagreeing, in opposite directions.

I am a freshman working through this codebase and I used Claude Code alongside it. Every number above came from a run on this machine.
