### PR TITLE
fix(metal): revert inactive NAX MoE simdgroup skipping

### DIFF
--- a/mlx/backend/metal/kernels/fp_quantized_nax.h
+++ b/mlx/backend/metal/kernels/fp_quantized_nax.h
@@ -897,10 +897,6 @@ template <
     threadgroup_barrier(mem_flags::mem_none);
 
     // Prepare threadgroup mma operation
-    const short m_lo_lim = min(int(sgp_sm), max(0, offset - tm));
-    const short m_hi_lim = min(int(sgp_sm), max(0, offset_next - tm));
-    const bool sg_active = m_hi_lim > m_lo_lim;
-
     NAXTile<AccumType, TM, TN> Dtile;
     Dtile.clear();
 
@@ -930,35 +926,33 @@ template <
 
           STEEL_PRAGMA_NO_UNROLL
           for (int kk1 = 0; kk1 < BK; kk1 += SK) {
-            if (sg_active) {
-              NAXTile<T, TM, TK> Atile;
-              NAXTile<Wtype, BR, BC> Btile;
+            NAXTile<T, TM, TK> Atile;
+            NAXTile<Wtype, BR, BC> Btile;
 
-              volatile int compiler_barrier;
+            volatile int compiler_barrier;
 
-              if constexpr (kAlignedM.value) {
-                Atile.load(xn + kk1, K);
-              } else {
-                Atile.load_safe(xn + kk1, K, short2(SK, sgp_sm));
-              }
-
-              if constexpr (transpose) {
-                Btile.template load<Wtype, BK_padded, 1>(
-                    Ws + tn * BK_padded + kk1);
-              } else {
-                Btile.template load<Wtype, BN_padded, 1>(
-                    Ws + tn + kk1 * BN_padded);
-              }
-
-              tile_matmad_nax(
-                  Dtile,
-                  Atile,
-                  metal::bool_constant<false>{},
-                  Btile,
-                  metal::bool_constant<transpose>{});
-
-              (void)compiler_barrier;
+            if constexpr (kAlignedM.value) {
+              Atile.load(xn + kk1, K);
+            } else {
+              Atile.load_safe(xn + kk1, K, short2(SK, sgp_sm));
             }
+
+            if constexpr (transpose) {
+              Btile.template load<Wtype, BK_padded, 1>(
+                  Ws + tn * BK_padded + kk1);
+            } else {
+              Btile.template load<Wtype, BN_padded, 1>(
+                  Ws + tn + kk1 * BN_padded);
+            }
+
+            tile_matmad_nax(
+                Dtile,
+                Atile,
+                metal::bool_constant<false>{},
+                Btile,
+                metal::bool_constant<transpose>{});
+
+            (void)compiler_barrier;
           }
 
           xn += BK;
@@ -972,36 +966,37 @@ template <
 
           STEEL_PRAGMA_NO_UNROLL
           for (int kk1 = 0; kk1 < BK; kk1 += SK) {
-            if (sg_active) {
-              NAXTile<T, TM, TK> Atile;
-              NAXTile<Wtype, BR, BC> Btile;
+            NAXTile<T, TM, TK> Atile;
+            NAXTile<Wtype, BR, BC> Btile;
 
-              volatile int compiler_barrier;
+            volatile int compiler_barrier;
 
-              const short psk = min(int(SK), max(0, (BK - kk1)));
-              Atile.load_safe(xn + kk1, K, short2(psk, sgp_sm));
+            const short psk = min(int(SK), max(0, (BK - kk1)));
+            Atile.load_safe(xn + kk1, K, short2(psk, sgp_sm));
 
-              if constexpr (transpose) {
-                Btile.template load<Wtype, BK_padded, 1>(
-                    Ws + tn * BK_padded + kk1);
-              } else {
-                Btile.template load<Wtype, BN_padded, 1>(
-                    Ws + tn + kk1 * BN_padded);
-              }
-
-              tile_matmad_nax(
-                  Dtile,
-                  Atile,
-                  metal::bool_constant<false>{},
-                  Btile,
-                  metal::bool_constant<transpose>{});
-
-              (void)compiler_barrier;
+            if constexpr (transpose) {
+              Btile.template load<Wtype, BK_padded, 1>(
+                  Ws + tn * BK_padded + kk1);
+            } else {
+              Btile.template load<Wtype, BN_padded, 1>(
+                  Ws + tn + kk1 * BN_padded);
             }
+
+            tile_matmad_nax(
+                Dtile,
+                Atile,
+                metal::bool_constant<false>{},
+                Btile,
+                metal::bool_constant<transpose>{});
+
+            (void)compiler_barrier;
           }
         }
 
         threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        const short m_lo_lim = min(int(sgp_sm), max(0, offset - tm));
+        const short m_hi_lim = min(int(sgp_sm), max(0, offset_next - tm));
 
         // Store results to device memory
         if constexpr (kAlignedN.value) {

--- a/mlx/backend/metal/kernels/quantized_nax.h
+++ b/mlx/backend/metal/kernels/quantized_nax.h
@@ -1576,10 +1576,6 @@ template <
     }
     threadgroup_barrier(mem_flags::mem_none);
 
-    const short m_lo_lim = min(int(sgp_sm), max(0, offset - tm));
-    const short m_hi_lim = min(int(sgp_sm), max(0, offset_next - tm));
-    const bool sg_active = m_hi_lim > m_lo_lim;
-
     NAXTile<AccumType, TM, TN> Dtile;
     Dtile.clear();
 
@@ -1610,33 +1606,31 @@ template <
 
           STEEL_PRAGMA_NO_UNROLL
           for (int kk1 = 0; kk1 < BK; kk1 += SK) {
-            if (sg_active) {
-              NAXTile<T, TM, TK> Atile;
-              NAXTile<T, BR, BC> Btile;
+            NAXTile<T, TM, TK> Atile;
+            NAXTile<T, BR, BC> Btile;
 
-              volatile int compiler_barrier;
+            volatile int compiler_barrier;
 
-              if constexpr (kAlignedM.value) {
-                Atile.load(xn + kk1, K);
-              } else {
-                Atile.load_safe(xn + kk1, K, short2(SK, sgp_sm));
-              }
-
-              if constexpr (transpose) {
-                Btile.template load<T, BK_padded, 1>(Ws + tn * BK_padded + kk1);
-              } else {
-                Btile.template load<T, BN_padded, 1>(Ws + tn + kk1 * BN_padded);
-              }
-
-              tile_matmad_nax(
-                  Dtile,
-                  Atile,
-                  metal::bool_constant<false>{},
-                  Btile,
-                  metal::bool_constant<transpose>{});
-
-              (void)compiler_barrier;
+            if constexpr (kAlignedM.value) {
+              Atile.load(xn + kk1, K);
+            } else {
+              Atile.load_safe(xn + kk1, K, short2(SK, sgp_sm));
             }
+
+            if constexpr (transpose) {
+              Btile.template load<T, BK_padded, 1>(Ws + tn * BK_padded + kk1);
+            } else {
+              Btile.template load<T, BN_padded, 1>(Ws + tn + kk1 * BN_padded);
+            }
+
+            tile_matmad_nax(
+                Dtile,
+                Atile,
+                metal::bool_constant<false>{},
+                Btile,
+                metal::bool_constant<transpose>{});
+
+            (void)compiler_barrier;
           }
 
           xn += BK;
@@ -1650,34 +1644,35 @@ template <
 
           STEEL_PRAGMA_NO_UNROLL
           for (int kk1 = 0; kk1 < BK; kk1 += SK) {
-            if (sg_active) {
-              NAXTile<T, TM, TK> Atile;
-              NAXTile<T, BR, BC> Btile;
+            NAXTile<T, TM, TK> Atile;
+            NAXTile<T, BR, BC> Btile;
 
-              volatile int compiler_barrier;
+            volatile int compiler_barrier;
 
-              const short psk = min(int(SK), max(0, (BK - kk1)));
-              Atile.load_safe(xn + kk1, K, short2(psk, sgp_sm));
+            const short psk = min(int(SK), max(0, (BK - kk1)));
+            Atile.load_safe(xn + kk1, K, short2(psk, sgp_sm));
 
-              if constexpr (transpose) {
-                Btile.template load<T, BK_padded, 1>(Ws + tn * BK_padded + kk1);
-              } else {
-                Btile.template load<T, BN_padded, 1>(Ws + tn + kk1 * BN_padded);
-              }
-
-              tile_matmad_nax(
-                  Dtile,
-                  Atile,
-                  metal::bool_constant<false>{},
-                  Btile,
-                  metal::bool_constant<transpose>{});
-
-              (void)compiler_barrier;
+            if constexpr (transpose) {
+              Btile.template load<T, BK_padded, 1>(Ws + tn * BK_padded + kk1);
+            } else {
+              Btile.template load<T, BN_padded, 1>(Ws + tn + kk1 * BN_padded);
             }
+
+            tile_matmad_nax(
+                Dtile,
+                Atile,
+                metal::bool_constant<false>{},
+                Btile,
+                metal::bool_constant<transpose>{});
+
+            (void)compiler_barrier;
           }
         }
 
         threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        const short m_lo_lim = min(int(sgp_sm), max(0, offset - tm));
+        const short m_hi_lim = min(int(sgp_sm), max(0, offset_next - tm));
 
         // Store results to device memory
         if constexpr (kAlignedN.value) {


### PR DESCRIPTION
## Summary

Revert #4352's inactive-simdgroup NAX MoE optimization after a physical mixed-Mac tensor-parallel A/B isolated it as the trigger for repeatable lost JACCL completions.

## Evidence

- v0.32.2 with #4352: two clean 30K DS4 TP2 failures, including one after reboot; rank 1 stops making `all_reduce` progress and the request returns zero tokens.
- v0.32.2 with only #4352 reverted: the original 120K -> 30K failure sequence passes, plus an additional cold 30K rotation, cache reuse, B2 decode, and mixed decode+prefill.
- 3,440 dependent synthetic collectives complete correctly in 0.829 seconds on the reverted build.

The detailed physical reproducer and measurements are linked in the issue.

## Why a revert

The issue is hardware/workload-specific and current CI cannot exercise a heterogeneous M3 Ultra + M5 Max JACCL pair. Restoring the pre-#4352 code is the smallest proven-safe change. A follow-up can reintroduce the optimization with a safe uniform execution scheme or an explicit capability gate.

This PR is a draft pending maintainer guidance and any additional isolated-kernel reproducer they want.

Refs #4403.
