### PR TITLE
Fix Metal grid sizing for strided scans

### DIFF
--- a/mlx/backend/common/utils.cpp
+++ b/mlx/backend/common/utils.cpp
@@ -1,6 +1,7 @@
 // Copyright © 2023-2024 Apple Inc.
 
 #include <dlfcn.h>
+#include <numeric>
 
 #include "mlx/backend/common/utils.h"
 
@@ -176,6 +177,20 @@ Dims get_2d_grid_dims_common(
     size_t divisor) {
   // Compute the 2d grid dimensions such that the total size of the grid is
   // divided by divisor.
+  Shape divided_shape = shape;
+  size_t remaining_divisor = divisor;
+  for (int i = 0; i < shape.size(); ++i) {
+    if (strides[i] == 0) {
+      continue;
+    }
+    auto factor = std::gcd(static_cast<size_t>(shape[i]), remaining_divisor);
+    divided_shape[i] /= factor;
+    remaining_divisor /= factor;
+  }
+  if (remaining_divisor == 1) {
+    return get_2d_grid_dims_common(divided_shape, strides);
+  }
+
   size_t grid_x = 1;
   size_t grid_y = 1;
   for (int i = 0; i < shape.size(); ++i) {

--- a/mlx/backend/common/utils.cpp
+++ b/mlx/backend/common/utils.cpp
@@ -175,8 +175,8 @@ Dims get_2d_grid_dims_common(
     const Shape& shape,
     const Strides& strides,
     size_t divisor) {
-  // Compute the 2d grid dimensions such that the total size of the grid is
-  // divided by divisor.
+  // Non-broadcast dimensions multiply to the grid size, so factors with product
+  // divisor divide it by divisor. For 36: {2 / 2, 4 / 2, 9 / 9} = {1, 2, 1}.
   Shape divided_shape = shape;
   size_t remaining_divisor = divisor;
   for (int i = 0; i < shape.size(); ++i) {

--- a/mlx/backend/common/utils.cpp
+++ b/mlx/backend/common/utils.cpp
@@ -175,8 +175,8 @@ Dims get_2d_grid_dims_common(
     const Shape& shape,
     const Strides& strides,
     size_t divisor) {
-  // Non-broadcast dimensions multiply to the grid size, so factors with product
-  // divisor divide it by divisor. For 36: {2 / 2, 4 / 2, 9 / 9} = {1, 2, 1}.
+  // Shortcut when size is a multiple of divisor, for example:
+  // 36: {2 / 2, 4 / 2, 9 / 9} = {1, 2, 1}
   Shape divided_shape = shape;
   size_t remaining_divisor = divisor;
   for (int i = 0; i < shape.size(); ++i) {
@@ -191,6 +191,8 @@ Dims get_2d_grid_dims_common(
     return get_2d_grid_dims_common(divided_shape, strides);
   }
 
+  // Compute the 2d grid dimensions such that the total size of the grid is
+  // divided by divisor.
   size_t grid_x = 1;
   size_t grid_y = 1;
   for (int i = 0; i < shape.size(); ++i) {

--- a/tests/gpu_tests.cpp
+++ b/tests/gpu_tests.cpp
@@ -57,6 +57,23 @@ TEST_CASE("test gpu full") {
   }
 }
 
+TEST_CASE("test gpu strided scan grid") {
+  std::vector<float> values(72, 1.0f);
+  auto x = array(values.data(), {72});
+  x = transpose(reshape(x, {2, 9, 4}, Device::gpu), {0, 2, 1}, Device::gpu);
+  x = cumsum(x, -1, false, true, Device::gpu);
+
+  auto causal = tril(ones({9, 9}, float32, Device::gpu), 0, Device::gpu);
+  auto relative = subtract(
+      expand_dims(x, -1, Device::gpu),
+      expand_dims(x, -2, Device::gpu),
+      Device::gpu);
+  eval(relative, causal);
+
+  auto expected = tri(9, 9, 0, float32, Device::cpu);
+  CHECK(array_equal(causal, expected, Device::cpu).item<bool>());
+}
+
 TEST_CASE("test gpu astype") {
   array x = array({-4, -3, -2, -1, 0, 1, 2, 3});
   // Check all types work

--- a/tests/gpu_tests.cpp
+++ b/tests/gpu_tests.cpp
@@ -58,6 +58,7 @@ TEST_CASE("test gpu full") {
 }
 
 TEST_CASE("test gpu strided scan grid") {
+  // Regression for #4419 strided_scan writes out of bounds.
   std::vector<float> values(72, 1.0f);
   auto x = array(values.data(), {72});
   x = transpose(reshape(x, {2, 9, 4}, Device::gpu), {0, 2, 1}, Device::gpu);


### PR DESCRIPTION
- ☑️ I understand it is strictly prohibited to use AI to write PR description
- AI usage disclosure: 
I used OpenAI Codex to help identify the cause of the bug, write the corrected code and the regression test.

This will fix #4419

The root cause for the corruption was that the calculation for how many thread groups to launch for a transposed cumsum is off.

Concretely the grid calculation failed to divide a scan factor distributed across multiple dimensions, launching extra Metal thread groups that wrote beyond the output buffer.

The regression test didn't pass before the patch and passed after.