### PR TITLE
Validate GGUF tensor dimensions

### DIFF
--- a/mlx/io/gguf.cpp
+++ b/mlx/io/gguf.cpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <cstring>
 #include <fstream>
+#include <limits>
 #include <numeric>
 
 #include "mlx/io/gguf.h"
@@ -47,11 +48,33 @@ std::optional<Dtype> gguf_type_to_dtype(const uint32_t& gguf_type) {
   }
 }
 
+[[noreturn]] void tensor_error(
+    const gguf_tensor& tensor,
+    const std::string& what) {
+  std::ostringstream msg;
+  msg << "[load_gguf] Tensor '" << std::string(tensor.name, tensor.namelen)
+      << "' " << what << ". Perhaps an incomplete download or corrupt file?";
+  throw std::runtime_error(msg.str());
+}
+
 Shape get_shape(const gguf_tensor& tensor) {
   Shape shape;
+  // Only the byte size is checked against the file, so a dimension that does
+  // not survive the narrowing to ShapeElem, or a product that wraps, would let
+  // the shape and tensor.num_weights describe different sizes.
+  uint64_t num_weights = 1;
   // The dimension order in GGML is the reverse of the order used in MLX.
   for (int i = tensor.ndim - 1; i >= 0; i--) {
-    shape.push_back(tensor.dim[i]);
+    auto dim = tensor.dim[i];
+    if (dim > std::numeric_limits<ShapeElem>::max()) {
+      tensor_error(tensor, "has a dimension that is too large");
+    }
+    if (dim != 0 && num_weights > std::numeric_limits<uint64_t>::max() / dim) {
+      tensor_error(
+          tensor, "has a dimension product that does not fit in 64 bits");
+    }
+    num_weights *= dim;
+    shape.push_back(dim);
   }
   return shape;
 }
@@ -303,20 +326,14 @@ std::unordered_map<std::string, GGUFMetaData> load_metadata(gguf_ctx* ctx) {
 }
 
 void check_tensor_in_file(const gguf_ctx* ctx, const gguf_tensor& tensor) {
-  auto fail = [&tensor](const std::string& what) {
-    std::ostringstream msg;
-    msg << "[load_gguf] Tensor '" << std::string(tensor.name, tensor.namelen)
-        << "' " << what << ". Perhaps an incomplete download or corrupt file?";
-    throw std::runtime_error(msg.str());
-  };
   if (tensor.offset < ctx->data_off) {
-    fail("has a data offset that overflows the data section");
+    tensor_error(tensor, "has a data offset that overflows the data section");
   }
   if (tensor.offset > ctx->size) {
-    fail("has a data offset past the end of the file");
+    tensor_error(tensor, "has a data offset past the end of the file");
   }
   if (tensor.bsize > ctx->size - tensor.offset) {
-    fail("extends past the end of the file");
+    tensor_error(tensor, "extends past the end of the file");
   }
 }
 

--- a/mlx/io/gguf.cpp
+++ b/mlx/io/gguf.cpp
@@ -59,9 +59,6 @@ std::optional<Dtype> gguf_type_to_dtype(const uint32_t& gguf_type) {
 
 Shape get_shape(const gguf_tensor& tensor) {
   Shape shape;
-  // Only the byte size is checked against the file, so a dimension that does
-  // not survive the narrowing to ShapeElem, or a product that wraps, would let
-  // the shape and tensor.num_weights describe different sizes.
   uint64_t num_weights = 1;
   // The dimension order in GGML is the reverse of the order used in MLX.
   for (int i = tensor.ndim - 1; i >= 0; i--) {

--- a/mlx/io/gguf_quants.cpp
+++ b/mlx/io/gguf_quants.cpp
@@ -112,6 +112,11 @@ void gguf_load_quantized(
   std::string name(tensor.name, tensor.namelen);
 
   auto shape = get_shape(tensor);
+  if (shape.empty()) {
+    std::ostringstream msg;
+    msg << "[load_gguf] quantized tensor " << name << " has no dimensions";
+    throw std::runtime_error(msg.str());
+  }
   const uint64_t weights_per_block = 32;
   if (shape[shape.size() - 1] % weights_per_block != 0) {
     std::ostringstream msg;
@@ -125,15 +130,17 @@ void gguf_load_quantized(
   auto w_nbytes = uint32.size() *
       std::accumulate(weights_shape.begin(),
                       weights_shape.end(),
-                      1,
+                      size_t{1},
                       std::multiplies<size_t>());
 
   array weights(allocator::malloc(w_nbytes), std::move(weights_shape), uint32);
 
   // For scales and bias
   shape[shape.size() - 1] = shape[shape.size() - 1] / weights_per_block;
-  auto sb_nbytes = float16.size() *
-      std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<size_t>());
+  auto sb_nbytes =
+      float16.size() *
+      std::accumulate(
+          shape.begin(), shape.end(), size_t{1}, std::multiplies<size_t>());
 
   array scales(allocator::malloc(sb_nbytes), shape, float16);
   array biases(allocator::malloc(sb_nbytes), std::move(shape), float16);

--- a/tests/load_tests.cpp
+++ b/tests/load_tests.cpp
@@ -257,6 +257,104 @@ TEST_CASE("test gguf tensor data offset validation") {
   }
 }
 
+// Writes a one-tensor GGUF whose tensor header carries `dims` and `type`
+// verbatim, so a test can drive the dimension product independently of the
+// amount of tensor data in the file. The name ends in ".weight" because the
+// quantized loader derives the scales and biases names from it.
+void write_raw_gguf_dims(
+    const std::string& path,
+    const std::vector<uint64_t>& dims,
+    uint32_t type,
+    size_t data_bytes) {
+  std::ofstream out(path, std::ios::binary);
+  auto u32 = [&out](uint32_t v) {
+    out.write(reinterpret_cast<const char*>(&v), 4);
+  };
+  auto u64 = [&out](uint64_t v) {
+    out.write(reinterpret_cast<const char*>(&v), 8);
+  };
+  out.write("GGUF", 4);
+  u32(3); // version
+  u64(1); // tensor_count
+  u64(0); // metadata_kv_count
+  u64(8); // tensor name length
+  out.write("w.weight", 8);
+  u32(dims.size());
+  for (auto dim : dims) {
+    u64(dim);
+  }
+  u32(type);
+  u64(0); // tensor data offset
+  while (out.tellp() % 32 != 0) { // default GGUF alignment
+    out.put(0);
+  }
+  std::vector<char> data(data_bytes, 0);
+  out.write(data.data(), data.size());
+}
+
+TEST_CASE("test gguf tensor dimension validation") {
+  // The element count exists in two widths: gguflib keeps the 64 bit product in
+  // tensor.num_weights, and get_shape narrows each dimension to a 32 bit
+  // ShapeElem. Only the byte size is checked against the file, so dimensions
+  // that make the two disagree size a buffer from one and index it with the
+  // other. See ml-explore/mlx#4244.
+  const uint32_t q8_0 = 8;
+
+  SUBCASE("valid quantized tensor loads") {
+    std::string file_path = get_temp_file("test_gguf_dims_ok.gguf");
+    // One block of 32 weights: 2 bytes of scale plus 32 bytes of weights.
+    write_raw_gguf_dims(file_path, {32}, q8_0, 34);
+    auto [weights, metadata] = load_gguf(file_path);
+    CHECK_EQ(weights.at("w.weight").shape(), Shape{8});
+    CHECK_EQ(weights.at("w.scales").shape(), Shape{1});
+    CHECK_EQ(weights.at("w.biases").shape(), Shape{1});
+  }
+
+  SUBCASE("dimension past the ShapeElem range") {
+    // Narrows to a shape of 32 that no longer describes the file.
+    std::string file_path = get_temp_file("test_gguf_dim_narrowed.gguf");
+    write_raw_gguf_dims(file_path, {(1ull << 32) + 32}, q8_0, 34);
+    CHECK_THROWS_AS(load_gguf(file_path), std::runtime_error);
+  }
+
+  SUBCASE("dimension that narrows to a negative shape") {
+    std::string file_path = get_temp_file("test_gguf_dim_negative.gguf");
+    write_raw_gguf_dims(file_path, {1ull << 31}, q8_0, 34);
+    CHECK_THROWS_AS(load_gguf(file_path), std::runtime_error);
+  }
+
+  SUBCASE("dimension product that wraps to a small byte size") {
+    // 96 * 384307168202282326 wraps to 64, so the tensor needs only 68 bytes of
+    // data and passes the byte size check, while the narrowed shape
+    // {1431655766, 96} still describes 2^37 elements. That drives the scales
+    // element count past INT32_MAX, which is what truncates the allocation size
+    // while the extractor still loops over the full count.
+    std::string file_path = get_temp_file("test_gguf_dim_wrap.gguf");
+    write_raw_gguf_dims(file_path, {96, 384307168202282326ull}, q8_0, 68);
+    CHECK_THROWS_AS(load_gguf(file_path), std::runtime_error);
+  }
+
+  SUBCASE("dimension product that wraps to zero") {
+    // Wraps num_weights to exactly 0, so the tensor claims no data at all.
+    std::string file_path = get_temp_file("test_gguf_dim_wrap_zero.gguf");
+    write_raw_gguf_dims(
+        file_path,
+        {(1ull << 32) + (1ull << 25),
+         (1ull << 32) + (1ull << 15),
+         (1ull << 32) + (1ull << 24)},
+        q8_0,
+        0);
+    CHECK_THROWS_AS(load_gguf(file_path), std::runtime_error);
+  }
+
+  SUBCASE("tensor without dimensions") {
+    // gguf_load_quantized indexes the last shape element unconditionally.
+    std::string file_path = get_temp_file("test_gguf_no_dims.gguf");
+    write_raw_gguf_dims(file_path, {}, q8_0, 0);
+    CHECK_THROWS_AS(load_gguf(file_path), std::runtime_error);
+  }
+}
+
 // Writes a metadata-only GGUF (no tensors) whose metadata KV section is
 // `kv_section` verbatim, so a caller can encode values whose lengths exceed the
 // file to exercise check_metadata_value_in_file(). `kv_count` must match the


### PR DESCRIPTION
Fixes #4244 (thanks @perparimmjeku for the report).

## The bug

GGUF stores tensor dimensions as 64-bit values, while MLX represents dimensions with `ShapeElem`, which is `int32_t`.

Previously, `get_shape()` copied GGUF dimensions directly into the MLX shape, allowing a 64-bit dimension to narrow to a different 32-bit value. In the quantized loader, this could make the allocation size smaller than the number of elements subsequently processed, resulting in a heap-buffer-overflow during tensor extraction.

The dimension product could also wrap in 64-bit arithmetic, causing the MLX shape and the tensor's element count to describe different sizes.

## Reproducing it

The regression tests cover:

- `{32}` as a valid quantized tensor dimension.
- `(1ull << 32) + 32` to test a dimension larger than the `ShapeElem` range.
- `1ull << 31` to test a value that would become negative when represented as signed `int32_t`.
- `{96, 384307168202282326ull}` to produce a dimension product that wraps in 64-bit arithmetic.
- Three large dimensions whose product wraps to zero.
- `{}` to test a quantized tensor with no dimensions.

On unmodified `main`, the crafted dimension-product case produces:

```
==82611==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6020000008fc
WRITE of size 2 at 0x6020000008fc thread T0
    #0 mlx::core::extract_q8_0_data(...) gguf_quants.cpp:90
    #1 mlx::core::gguf_load_quantized(...) gguf_quants.cpp:145
    #2 mlx::core::load_arrays(gguf_ctx*) gguf.cpp:340
    #3 mlx::core::load_gguf(...) gguf.cpp:367

0x6020000008fc is located 0 bytes after 12-byte region [0x6020000008f0,0x6020000008fc)
allocated by thread T0 here:
    #1 mlx::core::allocator::CommonAllocator::malloc(unsigned long) allocator.cpp:102
    #3 mlx::core::gguf_load_quantized(...) gguf_quants.cpp:138
```

The allocation size is derived from a 32-bit accumulator, while the extraction loop operates on the full shape-derived element count. This allows the loop to write beyond the allocated buffer.

The same underlying issue is present in the Q4_0 and Q4_1 extraction paths.

## The fix

### `mlx/io/gguf.cpp`

- Added `<limits>`.
- Added `tensor_error()` to centralize tensor validation errors.
- `get_shape()` now validates every GGUF dimension against the maximum representable `ShapeElem` value before narrowing.
- Added overflow-safe multiplication using `uint64_t` maximum divided by the next dimension.
- Reused `tensor_error()` for the existing tensor file-boundary validation.

The validation is performed before narrowing or multiplying, so malformed dimensions cannot silently produce a different MLX shape or a wrapped element count.

### `mlx/io/gguf_quants.cpp`

- Added an explicit check for an empty shape before the quantized loader indexes the last dimension. A zero-dimensional tensor is valid elsewhere in MLX, so this check is kept in the quantized path where a last dimension is required.
- Changed both `std::accumulate()` initial values from `1` to `size_t{1}`.

The `std::accumulate()` change is important because its accumulator type is deduced from the initial value, not from the binary operation. With the literal `1`, the accumulator is an `int`, even though the operation is `std::multiplies<size_t>`. This causes intermediate products to be converted back to 32-bit `int`. Using `size_t{1}` keeps the accumulation in the intended width.

I did not add allocator-failure checks in this change. Once GGUF dimensions are validated, an allocation of genuinely enormous size requires a correspondingly enormous input file; handling general out-of-memory conditions is outside the scope of this fix.

### Why not compare against `tensor.num_weights`?

`tensor.num_weights` is the 64-bit product maintained by gguflib, but comparing a newly calculated product against it would not solve the representation problem.

MLX ultimately stores dimensions as `ShapeElem`, which is `int32_t`, so every individual dimension must first be proven representable in that type. The multiplication must then be proven safe before calculating the product.

The fix therefore validates the GGUF inputs before narrowing and before multiplication, rather than relying on a potentially narrowed shape or a wrapped product.

## Prior art

- #4179 validates GGUF tensor data offsets and byte extents against the mapped file.
- #4212 validates GGUF metadata string and array lengths against the mapped file.

This PR addresses a different issue: malformed tensor dimensions and dimension-product arithmetic can cause the MLX shape and element count to disagree, leading to unsafe allocation and indexing behavior in the quantized loader.

## Testing

Added `TEST_CASE("test gguf tensor dimension validation")` in `tests/load_tests.cpp`, covering six cases.

Built CPU-only with AddressSanitizer:

```
cmake -S . -B build-asan -DCMAKE_BUILD_TYPE=Debug -DMLX_BUILD_METAL=OFF \
  -DMLX_BUILD_TESTS=ON \
  -DCMAKE_CXX_FLAGS="-fsanitize=address -fno-omit-frame-pointer -g" \
  -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address"

cmake --build build-asan -j10 --target tests
```

On unmodified `main`, the new dimension-product test triggers the heap-buffer-overflow shown above.

With this change, the whole C++ suite passes under ASAN:

```
[doctest] test cases:  252 |  252 passed | 0 failed | 0 skipped
[doctest] assertions: 3366 | 3366 passed | 0 failed |
```

Python load and quantized tests:

```
51 passed, 3 skipped, 3291 subtests passed
```

`uvx pre-commit run --all` is clean.

The reporter's four PoC files are also rejected by the loader with:

```
[load_gguf] Tensor 'w.weight' has a dimension that is too large. Perhaps an incomplete download or corrupt file?
```

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
- [x] I understand it is strictly prohibited to use AI to write PR description
- [x] 100% responsible for every line, however it was produced, I reviewed the change, understand it, and take responsibility. 
- AI usage disclosure: AI was used to:
  - read and analyse the GGUF load path
  - derive the smaller reproducer, including the constraint solve that produced dim[0] = 96, dim[1] = 384307168202282326
  - write the change to mlx/io/gguf.cpp
  - write the change to mlx/io/gguf_quants.cpp
  - write the six-subcase regression test
  - run the ASAN build, the C++ suite, the Python tests, and pre-commit
  - confirm the test fails on unmodified main, and that the PoC files are rejected
  - typeset my PR description's markdown — no wording changed
