### PR TITLE
python: Make axis of put_along_axis optional

### DIFF
--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -1807,7 +1807,7 @@ void init_ops(nb::module_& m) {
       nb::arg(),
       "indices"_a,
       "values"_a,
-      "axis"_a.none(),
+      "axis"_a = nb::none(),
       nb::kw_only(),
       "stream"_a = nb::none(),
       nb::sig(


### PR DESCRIPTION
### What is wrong

`mx.put_along_axis` documents `axis` as optional with a default of `None`, and its implementation already handles the `None` case (flatten to 1D then index), but the binding marks `axis` as required. Calling it without `axis` raises, and the error message prints the very signature it just rejected:

```python
import mlx.core as mx
a = mx.array([[1, 2], [3, 4]])
mx.put_along_axis(a, mx.array([0, 3]), mx.array([7, 8]))
```
```
TypeError: put_along_axis(): incompatible function arguments. The following argument types are supported:
    1. put_along_axis(a: array, /, indices: array, values: array, axis: int | None = None, *, stream: StreamOrDevice = None) -> array
```

The `nb::sig` string and the docstring both say `axis: int | None = None`, so the reference and the actual binding disagree.

### Why

The parameter is declared `"axis"_a.none()`, which permits `None` to be passed but sets no default value, so the argument stays required. This is the same defect that #4357 just fixed for the sibling `take_along_axis`; `put_along_axis` has the identical signature and the identical `axis.has_value()` flatten path, and was missed.

### What this changes

One line, mirroring #4357:

```cpp
-      "axis"_a.none(),
+      "axis"_a = nb::none(),
```

After it, the flattened form works and matches the documented signature:

```python
mx.put_along_axis(a, mx.array([0, 3]), mx.array([7, 8]))          # [[7, 2], [3, 8]]
mx.put_along_axis(a, mx.array([0, 3]), mx.array([7, 8]), axis=None)  # same
mx.put_along_axis(a, mx.array([[0],[1]]), mx.array([[9],[9]]), axis=1)  # unchanged
```

No test added, matching #4357 which shipped the same one-line fix for `take_along_axis` without one. Full CPU rebuild, clang-format clean, and the compiled binding verified by the calls above.

---
I am new and lean on Claude Code, so I kept this to the exact shape of the merged sibling fix and checked the rebuilt binding by hand rather than trusting the source. Point me at anything you want done differently.
