### PR TITLE
Support Relocatable CUDA DLLs on Windows

### DIFF
--- a/mlx/backend/cuda/CMakeLists.txt
+++ b/mlx/backend/cuda/CMakeLists.txt
@@ -74,6 +74,7 @@ target_sources(
 
 # Put dynamic defines in the dirs.cpp file.
 add_library(mlx_dirs OBJECT ${CMAKE_CURRENT_SOURCE_DIR}/dirs.cpp)
+target_include_directories(mlx_dirs PRIVATE "${PROJECT_SOURCE_DIR}")
 target_link_libraries(mlx PRIVATE $<BUILD_INTERFACE:mlx_dirs>)
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/binary)
@@ -177,8 +178,32 @@ message(STATUS "CUDA architectures: ${MLX_CUDA_ARCHITECTURES}")
 set_target_properties(mlx PROPERTIES CUDA_ARCHITECTURES
                                      "${MLX_CUDA_ARCHITECTURES}")
 
-# Search CUDA libs from installed python packages.
+# Configure Windows CUDA DLL loading.
 if(WIN32)
+  set(MLX_CUDA_BIN_DIR
+      ""
+      CACHE STRING "Directory containing CUDA DLLs for Windows delay-loading")
+  set(MLX_CUDNN_BIN_DIR
+      ""
+      CACHE STRING "Directory containing cuDNN DLLs for Windows delay-loading")
+
+  # With MLX_LOAD_CUDA_LIBS_FROM_PYTHON, unset dirs use the wheel layout.
+  # Relative dirs are resolved from the MLX binary.
+  if(NOT MLX_LOAD_CUDA_LIBS_FROM_PYTHON)
+    if("${MLX_CUDA_BIN_DIR}" STREQUAL "")
+      set(MLX_CUDA_BIN_DIR "${CUDAToolkit_BIN_DIR}/x64")
+    endif()
+    if("${MLX_CUDNN_BIN_DIR}" STREQUAL "")
+      set(MLX_CUDNN_BIN_DIR "${CUDNN_BIN_DIR}")
+    endif()
+  endif()
+
+  function(mlx_add_dir_definition name)
+    if(NOT "${${name}}" STREQUAL "")
+      target_compile_definitions(mlx_dirs PRIVATE ${name}="${${name}}")
+    endif()
+  endfunction()
+
   # Resolve paths of unfound DLL at runtime.
   if(BUILD_SHARED_LIBS)
     target_link_libraries(mlx PRIVATE "delayimp.lib")
@@ -199,11 +224,9 @@ if(WIN32)
     target_link_options(mlx PUBLIC "/DELAYLOAD:${CUDA_DLL}")
   endforeach()
   # Pass the locations where CUDA DLLs are placed.
-  if(NOT MLX_LOAD_CUDA_LIBS_FROM_PYTHON)
-    target_compile_definitions(
-      mlx_dirs PRIVATE MLX_CUDA_BIN_DIR="${CUDAToolkit_BIN_DIR}/x64"
-                       MLX_CUDNN_BIN_DIR="${CUDNN_BIN_DIR}")
-  endif()
+  foreach(dir_var MLX_CUDA_BIN_DIR MLX_CUDNN_BIN_DIR)
+    mlx_add_dir_definition(${dir_var})
+  endforeach()
 else()
   # For POSIX we rely on RPATH to search for CUDA libs.
   if(MLX_LOAD_CUDA_LIBS_FROM_PYTHON)

--- a/mlx/backend/cuda/delayload.cpp
+++ b/mlx/backend/cuda/delayload.cpp
@@ -20,23 +20,31 @@ inline fs::path relative_to_current_binary(const char* relative) {
 }
 
 inline fs::path cublas_dir() {
-  return cuda_bin_dir() ? fs::path(cuda_bin_dir())
-                        : relative_to_current_binary("../nvidia/cublas/bin");
+  if (const char* dir = cuda_bin_dir()) {
+    return fs::path(dir);
+  }
+  return relative_to_current_binary("../nvidia/cublas/bin");
 }
 
 fs::path load_nvrtc() {
-  fs::path nvrtc_dir = cuda_bin_dir()
-      ? fs::path(cuda_bin_dir())
-      : relative_to_current_binary("../nvidia/cuda_nvrtc/bin");
+  fs::path nvrtc_dir;
+  if (const char* dir = cuda_bin_dir()) {
+    nvrtc_dir = fs::path(dir);
+  } else {
+    nvrtc_dir = relative_to_current_binary("../nvidia/cuda_nvrtc/bin");
+  }
   // Internally nvrtc loads some libs dynamically, add to search dirs.
   ::AddDllDirectory(nvrtc_dir.c_str());
   return nvrtc_dir;
 }
 
 fs::path load_cudnn() {
-  fs::path cudnn_dir = cudnn_bin_dir()
-      ? fs::path(cudnn_bin_dir())
-      : relative_to_current_binary("../nvidia/cudnn/bin");
+  fs::path cudnn_dir;
+  if (const char* dir = cudnn_bin_dir()) {
+    cudnn_dir = fs::path(dir);
+  } else {
+    cudnn_dir = relative_to_current_binary("../nvidia/cudnn/bin");
+  }
   // Must load cudnn_graph64_9.dll before locating symbols, otherwise We would
   // get errors like "Invalid handle. Cannot load symbol cudnnCreate".
   for (const auto& dll : fs::directory_iterator(cudnn_dir)) {
@@ -66,6 +74,8 @@ FARPROC WINAPI delayload_helper(unsigned dliNotify, PDelayLoadInfo pdli) {
     } else if (dll.starts_with("nvrtc")) {
       static auto nvrtc_dir = load_nvrtc();
       mod = ::LoadLibraryW((nvrtc_dir / dll).c_str());
+    } else if (const char* dir = cuda_bin_dir()) {
+      mod = ::LoadLibraryW((fs::path(dir) / dll).c_str());
     }
   }
   return reinterpret_cast<FARPROC>(mod);

--- a/mlx/backend/cuda/dirs.cpp
+++ b/mlx/backend/cuda/dirs.cpp
@@ -1,6 +1,24 @@
 // Copyright © 2026 Apple Inc.
 
+#include "mlx/backend/common/utils.h"
+
+#include <filesystem>
+#include <string>
+
 namespace mlx::core::cu {
+namespace {
+
+namespace fs = std::filesystem;
+
+std::string resolve_bin_dir(const char* dir) {
+  fs::path path(dir);
+  if (path.is_absolute()) {
+    return path.string();
+  }
+  return fs::absolute(current_binary_dir() / path).string();
+}
+
+} // namespace
 
 const char* cccl_dir() {
 #if defined(MLX_CCCL_DIR)
@@ -12,7 +30,8 @@ const char* cccl_dir() {
 
 const char* cuda_bin_dir() {
 #if defined(MLX_CUDA_BIN_DIR)
-  return MLX_CUDA_BIN_DIR;
+  static const std::string dir = resolve_bin_dir(MLX_CUDA_BIN_DIR);
+  return dir.c_str();
 #else
   return nullptr;
 #endif
@@ -20,7 +39,8 @@ const char* cuda_bin_dir() {
 
 const char* cudnn_bin_dir() {
 #if defined(MLX_CUDNN_BIN_DIR)
-  return MLX_CUDNN_BIN_DIR;
+  static const std::string dir = resolve_bin_dir(MLX_CUDNN_BIN_DIR);
+  return dir.c_str();
 #else
   return nullptr;
 #endif


### PR DESCRIPTION
Windows CUDA builds can currently leak cuDNN DLL paths from the build machine. 
```
directory_iterator::directory_iterator: The system cannot find the path specified.:
  "C:/Program Files/NVIDIA/CUDNN/bin/x64"
```

This adds `MLX_CUDA_BIN_DIR` and `MLX_CUDNN_BIN_DIR` to specify relocatable DLL locations (absolute or relative to the MLX binary.) 

- ☑️ I understand it is strictly prohibited to use AI to write PR description
- AI usage disclosure: co-developed with an AI agent