### PR TITLE
Fix crash on ellipsis indexing with too many trailing indices

### DIFF
--- a/python/src/indexing.cpp
+++ b/python/src/indexing.cpp
@@ -253,8 +253,13 @@ auto mlx_expand_ellipsis(const mx::Shape& shape, const nb::tuple& entries) {
 
   // Expand ellipsis
   if (has_ellipsis) {
-    for (int axis = non_none_indices_before;
-         axis < shape.size() - non_none_indices_after;
+    int ndim = static_cast<int>(shape.size());
+    if (non_none_indices > ndim) {
+      std::ostringstream msg;
+      msg << "Too many indices for array with " << ndim << " dimensions.";
+      throw std::invalid_argument(msg.str());
+    }
+    for (int axis = non_none_indices_before; axis < ndim - non_none_indices_after;
          axis++) {
       indices.push_back(
           nb::slice(mx::ShapeElem{0}, shape[axis], mx::ShapeElem{1}));

--- a/python/src/indexing.cpp
+++ b/python/src/indexing.cpp
@@ -259,7 +259,8 @@ auto mlx_expand_ellipsis(const mx::Shape& shape, const nb::tuple& entries) {
       msg << "Too many indices for array with " << ndim << " dimensions.";
       throw std::invalid_argument(msg.str());
     }
-    for (int axis = non_none_indices_before; axis < ndim - non_none_indices_after;
+    for (int axis = non_none_indices_before;
+         axis < ndim - non_none_indices_after;
          axis++) {
       indices.push_back(
           nb::slice(mx::ShapeElem{0}, shape[axis], mx::ShapeElem{1}));

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -1267,6 +1267,26 @@ class TestArray(mlx_tests.MLXTestCase):
         a_mlx = mx.array(a_np)
         self.assertTrue(np.array_equal(a_np[2:-1, 0], np.array(a_mlx[2:-1, 0])))
 
+    def test_indexing_too_many_after_ellipsis(self):
+        # Regression test: indexing with an ellipsis followed by more
+        # non-None indices than the array has dimensions used to compute an
+        # unsigned (size_t) underflow in the ellipsis-expansion loop bound,
+        # causing an out-of-bounds read / crash instead of raising.
+        a = mx.array([1, 2, 3])
+        with self.assertRaises(ValueError):
+            a[..., 0, 0]
+        with self.assertRaises(ValueError):
+            a[..., 0, 0, 0]
+        with self.assertRaises(ValueError):
+            a[..., 0:1, 0:1]
+
+        a2 = mx.zeros((2, 2))
+        with self.assertRaises(ValueError):
+            a2[..., 0, 0, 0]
+
+        with self.assertRaises(ValueError):
+            a[..., 0, 0] = 5
+
     def test_indexing_grad(self):
         x = mx.array([[1, 2], [3, 4]]).astype(mx.float32)
         ind = mx.array([0, 1, 0]).astype(mx.float32)

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -1267,25 +1267,12 @@ class TestArray(mlx_tests.MLXTestCase):
         a_mlx = mx.array(a_np)
         self.assertTrue(np.array_equal(a_np[2:-1, 0], np.array(a_mlx[2:-1, 0])))
 
-    def test_indexing_too_many_after_ellipsis(self):
-        # Regression test: indexing with an ellipsis followed by more
-        # non-None indices than the array has dimensions used to compute an
-        # unsigned (size_t) underflow in the ellipsis-expansion loop bound,
-        # causing an out-of-bounds read / crash instead of raising.
-        a = mx.array([1, 2, 3])
+        # Ellipsis with more trailing indices than dimensions
+        a_mlx = mx.array([1, 2, 3])
         with self.assertRaises(ValueError):
-            a[..., 0, 0]
+            a_mlx[..., 0, 0]
         with self.assertRaises(ValueError):
-            a[..., 0, 0, 0]
-        with self.assertRaises(ValueError):
-            a[..., 0:1, 0:1]
-
-        a2 = mx.zeros((2, 2))
-        with self.assertRaises(ValueError):
-            a2[..., 0, 0, 0]
-
-        with self.assertRaises(ValueError):
-            a[..., 0, 0] = 5
+            a_mlx[..., 0, 0] = 5
 
     def test_indexing_grad(self):
         x = mx.array([[1, 2], [3, 4]]).astype(mx.float32)


### PR DESCRIPTION
Fixes #4398

Indexing with an ellipsis followed by more non-None indices than the array has dimensions computed an unsigned (size_t) underflow in the ellipsis-expansion loop bound, causing an out-of-bounds read / crash instead of raising a `ValueError`. Adds a regression test covering getitem and setitem.