### PR TITLE
Make concurrency cap on load adaptative so that I/O scales with the machine

### DIFF
--- a/mlx/io/load.cpp
+++ b/mlx/io/load.cpp
@@ -334,15 +334,25 @@ array load(std::string file, StreamOrDevice s) {
 
 namespace io {
 
+namespace {
+
+// Scale I/O threads with the core count to saturate fast SSDs.
+size_t io_thread_count() {
+  size_t n_cores = std::thread::hardware_concurrency();
+  return std::clamp<size_t>(n_cores / 2, 4, 16);
+}
+
+} // namespace
+
 ThreadPool& thread_pool() {
   // Leak - see Scheduler singleton comment in scheduler.cpp.
-  static ThreadPool* pool_ = new ThreadPool{4};
+  static ThreadPool* pool_ = new ThreadPool{io_thread_count()};
   return *pool_;
 }
 
 ThreadPool& ParallelFileReader::thread_pool() {
   // Leak - see Scheduler singleton comment in scheduler.cpp.
-  static ThreadPool* thread_pool = new ThreadPool{4};
+  static ThreadPool* thread_pool = new ThreadPool{io_thread_count()};
   return *thread_pool;
 }
 

--- a/mlx/io/load.cpp
+++ b/mlx/io/load.cpp
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <limits>
 #include <sstream>
+#include <thread>
 
 // Used by pread implementation.
 #ifdef _WIN32
@@ -336,24 +337,47 @@ namespace io {
 
 namespace {
 
-// Scale I/O threads with the core count to saturate fast SSDs.
-size_t io_thread_count() {
+// The reads to keep in flight while reading a file in batches. The disk, not
+// the cpu, is the limit here: a thread waits for it most of the time, but a
+// queue deeper than the device can serve only adds latency. Half the cores
+// saturates the storage of a machine, which is faster on the machines that
+// have more cores.
+size_t batch_thread_count() {
   size_t n_cores = std::thread::hardware_concurrency();
   return std::clamp<size_t>(n_cores / 2, 4, 16);
+}
+
+// The pool of the batched reads. Every reader shares it, because the disk is
+// one resource: a pool per file would multiply the reads in flight by the
+// number of open files, which is how a sharded model is read.
+//
+// It is held with a weak reference, so the threads start with the first
+// batched read and stop once the readers that use them are destroyed. Reading
+// a file is a startup task, and this keeps no thread for the rest of the run.
+std::shared_ptr<ThreadPool> acquire_batch_pool() {
+  static std::mutex mtx;
+  static std::weak_ptr<ThreadPool> weak_pool;
+
+  std::lock_guard<std::mutex> lock(mtx);
+  auto pool = weak_pool.lock();
+  if (!pool) {
+    pool = std::make_shared<ThreadPool>(batch_thread_count());
+    weak_pool = pool;
+  }
+  return pool;
 }
 
 } // namespace
 
 ThreadPool& thread_pool() {
   // Leak - see Scheduler singleton comment in scheduler.cpp.
-  static ThreadPool* pool_ = new ThreadPool{io_thread_count()};
+  static ThreadPool* pool_ = new ThreadPool{4};
   return *pool_;
 }
 
 ThreadPool& ParallelFileReader::thread_pool() {
-  // Leak - see Scheduler singleton comment in scheduler.cpp.
-  static ThreadPool* thread_pool = new ThreadPool{io_thread_count()};
-  return *thread_pool;
+  std::call_once(pool_once_, [this]() { pool_ = acquire_batch_pool(); });
+  return *pool_;
 }
 
 void ParallelFileReader::read(char* data, size_t n) {
@@ -381,26 +405,22 @@ void ParallelFileReader::read(char* data, size_t n, size_t offset) {
     }
     return true;
   };
+  // Read the whole batches in the pool and what is left in this thread.
   std::vector<std::future<bool>> futs;
-  while (n != 0) {
-    if (n < batch_size_) {
-      if (!readfn(offset, n, data)) {
-        throw std::runtime_error("[read] Unable to read from file.");
-      }
-      break;
-    } else {
-      size_t m = batch_size_;
-      futs.emplace_back(
-          ParallelFileReader::thread_pool().enqueue(readfn, offset, m, data));
-      data += m;
-      n -= m;
-      offset += m;
-    }
+  while (n >= batch_size_) {
+    futs.emplace_back(thread_pool().enqueue(readfn, offset, batch_size_, data));
+    data += batch_size_;
+    offset += batch_size_;
+    n -= batch_size_;
   }
+  bool ok = n == 0 || readfn(offset, n, data);
+
+  // Wait for every batch, they all write into |data|.
   for (auto& f : futs) {
-    if (!f.get()) {
-      throw std::runtime_error("[read] Unable to read from file.");
-    }
+    ok = f.get() && ok;
+  }
+  if (!ok) {
+    throw std::runtime_error("[read] Unable to read from file.");
   }
 }
 

--- a/mlx/io/load.h
+++ b/mlx/io/load.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 #include <sstream>
 
 #include <fcntl.h>
@@ -102,10 +103,18 @@ class ParallelFileReader : public Reader {
   }
 
  private:
+  // Reads larger than this are split in batches and read in parallel.
   static constexpr size_t batch_size_ = 1 << 25;
-  static ThreadPool& thread_pool();
+
+  // The pool that reads the batches, held from the first batched read until
+  // the reader is destroyed. It cannot be io::thread_pool(), the tasks that
+  // run there wait for these batches and would deadlock in the same pool.
+  ThreadPool& thread_pool();
+
   int fd_;
   std::string label_;
+  std::once_flag pool_once_;
+  std::shared_ptr<ThreadPool> pool_;
 };
 
 class FileWriter : public Writer {


### PR DESCRIPTION
This is a continuation on the work I have already done on https://github.com/ml-explore/mlx-swift-lm/pull/575.
Another little optimization to try to use the whole power of the local SSD when reading the model tensor files from disk. 

### Benchmarks

Tested on my work MacBook: Apple M4 Pro 24GB RAM and 1TB Disk.

  | Build      | Cache | Model (size on disk)              | Run | Old (4 threads)     | New (adaptive, 7)   |  time  |
  |------------|-------|-----------------------------------|-----|---------------------|---------------------|---------|
  | CPU-only   | warm  | Qwen3.5-9B-8bit (10.43 GB)        | 1   | 2.504 s · 4.16 GB/s | 2.430 s · 4.29 GB/s | −3.0%   |
  | CPU-only   | warm  | Qwen3.5-9B-8bit (10.43 GB)        | 2   | 2.215 s · 4.71 GB/s | 2.176 s · 4.79 GB/s | −1.8%   |
  | CPU-only   | warm  | Qwen3.5-9B-8bit (10.43 GB)        | 3   | 2.164 s · 4.82 GB/s | 2.067 s · 5.04 GB/s | −4.5%   |
  | CPU-only   | cold  | Qwen3.5-9B-8bit (10.43 GB)        | 1   | 1.670 s · 6.24 GB/s | 1.663 s · 6.27 GB/s | −0.4%   |
  | CPU-only   | cold  | Qwen3.5-9B-8bit (10.43 GB)        | 2   | 1.731 s · 6.02 GB/s | 1.688 s · 6.18 GB/s | −2.5%   |
  | Metal      | cold  | Qwen3.5-9B-8bit (10.43 GB)        | 1   | 1.812 s · 5.75 GB/s | 1.811 s · 5.76 GB/s | −0.1%   |
  | Metal      | cold  | Qwen3.5-9B-8bit (10.43 GB)        | 2   | 1.798 s · 5.80 GB/s | 1.777 s · 5.87 GB/s | −1.2%   |
  | Metal      | cold  | Muse-Glimmer-30B-4bit (19.41 GB)  | 1   | 3.294 s · 5.89 GB/s | 3.151 s · 6.16 GB/s | −4.3%   |
  
 Note: the change matters most on hardware with faster storage (Mac Studio/Ultra), where a fixed 4 threads becomes the cap.
 
 ## Updated PR after recent commit
 
 **Design comparison **

| design | reader threads | cold GB/s | peak threads during read | threads left after load |
|---|---|---:|---:|---:|
| upstream `main` (fixed 4 + 4, permanent) | 8 total, always on | 3.44 – 3.50 | 13 | 12 |
| pool per reader, sized by file size | up to `cores` per file | 3.23 – 3.26 | **25** | 8 |
| **this PR** (one shared pool, `clamp(cores/2, 4, 16)`, starts/stops with loading) | 4 on this machine, 0 at idle | 3.26 – 3.36 | 13 | **4** |

- ☑️ I understand it is strictly prohibited to use AI to write PR description
- AI usage disclosure: _for the second commit I have indeed used Ai, specifically GLM 5.3, so that I could workout in the gym while my poor MacBook Pro M2 could automatically go through a series of benchmarks, then when back I made the decision, documented in the comment below..._ 
