### PR TITLE
Update nanobind to 3.0.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,7 +396,7 @@ if(MLX_BUILD_PYTHON_BINDINGS)
   FetchContent_Declare(
     nanobind
     GIT_REPOSITORY https://github.com/wjakob/nanobind.git
-    GIT_TAG v2.15.0
+    GIT_TAG v3.0.1
     GIT_SHALLOW TRUE
     EXCLUDE_FROM_ALL)
   FetchContent_MakeAvailable(nanobind)

--- a/docs/src/dev/extensions.rst
+++ b/docs/src/dev/extensions.rst
@@ -711,7 +711,7 @@ build utilities defined in :mod:`mlx.extension`:
             package_data={"mlx_sample_extensions": ["*.so", "*.dylib", "*.metallib"]},
             extras_require={"dev":[]},
             zip_safe=False,
-            python_requires=">=3.8",
+            python_requires=">=3.10",
         )
 
 .. note::

--- a/examples/extensions/CMakeLists.txt
+++ b/examples/extensions/CMakeLists.txt
@@ -23,7 +23,7 @@ find_package(
 FetchContent_Declare(
   nanobind
   GIT_REPOSITORY https://github.com/wjakob/nanobind.git
-  GIT_TAG v2.15.0
+  GIT_TAG v3.0.1
   GIT_SHALLOW TRUE
   EXCLUDE_FROM_ALL)
 FetchContent_MakeAvailable(nanobind)

--- a/python/src/convert.h
+++ b/python/src/convert.h
@@ -14,24 +14,6 @@ namespace nb = nanobind;
 
 namespace nanobind {
 
-template <>
-struct ndarray_traits<mx::float16_t> {
-  static constexpr bool is_complex = false;
-  static constexpr bool is_float = true;
-  static constexpr bool is_bool = false;
-  static constexpr bool is_int = false;
-  static constexpr bool is_signed = true;
-};
-
-template <>
-struct ndarray_traits<mx::bfloat16_t> {
-  static constexpr bool is_complex = false;
-  static constexpr bool is_float = true;
-  static constexpr bool is_bool = false;
-  static constexpr bool is_int = false;
-  static constexpr bool is_signed = true;
-};
-
 namespace detail {
 
 template <>

--- a/python/src/small_vector.h
+++ b/python/src/small_vector.h
@@ -31,7 +31,7 @@ struct type_caster<::mlx::core::SmallVector<Type, Size, Alloc>> {
 
   // Not noexcept: on overflow of a narrow integer element we raise
   // OverflowError so nanobind surfaces a clean error to the user.
-  bool from_python(handle src, uint8_t flags, cleanup_list* cleanup) {
+  bool from_python(handle src, uint32_t flags, cleanup_list* cleanup) {
     size_t size;
     PyObject* temp;
 

--- a/python/src/transforms.cpp
+++ b/python/src/transforms.cpp
@@ -814,8 +814,8 @@ class PyCustomFunction {
       }
       int array_index = 0;
       int tangent_index = 0;
-      auto new_tangents =
-          nb::cast<nb::tuple>(tree_map(args, [&](nb::handle element) {
+      auto new_tangents = nb::cast<nb::tuple>(
+          tree_map(args, [&](nb::handle element) -> nb::object {
             if (nb::isinstance<mx::array>(element) &&
                 have_tangents[array_index++]) {
               return nb::cast(tangents[tangent_index++]);
@@ -861,8 +861,8 @@ class PyCustomFunction {
       }
 
       int arr_index = 0;
-      auto new_axes =
-          nb::cast<nb::tuple>(tree_map(args, [&](nb::handle element) {
+      auto new_axes = nb::cast<nb::tuple>(
+          tree_map(args, [&](nb::handle element) -> nb::object {
             int axis = axes[arr_index++];
             if (nb::isinstance<mx::array>(element) && axis >= 0) {
               return nb::cast(axis);


### PR DESCRIPTION
- ☑️ I understand it is strictly prohibited to use AI to write PR description
- AI usage disclosure: Codex run tests for me

## Proposed changes

This updates MLX from nanobind 2.15.0 to 3.0.1 while keeping the existing linked-mode build configuration.

The required binding updates are:

- update the custom caster flags type from `uint8_t` to `uint32_t`
- give the custom JVP and custom vmap tree-mapping lambdas an explicit `nb::object` return type, cause `nb::none` is now a distinct wrapper type
- remove the obsolete `ndarray_traits` specializations while retaining the existing `dtype_traits` mappings for float16 and bfloat16 types
- align the extension documentation with the Python 3.10 minimum
