### PR TITLE
WIP: CI: run the Array API test suite

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -145,14 +145,13 @@ jobs:
     needs: check_lint
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-linux
       - uses: ./.github/actions/build-linux
       - name: Checkout array-api-tests
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: data-apis/array-api-tests
-          ref: '41379d15d26d67a1e66c840e775d41a8a7fb1516'  # v2026.02.26
           submodules: 'true'
           path: 'array-api-tests'
           persist-credentials: false
@@ -162,10 +161,12 @@ jobs:
       - name: Run the test suite
         env:
           ARRAY_API_TESTS_MODULE: mlx.core
+          ARRAY_API_TESTS_SKIP_DTYPES: float64,complex128
+          ARRAY_API_TESTS_FAIL_MARK: skip
           PYTHONWARNINGS: 'ignore::UserWarning::,ignore::DeprecationWarning::,ignore::RuntimeWarning::'
         run: |
           cd ${GITHUB_WORKSPACE}/array-api-tests
-          pytest array_api_tests -v -c pytest.ini -n 2 --max-examples=1000 --derandomize --disable-deadline
+          pytest array_api_tests -v -c pytest.ini -n 2 --max-examples=1000 --derandomize --disable-deadline --disable-data-dependent-shapes
 
   build_documentation:
     name: Build Documentation

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -146,8 +146,6 @@ jobs:
     needs: mac_build
     steps:
       - uses: actions/checkout@v7
-      - uses: ./.github/actions/setup-linux
-      - uses: ./.github/actions/build-linux
       - name: Checkout array-api-tests
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -141,7 +141,7 @@ jobs:
 
   array_api_tests:
     name: Array API Tests
-    if: github.repository == 'ml-explore/mlx'
+  ####  if: github.repository == 'ml-explore/mlx'
     needs: check_lint
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -139,6 +139,34 @@ jobs:
         with:
           toolkit: ${{ matrix.toolkit }}
 
+  array_api_tests:
+    name: Array API Tests
+    if: github.repository == 'ml-explore/mlx'
+    needs: check_lint
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-linux
+      - uses: ./.github/actions/build-linux
+      - name: Checkout array-api-tests
+        uses: actions/checkout@v6
+        with:
+          repository: data-apis/array-api-tests
+          ref: '41379d15d26d67a1e66c840e775d41a8a7fb1516'  # v2026.02.26
+          submodules: 'true'
+          path: 'array-api-tests'
+          persist-credentials: false
+      - name: Install dependencies
+        run: |
+          python -m pip install pytest-xdist -r array-api-tests/requirements.txt
+      - name: Run the test suite
+        env:
+          ARRAY_API_TESTS_MODULE: mlx.core
+          PYTHONWARNINGS: 'ignore::UserWarning::,ignore::DeprecationWarning::,ignore::RuntimeWarning::'
+        run: |
+          cd ${GITHUB_WORKSPACE}/array-api-tests
+          pytest array_api_tests -v -c pytest.ini -n 2 --max-examples=1000 --derandomize --disable-deadline
+
   build_documentation:
     name: Build Documentation
     if: github.repository == 'ml-explore/mlx'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -142,8 +142,8 @@ jobs:
   array_api_tests:
     name: Array API Tests
   ####  if: github.repository == 'ml-explore/mlx'
-    needs: check_lint
-    runs-on: ubuntu-22.04
+    runs-on: [macos]
+    needs: mac_build
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-linux


### PR DESCRIPTION
- ☑️ I understand it is strictly prohibited to use AI to write PR description
- AI usage disclosure: no AI used

closes gh-3514

This is a resubmit of gh-3526: since May 2026, there were significant strides in Array API compatibility in both MLX and the test suite itself. Also add several test suite specific toggles: disable testing functions with data-dependent shapes, disable testing with unsupported dtypes.

This is work-in-progress: the is CI is expected to fail, and we'll update the xfail listings based on what actually fails.  

