### PR TITLE
docs: fix typo recived -> received

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -1758,7 +1758,7 @@ array transpose(
   }
   if (axes.size() != a.ndim()) {
     std::ostringstream msg;
-    msg << "[transpose] Recived " << axes.size() << " axes for array with "
+    msg << "[transpose] Received " << axes.size() << " axes for array with "
         << a.ndim() << " dimensions.";
     throw std::invalid_argument(msg.str());
   }


### PR DESCRIPTION
Corrects the misspelling `recived` -> `received` in `mlx/ops.cpp`.

Documentation only, no behaviour change.