### PR TITLE
Clean up main thread compile cache before python interpreter shuts down

### DIFF
--- a/python/src/transforms.cpp
+++ b/python/src/transforms.cpp
@@ -1538,4 +1538,11 @@ void init_transforms(nb::module_& m) {
           A callable that recomputes intermediate states during gradient
           computation.
       )pbdoc");
+
+  // Clean up main thread compile cache before python interpreter shuts down.
+  auto atexit = nb::module_::import_("atexit");
+  atexit.attr("register")(
+      nb::cpp_function([cache = mx::detail::compile_cache()]() {
+        mx::detail::compile_clear_cache(cache);
+      }));
 }


### PR DESCRIPTION
Fix a regression of https://github.com/ml-explore/mlx/pull/4248 that so we don't require users to call `mx.clear_streams()` in the main thread, because it is safe for us to do it with python's `atexit` register.

Note that it is still required to call `mx.clear_streams()` in each worker thread as python does not have a thread-level `atexit` register, and it is unsafe for us to do automatic cleanup because they may run after python interpreter and cuda runtime shuts down.