### PR TITLE
python: Add explicit index and bytes support

### DIFF
--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -1034,7 +1034,15 @@ void init_array(nb::module_& m) {
           [](mx::array& a) {
             return nb::cast<std::complex<double>>(to_scalar(a));
           })
-      .def("__index__", [](mx::array& a) { return nb::int_(to_scalar(a)); })
+      .def(
+          "__index__",
+          [](mx::array& a) {
+            if (!mx::issubdtype(a.dtype(), mx::integer) || a.ndim() != 0) {
+              throw nb::type_error(
+                  "Only 0-dimensional integer arrays can be converted to an index.");
+            }
+            return nb::int_(to_scalar(a));
+          })
       .def(
           "__bytes__",
           [](mx::array& a) {

--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -1034,6 +1034,14 @@ void init_array(nb::module_& m) {
           [](mx::array& a) {
             return nb::cast<std::complex<double>>(to_scalar(a));
           })
+      .def("__index__", [](mx::array& a) { return nb::int_(to_scalar(a)); })
+      .def(
+          "__bytes__",
+          [](mx::array& a) {
+            a.eval();
+            return nb::bytes(
+                reinterpret_cast<const char*>(a.data<void>()), a.nbytes());
+          })
       .def(
           "__format__",
           [](mx::array& a, nb::object format_spec) {

--- a/python/src/indexing.cpp
+++ b/python/src/indexing.cpp
@@ -5,6 +5,7 @@
 
 #include <nanobind/ndarray.h>
 
+#include "mlx/dtype.h"
 #include "mlx/ops.h"
 #include "python/src/convert.h"
 #include "python/src/indexing.h"
@@ -18,6 +19,10 @@ bool is_none_slice(const nb::slice& in_slice) {
 
 bool is_index_scalar(const nb::object& obj) {
   if (nb::isinstance<nb::bool_>(obj)) {
+    return false;
+  }
+  if (nb::isinstance<mx::array>(obj) &&
+      nb::cast<mx::array>(obj).dtype() == mx::bool_) {
     return false;
   }
   if (!PyIndex_Check(obj.ptr())) {

--- a/python/src/indexing.cpp
+++ b/python/src/indexing.cpp
@@ -21,8 +21,7 @@ bool is_index_scalar(const nb::object& obj) {
   if (nb::isinstance<nb::bool_>(obj)) {
     return false;
   }
-  if (nb::isinstance<mx::array>(obj) &&
-      nb::cast<mx::array>(obj).dtype() == mx::bool_) {
+  if (nb::isinstance<mx::array>(obj)) {
     return false;
   }
   if (!PyIndex_Check(obj.ptr())) {

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -155,6 +155,15 @@ class TestDtypes(mlx_tests.MLXTestCase):
                 self.assertEqual(operator.index(mx.array(2, dtype)), 2)
                 self.assertEqual(list(range(mx.array(3, dtype))), [0, 1, 2])
 
+    def test_index_conversion_invalid(self):
+        for dtype in [mx.float16, mx.float32, mx.bfloat16, mx.complex64, mx.bool_]:
+            with self.subTest(dtype=dtype):
+                with self.assertRaises(TypeError):
+                    operator.index(mx.array(2, dtype))
+
+                with self.assertRaises(TypeError):
+                    list(range(mx.array(3, dtype)))
+
     def test_finfo(self):
         with self.assertRaises(ValueError):
             mx.finfo(mx.int32)

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -140,6 +140,21 @@ class TestDtypes(mlx_tests.MLXTestCase):
                 self.assertListEqual(list(z.shape), list(x.shape))
                 self.assertListEqual(list(z.shape), list(y.shape))
 
+    def test_index_conversion(self):
+        for dtype in [
+            mx.uint8,
+            mx.uint16,
+            mx.uint32,
+            mx.uint64,
+            mx.int8,
+            mx.int16,
+            mx.int32,
+            mx.int64,
+        ]:
+            with self.subTest(dtype=dtype):
+                self.assertEqual(operator.index(mx.array(2, dtype)), 2)
+                self.assertEqual(list(range(mx.array(3, dtype))), [0, 1, 2])
+
     def test_finfo(self):
         with self.assertRaises(ValueError):
             mx.finfo(mx.int32)


### PR DESCRIPTION
- ☑️ I understand it is strictly prohibited to use AI to write PR description
Hi, this PR adds `__index__` support to MLX arrays, allowing integer-valued scalar arrays to be used directly as Python indices. I found MLX did not had `__index__`   in [`data-apis/array-api-compat#451`](https://github.com/data-apis/array-api-compat/issues/451), adding `__index__` caused regressions in boolean masking and `bytes()` conversion. Fixed boolean masking indexing behavior and added an explicit `__bytes__` implementation.

- AI usage disclosure:
AI was used for bug Identification and diagnosis caused by introducing `__index__`.
