### PR TITLE
chore: Use normalize_axis_index in scan ops

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -4148,14 +4148,7 @@ array cumsum(
     bool inclusive /* = true*/,
     std::optional<Dtype> dtype /* = std::nullopt*/,
     StreamOrDevice s /* = {}*/) {
-  int ndim = a.ndim();
-  if (axis >= ndim || axis < -ndim) {
-    std::ostringstream msg;
-    msg << "[cumsum] Axis " << axis << " is out of bounds for array with "
-        << a.ndim() << " dimensions.";
-    throw std::invalid_argument(msg.str());
-  }
-  axis = (axis + a.ndim()) % a.ndim();
+  axis = normalize_axis_index(axis, a.ndim(), "[cumsum] ");
   auto x = dtype ? astype(a, *dtype, s) : a;
   auto out_type = x.dtype() == bool_ ? int32 : x.dtype();
   return array(
@@ -4183,14 +4176,7 @@ array cumprod(
     bool inclusive /* = true*/,
     std::optional<Dtype> dtype /* = std::nullopt*/,
     StreamOrDevice s /* = {}*/) {
-  int ndim = a.ndim();
-  if (axis >= ndim || axis < -ndim) {
-    std::ostringstream msg;
-    msg << "[cumprod] Axis " << axis << " is out of bounds for array with "
-        << a.ndim() << " dimensions.";
-    throw std::invalid_argument(msg.str());
-  }
-  axis = (axis + a.ndim()) % a.ndim();
+  axis = normalize_axis_index(axis, a.ndim(), "[cumprod] ");
   auto x = dtype ? astype(a, *dtype, s) : a;
   return array(
       x.shape(),
@@ -4215,14 +4201,7 @@ array cummax(
     bool reverse /* = false*/,
     bool inclusive /* = true*/,
     StreamOrDevice s /* = {}*/) {
-  int ndim = a.ndim();
-  if (axis >= ndim || axis < -ndim) {
-    std::ostringstream msg;
-    msg << "[cummax] Axis " << axis << " is out of bounds for array with "
-        << a.ndim() << " dimensions.";
-    throw std::invalid_argument(msg.str());
-  }
-  axis = (axis + a.ndim()) % a.ndim();
+  axis = normalize_axis_index(axis, a.ndim(), "[cummax] ");
   return array(
       a.shape(),
       a.dtype(),
@@ -4245,14 +4224,7 @@ array cummin(
     bool reverse /* = false*/,
     bool inclusive /* = true*/,
     StreamOrDevice s /* = {}*/) {
-  int ndim = a.ndim();
-  if (axis >= ndim || axis < -ndim) {
-    std::ostringstream msg;
-    msg << "[cummin] Axis " << axis << " is out of bounds for array with "
-        << a.ndim() << " dimensions.";
-    throw std::invalid_argument(msg.str());
-  }
-  axis = (axis + a.ndim()) % a.ndim();
+  axis = normalize_axis_index(axis, a.ndim(), "[cummin] ");
   return array(
       a.shape(),
       a.dtype(),
@@ -4302,14 +4274,7 @@ array logcumsumexp(
     bool reverse /* = false*/,
     bool inclusive /* = true*/,
     StreamOrDevice s /* = {}*/) {
-  int ndim = a.ndim();
-  if (axis >= ndim || axis < -ndim) {
-    std::ostringstream msg;
-    msg << "[logcumsumexp] Axis " << axis << " is out of bounds for array with "
-        << a.ndim() << " dimensions.";
-    throw std::invalid_argument(msg.str());
-  }
-  axis = (axis + a.ndim()) % a.ndim();
+  axis = normalize_axis_index(axis, a.ndim(), "[logcumsumexp] ");
   return array(
       a.shape(),
       a.dtype(),

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -2578,9 +2578,11 @@ class TestOps(mlx_tests.MLXTestCase):
                     mxop(a, axis=ax)
 
             # Valid negative axes still work and agree with the positive one
+            # logcumsumexp has no integer kernel, so use a float input
+            a_ = a.astype(mx.float32) if op == "logcumsumexp" else a
             for ax in [-1, -2, -3]:
-                out_neg = mxop(a, axis=ax)
-                out_pos = mxop(a, axis=ax + a.ndim)
+                out_neg = mxop(a_, axis=ax)
+                out_pos = mxop(a_, axis=ax + a_.ndim)
                 self.assertTrue(mx.array_equal(out_neg, out_pos))
 
     def test_scans(self):

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -2568,6 +2568,21 @@ class TestOps(mlx_tests.MLXTestCase):
         c_mlx = mxop(a_mlx, axis=-1)
         self.assertTrue(np.allclose(c_npy, c_mlx, rtol=1e-3, atol=1e-3))
 
+    def test_scan_invalid_axis(self):
+        a = mx.arange(24).reshape(2, 3, 4)
+
+        for op in ["cumsum", "cumprod", "cummax", "cummin", "logcumsumexp"]:
+            mxop = getattr(mx, op)
+            for ax in [3, 4, 100, -4, -5, -100]:
+                with self.assertRaises(ValueError):
+                    mxop(a, axis=ax)
+
+            # Valid negative axes still work and agree with the positive one
+            for ax in [-1, -2, -3]:
+                out_neg = mxop(a, axis=ax)
+                out_pos = mxop(a, axis=ax + a.ndim)
+                self.assertTrue(mx.array_equal(out_neg, out_pos))
+
     def test_scans(self):
         a_npy = np.random.randn(32, 32, 32).astype(np.float32)
         a_mlx = mx.array(a_npy)


### PR DESCRIPTION
### Proposed changes

`cumsum`, `cumprod`, `cummax`, `cummin` and `logcumsumexp` in `mlx/ops.cpp` each reimplement the same axis bounds check and normalization inline:

```cpp
int ndim = a.ndim();
if (axis >= ndim || axis < -ndim) {
  std::ostringstream msg;
  msg << "[cumsum] Axis " << axis << " is out of bounds for array with "
      << a.ndim() << " dimensions.";
  throw std::invalid_argument(msg.str());
}
axis = (axis + a.ndim()) % a.ndim();
```

`normalize_axis_index` (in `mlx/utils.h`) already does exactly this and is used throughout the rest of `ops.cpp`. #4288 did this same cleanup for `split`/`unstack`/`partition`/`topk`, but the five scan ops were left with their own copy of the pattern.

Replaced each with a single call, e.g.:

```cpp
axis = normalize_axis_index(axis, a.ndim(), "[cumsum] ");
```

No behavior change: same bounds (`[-ndim, ndim)`), the same error message text (`"[cumsum] Axis N is out of bounds for array with M dimensions."`), and the same normalized axis value.

### Tests

Added `test_scan_invalid_axis` in `python/tests/test_ops.py`, covering all five ops: out-of-bounds axes (both positive and negative, matching the pattern of the existing `test_along_axis_invalid_axis`) raise `ValueError`, and valid negative axes agree with their positive equivalent.