### PR TITLE
Widen float16/bfloat16 to float32 in cpu reduce

### DIFF
--- a/mlx/backend/cpu/reduce.cpp
+++ b/mlx/backend/cpu/reduce.cpp
@@ -68,12 +68,11 @@ const complex64_t Limits<complex64_t>::max =
 const complex64_t Limits<complex64_t>::min =
     -std::numeric_limits<float>::infinity();
 
-struct SumReduce;
-struct ProdReduce;
-
 template <typename T, typename U, typename Op>
 struct ReductionAccumulator {
   static constexpr int N = std::min(simd::max_size<T>, simd::max_size<U>);
+  // Widen to float32 only if the input is float16 (with N=1) or bfloat16 as it
+  // improves performance.
   static constexpr bool widen_to_float =
       (std::is_same_v<T, bfloat16_t> ||
        (N == 1 && std::is_same_v<T, float16_t>));

--- a/mlx/backend/cpu/reduce.cpp
+++ b/mlx/backend/cpu/reduce.cpp
@@ -68,6 +68,23 @@ const complex64_t Limits<complex64_t>::max =
 const complex64_t Limits<complex64_t>::min =
     -std::numeric_limits<float>::infinity();
 
+struct SumReduce;
+struct ProdReduce;
+
+template <typename T, typename U, typename Op>
+struct ReductionAccumulator {
+  static constexpr int N = std::min(simd::max_size<T>, simd::max_size<U>);
+  static constexpr bool widen_to_float =
+      (std::is_same_v<T, bfloat16_t> ||
+       (N == 1 && std::is_same_v<T, float16_t>));
+  static constexpr bool widen_to_double = N == 1 && std::is_same_v<T, float>;
+
+  using type = std::conditional_t<
+      widen_to_double,
+      double,
+      std::conditional_t<widen_to_float, float, U>>;
+};
+
 template <typename T, typename U, typename Op>
 void strided_reduce(
     const T* x,
@@ -261,6 +278,26 @@ void reduction_op(
   }
 }
 
+template <typename T, typename U, typename Op>
+void float_reduction(
+    const array& x,
+    array& out,
+    const std::vector<int>& axes,
+    U init) {
+  using AccT = ReductionAccumulator<T, U, Op>::type;
+  if constexpr (std::is_same_v<AccT, U>) {
+    reduction_op<T, U, Op>(x, out, axes, init);
+  } else {
+    auto acc_dtype = ReductionAccumulator<T, U, Op>::widen_to_double
+        ? float64
+        : TypeToDtype<AccT>();
+    array temp(out.shape(), acc_dtype, nullptr, {});
+    temp.set_data(allocator::malloc(temp.nbytes()));
+    reduction_op<T, AccT, Op>(x, temp, axes, static_cast<AccT>(init));
+    std::copy_n(temp.data<AccT>(), out.size(), out.data<U>());
+  }
+}
+
 struct AndReduce {
   template <typename T>
   bool operator()(bool x, T y) {
@@ -420,13 +457,13 @@ void reduce_dispatch_sum_prod(
     if constexpr (std::is_integral_v<InT> && sizeof(InT) <= 4) {
       reduction_op<InT, int32_t, SumReduce>(in, out, axes, 0);
     } else {
-      reduction_op<InT, InT, SumReduce>(in, out, axes, 0);
+      float_reduction<InT, InT, SumReduce>(in, out, axes, 0);
     }
   } else {
     if constexpr (std::is_integral_v<InT> && sizeof(InT) <= 4) {
       reduction_op<InT, int32_t, ProdReduce>(in, out, axes, 1);
     } else {
-      reduction_op<InT, InT, ProdReduce>(in, out, axes, 1);
+      float_reduction<InT, InT, ProdReduce>(in, out, axes, 1);
     }
   }
 }

--- a/mlx/backend/cpu/reduce.cpp
+++ b/mlx/backend/cpu/reduce.cpp
@@ -283,10 +283,7 @@ void float_reduction(
   if constexpr (std::is_same_v<AccT, U>) {
     reduction_op<T, U, Op>(x, out, axes, init);
   } else {
-    auto acc_dtype = ReductionAccumulator<T, U, Op>::widen_to_double
-        ? float64
-        : TypeToDtype<AccT>();
-    array temp(out.shape(), acc_dtype, nullptr, {});
+    array temp(out.shape(), TypeToDtype<AccT>(), nullptr, {});
     temp.set_data(allocator::malloc(temp.nbytes()));
     reduction_op<T, AccT, Op>(x, temp, axes, static_cast<AccT>(init));
     std::copy_n(temp.data<AccT>(), out.size(), out.data<U>());

--- a/mlx/backend/cpu/reduce.cpp
+++ b/mlx/backend/cpu/reduce.cpp
@@ -76,12 +76,8 @@ struct ReductionAccumulator {
   static constexpr bool widen_to_float =
       (std::is_same_v<T, bfloat16_t> ||
        (N == 1 && std::is_same_v<T, float16_t>));
-  static constexpr bool widen_to_double = N == 1 && std::is_same_v<T, float>;
 
-  using type = std::conditional_t<
-      widen_to_double,
-      double,
-      std::conditional_t<widen_to_float, float, U>>;
+  using type = std::conditional_t<widen_to_float, float, U>;
 };
 
 template <typename T, typename U, typename Op>

--- a/python/tests/test_bf16.py
+++ b/python/tests/test_bf16.py
@@ -141,6 +141,21 @@ class TestBF16(mlx_tests.MLXTestCase):
                             torch_op="a" + op,
                         )
 
+    def test_arithmetic_reduction_ops(self):
+        cases = {
+            "sum": np.ones((4096, 4), dtype=np.float32),
+            "prod": np.full((128, 4), 1.0078125, dtype=np.float32),
+        }
+        for op, values in cases.items():
+            with self.subTest(op=op):
+                x = mx.array(values, dtype=mx.bfloat16)
+                expected = mx.array(
+                    getattr(np, op)(values, axis=0, dtype=np.float32),
+                    dtype=mx.bfloat16,
+                )
+                actual = getattr(mx, op)(x, axis=0, stream=mx.cpu)
+                self.assertEqual(actual.tolist(), expected.tolist())
+
     def test_arg_reduction_ops(self):
         data = np.random.rand(10, 12, 13).astype(np.float32)
         x = mx.array(data).astype(mx.bfloat16)


### PR DESCRIPTION
## Proposed changes

Addresses issue: #4379 and continues on #3909. Modifies routing logic of `reduction_op` in `mlx/backend/cpu/reduce.cpp` so that the floating-point accumulator is correctly chosen for arithmetic reduction operations (`SumReduce` and `ProdReduce`). As noted in #3909 for apple silicon devices only bfloat16 is being promoted to float32, while float16 and float32 are left unchanged (due to performance implications). However, for devices which use a `basic_simd.h` bfloat16, float16 are promoted to float32 and float32 is promoted to double.

### Benchmark
```python
import time
import mlx.core as mx


N_WARMUP = 5
N_ITERS = 200
ALL_REDUCE_SIZE = 4 * 1024 * 1024
MATRIX_SHAPE = (4096, 4096)


def time_fn(fn):
    for _ in range(N_WARMUP):
        mx.eval(fn())
    mx.synchronize(mx.cpu)

    start = time.perf_counter()
    for _ in range(N_ITERS):
        mx.eval(fn())
    mx.synchronize(mx.cpu)
    return (time.perf_counter() - start) * 1e3 / N_ITERS


def print_table(rows):
    case_width = max(len("case"), *(len(case) for case, _ in rows))
    time_width = len("ms/call")
    print(f"{'case':<{case_width}}  {'ms/call':>{time_width}}")
    print(f"{'-' * case_width}  {'-' * time_width}")
    for case, milliseconds in rows:
        print(f"{case:<{case_width}}  {milliseconds:>{time_width}.5f}")


def benchmark_dtype(name, dtype):
    all_input = mx.ones((ALL_REDUCE_SIZE,), dtype=dtype)
    matrix_input = mx.ones(MATRIX_SHAPE, dtype=dtype)
    mx.eval(all_input, matrix_input)
    mx.synchronize(mx.cpu)

    return [
        (f"{name} sum, all (4M)", time_fn(lambda: mx.sum(all_input))),
        (
            f"{name} sum, axis=-1",
            time_fn(lambda: mx.sum(matrix_input, axis=-1)),
        ),
        (
            f"{name} sum, axis=0 (strided)",
            time_fn(lambda: mx.sum(matrix_input, axis=0)),
        ),
        (
            f"{name} mean, axis=-1",
            time_fn(lambda: mx.mean(matrix_input, axis=-1)),
        ),
    ]



mx.set_default_device(mx.cpu)
rows = []
for name, dtype in [
    ("bf16", mx.bfloat16),
    ("f16", mx.float16),
    ("f32", mx.float32),
]:
    rows.extend(benchmark_dtype(name, dtype))
print_table(rows)
```
Using this benchmarking script the performance changes are:

Case | Before (ms) | After (ms) | Speedup
-- | -- | -- | --
bf16 sum, all (4M) | 16.89136 | 2.16033 | **7.82×**
bf16 sum, axis=-1 | 67.32574 | 8.10352 | **8.31×**
bf16 sum, axis=0 (strided) | 2.22895 | 0.77700 | **2.87×**
bf16 mean, axis=-1 | 67.14907 | 8.05400 | **8.34×**
f16 sum, all (4M) | 0.29753 | 0.29658 | 1.00×
f16 sum, axis=-1 | 0.96503 | 0.96865 | 1.00×
f16 sum, axis=0 (strided) | 0.56356 | 0.55670 | 1.01×
f16 mean, axis=-1 | 0.96479 | 0.96691 | 1.00×
f32 sum, all (4M) | 0.32213 | 0.30211 | 1.07×
f32 sum, axis=-1 | 1.06188 | 1.09947 | 0.97×
f32 sum, axis=0 (strided) | 1.07307 | 1.01758 | 1.05×
f32 mean, axis=-1 | 1.07505 | 1.07238 | 1.00×

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
