### PR TITLE
Collapse the non sorted axes to pick the contiguous sort kernel

### DIFF
--- a/mlx/backend/cuda/sort.cu
+++ b/mlx/backend/cuda/sort.cu
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <cstdint>
 
+#include "mlx/backend/common/utils.h"
 #include "mlx/backend/cuda/device.h"
 #include "mlx/backend/cuda/device/fp16_math.cuh"
 #include "mlx/backend/cuda/kernel_utils.cuh"
@@ -791,6 +792,27 @@ void single_block_sort(
   };
   contiguous &= check_strides(in, in_stride_sorted_axis);
   contiguous &= check_strides(out, out_stride_sorted_axis);
+  // The contiguous kernel walks the rows with a single stride, so the axes
+  // that are not sorted have to collapse to a single run. The contiguous
+  // flag above also keeps out the negative strides that the unsigned row
+  // index cannot address.
+  auto single_run =
+      [](const Shape& shape, const Strides& strides, int64_t& stride) {
+        auto [cshape, cstrides] = collapse_contiguous_dims(shape, strides);
+        int runs = 0;
+        stride = 0;
+        for (int i = 0; i < cshape.size(); i++) {
+          if (cshape[i] != 1) {
+            runs++;
+            stride = cstrides[i];
+          }
+        }
+        return runs <= 1;
+      };
+  int64_t in_seg = 0;
+  int64_t out_seg = 0;
+  contiguous &= single_run(nc_shape, in_nc_str, in_seg);
+  contiguous &= single_run(nc_shape, out_nc_str, out_seg);
 
   auto& encoder = cu::get_command_encoder(s);
   out.set_data(cu::malloc_async(out.nbytes(), encoder));
@@ -817,20 +839,11 @@ void single_block_sort(
                 ARG_SORT,
                 BLOCK_THREADS,
                 N_PER_THREAD>;
-            int64_t in_stride_segment_axis = INT64_MAX;
-            int64_t out_stride_segment_axis = INT64_MAX;
-            for (int i = 0; i < nc_shape.size(); i++) {
-              if (nc_shape[i] == 1) {
-                continue;
-              }
-              if (in_nc_str[i] > INT32_MAX || out_nc_str[i] > INT32_MAX) {
-                throw std::runtime_error("[Sort::eval_gpu] Stride too large.");
-              }
-              in_stride_segment_axis =
-                  std::min(in_stride_segment_axis, in_nc_str[i]);
-              out_stride_segment_axis =
-                  std::min(out_stride_segment_axis, out_nc_str[i]);
+            if (in_seg > INT32_MAX || out_seg > INT32_MAX) {
+              throw std::runtime_error("[Sort::eval_gpu] Stride too large.");
             }
+            int64_t in_stride_segment_axis = in_seg;
+            int64_t out_stride_segment_axis = out_seg;
             encoder.add_kernel_node(
                 kernel,
                 grid,

--- a/mlx/backend/metal/sort.cpp
+++ b/mlx/backend/metal/sort.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 
+#include "mlx/backend/common/utils.h"
 #include "mlx/backend/gpu/copy.h"
 #include "mlx/backend/metal/device.h"
 #include "mlx/backend/metal/kernels.h"
@@ -50,6 +51,27 @@ void single_block_sort(
   };
   contiguous &= check_strides(in, in_stride_sorted_axis);
   contiguous &= check_strides(out, out_stride_sorted_axis);
+  // The contiguous kernel walks the rows with a single stride, so the axes
+  // that are not sorted have to collapse to a single run. The contiguous
+  // flag above also keeps out the negative strides that the unsigned row
+  // index cannot address.
+  auto single_run =
+      [](const Shape& shape, const Strides& strides, int64_t& stride) {
+        auto [cshape, cstrides] = collapse_contiguous_dims(shape, strides);
+        int runs = 0;
+        stride = 0;
+        for (int i = 0; i < cshape.size(); i++) {
+          if (cshape[i] != 1) {
+            runs++;
+            stride = cstrides[i];
+          }
+        }
+        return runs <= 1;
+      };
+  int64_t in_seg = 0;
+  int64_t out_seg = 0;
+  contiguous &= single_run(nc_shape, in_nc_str, in_seg);
+  contiguous &= single_run(nc_shape, out_nc_str, out_seg);
 
   // Prepare kernel name
   std::ostringstream kname;
@@ -74,20 +96,11 @@ void single_block_sort(
   compute_encoder.set_bytes(out_stride_sorted_axis, 4);
 
   if (contiguous) {
-    int in_stride_segment_axis = INT32_MAX;
-    int out_stride_segment_axis = INT32_MAX;
-    for (int i = 0; i < in_nc_str.size(); i++) {
-      if (nc_shape[i] == 1) {
-        continue;
-      }
-      if (in_nc_str[i] > INT32_MAX || out_nc_str[i] > INT32_MAX) {
-        throw std::runtime_error("[Sort::eval_gpu] Stride too large.");
-      }
-      in_stride_segment_axis =
-          std::min(in_stride_segment_axis, static_cast<int>(in_nc_str[i]));
-      out_stride_segment_axis =
-          std::min(out_stride_segment_axis, static_cast<int>(out_nc_str[i]));
+    if (in_seg > INT32_MAX || out_seg > INT32_MAX) {
+      throw std::runtime_error("[Sort::eval_gpu] Stride too large.");
     }
+    int in_stride_segment_axis = static_cast<int>(in_seg);
+    int out_stride_segment_axis = static_cast<int>(out_seg);
     compute_encoder.set_bytes(in_stride_segment_axis, 5);
     compute_encoder.set_bytes(out_stride_segment_axis, 6);
   } else {

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -4263,6 +4263,28 @@ class TestOps(mlx_tests.MLXTestCase):
         with self.assertRaises(ValueError):
             mx.broadcast_shapes()
 
+    def test_sort_transposed(self):
+        # The sorted axis can keep the smallest or largest stride while the
+        # axes that are not sorted are no longer a row major block, which is
+        # what the contiguous kernel's row enumeration assumes.
+        np.random.seed(0)
+        for shape in [(3, 4, 8), (2, 1, 6), (2, 3, 4, 2), (2, 1, 3, 4)]:
+            a_np = np.random.uniform(0, 100, size=shape).astype(np.float32)
+            a_mx = mx.array(a_np)
+            for perm in permutations(range(len(shape))):
+                b_np = np.transpose(a_np, perm)
+                b_mx = mx.transpose(a_mx, perm)
+                for axis in range(len(shape)):
+                    with self.subTest(shape=shape, perm=perm, axis=axis):
+                        s_np = np.sort(b_np, axis=axis)
+                        self.assertTrue(np.array_equal(s_np, mx.sort(b_mx, axis=axis)))
+                        idx = np.array(mx.argsort(b_mx, axis=axis))
+                        self.assertTrue(
+                            np.array_equal(
+                                s_np, np.take_along_axis(b_np, idx, axis=axis)
+                            )
+                        )
+
     def test_sort_nan(self):
         for dtype in [mx.float32, mx.float16, mx.bfloat16]:
             with self.subTest(dtype=dtype):


### PR DESCRIPTION
Supersedes #4137.

`mx.sort` and `mx.argsort` return silently wrong results on some transposed views on the GPU, with no error raised and no crash.

## Reproducer

```python
import mlx.core as mx
import numpy as np

a = np.random.RandomState(0).randn(3, 4, 8).astype(np.float32)
y = mx.swapaxes(mx.array(a), 0, 1)

print(np.array_equal(np.array(mx.sort(y, axis=-1)),
                     np.sort(np.swapaxes(a, 0, 1), axis=-1)))
```

`False` before, `True` after.

Each output row is internally sorted but holds the wrong input row's data, so a check that only asks whether the output is sorted still passes. `stream=mx.cpu` is correct either way, as is any 2-D transpose. The failure needs a rank 3 or higher view whose non-sorted axes are no longer in row major order relative to each other.

## Cause

The contiguous kernel addresses row `r` at `r * in_stride_segment_axis` (`kernels/sort.h:283`, `cuda/sort.cu:305`). The nc kernel decodes the same row with `elem_to_loc` (`kernels/sort.h:393`, `cuda/sort.cu:398`). Selection is on `in.flags().contiguous` (`metal/sort.cpp:45`, `cuda/sort.cu:784`), which only means dense storage with no gaps. That does not imply the non-sorted axes form a single ordered run, so a transposed view can take the contiguous kernel and sort the wrong rows.

## Fix

Collapse the non-sorted axes with `collapse_contiguous_dims` and take the fast path only when they reduce to a single run, with the segment stride read from that run. The hand-rolled min-stride loop goes away.

This cannot demote an input that already works. The contiguous kernel is correct for a layout exactly when `elem_to_loc(r) == r * stride` holds for every `r`, and that is the arithmetic progression `collapse_contiguous_dims` merges, so every layout main gets right is still accepted.

Over 1058 (array, axis) cases, built from 15 base shapes of rank 1 to 4 by applying every axis permutation, `expand_dims`, `broadcast_to`, and forward, reversed and strided slices:

| variant | fast + correct | fast + wrong | demoted |
| --- | ---: | ---: | ---: |
| main | 359 | 122 | n/a |
| #4137 `row_contiguous` | 301 | 0 | 58 |
| this | 359 | 0 | 0 |

The 122 layouts the selection predicate marks wrong on main are exactly the 122 whose GPU result differs from the CPU backend, with nothing in either set that is not in the other.

`in.flags().contiguous` stays in the condition. It is what keeps negative strides out of the contiguous kernel, whose row index is unsigned.

## Testing

The new test covers `(3, 4, 8)`, `(2, 1, 6)`, `(2, 3, 4, 2)` and `(2, 1, 3, 4)` under every axis permutation and every axis. It fails on main and passes here; CPU is correct either way.

- Python: 898 passed, 5 skipped
- C++: 290/290 on GPU and on CPU
- pre-commit: clean

`multi_block_sort` is unaffected; multi block starts when the sorted axis exceeds 2048.

## Benchmark

M3 Pro. Each entry is the median of 3 runs, each itself the median of 9 repeats x 50 iterations, in ms.

| case | main | this |
| --- | ---: | ---: |
| `(1024,1024)` axis 1, contiguous | 0.4422 | 0.4496 |
| `(1024,1024)` T(1,0) axis 0, transposed | 0.4668 | 0.4725 |
| `(256,64,64)` axis 2, contiguous | 0.4856 | 0.4898 |
| `(64,64,256)` T(1,0,2) axis 2 | 0.3636 | 0.4918 |
| `(512,512)` axis 1, multi block | 0.1950 | 0.1971 |

The first, second, third and fifth rows are unchanged within run to run spread; main alone varied from 0.4265 to 0.4587 on the first row across runs.

`(64,64,256) T(1,0,2)` is one of the layouts main sorts incorrectly, so this change moves it to the general path. That is the cost of correctness, not a regression on an input that worked. The transposed row above it is an input main sorts correctly, and it stays on the fast path.

CUDA validation is source level only. No NVIDIA hardware was used.

## Checklist

* [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
* [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing this change
* [x] I have added tests that prove my fix is effective or that my feature works
* [ ] I have updated the necessary documentation (if needed)
