### PR TITLE
Fix pad with an axes subset and negative axes

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -1465,7 +1465,7 @@ array reflect_pad(
   Shape starts(a.ndim(), 0);
   auto stops = a.shape();
   for (size_t i = 0; i < axes.size(); i++) {
-    int ax = axes[i];
+    int ax = normalize_axis_index(axes[i], a.ndim(), "[pad] ");
     starts[ax] = low_pad_size[i];
     stops[ax] += low_pad_size[i];
   }
@@ -1473,7 +1473,7 @@ array reflect_pad(
   array padded = slice_update(out, a, starts, stops, s);
 
   for (size_t i = 0; i < axes.size(); i++) {
-    int ax = axes[i];
+    int ax = normalize_axis_index(axes[i], a.ndim(), "[pad] ");
     int n = a.shape(ax);
     int L = low_pad_size[i];
     int H = high_pad_size[i];
@@ -1546,37 +1546,41 @@ array edge_pad(
     const Shape& out_shape,
     StreamOrDevice s /* = {}*/) {
   array out = zeros(out_shape, a.dtype(), s);
-  auto stops = a.shape();
-  for (int i = 0; i < stops.size(); i++) {
-    stops[i] += low_pad_size[i];
+  Shape in_starts(a.ndim(), 0);
+  auto in_stops = a.shape();
+  for (size_t i = 0; i < axes.size(); i++) {
+    int ax = normalize_axis_index(axes[i], a.ndim(), "[pad] ");
+    in_starts[ax] = low_pad_size[i];
+    in_stops[ax] += low_pad_size[i];
   }
   // Copy over values from the unpadded array
-  array padded = slice_update(out, a, low_pad_size, stops, s);
+  array padded = slice_update(out, a, in_starts, in_stops, s);
 
-  for (int axis = 0; axis < a.ndim(); axis++) {
-    if (low_pad_size[axis] > 0) {
+  for (size_t i = 0; i < axes.size(); i++) {
+    int ax = normalize_axis_index(axes[i], a.ndim(), "[pad] ");
+    if (low_pad_size[i] > 0) {
       Shape starts(a.ndim(), 0);
-      starts[axis] = low_pad_size[axis];
+      starts[ax] = low_pad_size[i];
       auto stops = out.shape();
-      stops[axis] = low_pad_size[axis] + 1;
+      stops[ax] = low_pad_size[i] + 1;
       // Fetch edge values
       array edge_value = slice(padded, starts, stops, s);
 
-      starts[axis] = 0;
-      stops[axis] = low_pad_size[axis];
+      starts[ax] = 0;
+      stops[ax] = low_pad_size[i];
       // Update edge values in the padded array
       padded = slice_update(padded, edge_value, starts, stops, s);
     }
 
-    if (high_pad_size[axis] > 0) {
+    if (high_pad_size[i] > 0) {
       Shape starts(a.ndim(), 0);
-      starts[axis] = -high_pad_size[axis] - 1;
+      starts[ax] = -high_pad_size[i] - 1;
       auto stops = out.shape();
-      stops[axis] = -high_pad_size[axis];
+      stops[ax] = -high_pad_size[i];
       array edge_value = slice(padded, starts, stops, s);
 
-      starts[axis] = -high_pad_size[axis];
-      stops[axis] = out.shape(axis);
+      starts[ax] = -high_pad_size[i];
+      stops[ax] = out.shape(ax);
       padded = slice_update(padded, edge_value, starts, stops, s);
     }
   }
@@ -1618,7 +1622,7 @@ array pad(
       throw std::invalid_argument(msg.str());
     }
 
-    auto ax = axes[i] < 0 ? a.ndim() + axes[i] : axes[i];
+    auto ax = normalize_axis_index(axes[i], a.ndim(), "[pad] ");
     out_shape[ax] = safe_cast(
         static_cast<int64_t>(out_shape[ax]) + low_pad_size[i] +
             high_pad_size[i],

--- a/tests/ops_tests.cpp
+++ b/tests/ops_tests.cpp
@@ -4525,6 +4525,68 @@ TEST_CASE("test conv shape overflow") {
       Shape{1, 8, 8, 1});
 }
 
+TEST_CASE("test pad with an axes subset") {
+  // edge_pad ignored `axes` and indexed the pad sizes by array axis, so it
+  // read past the end of those vectors and placed the input on the wrong
+  // axes. reflect and symmetric indexed by position but did not normalize a
+  // negative axis.
+  auto x = reshape(arange(24.0f), {2, 3, 4});
+  auto all = {"constant", "edge", "reflect", "symmetric"};
+
+  // Padding a subset of the axes matches the equivalent all-axes spelling.
+  for (auto mode : all) {
+    CHECK(array_equal(
+              pad(x, {1}, Shape{1}, Shape{2}, array(0.0f), mode),
+              pad(x,
+                  {0, 1, 2},
+                  Shape{0, 1, 0},
+                  Shape{0, 2, 0},
+                  array(0.0f),
+                  mode))
+              .item<bool>());
+  }
+
+  // A negative axis matches its non-negative spelling.
+  for (auto mode : all) {
+    CHECK(array_equal(
+              pad(x, {-2}, Shape{1}, Shape{2}, array(0.0f), mode),
+              pad(x, {1}, Shape{1}, Shape{2}, array(0.0f), mode))
+              .item<bool>());
+  }
+
+  // The order of `axes` does not change the result.
+  auto y = reshape(arange(25.0f), {5, 5});
+  for (auto mode : all) {
+    CHECK(array_equal(
+              pad(y, {1, 0}, Shape{1, 2}, Shape{1, 2}, array(0.0f), mode),
+              pad(y, {0, 1}, Shape{2, 1}, Shape{2, 1}, array(0.0f), mode))
+              .item<bool>());
+  }
+
+  // An ndim past SmallVector's inline capacity puts the pad sizes on the heap,
+  // where the old read ran off the end of the allocation.
+  std::vector<int> wide_axes(11);
+  std::iota(wide_axes.begin(), wide_axes.end(), 0);
+  auto wide =
+      pad(zeros(Shape(34, 1)),
+          wide_axes,
+          Shape(11, 1),
+          Shape(11, 0),
+          array(0.0f),
+          "edge");
+  CHECK_EQ(wide.size(), 2048);
+
+  // An axis outside the array is rejected rather than indexed.
+  for (auto mode : all) {
+    CHECK_THROWS_AS(
+        pad(x, {5}, Shape{1}, Shape{1}, array(0.0f), mode),
+        std::invalid_argument);
+    CHECK_THROWS_AS(
+        pad(x, {-5}, Shape{1}, Shape{1}, array(0.0f), mode),
+        std::invalid_argument);
+  }
+}
+
 TEST_CASE("test pad shape overflow") {
   // A padding sum that overflows int32 is rejected, not wrapped.
   // https://github.com/ml-explore/mlx/issues/3611


### PR DESCRIPTION
## Proposed changes

`edge_pad` ignores its `axes` argument and indexes the pad-size vectors by
array axis rather than by position in `axes` (ops.cpp:1550, 1556). Padding a
subset of the axes therefore reads past the end of those vectors, and a
permuted `axes` list silently pads the wrong axis:

```cpp
auto x = reshape(arange(25.0f), {5, 5});
pad(x, {1, 0}, Shape{1, 2}, Shape{1, 2}, array(0.0f), "edge");
// input lands on the wrong axis and 3 rows are left zero; no error
```

A debug build traps in `SmallVector::operator[]` with `edge_pad` at
ops.cpp:1551 on the stack. ASan is quiet at small `ndim` because `Shape` is a
`SmallVector` with 10 inline slots, so the read stays inside the object. Once
`ndim` puts the pad sizes on the heap it reports the overflow directly:

```
ERROR: AddressSanitizer: heap-buffer-overflow
READ of size 4 ... 0 bytes after 128-byte region
    #0 mlx::core::edge_pad(...)
```

`reflect_pad` indexes by position and is correct for a subset, but it does not
normalize a negative axis (ops.cpp:1468, 1476), so `axes = {-1}` indexes
`starts[-1]`:

```
small_vector.h:316: runtime error: addition of unsigned offset to
0x...060 overflowed to 0x...058
```

Axis handling across the pad family now goes through `normalize_axis_index`,
the same consolidation #4288 applied to `split`, `unstack`, `partition` and
`topk`. That helper also range checks, which changes behaviour in one place:
`pad` previously indexed `out_shape` with an unvalidated axis (ops.cpp:1621),
so an out-of-range axis was undefined behaviour for every mode. It now raises
`std::invalid_argument`. That is a new error path, not just a bug fix.

`pad` validates and normalizes every axis before the mode dispatch, so the
calls inside `edge_pad` and `reflect_pad` are redundant by construction.
Normalizing once in `pad` and passing the normalized vector down measures
+27/-20 on this file against +22/-18, and it changes what the `Pad` primitive
stores, and with it `is_equivalent`, `state()` and the axes `Pad::vmap` sees.
Keeping the helper at each site leaves the primitive untouched, but the
single-call version is a small change if you prefer it.

`edge_pad` landed in 635ccd9e2 (2024-08-06, #1309). `reflect_pad` is newer,
9f35f7742 (2026-08-11, #3608), and already indexes by position; this adds the
axis normalization it was missing and brings `edge_pad` in line with it.
`constant` was already correct in both respects.

This is reachable from `mlx_pad` in mlx-c (mlx/c/ops.h:730), which forwards
caller-supplied `axes`, independent pad-size lengths, and a `mode` string. No
Python path reaches it: the bindings only build full-length `axes`
(python/src/ops.cpp:3493), which is also why the existing tests miss it, the
only C++ test on this overload using a 1-D array where `axes.size() == ndim`.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
