### PR TITLE
Hold GIL in AttachedData destructor

### DIFF
--- a/python/src/transforms.cpp
+++ b/python/src/transforms.cpp
@@ -422,6 +422,11 @@ struct PyCompiledFun {
 
     AttachedData(nb::object output_structure_, int num_outputs_)
         : output_structure(output_structure_), num_outputs(num_outputs_) {}
+
+    ~AttachedData() {
+      nb::gil_scoped_acquire gil;
+      output_structure.reset();
+    }
   };
 
   PyCompiledFun(


### PR DESCRIPTION
Observed crash when testing mlx-lm:

```
Critical nanobind error: nanobind::detail::decref_check(): attempted to change the reference count of a Python object while the GIL was not held.
Process 21506 stopped
* thread #16, stop reason = EXC_BREAKPOINT (code=1, subcode=0x191164ba0)
    frame #0: 0x0000000191164ba0 libsystem_c.dylib`__abort + 164
libsystem_c.dylib`__abort:
->  0x191164ba0 <+164>: brk    #0x1

libsystem_c.dylib`abort_report_np:
    0x191164ba4 <+0>:   pacibsp 
    0x191164ba8 <+4>:   sub    sp, sp, #0x30
    0x191164bac <+8>:   stp    x20, x19, [sp, #0x10]
Target 0: (python) stopped.
(lldb) bt
* thread #16, stop reason = EXC_BREAKPOINT (code=1, subcode=0x191164ba0)
  * frame #0: 0x0000000191164ba0 libsystem_c.dylib`__abort + 164
    frame #1: 0x0000000191164afc libsystem_c.dylib`abort + 136
    frame #2: 0x000000010282ad80 core.cpython-313-darwin.so`nanobind::detail::fail(fmt="nanobind::detail::decref_check(): attempted to change the reference count of a Python object while the GIL was not held.") at common.cpp:80:5
    frame #3: 0x000000010282f814 core.cpython-313-darwin.so`nanobind::detail::decref_checked(o=0x0000000138437e30) at common.cpp:1193:9
    frame #4: 0x00000001024db068 core.cpython-313-darwin.so`nanobind::handle::dec_ref(this=0x0000600001e0f0a8) const & at nb_types.h:225:9
    frame #5: 0x00000001024db038 core.cpython-313-darwin.so`nanobind::object::~object(this=0x0000600001e0f0a8) at nb_types.h:245:17
    frame #6: 0x00000001024daf04 core.cpython-313-darwin.so`nanobind::object::~object(this=0x0000600001e0f0a8) at nb_types.h:245:15
    frame #7: 0x00000001027b7cb8 core.cpython-313-darwin.so`PyCompiledFun::AttachedData::~AttachedData(this=0x0000600001e0f0a8) at transforms.cpp:419:10
    frame #8: 0x00000001027b7c8c core.cpython-313-darwin.so`PyCompiledFun::AttachedData::~AttachedData(this=0x0000600001e0f0a8) at transforms.cpp:419:10
    frame #9: 0x00000001027b7c64 core.cpython-313-darwin.so`void std::__1::__destroy_at[abi:ne200100]<PyCompiledFun::AttachedData, 0>(__loc=0x0000600001e0f0a8) at construct_at.h:66:11
    frame #10: 0x00000001027b7c40 core.cpython-313-darwin.so`void std::__1::allocator_traits<std::__1::allocator<PyCompiledFun::AttachedData>>::destroy[abi:ne200100]<PyCompiledFun::AttachedData, void, 0>((null)=0x000000033caa6887, __p=0x0000600001e0f0a8) at allocator_traits.h:329:5
    frame #11: 0x00000001027b7c10 core.cpython-313-darwin.so`void std::__1::__shared_ptr_emplace<PyCompiledFun::AttachedData, std::__1::allocator<PyCompiledFun::AttachedData>>::__on_zero_shared_impl[abi:ne200100]<std::__1::allocator<PyCompiledFun::AttachedData>, 0>(this=0x0000600001e0f090) at shared_ptr.h:180:5
    frame #12: 0x00000001027b798c core.cpython-313-darwin.so`std::__1::__shared_ptr_emplace<PyCompiledFun::AttachedData, std::__1::allocator<PyCompiledFun::AttachedData>>::__on_zero_shared(this=0x0000600001e0f090) at shared_ptr.h:183:78
    frame #13: 0x000000010657f4f0 libmlx.dylib`std::__1::__shared_count::__release_shared[abi:ne200100](this=0x0000600001e0f090) at shared_count.h:91:7
    frame #14: 0x000000010657f494 libmlx.dylib`std::__1::__shared_weak_count::__release_shared[abi:ne200100](this=0x0000600001e0f090) at shared_count.h:120:25
    frame #15: 0x000000010657f71c libmlx.dylib`std::__1::shared_ptr<void>::~shared_ptr[abi:ne200100](this=0x0000000324ca46f0) at shared_ptr.h:558:17
    frame #16: 0x000000010657f658 libmlx.dylib`std::__1::shared_ptr<void>::~shared_ptr[abi:ne200100](this=0x0000000324ca46f0) at shared_ptr.h:556:39
    frame #17: 0x00000001065c8fec libmlx.dylib`mlx::core::detail::CompileCache::CacheEntry::~CacheEntry(this=0x0000000324ca4678) at compile.cpp:304:10
    frame #18: 0x00000001065c54e4 libmlx.dylib`mlx::core::detail::CompileCache::CacheEntry::~CacheEntry(this=0x0000000324ca4678) at compile.cpp:304:10
    frame #19: 0x00000001065c78d0 libmlx.dylib`void std::__1::__destroy_at[abi:ne200100]<mlx::core::detail::CompileCache::CacheEntry, 0>(__loc=0x0000000324ca4678) at construct_at.h:66:11
    frame #20: 0x00000001065c7898 libmlx.dylib`void std::__1::allocator_traits<std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>::destroy[abi:ne200100]<mlx::core::detail::CompileCache::CacheEntry, void, 0>((null)=0x0000600001e1e578, __p=0x0000000324ca4678) at allocator_traits.h:329:5
    frame #21: 0x00000001065c7844 libmlx.dylib`std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>::__base_destruct_at_end[abi:ne200100](this=0x0000600001e1e568 size=2, __new_last=0x0000000324ca45f0) at vector.h:749:7
    frame #22: 0x00000001065c7734 libmlx.dylib`std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>::clear[abi:ne200100](this=0x0000600001e1e568 size=2) at vector.h:531:5
    frame #23: 0x00000001065c7694 libmlx.dylib`std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>::__destroy_vector::operator()[abi:ne200100](this=0x000000033caa6a90) at vector.h:248:16
    frame #24: 0x00000001065c7614 libmlx.dylib`std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>::~vector[abi:ne200100](this=0x0000600001e1e568 size=2) at vector.h:259:67
    frame #25: 0x00000001065c75d8 libmlx.dylib`std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>::~vector[abi:ne200100](this=0x0000600001e1e568 size=2) at vector.h:259:65
    frame #26: 0x00000001065c75b0 libmlx.dylib`void std::__1::__destroy_at[abi:ne200100]<std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>, 0>(__loc=0x0000600001e1e568 size=2) at construct_at.h:66:11
    frame #27: 0x00000001065c758c libmlx.dylib`void std::__1::allocator_traits<std::__1::allocator<std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>>>::destroy[abi:ne200100]<std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>, void, 0>((null)=0x000000033caa6b27, __p=0x0000600001e1e568 size=2) at allocator_traits.h:329:5
    frame #28: 0x00000001065c755c libmlx.dylib`void std::__1::__shared_ptr_emplace<std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>, std::__1::allocator<std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>>>::__on_zero_shared_impl[abi:ne200100]<std::__1::allocator<std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>>, 0>(this=0x0000600001e1e550) at shared_ptr.h:180:5
    frame #29: 0x00000001065c72e8 libmlx.dylib`std::__1::__shared_ptr_emplace<std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>, std::__1::allocator<std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>>>::__on_zero_shared(this=0x0000600001e1e550) at shared_ptr.h:183:78
    frame #30: 0x000000010657f4f0 libmlx.dylib`std::__1::__shared_count::__release_shared[abi:ne200100](this=0x0000600001e1e550) at shared_count.h:91:7
    frame #31: 0x000000010657f494 libmlx.dylib`std::__1::__shared_weak_count::__release_shared[abi:ne200100](this=0x0000600001e1e550) at shared_count.h:120:25
    frame #32: 0x00000001065b1d7c libmlx.dylib`std::__1::shared_ptr<std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>>::~shared_ptr[abi:ne200100](this=0x0000600001e1f108) at shared_ptr.h:558:17
    frame #33: 0x00000001065b1d34 libmlx.dylib`std::__1::shared_ptr<std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>>::~shared_ptr[abi:ne200100](this=0x0000600001e1f108) at shared_ptr.h:556:39
    frame #34: 0x00000001065b1d08 libmlx.dylib`std::__1::pair<unsigned long const, std::__1::shared_ptr<std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>>>::~pair(this=0x0000600001e1f100) at pair.h:63:29
    frame #35: 0x00000001065b1cd8 libmlx.dylib`std::__1::pair<unsigned long const, std::__1::shared_ptr<std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>>>::~pair(this=0x0000600001e1f100) at pair.h:63:29
    frame #36: 0x00000001065b1cb0 libmlx.dylib`void std::__1::__destroy_at[abi:ne200100]<std::__1::pair<unsigned long const, std::__1::shared_ptr<std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>>>, 0>(__loc=0x0000600001e1f100) at construct_at.h:66:11
    frame #37: 0x00000001065b1c10 libmlx.dylib`void std::__1::allocator_traits<std::__1::allocator<std::__1::__hash_node<std::__1::__hash_value_type<unsigned long, std::__1::shared_ptr<std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>>>, void*>>>::destroy[abi:ne200100]<std::__1::pair<unsigned long const, std::__1::shared_ptr<std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>>>, void, 0>((null)=0x0000600002cdce38, __p=0x0000600001e1f100) at allocator_traits.h:329:5
    frame #38: 0x00000001065b20ec libmlx.dylib`std::__1::__hash_table<std::__1::__hash_value_type<unsigned long, std::__1::shared_ptr<std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>>>, std::__1::__unordered_map_hasher<unsigned long, std::__1::__hash_value_type<unsigned long, std::__1::shared_ptr<std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>>>, std::__1::hash<unsigned long>, std::__1::equal_to<unsigned long>, true>, std::__1::__unordered_map_equal<unsigned long, std::__1::__hash_value_type<unsigned long, std::__1::shared_ptr<std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>>>, std::__1::equal_to<unsigned long>, std::__1::hash<unsigned long>, true>, std::__1::allocator<std::__1::__hash_value_type<unsigned long, std::__1::shared_ptr<std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>>>>>::__deallocate_node(this=0x0000600002cdce28, __np=0x0000600001e1f0f0) at __hash_table:1163:5
    frame #39: 0x00000001065b929c libmlx.dylib`std::__1::__hash_table<std::__1::__hash_value_type<unsigned long, std::__1::shared_ptr<std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>>>, std::__1::__unordered_map_hasher<unsigned long, std::__1::__hash_value_type<unsigned long, std::__1::shared_ptr<std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>>>, std::__1::hash<unsigned long>, std::__1::equal_to<unsigned long>, true>, std::__1::__unordered_map_equal<unsigned long, std::__1::__hash_value_type<unsigned long, std::__1::shared_ptr<std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>>>, std::__1::equal_to<unsigned long>, std::__1::hash<unsigned long>, true>, std::__1::allocator<std::__1::__hash_value_type<unsigned long, std::__1::shared_ptr<std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>>>>>::~__hash_table(this=0x0000600002cdce28) at __hash_table:1131:3
    frame #40: 0x00000001065b926c libmlx.dylib`std::__1::__hash_table<std::__1::__hash_value_type<unsigned long, std::__1::shared_ptr<std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>>>, std::__1::__unordered_map_hasher<unsigned long, std::__1::__hash_value_type<unsigned long, std::__1::shared_ptr<std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>>>, std::__1::hash<unsigned long>, std::__1::equal_to<unsigned long>, true>, std::__1::__unordered_map_equal<unsigned long, std::__1::__hash_value_type<unsigned long, std::__1::shared_ptr<std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>>>, std::__1::equal_to<unsigned long>, std::__1::hash<unsigned long>, true>, std::__1::allocator<std::__1::__hash_value_type<unsigned long, std::__1::shared_ptr<std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>>>>>::~__hash_table(this=0x0000600002cdce28) at __hash_table:1125:59
    frame #41: 0x00000001065b9240 libmlx.dylib`std::__1::unordered_map<unsigned long, std::__1::shared_ptr<std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>>, std::__1::hash<unsigned long>, std::__1::equal_to<unsigned long>, std::__1::allocator<std::__1::pair<unsigned long const, std::__1::shared_ptr<std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>>>>>::~unordered_map[abi:ne200100](this=0x0000600002cdce28 size=3) at unordered_map:1192:3
    frame #42: 0x00000001065b8e34 libmlx.dylib`std::__1::unordered_map<unsigned long, std::__1::shared_ptr<std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>>, std::__1::hash<unsigned long>, std::__1::equal_to<unsigned long>, std::__1::allocator<std::__1::pair<unsigned long const, std::__1::shared_ptr<std::__1::vector<mlx::core::detail::CompileCache::CacheEntry, std::__1::allocator<mlx::core::detail::CompileCache::CacheEntry>>>>>>::~unordered_map[abi:ne200100](this=0x0000600002cdce28 size=3) at unordered_map:1190:42
    frame #43: 0x00000001065b9658 libmlx.dylib`mlx::core::detail::CompileCache::~CompileCache(this=0x0000600002cdce28) at compile.cpp:302:7
    frame #44: 0x00000001065b9620 libmlx.dylib`mlx::core::detail::CompileCache::~CompileCache(this=0x0000600002cdce28) at compile.cpp:302:7
    frame #45: 0x00000001065b95f8 libmlx.dylib`void std::__1::__destroy_at[abi:ne200100]<mlx::core::detail::CompileCache, 0>(__loc=0x0000600002cdce28) at construct_at.h:66:11
    frame #46: 0x00000001065b95d4 libmlx.dylib`void std::__1::allocator_traits<std::__1::allocator<mlx::core::detail::CompileCache>>::destroy[abi:ne200100]<mlx::core::detail::CompileCache, void, 0>((null)=0x000000033caa6de7, __p=0x0000600002cdce28) at allocator_traits.h:329:5
    frame #47: 0x00000001065b95a4 libmlx.dylib`void std::__1::__shared_ptr_emplace<mlx::core::detail::CompileCache, std::__1::allocator<mlx::core::detail::CompileCache>>::__on_zero_shared_impl[abi:ne200100]<std::__1::allocator<mlx::core::detail::CompileCache>, 0>(this=0x0000600002cdce10) at shared_ptr.h:180:5
    frame #48: 0x00000001065b8be8 libmlx.dylib`std::__1::__shared_ptr_emplace<mlx::core::detail::CompileCache, std::__1::allocator<mlx::core::detail::CompileCache>>::__on_zero_shared(this=0x0000600002cdce10) at shared_ptr.h:183:78
    frame #49: 0x000000010657f4f0 libmlx.dylib`std::__1::__shared_count::__release_shared[abi:ne200100](this=0x0000600002cdce10) at shared_count.h:91:7
    frame #50: 0x000000010657f494 libmlx.dylib`std::__1::__shared_weak_count::__release_shared[abi:ne200100](this=0x0000600002cdce10) at shared_count.h:120:25
    frame #51: 0x00000001065b98f0 libmlx.dylib`std::__1::shared_ptr<mlx::core::detail::CompileCache>::~shared_ptr[abi:ne200100](this=0x0000000139be8980) at shared_ptr.h:558:17
    frame #52: 0x0000000106597244 libmlx.dylib`std::__1::shared_ptr<mlx::core::detail::CompileCache>::~shared_ptr[abi:ne200100](this=0x0000000139be8980) at shared_ptr.h:556:39
    frame #53: 0x0000000191265bcc libdyld.dylib`invocation function for block in dyld::ThreadLocalVariables::finalizeList(void*) + 56
    frame #54: 0x0000000191265b20 libdyld.dylib`dyld::ThreadLocalVariables::finalizeList(void*) + 108
    frame #55: 0x00000001912595f8 libsystem_pthread.dylib`_pthread_tsd_cleanup + 488
    frame #56: 0x000000019125c2a8 libsystem_pthread.dylib`_pthread_exit + 84
    frame #57: 0x000000019125bbd4 libsystem_pthread.dylib`_pthread_start + 148
```