### PR TITLE
Fix quantizing sliced arrays

### DIFF
--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -249,21 +249,18 @@ void quantize_impl(
   auto w = ensure_row_contiguous(w_pre, d, s);
   if (dequantize) {
     auto scales = ensure_row_contiguous(inputs[1], d, s);
-    compute_encoder.set_input_array(w, 0);
-    compute_encoder.set_input_array(scales, 1);
     if (has_biases) {
       auto biases = ensure_row_contiguous(inputs[2], d, s);
       compute_encoder.set_input_array(biases, 2);
     } else if (has_global_scale) {
       compute_encoder.set_input_array(inputs[2], 2);
     }
+    compute_encoder.set_input_array(w, 0);
+    compute_encoder.set_input_array(scales, 1);
     compute_encoder.set_output_array(out, 3);
   } else {
     auto& scales = outputs[1];
     scales.set_data(allocator::malloc(scales.nbytes()));
-    compute_encoder.set_input_array(w, 0);
-    compute_encoder.set_output_array(out, 1);
-    compute_encoder.set_output_array(scales, 2);
     if (has_biases) {
       auto& biases = outputs[2];
       biases.set_data(allocator::malloc(biases.nbytes()));
@@ -271,6 +268,9 @@ void quantize_impl(
     } else if (has_global_scale) {
       compute_encoder.set_input_array(inputs[1], 3);
     }
+    compute_encoder.set_input_array(w, 0);
+    compute_encoder.set_output_array(out, 1);
+    compute_encoder.set_output_array(scales, 2);
   }
 
   auto type_string = dequantize ? get_type_string(out.dtype())

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -39,6 +39,18 @@ class TestQuantized(mlx_tests.MLXTestCase):
                 a_hat = mx.dequantize(w_q, scales, biases, gs, b)
                 self.assertTrue(mx.all(a_hat == 0))
 
+        # slices
+        if mx.default_device() == mx.gpu:
+            w = mx.random.normal(shape=(2, 256, 32))
+            quant = {"group_size": 32, "bits": 4}
+            wq, scales, biases = mx.quantize(w, **quant)
+            wq_s = wq[:, :16, :]
+            scales_s = scales[:, :16, :]
+            biases_s = biases[:, :16, :]
+            dq_cpu = mx.dequantize(wq_s, scales_s, biases_s, **quant, stream=mx.cpu)
+            dq_gpu = mx.dequantize(wq_s, scales_s, biases_s, **quant, stream=mx.gpu)
+            self.assertTrue(mx.abs(dq_cpu - dq_gpu).max().item() < 1e-6)
+
     def test_mxfp4_quantize_dequantize(self):
         lut = mx.array(
             [


### PR DESCRIPTION
Close https://github.com/ml-explore/mlx/issues/4370, a regression introduced by https://github.com/ml-explore/mlx/pull/3757 that, calling `set_input_array` before `ensure_row_contiguous` would mess up the graph.