### PR TITLE
Prevent zero-copy adoption across dtype conversion

### DIFF
--- a/python/src/convert.cpp
+++ b/python/src/convert.cpp
@@ -190,8 +190,9 @@ mx::array cpu_nd_array_to_mlx(
 std::optional<mx::array> cpu_nd_array_to_mlx_no_copy(
     nb::ndarray<nb::ro> nd_array,
     const mx::Shape& shape,
+    mx::Dtype src_dtype,
     mx::Dtype dst_dtype) {
-  if (!mx::metal::is_available() ||
+  if (!mx::metal::is_available() || src_dtype != dst_dtype ||
       nd_array.itemsize() != mx::size_of(dst_dtype)) {
     return std::nullopt;
   }
@@ -283,8 +284,8 @@ mx::array nd_array_to_mlx(
       // zero-copy adoption of the host buffer first. A copy is passed by value
       // so the source is preserved for the fallback below.
       if (!copy.value_or(false)) {
-        if (auto out =
-                cpu_nd_array_to_mlx_no_copy(nd_array, shape, dst_dtype)) {
+        if (auto out = cpu_nd_array_to_mlx_no_copy(
+                nd_array, shape, src_mlx_dtype, dst_dtype)) {
           return *out;
         }
         if (no_copy) {

--- a/python/tests/test_zero_copy.py
+++ b/python/tests/test_zero_copy.py
@@ -51,6 +51,12 @@ class TestZeroCopy(mlx_tests.MLXTestCase):
         with self.assertRaises(Exception):
             mx.asarray(a, dtype=mx.float32, copy=False)
 
+    def test_dtype_conversion_preserves_values(self):
+        a = np.arange(16, dtype=np.float64)
+        x = mx.asarray(a, dtype=mx.complex64)
+        mx.eval(x)
+        self.assertTrue(np.array_equal(np.array(x), a.astype(np.complex64)))
+
     def test_source_lifetime(self):
         if not mx.metal.is_available():
             self.skipTest("copy=False requires Metal")


### PR DESCRIPTION
When a NumPy buffer is adopted through the zero-copy path, the current conversion code can return a view with the destination dtype even when the source dtype differs. This corrupts values, for example float64 input requested as complex64.

The patch passes the source MLX dtype into the no-copy check and rejects adoption when source and destination dtypes differ, allowing the existing conversion path to preserve values.

Validation: `python python/tests/test_zero_copy.py` (7 passed).
