### PR TITLE
Small input linear and cubic upsampling should use dense matmuls

### DIFF
--- a/python/mlx/nn/layers/upsample.py
+++ b/python/mlx/nn/layers/upsample.py
@@ -288,6 +288,41 @@ def _interpolate_separable(
     return out
 
 
+_MATMUL_MAX_INPUT_SIZE_LINEAR = 128
+_MATMUL_MAX_INPUT_SIZE_CUBIC = 32
+
+
+def _weight_matrix(N, taps):
+    # float32, so low precision inputs are promoted as in the gather path
+    A = None
+    for idx, weight in taps:
+        onehot = mx.expand_dims(idx.reshape(-1), 1) == mx.arange(N, dtype=mx.uint32)
+        term = onehot.astype(mx.float32) * mx.expand_dims(weight.reshape(-1), 1)
+        A = term if A is None else A + term
+    return A
+
+
+def _interpolate_matmul(
+    x: mx.array, scale_factor: Tuple, indices_fn: Callable, align_corners: bool = False
+):
+    dims = x.ndim - 2
+    if dims != len(scale_factor):
+        raise ValueError("A scale needs to be provided for each spatial dimension")
+
+    _, *N, _ = x.shape
+    out = x
+    for i, (n, s) in enumerate(zip(N, scale_factor)):
+        axis = i + 1
+        A = _weight_matrix(n, indices_fn(n, s, align_corners, i, dims))
+        out = mx.moveaxis(mx.tensordot(out, A, axes=[[axis], [1]]), -1, axis)
+    return out
+
+
+def _use_matmul(N, scale_factor, max_size):
+    upscaling = all(s >= 1 for s in scale_factor)
+    return upscaling and all(n <= max_size for n in N)
+
+
 def upsample_linear(
     x: mx.array,
     scale_factor: Tuple,
@@ -300,6 +335,16 @@ def upsample_linear(
             x=x,
             scale_factor=scale_factor,
             indices_fn=_linear_aa_indices,
+            align_corners=align_corners,
+        )
+    # Dense per-axis matmuls are faster than gathers when upscaling small
+    # spatial sizes. The gradient is also a matmul, which avoids the
+    # scatter-add of gathers.
+    if _use_matmul(x.shape[1:-1], scale_factor, _MATMUL_MAX_INPUT_SIZE_LINEAR):
+        return _interpolate_matmul(
+            x=x,
+            scale_factor=scale_factor,
+            indices_fn=_linear_indices,
             align_corners=align_corners,
         )
     return _interpolate(
@@ -322,6 +367,13 @@ def upsample_cubic(
             x=x,
             scale_factor=scale_factor,
             indices_fn=_cubic_aa_indices,
+            align_corners=align_corners,
+        )
+    if _use_matmul(x.shape[1:-1], scale_factor, _MATMUL_MAX_INPUT_SIZE_CUBIC):
+        return _interpolate_matmul(
+            x=x,
+            scale_factor=scale_factor,
+            indices_fn=_cubic_indices,
             align_corners=align_corners,
         )
     return _interpolate(

--- a/python/tests/test_upsample.py
+++ b/python/tests/test_upsample.py
@@ -312,6 +312,83 @@ class TestUpsample(mlx_tests.MLXTestCase):
                         1e-6,
                     )
 
+    def test_matmul_gather_path_parity(self):
+        from mlx.nn.layers import upsample
+
+        indices_fns = {
+            "linear": upsample._linear_indices,
+            "cubic": upsample._cubic_indices,
+        }
+        # (mode, idim, scale_factor) straddling the matmul routing thresholds
+        cases = [
+            ("linear", (16, 16), (2.0, 2.0)),
+            ("linear", (11, 21), (3.0, 2.0)),
+            ("linear", (200, 200), (2.0, 2.0)),
+            ("linear", (16, 16), (0.5, 0.5)),
+            ("linear", (16,), (4.0,)),
+            ("cubic", (16, 16), (2.0, 2.0)),
+            ("cubic", (64, 64), (2.0, 2.0)),
+        ]
+        for mode, idim, scale in cases:
+            for align_corners in (False, True):
+                with self.subTest(
+                    mode=mode, idim=idim, scale=scale, align_corners=align_corners
+                ):
+                    np.random.seed(0)
+                    in_np = np.random.normal(-1.0, 1.0, (2, *idim, 3)).astype(
+                        np.float32
+                    )
+                    in_mx = mx.array(in_np)
+                    out_gather = upsample._interpolate(
+                        in_mx, scale, indices_fns[mode], align_corners
+                    )
+                    out_matmul = upsample._interpolate_matmul(
+                        in_mx, scale, indices_fns[mode], align_corners
+                    )
+                    self.assertEqual(out_gather.shape, out_matmul.shape)
+                    self.assertTrue(
+                        mx.allclose(out_gather, out_matmul, atol=1e-5).item()
+                    )
+
+    def test_matmul_gather_grad_parity(self):
+        from mlx.nn.layers import upsample
+
+        np.random.seed(0)
+        in_mx = mx.array(np.random.normal(-1.0, 1.0, (2, 8, 16, 3)).astype(np.float32))
+        scale = (10.0, 10.0)
+
+        def loss_gather(x):
+            return (
+                upsample._interpolate(x, scale, upsample._linear_indices) ** 2
+            ).mean()
+
+        def loss_matmul(x):
+            return (
+                upsample._interpolate_matmul(x, scale, upsample._linear_indices) ** 2
+            ).mean()
+
+        grad_gather = mx.grad(loss_gather)(in_mx)
+        grad_matmul = mx.grad(loss_matmul)(in_mx)
+        self.assertTrue(mx.allclose(grad_gather, grad_matmul, atol=1e-5).item())
+
+    def test_matmul_path_routing(self):
+        from mlx.nn.layers import upsample
+
+        max_linear = upsample._MATMUL_MAX_INPUT_SIZE_LINEAR
+        max_cubic = upsample._MATMUL_MAX_INPUT_SIZE_CUBIC
+        # (spatial dims, scale, max_size, expected)
+        cases = [
+            ((max_linear, max_linear), (2.0, 2.0), max_linear, True),
+            ((max_linear + 1, max_linear), (2.0, 2.0), max_linear, False),
+            ((16, 16), (0.5, 2.0), max_linear, False),
+            ((16, 16), (1.0, 1.0), max_linear, True),
+            ((max_cubic, max_cubic), (2.0, 2.0), max_cubic, True),
+            ((max_cubic + 1, max_cubic), (2.0, 2.0), max_cubic, False),
+        ]
+        for dims, scale, max_size, expected in cases:
+            with self.subTest(dims=dims, scale=scale, max_size=max_size):
+                self.assertEqual(upsample._use_matmul(dims, scale, max_size), expected)
+
 
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner()


### PR DESCRIPTION
Gather-based interpolation backward is a scatter-add, which is slow on Metal. For upscaling with small spatial inputs, we can instead build per-axis interpolation matrices and contract them. 

I found this to be 2-4x faster forward and backward for linear with N <= 128 and cubic gated with N <= 32.

- ☑️ I understand it is strictly prohibited to use AI to write PR description
- AI usage disclosure: I used AI to help me benchmark this change

### Benchmark data

Setup: 

* Apple M5 Max (MacBook Pro)
* macOS 26
* mlx 0.32.2
* float32
* `MLX_ENABLE_TF32=0`

Times in ms, mean of 10–30 calls after warmup; "fwd+bwd" is `mx.grad` of a mean-square loss through the op.

<details>
<summary>crossover sweeps</summary>

#### Crossover sweep — linear, ×2 upscale, input `(4, N, N, 32)`

| N_in | matmul fwd | gather fwd | matmul fwd+bwd | gather fwd+bwd | gated path |
|---:|---:|---:|---:|---:|---|
| 8 | 0.18 | 0.17 | 0.20 | 0.22 | matmul |
| 16 | 0.17 | 0.28 | 0.20 | 0.39 | matmul |
| 32 | 0.21 | 0.52 | 0.18 | 0.51 | matmul |
| 64 | 0.41 | 0.76 | 0.33 | 1.06 | matmul |
| 96 | 0.77 | 1.54 | 0.65 | 2.38 | matmul |
| 128 | 1.14 | 2.63 | 1.08 | 4.48 | matmul |
| 192 | 2.59 | 6.18 | 2.80 | 9.55 | gather |
| 256 | 4.27 | 11.92 | 5.77 | 17.06 | gather |
| 384 | 12.59 | 25.95 | 16.84 | 39.52 | gather |
| 512 | 21.60 | 893.76 | 92.01 | 71.28 | gather |

#### Cases the gate excludes (gather wins or matmul loses)

| case | matmul fwd | gather fwd | matmul fwd+bwd | gather fwd+bwd |
|---|---:|---:|---:|---:|
| N=256, ×0.5 downscale | 1.14 | 0.73 | 0.88 | 2.06 |
| N=512, ×0.5 downscale | 20.38 | 14.50 | 5.11 | 7.73 |
| N=512, ×2 (backward) | — | — | 92.01 | 71.28 |

### Other measured points

| case | matmul | gather |
|---|---:|---:|
| linear `(64, 8, 16, 64)` ×10, fwd | 4.60 | 16.81 |
| linear `(64, 8, 16, 64)` ×10, bwd | 3.90 | 27.57 |
| cubic `(4, 32, 32, 32)` ×2, fwd | 0.40 | 0.93 |

</details>

### Testing

- Full `python/tests/test_upsample.py` passes: 9 tests, 172 subtests (was 6 / 152 before the PR), including torch parity across fractional scales and both `align_corners` settings.
- Matmul path agrees with the gather path to 2.4e-7 max deviation (with `MLX_ENABLE_TF32=0`; see caveats).
- New tests added in the PR:
  - `test_matmul_gather_path_parity` — matmul vs gather output equality across cases straddling both thresholds, including a downscale case,  a 1D case, and both `align_corners` settings.
  - `test_matmul_gather_grad_parity` — gradient equality at the motivating shape (8×16, ×10), since the backward pass is the point of the change.
  - `test_matmul_path_routing` — exact threshold boundaries for both modes (tied to the constants, so retuning keeps the test valid), mixed up/down scale rejected, scale=1.0 accepted.
- The new tests error on `main` (`_interpolate_matmul` and the threshold constants do not exist there), demonstrating they exercise only new code.
- `pre-commit` (black, isort) clean on both changed files.

### Caveats

- Thresholds are measured on one machine (M5 Max). 
- Cubic is gated at 32 on a single measured point;  its crossover is lower than the linear one, but it has not been swept.
- TF32 interaction: the matmul path runs through GEMM, so under the default `MLX_ENABLE_TF32=1` on M5 Metal / CUDA it loses ~1e-3 accuracy relative to the gather path (which never touches GEMM). With `MLX_ENABLE_TF32=0`, parity is 2.4e-7. Relates to ml-explore/mlx#3860.