### PR TITLE
Use cast_to for fused AsType in compiled Metal kernels

### DIFF
--- a/mlx/backend/metal/compiled.cpp
+++ b/mlx/backend/metal/compiled.cpp
@@ -208,7 +208,7 @@ inline void build_kernel(
         "  {0} tmp_{1} = ", get_type_string(x.dtype()), namer.get_name(x));
     if (is_static_cast(x.primitive())) {
       os += fmt::format(
-          "static_cast<{0}>(tmp_{1});\n",
+          "cast_to<{0}>(tmp_{1});\n",
           get_type_string(x.dtype()),
           namer.get_name(x.inputs()[0]));
     } else {

--- a/python/tests/test_compile.py
+++ b/python/tests/test_compile.py
@@ -1623,6 +1623,16 @@ class TestCompile(mlx_tests.MLXTestCase):
             x = mx.array([1, 2, 3], dtype)
             self.assertTrue(mx.array_equal(mx.compile(fun)(x), fun(x)))
 
+    def test_compiled_subnormal_bool_cast(self):
+        f32_sub = mx.array(np.array([0x00000001] * 4, dtype=np.uint32)).view(mx.float32)
+        f16_sub = mx.array(np.array([0x0001] * 4, dtype=np.uint16)).view(mx.float16)
+        bf16_sub = mx.array(np.array([0x0001] * 4, dtype=np.uint16)).view(mx.bfloat16)
+
+        # A single-op compile does not fuse; the fused path needs >= 2 ops.
+        fn = mx.compile(lambda x: mx.broadcast_to(x, (2, 4)).astype(mx.bool_))
+        for sub in (f32_sub, f16_sub, bf16_sub):
+            self.assertTrue(mx.all(fn(sub)).item())
+
 
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner()


### PR DESCRIPTION
Follow-up to #4224 (#4205). The compiled/fused path still flushes float32 and bfloat16 subnormals to `False` on `.astype(mx.bool_)`: `build_kernel` in `mlx/backend/metal/compiled.cpp` emits a raw `static_cast` for `is_static_cast` primitives, so a fused `AsType` never reaches `cast_to`. This swaps it for `cast_to`, which is already in every generated kernel's preamble via `metal::utils()`.

Repro — needs at least two fusable ops; a single-op `mx.compile(lambda x: x.astype(mx.bool_))` doesn't fuse and falls back to the already-correct copy kernel:

```python
import numpy as np, mlx.core as mx

sub = mx.array(np.array([0x00000001] * 4, dtype=np.uint32)).view(mx.float32)
print(np.array(sub.astype(mx.bool_)))   # [True True True True] -- fixed by #4224

f = mx.compile(lambda x: mx.broadcast_to(x, (2, 4)).astype(mx.bool_))
print(np.array(f(sub)))                 # all False on main     -- this PR
```

`broadcast_to` is deliberate: the fused broadcast preserves the input bits (`0x00000001` in and out), so what fails is the cast, not FTZ arithmetic. Same failure on bfloat16. float16 is unaffected — Metal's `static_cast<bool>` on half is already correct (probed directly with `mx.fast.metal_kernel`).

Out of scope, and not claimed fixed: `!=`, `>`, `==` on subnormals still diverge from the CPU backend after this. Eager `x + 0.0` zeroes the bits too, so that's ordinary Metal FTZ arithmetic, a different class from the cast. I also checked the other `static_cast` in this file (constant-input loads around line 121): it casts the printed constant to its own dtype, so there is nothing to fix there.

Tested on an M3 Max: the new test in `test_compile.py` fails on current main and passes with the change; full `python/tests` suite is green (801 passed, 51 skipped, 11293 subtests).

Investigation and test runs were AI-assisted; I've reviewed and understand the change.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)