### PR TITLE
Add script to run python tests

### DIFF
--- a/.github/actions/test-linux/action.yml
+++ b/.github/actions/test-linux/action.yml
@@ -36,14 +36,14 @@ runs:
       shell: bash
       env:
         DEVICE: cpu
-      run: python -m unittest discover python/tests -v
+      run: python python/tests/run.py -v
 
     - name: Run Python tests - GPU
       if: steps.gpu-check.outputs.good == 'true'
       shell: bash
       env:
         DEVICE: gpu
-      run: python -m tests discover python/tests -v
+      run: python python/tests/run.py -v
 
     - name: Run CPP tests - CPU
       shell: bash

--- a/.github/actions/test-macos/action.yml
+++ b/.github/actions/test-macos/action.yml
@@ -47,7 +47,7 @@ runs:
           echo "::endgroup::"
 
           echo "::group::Run Python tests"
-          python -m unittest discover -v python/tests
+          uv run python/tests/run.py -v
           echo "::endgroup::"
 
           if ${{ inputs.toolkit != 'cpu' }} ; then

--- a/.github/actions/test-wheel/action.yml
+++ b/.github/actions/test-wheel/action.yml
@@ -46,4 +46,9 @@ runs:
           echo "No matching backend wheel to install"
           exit 1
         fi
-        python -m tests discover -v python/tests
+        if ${{ runner.os == 'macOS' }} ; then
+          # FIXME: run.py does not quit in macOS CI.
+          python -m unittest discover -v python/tests
+        else
+          uv run python/tests/run.py -v --failfast
+        fi

--- a/.github/actions/test-windows/action.yml
+++ b/.github/actions/test-windows/action.yml
@@ -8,7 +8,7 @@ runs:
       shell: bash
       env:
         DEVICE: cpu
-      run: python -m unittest discover python/tests -v
+      run: uv run python/tests/run.py -v
 
     - name: Run CPP tests - CPU
       shell: bash

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,6 +1,7 @@
 name: Build and Test
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:

--- a/docs/src/install.rst
+++ b/docs/src/install.rst
@@ -121,13 +121,13 @@ Once the development dependencies are installed, you can build faster with:
 
 .. code-block:: shell
 
- python setup.py build_ext --inplace
+  python setup.py build_ext --inplace
 
 Run the tests with:
 
 .. code-block:: shell
 
-  python -m unittest discover python/tests
+  python python/tests/run.py
 
 C++ API
 ^^^^^^^

--- a/python/tests/__main__.py
+++ b/python/tests/__main__.py
@@ -1,5 +1,0 @@
-from . import mlx_tests
-
-__unittest = True
-
-mlx_tests.MLXTestRunner(module=None)

--- a/python/tests/mlx_tests.py
+++ b/python/tests/mlx_tests.py
@@ -1,13 +1,6 @@
 # Copyright © 2023 Apple Inc.
 
 import os
-
-# Use regular fp32 precision for tests
-os.environ["MLX_ENABLE_TF32"] = "0"
-
-# Do not abort on cache thrashing
-os.environ["MLX_ENABLE_CACHE_THRASHING_CHECK"] = "0"
-
 import platform
 import sys
 import unittest

--- a/python/tests/run.py
+++ b/python/tests/run.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+# Use regular fp32 precision for tests
+os.environ["MLX_ENABLE_TF32"] = "0"
+
+# Do not abort on cache thrashing
+os.environ["MLX_ENABLE_CACHE_THRASHING_CHECK"] = "0"
+
+__unittest = True
+
+import mlx_tests
+
+if __name__ == "__main__":
+    # Run all tests by default.
+    dirname = os.path.dirname(os.path.realpath(__file__))
+    argv = [sys.argv[0], "discover", dirname, *sys.argv[1:]]
+    mlx_tests.MLXTestRunner(argv=argv, module=None)


### PR DESCRIPTION
For running tests under CUDA backend we need to setup some environment variables before importing mlx, which however is impossible when running tests via `python -m unittest discover python/tests`, and we have been relying on a hack with `python -m tests` which executes `python/tests/__main__.py` under editable install.

This hack however does not work when testing release wheels because there is no editable install. To solve it this PR adds a `python/tests/run.py` script which adds the env vars and automatically run all tests.