### PR TITLE
Declare DLPackCompatible protocol members as methods, not settable attributes

### DIFF
--- a/python/mlx/_stub_patterns.txt
+++ b/python/mlx/_stub_patterns.txt
@@ -3,8 +3,8 @@ mlx.core.__prefix__:
   P = ParamSpec("P")
   R = TypeVar("R")
   class DLPackCompatible(Protocol):
-    __dlpack__: Callable[..., Any]
-    __dlpack_device__: Callable[..., Any]
+    def __dlpack__(self, *args: Any, **kwargs: Any) -> Any: ...
+    def __dlpack_device__(self, *args: Any, **kwargs: Any) -> Any: ...
 
 mlx.core.__suffix__:
   scalar: TypeAlias = int | float | bool | complex


### PR DESCRIPTION
Fixes #4371.

### Proposed changes

`DLPackCompatible` in the generated type stub pattern declares its members as variables:

```python
class DLPackCompatible(Protocol):
    __dlpack__: Callable[..., Any]
    __dlpack_device__: Callable[..., Any]
```

A `Protocol` member declared this way is invariant and requires the matching attribute to be settable. `numpy.ndarray` defines `__dlpack__` as an ordinary read-only method, so it fails structural typing against this protocol under mypy even though it works fine at runtime — breaking type checking for `mx.array`, `mx.asarray` and `mx.from_dlpack` on any DLPack-producing object such as a NumPy array.

```
error: Argument 1 to "array" has incompatible type "ndarray[Any, dtype[Any]]"; expected "DLPackCompatible"  [arg-type]
```

Declaring the members as methods instead makes them covariant, so a read-only method implementation like NumPy's satisfies the protocol, matching how `numpy.ndarray` and other DLPack producers actually implement it.

### Tests

Stub-only change; verified with a standalone `mypy` run reproducing the exact before/after from the issue — the reported error is gone after the fix and there is no existing test suite for the generated stub file to extend.