### PR TITLE
Fix tests/run.py stuck in macOS CI

### DIFF
--- a/.github/actions/test-macos/action.yml
+++ b/.github/actions/test-macos/action.yml
@@ -47,7 +47,7 @@ runs:
           echo "::endgroup::"
 
           echo "::group::Run Python tests"
-          uv run python/tests/run.py -v
+          python -m unittest discover -v python/tests
           echo "::endgroup::"
 
           if ${{ inputs.toolkit != 'cpu' }} ; then

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -85,7 +85,7 @@ jobs:
       matrix:
         macos-target: ['14.0', '15.0', '26.2']
         toolkit: ['cpu', 'metal', 'jit']
-    runs-on: 'macos-26'
+    runs-on: 'macos-26-xlarge'
     needs: check_lint
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,7 @@ jobs:
     strategy:
       matrix:
         python-version: *pyver
-    runs-on: 'macos-26'
+    runs-on: 'macos-26-xlarge'
     env: *build-env
     steps:
       - uses: actions/checkout@v7

--- a/python/tests/mlx_tests.py
+++ b/python/tests/mlx_tests.py
@@ -15,9 +15,7 @@ class MLXTestRunner(unittest.TestProgram):
         # Do not exit in runTests
         kwargs["exit"] = False
         super().__init__(*args, **kwargs)
-
-    def runTests(self):
-        super().runTests()
+        # Do cleanup before exiting
         mx.clear_streams()
         sys.exit(0 if self.result.wasSuccessful() else 1)
 


### PR DESCRIPTION
I'm out of idea why it is stuck in macOS CI and I can not reproduce locally :( 
Switch back to `python -m unittest discover -v python/tests` for macOS CI for now before I figure out