### PR TITLE
[Bug]: add default none value to axis parameter of the take_along_axis

### DIFF
--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -1556,16 +1556,16 @@ void init_ops(nb::module_& m) {
       "stream"_a = nb::none(),
       R"pbdoc(
         Return the Bartlett window.
-        
+
         The Bartlett window is a taper formed by using a weighted cosine.
 
         .. math::
           w(n) = 1 - \frac{2|n - (M-1)/2|}{M-1}
            \qquad 0 \le n \le M-1
-        
+
         Args:
             M (int): Number of points in the output window.
-            
+
         Returns:
             array: The window, with the maximum value normalized to one (the value one
                    appears only if the number of samples is odd).
@@ -1578,16 +1578,16 @@ void init_ops(nb::module_& m) {
       "stream"_a = nb::none(),
       R"pbdoc(
         Return the Hanning window.
-        
+
         The Hanning window is a taper formed by using a weighted cosine.
 
         .. math::
           w(n) = 0.5 - 0.5 \cos\left(\frac{2\pi n}{M-1}\right)
            \qquad 0 \le n \le M-1
-        
+
         Args:
             M (int): Number of points in the output window.
-            
+
         Returns:
             array: The window, with the maximum value normalized to one (the value one
                    appears only if the number of samples is odd).
@@ -1625,16 +1625,16 @@ void init_ops(nb::module_& m) {
           "def blackman(M: int, *, stream: StreamOrDevice = None) -> array"), // <--- J'ai rajouté ça
       R"pbdoc(
         Return the Blackman window.
-        
+
         The Blackman window is a taper formed by using the first three terms of a summation of cosines.
 
         .. math::
           w(n) = 0.42 - 0.5 \cos\left(\frac{2\pi n}{M-1}\right) + 0.08 \cos\left(\frac{4\pi n}{M-1}\right)
            \qquad 0 \le n \le M-1
-        
+
         Args:
             M (int): Number of points in the output window.
-            
+
         Returns:
             array: The window, with the maximum value normalized to one (the value one
                    appears only if the number of samples is odd).
@@ -1764,7 +1764,7 @@ void init_ops(nb::module_& m) {
       },
       nb::arg(),
       "indices"_a,
-      "axis"_a.none(),
+      "axis"_a = nb::none(),
       nb::kw_only(),
       "stream"_a = nb::none(),
       nb::sig(

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -1556,16 +1556,16 @@ void init_ops(nb::module_& m) {
       "stream"_a = nb::none(),
       R"pbdoc(
         Return the Bartlett window.
-
+        
         The Bartlett window is a taper formed by using a weighted cosine.
 
         .. math::
           w(n) = 1 - \frac{2|n - (M-1)/2|}{M-1}
            \qquad 0 \le n \le M-1
-
+        
         Args:
             M (int): Number of points in the output window.
-
+            
         Returns:
             array: The window, with the maximum value normalized to one (the value one
                    appears only if the number of samples is odd).
@@ -1578,16 +1578,16 @@ void init_ops(nb::module_& m) {
       "stream"_a = nb::none(),
       R"pbdoc(
         Return the Hanning window.
-
+        
         The Hanning window is a taper formed by using a weighted cosine.
 
         .. math::
           w(n) = 0.5 - 0.5 \cos\left(\frac{2\pi n}{M-1}\right)
            \qquad 0 \le n \le M-1
-
+        
         Args:
             M (int): Number of points in the output window.
-
+            
         Returns:
             array: The window, with the maximum value normalized to one (the value one
                    appears only if the number of samples is odd).
@@ -1625,16 +1625,16 @@ void init_ops(nb::module_& m) {
           "def blackman(M: int, *, stream: StreamOrDevice = None) -> array"), // <--- J'ai rajouté ça
       R"pbdoc(
         Return the Blackman window.
-
+        
         The Blackman window is a taper formed by using the first three terms of a summation of cosines.
 
         .. math::
           w(n) = 0.42 - 0.5 \cos\left(\frac{2\pi n}{M-1}\right) + 0.08 \cos\left(\frac{4\pi n}{M-1}\right)
            \qquad 0 \le n \le M-1
-
+        
         Args:
             M (int): Number of points in the output window.
-
+            
         Returns:
             array: The window, with the maximum value normalized to one (the value one
                    appears only if the number of samples is odd).

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -1468,13 +1468,8 @@ class TestOps(mlx_tests.MLXTestCase):
                 shape = [2] * 3
                 shape[ax] = 3
             out_np = np.take_along_axis(a_np, idx_np.reshape(shape), axis=ax)
-            indices = mx.reshape(idx_mlx, shape)
-            out_mlx = mx.take_along_axis(a_mlx, indices, axis=ax)
+            out_mlx = mx.take_along_axis(a_mlx, mx.reshape(idx_mlx, shape), axis=ax)
             self.assertTrue(np.array_equal(out_np, np.array(out_mlx)))
-            if ax is None:
-                self.assertTrue(
-                    mx.array_equal(out_mlx, mx.take_along_axis(a_mlx, indices))
-                )
 
     def test_along_axis_invalid_axis(self):
         # Negative out of bounds axes used to slip past the bounds check

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -1468,8 +1468,13 @@ class TestOps(mlx_tests.MLXTestCase):
                 shape = [2] * 3
                 shape[ax] = 3
             out_np = np.take_along_axis(a_np, idx_np.reshape(shape), axis=ax)
-            out_mlx = mx.take_along_axis(a_mlx, mx.reshape(idx_mlx, shape), axis=ax)
+            indices = mx.reshape(idx_mlx, shape)
+            out_mlx = mx.take_along_axis(a_mlx, indices, axis=ax)
             self.assertTrue(np.array_equal(out_np, np.array(out_mlx)))
+            if ax is None:
+                self.assertTrue(
+                    mx.array_equal(out_mlx, mx.take_along_axis(a_mlx, indices))
+                )
 
     def test_along_axis_invalid_axis(self):
         # Negative out of bounds axes used to slip past the bounds check


### PR DESCRIPTION
## Proposed changes

Please include a description of the problem or feature this PR is addressing. If there is a corresponding issue, include the issue #.

fixes data-apis/array-api-compat#466

where `take_along_axis` needed axis to be passed  even though docs says its default value was set to the `None`, nb signature didn't set a default value thus failing in cases where no axis was provided.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
