### PR TITLE
python: Fix __setitem__ with negative index preceded by None

### DIFF
--- a/python/src/indexing.cpp
+++ b/python/src/indexing.cpp
@@ -913,7 +913,7 @@ mlx_compute_slice_update_args(
       upd_ax--;
     } else if (is_index_scalar(pyidx)) {
       int st = safe_to_int32(pyidx);
-      st = (st < 0) ? st + src.shape(i) : st;
+      st = (st < 0) ? st + src.shape(ax) : st;
       starts[ax] = st;
       stops[ax] = st + 1;
       if (upd_ax >= 0) {

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -1348,6 +1348,13 @@ class TestArray(mlx_tests.MLXTestCase):
         a[0:1] = mx.array([1])
         self.assertEqual(a.tolist(), [1, 4, 4])
 
+        # Regression test: a negative integer index after a None
+        # (newaxis) used to be normalized against the wrong axis size,
+        # silently writing nothing instead of updating the last row.
+        b = mx.zeros((3, 4))
+        b[None, -1] = 9
+        self.assertEqual(b.tolist(), [[0, 0, 0, 0], [0, 0, 0, 0], [9, 9, 9, 9]])
+
         with self.assertRaises(ValueError):
             a[0:1] = mx.array([2, 3])
 


### PR DESCRIPTION
## Proposed changes

`a[None, -1] = v` (a negative scalar index preceded by a `None`/newaxis in the index tuple) silently writes nothing instead of updating the intended row.

Root cause: in `mlx_compute_slice_update_args` (python/src/indexing.cpp), the scalar-index branch normalizes a negative index using `src.shape(i)`, where `i` is the position of the entry in the raw index tuple, instead of `src.shape(ax)`, the actual source axis being written to. These two diverge whenever a `None` precedes the scalar index, since `None` consumes a tuple slot but not a source axis. The wrong axis size produces an out-of-range start/stop passed to `slice_update`, which silently no-ops instead of raising or writing.

```python
import mlx.core as mx
a = mx.zeros((3, 4))
a[None, -1] = 9
print(a)
# before: unchanged, all zeros
# after:  last row set to 9, matching numpy
```

Fuzz-tested ~1750 combinations of int/negative-int/slice/None indices against numpy across several shapes after the fix, with no remaining mismatches. Full `test_array.py` suite (79 tests) still passes.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)