### PR TITLE
Add d=512 vector SDPA kernels, reachable via force_fused

### DIFF
--- a/mlx/backend/metal/kernels/scaled_dot_product_attention.metal
+++ b/mlx/backend/metal/kernels/scaled_dot_product_attention.metal
@@ -35,11 +35,13 @@ using namespace metal;
   instantiate_sdpa_vector(type, 192, 128)        \
   instantiate_sdpa_vector(type, 192, 192)        \
   instantiate_sdpa_vector(type, 256, 256)        \
+  instantiate_sdpa_vector(type, 512, 512)        \
   instantiate_sdpa_vector_aggregation(type, 64)  \
   instantiate_sdpa_vector_aggregation(type, 96)  \
   instantiate_sdpa_vector_aggregation(type, 128) \
   instantiate_sdpa_vector_aggregation(type, 192) \
-  instantiate_sdpa_vector_aggregation(type, 256)
+  instantiate_sdpa_vector_aggregation(type, 256) \
+  instantiate_sdpa_vector_aggregation(type, 512)
 
 instantiate_sdpa_vector_heads(float)
 instantiate_sdpa_vector_heads(bfloat16_t)

--- a/mlx/backend/metal/kernels/sdpa_vector.h
+++ b/mlx/backend/metal/kernels/sdpa_vector.h
@@ -40,7 +40,10 @@ template <typename T, int D, int V = D>
     uint3 tpg [[threadgroups_per_grid]],
     uint simd_gid [[simdgroup_index_in_threadgroup]],
     uint simd_lid [[thread_index_in_simdgroup]]) {
-  constexpr int BN = 32;
+  // D >= 512 needs too many registers for 32 simdgroups on some GPUs (e.g.
+  // M1-class caps these pipelines below 1024 threads, and the cap shifts with
+  // compiler version and specialization); halve the simdgroup count instead.
+  constexpr int BN = D >= 512 ? 16 : 32;
   constexpr int BD = 32;
   constexpr int qk_per_thread = D / BD;
   constexpr int v_per_thread = V / BD;
@@ -53,7 +56,7 @@ template <typename T, int D, int V = D>
   thread U k[qk_per_thread];
   thread U o[v_per_thread];
 
-  threadgroup U outputs[BN * BD];
+  threadgroup U outputs[BD * BD];
   threadgroup U max_scores[BN];
   threadgroup U sum_exp_scores[BN];
 
@@ -78,7 +81,7 @@ template <typename T, int D, int V = D>
         simd_gid * mask_kv_seq_stride + q_seq_idx * mask_q_seq_stride;
   }
 
-  out += o_offset * V + simd_gid * v_per_thread;
+  out += o_offset * V;
 
   // Read the query and 0 the output accumulator
   for (int i = 0; i < qk_per_thread; i++) {
@@ -154,25 +157,27 @@ template <typename T, int D, int V = D>
     sum_exp_scores[simd_gid] = sum_exp_score;
   }
   threadgroup_barrier(mem_flags::mem_threadgroup);
-  max_score = max_scores[simd_lid];
+  max_score = simd_lid < BN ? max_scores[simd_lid] : Limits<U>::finite_min;
   U new_max = simd_max(max_score);
   U factor = fast::exp(max_score - new_max);
-  sum_exp_score = simd_sum(sum_exp_scores[simd_lid] * factor);
+  sum_exp_score =
+      simd_sum(simd_lid < BN ? sum_exp_scores[simd_lid] * factor : 0);
 
-  // Now we need to aggregate all the outputs
+  // Now we need to aggregate all the outputs. There are BD output slices of
+  // v_per_thread elements but only BN simdgroups, so when BN < BD each
+  // simdgroup aggregates and writes BD / BN slices.
   for (int i = 0; i < v_per_thread; i++) {
     outputs[simd_lid * BD + simd_gid] = o[i];
     threadgroup_barrier(mem_flags::mem_threadgroup);
-    o[i] = simd_sum(outputs[simd_gid * BD + simd_lid] * factor);
-    o[i] = sum_exp_score == 0 ? o[i] : (o[i] / sum_exp_score);
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-  }
-
-  // And write the output
-  if (simd_lid == 0) {
-    for (int i = 0; i < v_per_thread; i++) {
-      out[i] = static_cast<T>(o[i]);
+    for (int s = simd_gid; s < BD; s += BN) {
+      U agg =
+          simd_sum(simd_lid < BN ? outputs[s * BD + simd_lid] * factor : 0);
+      agg = sum_exp_score == 0 ? agg : (agg / sum_exp_score);
+      if (simd_lid == 0) {
+        out[s * v_per_thread + i] = static_cast<T>(agg);
+      }
     }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
   }
 }
 

--- a/mlx/backend/metal/scaled_dot_product_attention.cpp
+++ b/mlx/backend/metal/scaled_dot_product_attention.cpp
@@ -358,7 +358,9 @@ void sdpa_vector(
   size_t v_head_stride = v.shape(1) == 1 ? v.strides(0) : v.strides(1);
   size_t v_seq_stride = v.strides()[2];
 
-  MTL::Size group_dims(1024, 1, 1);
+  // Must match BN in sdpa_vector: 16 simdgroups for D >= 512 (register
+  // pressure caps these pipelines below 1024 threads on some GPUs).
+  MTL::Size group_dims(q.shape(-1) >= 512 ? 512 : 1024, 1, 1);
   MTL::Size grid_dims(q.shape(0) * q.shape(1), q.shape(2), 1);
 
   bool has_mask = mask.has_value();
@@ -645,13 +647,13 @@ std::tuple<bool, std::string> has_fused_kernel(
         (query_head_dim == value_head_dim &&
          (query_head_dim == 64 || query_head_dim == 96 ||
           query_head_dim == 128 || query_head_dim == 192 ||
-          query_head_dim == 256)) ||
+          query_head_dim == 256 || query_head_dim == 512)) ||
         (query_head_dim == 192 && value_head_dim == 128);
     if (!supported_head_dim) {
       msg << "the vector attention kernel supports head dims "
-          << "{64, 96, 128, 192, 256} with matching query/value head dims, "
-          << "or query head dim 192 with value head dim 128; got query head "
-          << "dim " << query_head_dim << " and value head dim "
+          << "{64, 96, 128, 192, 256, 512} with matching query/value head "
+          << "dims, or query head dim 192 with value head dim 128; got query "
+          << "head dim " << query_head_dim << " and value head dim "
           << value_head_dim << ".";
       return {false, msg.str()};
     }
@@ -714,7 +716,12 @@ bool ScaledDotProductAttention::use_fallback(
   if (query_sequence_length > 8) {
     return query_head_dim == 192 || query_head_dim == 256;
   } else {
-    return query_head_dim == value_head_dim && query_head_dim == 192;
+    // d=512 decode is a mixed bag under automatic routing (it wins on some
+    // device/shape/depth combinations and loses on others — see
+    // ml-explore/mlx#3885 for three-device sweeps), so like d=192 it is
+    // reachable only via force_fused.
+    return query_head_dim == value_head_dim &&
+        (query_head_dim == 192 || query_head_dim == 512);
   }
 }
 

--- a/python/tests/test_fast_sdpa.py
+++ b/python/tests/test_fast_sdpa.py
@@ -745,13 +745,26 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
                 self.assertTrue(mx.allclose(ref, out, atol=1e-3, rtol=1e-3))
 
         # Vector attention kernel.
-        for D in (192, 256):
+        for D in (192, 256, 512):
             with self.subTest(head_dim=D):
                 q, k, v = make_qkv(4, 16385, D, 4, 2)
                 scale = D**-0.5
                 ref = mlx_ref_attn(q, k, v, scale=scale)
                 out = mx.fast.scaled_dot_product_attention(
                     q, k, v, scale=scale, force_fused=True
+                )
+                self.assertTrue(mx.allclose(ref, out, atol=1e-3, rtol=1e-3))
+
+        # Short key sequences select the 1-pass kernel, which runs d=512 with
+        # a reduced simdgroup count to stay under register-limited pipeline
+        # caps (see #3885); check it against the reference in that regime.
+        for mask in (None, "causal"):
+            with self.subTest(head_dim=512, kernel="1pass", mask=mask):
+                q, k, v = make_qkv(1, 512, 512, 8, 4)
+                scale = 512**-0.5
+                ref = mlx_ref_attn(q, k, v, scale=scale, mask=mask)
+                out = mx.fast.scaled_dot_product_attention(
+                    q, k, v, scale=scale, mask=mask, force_fused=True
                 )
                 self.assertTrue(mx.allclose(ref, out, atol=1e-3, rtol=1e-3))
 


### PR DESCRIPTION

## Proposed changes

Builds on #4185: adds vector-kernel (decode) coverage for head_dim = 512 —
the shape of Gemma 4's global attention layers (32 q / 4 kv heads) — reachable
only via `force_fused`. Automatic routing is unchanged, mirroring the
d=192 precedent from #4185: three-device sweeps
(ml-explore/mlx#3885) show d=512 decode wins or loses depending on
device, shape, and depth, so the caller decides.

The 1-pass kernel runs D >= 512 with 16 simdgroups instead of 32. Register
pressure caps these pipelines below the 1024-thread launch on some GPUs, and
the cap is not a static device property: on the same M1 Max we have observed
three different cap configurations across five weeks (all-832 in July; 1-pass
bf16-nomask at 1024 with everything else 832 in early August; nearly
everything 832 including most 2-pass specializations by mid-August). A
portable dispatch has to fit the floor — 512 threads does, under every cap
observed — and if a future compiler squeezes below that, the dispatch-time
check from #4018 turns it into a loud error rather than silent zeros.
Lane-guarded reductions and per-simdgroup output slices keep the math
identical to the BN=32 form.

## Validation

- M1 Max (`applegpu_g13s`) + M4 Max (`applegpu_g16s`): force_fused output
  matches the composite path to input-dtype rounding for bf16 and fp16 across
  1-pass and 2-pass regimes, MHA/GQA/MQA shapes; the d=256 control is
  bit-exact (force and auto select the same kernel there).
- Throw paths verified on both machines: d=512 prefill (no full kernel) and
  d=72 (no kernel anywhere) raise with the supported-dims message; the vector
  message now lists 512.
- `python -m pytest python/tests/test_fast_sdpa.py`: 19 passed, 2 skipped,
  705 subtests — including new d=512 vector-loop and short-kL 1-pass cases
  (fp16, masked and unmasked — the specializations M1-class caps hardest).
  Rebased onto `main` post-#4185 merge; full `test_fast_sdpa.py` and
  `test_fast.py` pass unchanged on the new base.
- Decode perf landscape for the routing decision: three-device sweep data
  (M4 Max, M1 Max, M4 iPad Pro) in ml-explore/mlx#3885.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
