### PR TITLE
Round mxfp8 block scales up to avoid saturation

### DIFF
--- a/mlx/backend/cpu/quantized.cpp
+++ b/mlx/backend/cpu/quantized.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Apple Inc.
+// Copyright © 2023-2026 Apple Inc.
 
 #include "mlx/backend/common/quantized.h"
 #include "mlx/backend/common/unary.h"
@@ -1061,6 +1061,15 @@ uint8_t to_fp8_e8m0(float x) {
   return static_cast<uint8_t>(n + 127);
 }
 
+// Smallest E8M0 >= x, so a block's largest elements do not saturate.
+uint8_t to_fp8_e8m0_round_up(float x) {
+  uint8_t bits = to_fp8_e8m0(x);
+  if (bits < 0xFE && dequantize_scale<float, 32>(bits) < x) {
+    bits += 1;
+  }
+  return bits;
+}
+
 uint8_t to_fp4_e2m1(float x) {
   if (std::isnan(x)) {
     return 0x7;
@@ -1112,7 +1121,7 @@ void fp_quantize_dequantize(
     if (group_size == 16) {
       scale = dequantize_scale<float, 16>(detail::ToFP8()(scale));
     } else {
-      scale = dequantize_scale<float, 32>(to_fp8_e8m0(scale));
+      scale = dequantize_scale<float, 32>(to_fp8_e8m0_round_up(scale));
     }
 
     for (int j = 0; j < group_size; ++j) {

--- a/mlx/backend/metal/kernels/fp8.h
+++ b/mlx/backend/metal/kernels/fp8.h
@@ -78,3 +78,14 @@ struct fp8_e8m0 {
 
   uint8_t bits;
 };
+
+// Smallest E8M0 >= x. Scales are amax/max_element, so rounding one down
+// leaves the block's largest elements outside the element range, where they
+// saturate. Matches the CUDA backend, which rounds up via cutlass ue8m0.
+inline float mx_scale_round_up(float x) {
+  fp8_e8m0 s(x);
+  if (s.bits < 0xFE && float(s) < x) {
+    s.bits += 1;
+  }
+  return float(s);
+}

--- a/mlx/backend/metal/kernels/fp_quantized.h
+++ b/mlx/backend/metal/kernels/fp_quantized.h
@@ -2122,7 +2122,7 @@ template <typename T, int group_size, int bits, bool has_global_scale>
 
   float scale_dec_b;
   float w_thread = w[index];
-  if (use_mx_scale) {
+  if constexpr (use_mx_scale) {
     scale_dec_b = simd_max(abs(w_thread));
   } else {
     float w_max_l = simd_max(simd_lid < 16 ? abs(w_thread) : 0.0);
@@ -2132,8 +2132,7 @@ template <typename T, int group_size, int bits, bool has_global_scale>
   scale_dec_b /= bits == 4 ? F4E2M1_MAX : F8E4M3_MAX;
   if constexpr (has_global_scale) {
     scale_dec_b *= scale_enc;
-  }
-  if (use_mx_scale) {
+  } else if constexpr (use_mx_scale) {
     scale_dec_b = mx_scale_round_up(scale_dec_b);
   }
 
@@ -2217,7 +2216,7 @@ template <typename T, int group_size, int bits, bool has_global_scale>
 
   float scale_dec_b;
   float w_thread = w[index];
-  if (use_mx_scale) {
+  if constexpr (use_mx_scale) {
     scale_dec_b = simd_max(abs(w_thread));
   } else {
     float w_max_l = simd_max(simd_lid < 16 ? abs(w_thread) : 0.0);
@@ -2227,8 +2226,7 @@ template <typename T, int group_size, int bits, bool has_global_scale>
   scale_dec_b /= bits == 4 ? F4E2M1_MAX : F8E4M3_MAX;
   if constexpr (has_global_scale) {
     scale_dec_b *= scale_enc;
-  }
-  if (use_mx_scale) {
+  } else if constexpr (use_mx_scale) {
     scale_dec_b = mx_scale_round_up(scale_dec_b);
   }
 

--- a/mlx/backend/metal/kernels/fp_quantized.h
+++ b/mlx/backend/metal/kernels/fp_quantized.h
@@ -2133,6 +2133,9 @@ template <typename T, int group_size, int bits, bool has_global_scale>
   if constexpr (has_global_scale) {
     scale_dec_b *= scale_enc;
   }
+  if (use_mx_scale) {
+    scale_dec_b = mx_scale_round_up(scale_dec_b);
+  }
 
   using ScaleType = metal::conditional_t<use_mx_scale, fp8_e8m0, fp8_e4m3>;
   auto s = ScaleType(scale_dec_b);
@@ -2224,6 +2227,9 @@ template <typename T, int group_size, int bits, bool has_global_scale>
   scale_dec_b /= bits == 4 ? F4E2M1_MAX : F8E4M3_MAX;
   if constexpr (has_global_scale) {
     scale_dec_b *= scale_enc;
+  }
+  if (use_mx_scale) {
+    scale_dec_b = mx_scale_round_up(scale_dec_b);
   }
 
   using ScaleType = metal::conditional_t<use_mx_scale, fp8_e8m0, fp8_e4m3>;

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023-2024 Apple Inc.
+// Copyright © 2023-2026 Apple Inc.
 
 // Required for using M_PI in MSVC.
 #define _USE_MATH_DEFINES
@@ -5164,11 +5164,17 @@ std::vector<array> fp_quantize(
     } else {
       // convert to e8m0
       auto z = array(0, scales.dtype());
-      scales = where(
-          equal(scales, z, s),
-          z,
-          astype(round(log2(scales, s), s), int32, s),
+      // Round the scale up so the block maximum stays representable,
+      // matching the CUDA backend.
+      auto exponent = astype(round(log2(scales, s), s), int32, s);
+      auto decoded =
+          power(array(2.0f, float32), astype(exponent, float32, s), s);
+      exponent = where(
+          less(decoded, astype(scales, float32, s), s),
+          add(exponent, array(1, int32), s),
+          exponent,
           s);
+      scales = where(equal(scales, z, s), z, exponent, s);
 
       wq = divide(wq, power(array(2.0f, w.dtype()), scales, s), s);
       scales = astype(add(scales, array(127, int32), s), uint8, s);

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -1,5 +1,6 @@
 # Copyright © 2023-2026 Apple Inc.
 
+import math
 import os
 import platform
 import subprocess
@@ -120,6 +121,28 @@ class TestQuantized(mlx_tests.MLXTestCase):
         w_q, scales = mx.quantize(a, mode="mxfp8")
         w_hat = mx.dequantize(w_q, scales, mode="mxfp8")
         self.assertTrue(mx.all(w_hat == 0))
+
+    def test_mxfp8_block_scale_does_not_saturate(self):
+        # E4M3 has three mantissa bits, so an in-range element loses at most
+        # half a step, 6.25%. More than that means the block scale rounded
+        # below amax/448 and the block maximum saturated.
+        mx.random.seed(0)
+        group_size = 32
+        n_blocks = 512
+
+        # Sweep the block magnitude across one binade so both scale rounding
+        # directions are covered.
+        w = mx.random.normal(shape=(n_blocks, group_size))
+        w = w * mx.exp(mx.arange(n_blocks) / n_blocks * math.log(2.0)).reshape(-1, 1)
+
+        w_q, scales = mx.quantize(w, group_size=group_size, mode="mxfp8")
+        w_hat = mx.dequantize(w_q, scales, group_size=group_size, mode="mxfp8")
+
+        # Quantization is monotone in |w|, so a block's largest output is the
+        # reconstruction of its largest input.
+        amax = mx.max(mx.abs(w), axis=1)
+        rel = mx.abs(amax - mx.max(mx.abs(w_hat), axis=1)) / amax
+        self.assertLess(mx.max(rel).item(), 0.0626)
 
     def test_nvfp4_quantize_dequantize(self):
         lut = mx.array(


### PR DESCRIPTION
## Proposed changes

MX block scales are `amax / max_element`, converted to E8M0. Metal and the CPU
fallback round to nearest, which lands below the request about half the time;
the block's largest elements then fall outside the element format and saturate.

CUDA already rounds up — `cutlass::float_ue8m0_t` uses
`cvt.rp.satfinite.ue8m0x2.f32` on device and an explicit exponent bump on host,
for both 4- and 8-bit. So `mx.quantize` on an MX mode gives different results
per backend today. This aligns Metal and CPU with CUDA; no CUDA code changes.

For mxfp8, an in-range element loses at most half a step, 6.25%; anything
larger is saturation. On 512x32 synthetic blocks:

|        | worst loss on a block max | blocks over 6.25% |
|--------|--------------------------:|------------------:|
| before |                    29.27% |           243/512 |
| after  |                     5.84% |             0/512 |

29.27% is `1 - 1/sqrt(2)`, the worst case for round-to-nearest in log2 space.
CUTLASS v4.3.5 on the same inputs: max `amax/scale` 447.88, nothing over 448.

Real weights behave the same. On a Gemma 4 26B expert tensor, `amax/scale`
spans 318-632 against a 448 ceiling, and rel RMSE goes 7.11% -> 2.68%.

mxfp4 improves too, by less: on four Gemma 4 26B tensors, rel RMSE drops
0.8-2.5% relative and block-maximum clipping goes from about half of all blocks
to none. Round-up costs some underflow there, but it is the smaller effect.

Fixed in all three implementations: the `ops.cpp` fallback (the path CPU takes
for `mx.quantize`), `fp_quantize_dequantize`, and both Metal quantize kernels.

The test asserts the 6.25% property rather than a golden number and pins no
device. It fails on `main` and on the 0.31.0 wheel, and passes here.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
