### PR TITLE
chore: Validate eps in Adam at construction

### DIFF
--- a/python/mlx/optimizers/optimizers.py
+++ b/python/mlx/optimizers/optimizers.py
@@ -506,6 +506,9 @@ class Adam(Optimizer):
                     "instead"
                 )
 
+        if not 0.0 <= eps:
+            raise ValueError(f"Adam epsilon should be >=0, {eps} was provided instead")
+
         self._maybe_schedule("learning_rate", learning_rate)
         self.betas = betas
         self.eps = eps
@@ -627,10 +630,6 @@ class Adamax(Adam):
         eps: float = 1e-8,
     ):
         super().__init__(learning_rate, betas, eps)
-        if not 0.0 <= eps:
-            raise ValueError(
-                f"Epsilon value should be >=0, {self.eps} was provided instead"
-            )
 
     def init_single(self, parameter: mx.array, state: dict):
         """Initialize optimizer state"""

--- a/python/tests/test_optimizers.py
+++ b/python/tests/test_optimizers.py
@@ -180,13 +180,6 @@ class TestOptimizers(mlx_tests.MLXTestCase):
             with self.assertRaisesRegex(ValueError, ">0"):
                 optimizer(learning_rate=1e-2, eps=0.0)
 
-        # The Adam family follows the Adamax precedent: a negative eps is
-        # rejected with a ">=0" message and eps == 0 stays allowed.
-        for optimizer in (opt.Adam, opt.AdamW, opt.Adamax):
-            with self.assertRaisesRegex(ValueError, ">=0"):
-                optimizer(learning_rate=1e-2, eps=-1e-8)
-            optimizer(learning_rate=1e-2, eps=0.0)
-
     def test_adam(self):
         params = {
             "first": [mx.zeros((10,)), mx.zeros((1,))],

--- a/python/tests/test_optimizers.py
+++ b/python/tests/test_optimizers.py
@@ -180,6 +180,13 @@ class TestOptimizers(mlx_tests.MLXTestCase):
             with self.assertRaisesRegex(ValueError, ">0"):
                 optimizer(learning_rate=1e-2, eps=0.0)
 
+        # The Adam family follows the Adamax precedent: a negative eps is
+        # rejected with a ">=0" message and eps == 0 stays allowed.
+        for optimizer in (opt.Adam, opt.AdamW, opt.Adamax):
+            with self.assertRaisesRegex(ValueError, ">=0"):
+                optimizer(learning_rate=1e-2, eps=-1e-8)
+            optimizer(learning_rate=1e-2, eps=0.0)
+
     def test_adam(self):
         params = {
             "first": [mx.zeros((10,)), mx.zeros((1,))],


### PR DESCRIPTION
**ISSUE**

Adam and AdamW accept any eps, including negative values , while RMSprop, Adagrad, AdaDelta all reject eps <= 0 at construction. eps sits directly in the update denominator, so a bad value doesn't error, it just changes which direction the parameter moves 

**SOLUTION**

This adds a check to Adam.__init__, right after the existing betas validation. Since AdamW and Adamax both call this __init__ through super(), these check covers all three optimizers at once, and Adamax's own check becomes unnecessary so i removed it. The only visible side effect is that Adamax(eps=-1)'s error message now will be "Adam epsilon..." instead of "Epsilon value...".

```
>> git checkout main
>> python -c "import mlx.core as mx, mlx.optimizers as optim
>> print('mlx:', mx.__version__)
o = optim.Adam(1e-3, eps=-1e-4)
p = o.apply_gradients({'w': mx.full((2,), 1e-3)}, {'w': mx.ones((2,))})
print(p['w'].tolist())
"
>> mlx: 0.32.2.dev20260819+057cdc9e
>> [1.001462459564209, 1.001462459564209]

>> git checkout vraj/validate-adam-eps
>> python -c "import mlx.optimizers as optim; optim.Adam(1e-3, eps=-1e-4)"
>> ValueError: Adam epsilon should be >=0, -0.0001 was provided instead

```

The bound stays >=0 rather than >0, because Adamax already allows eps=0. Tightening that is a separate decision I'm leaving to maintainers, not something this fix should do. eps=0.0 and small positive values still construct for Adam, AdamW, and Adamax, unaffected by this change.

The new test cases fail on main with AssertionError: ValueError not raised, and pass on this branch under both DEVICE=cpu and DEVICE=gpu (26/26), with the full suite at 858 OK.

AI usage disclosure: 
I used Claude Code to help me but every number and error string above is from a run on my machine, and I reviewed and understand every line in this diff.

☑️ I understand it is strictly prohibited to use AI to write PR description