### PR TITLE
Dedupe all-axes boilerplate in ops.cpp with all_axes() helper

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -23,6 +23,13 @@ namespace mlx::core {
 
 namespace {
 
+// Returns {0, 1, ..., ndim - 1}, i.e. all axes of an ndim-dimensional array.
+std::vector<int> all_axes(int ndim) {
+  std::vector<int> axes(ndim);
+  std::iota(axes.begin(), axes.end(), 0);
+  return axes;
+}
+
 // Pass the reduction's name in `op_without_identity` when it has no identity
 // element, as max and min do not. Those are undefined over an empty axis, so
 // naming them here has that checked. Reductions with an identity, such as sum
@@ -717,9 +724,7 @@ array flip(const array& a, int axis, StreamOrDevice s /* = {} */) {
 }
 
 array flip(const array& a, StreamOrDevice s /* = {} */) {
-  std::vector<int> axes(a.ndim());
-  std::iota(axes.begin(), axes.end(), 0);
-  return flip(a, axes, s);
+  return flip(a, all_axes(a.ndim()), s);
 }
 
 // Slice helper
@@ -2174,9 +2179,7 @@ array isclose(
 }
 
 array all(const array& a, bool keepdims, StreamOrDevice s /* = {}*/) {
-  std::vector<int> axes(a.ndim());
-  std::iota(axes.begin(), axes.end(), 0);
-  return all(a, axes, keepdims, s);
+  return all(a, all_axes(a.ndim()), keepdims, s);
 }
 
 array all(
@@ -2208,9 +2211,7 @@ array all(
 }
 
 array any(const array& a, bool keepdims, StreamOrDevice s /* = {}*/) {
-  std::vector<int> axes(a.ndim());
-  std::iota(axes.begin(), axes.end(), 0);
-  return any(a, axes, keepdims, s);
+  return any(a, all_axes(a.ndim()), keepdims, s);
 }
 
 array any(
@@ -2242,9 +2243,7 @@ array any(
 }
 
 array sum(const array& a, bool keepdims, StreamOrDevice s /* = {}*/) {
-  std::vector<int> axes(a.ndim());
-  std::iota(axes.begin(), axes.end(), 0);
-  return sum(a, axes, keepdims, s);
+  return sum(a, all_axes(a.ndim()), keepdims, s);
 }
 
 array sum(
@@ -2290,9 +2289,7 @@ array count_nonzero(
     const array& a,
     bool keepdims /* = false */,
     StreamOrDevice s /* = {} */) {
-  std::vector<int> axes(a.ndim());
-  std::iota(axes.begin(), axes.end(), 0);
-  return count_nonzero(a, axes, keepdims, s);
+  return count_nonzero(a, all_axes(a.ndim()), keepdims, s);
 }
 
 array count_nonzero(
@@ -2313,9 +2310,7 @@ array count_nonzero(
 }
 
 array mean(const array& a, bool keepdims, StreamOrDevice s /* = {}*/) {
-  std::vector<int> axes(a.ndim());
-  std::iota(axes.begin(), axes.end(), 0);
-  return mean(a, axes, keepdims, to_stream(s));
+  return mean(a, all_axes(a.ndim()), keepdims, to_stream(s));
 }
 
 array mean(
@@ -2346,9 +2341,7 @@ array mean(
 }
 
 array median(const array& a, bool keepdims, StreamOrDevice s /* = {}*/) {
-  std::vector<int> axes(a.ndim());
-  std::iota(axes.begin(), axes.end(), 0);
-  return median(a, axes, keepdims, to_stream(s));
+  return median(a, all_axes(a.ndim()), keepdims, to_stream(s));
 }
 
 array median(
@@ -2441,9 +2434,7 @@ array var(
     bool keepdims,
     int ddof /* = 0*/,
     StreamOrDevice s /* = {}*/) {
-  std::vector<int> axes(a.ndim());
-  std::iota(axes.begin(), axes.end(), 0);
-  return var(a, axes, keepdims, ddof, to_stream(s));
+  return var(a, all_axes(a.ndim()), keepdims, ddof, to_stream(s));
 }
 
 array var(
@@ -2497,9 +2488,7 @@ array std(
     bool keepdims,
     int ddof /* = 0*/,
     StreamOrDevice s /* = {}*/) {
-  std::vector<int> axes(a.ndim());
-  std::iota(axes.begin(), axes.end(), 0);
-  return std(a, axes, keepdims, ddof, to_stream(s));
+  return std(a, all_axes(a.ndim()), keepdims, ddof, to_stream(s));
 }
 
 array std(
@@ -2521,9 +2510,7 @@ array std(
 }
 
 array prod(const array& a, bool keepdims, StreamOrDevice s /* = {}*/) {
-  std::vector<int> axes(a.ndim());
-  std::iota(axes.begin(), axes.end(), 0);
-  return prod(a, axes, keepdims, s);
+  return prod(a, all_axes(a.ndim()), keepdims, s);
 }
 
 array prod(
@@ -2566,9 +2553,7 @@ array prod(
 }
 
 array max(const array& a, bool keepdims, StreamOrDevice s /* = {}*/) {
-  std::vector<int> axes(a.ndim());
-  std::iota(axes.begin(), axes.end(), 0);
-  return max(a, axes, keepdims, s);
+  return max(a, all_axes(a.ndim()), keepdims, s);
 }
 
 array max(
@@ -2600,9 +2585,7 @@ array max(
 }
 
 array min(const array& a, bool keepdims, StreamOrDevice s /* = {}*/) {
-  std::vector<int> axes(a.ndim());
-  std::iota(axes.begin(), axes.end(), 0);
-  return min(a, axes, keepdims, s);
+  return min(a, all_axes(a.ndim()), keepdims, s);
 }
 
 array min(
@@ -2941,9 +2924,7 @@ array topk(const array& a, int k, int axis, StreamOrDevice s /* = {}*/) {
 }
 
 array logsumexp(const array& a, bool keepdims, StreamOrDevice s /* = {}*/) {
-  std::vector<int> axes(a.ndim());
-  std::iota(axes.begin(), axes.end(), 0);
-  return logsumexp(a, axes, keepdims, s);
+  return logsumexp(a, all_axes(a.ndim()), keepdims, s);
 }
 
 array logsumexp(
@@ -4122,9 +4103,7 @@ array softmax(
     const array& a,
     bool precise /* = false */,
     StreamOrDevice s /* = {}*/) {
-  std::vector<int> axes(a.ndim());
-  std::iota(axes.begin(), axes.end(), 0);
-  return softmax(a, axes, precise, s);
+  return softmax(a, all_axes(a.ndim()), precise, s);
 }
 
 array power(const array& a, const array& b, StreamOrDevice s /* = {} */) {


### PR DESCRIPTION
Rebase of #4290 on latest main (that PR could not be reopened after the branch was rebased — GitHub blocks reopening once a PR's branch has been force-pushed since it was closed).

Fourteen no-axes overloads (`flip`, `all`, `any`, `sum`, `count_nonzero`, `mean`, `median`, `var`, `std`, `prod`, `max`, `min`, `logsumexp`, `softmax`) each repeated the same `std::iota`-based boilerplate to build the "all axes" list before delegating to their axes-taking overload.

Extracted a shared `all_axes(int ndim)` helper into the existing anonymous namespace alongside `compute_reduce_shape`, and collapsed each call site to a one-liner. Net diff: 21 insertions / 42 deletions, single file (`mlx/ops.cpp`). Left `pad`'s default-axes logic and the `argmin`/`argmax` keepdims expansion untouched since they build a different range.

Behavior-preserving — verified with the full C++ test suite (`ops_tests.cpp`).