### PR TITLE
python: Make iter() throw TypeError for 0-dim array

### DIFF
--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -77,7 +77,7 @@ class ArrayPythonIterator {
  public:
   ArrayPythonIterator(mx::array x) : idx_(0), x_(std::move(x)) {
     if (x_.ndim() == 0) {
-      throw nb::type_error("iter() / list() 0-dimensional array.");
+      throw nb::type_error("iter() 0-dimensional array.");
     }
     if (x_.shape(0) > 0 && x_.shape(0) < 10) {
       splits_ = mx::split(x_, x_.shape(0));

--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -76,6 +76,9 @@ class ArrayAt {
 class ArrayPythonIterator {
  public:
   ArrayPythonIterator(mx::array x) : idx_(0), x_(std::move(x)) {
+    if (x_.ndim() == 0) {
+      throw nb::type_error("iter() / list() 0-dimensional array.");
+    }
     if (x_.shape(0) > 0 && x_.shape(0) < 10) {
       splits_ = mx::split(x_, x_.shape(0));
     }

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -1044,6 +1044,10 @@ class TestArray(mlx_tests.MLXTestCase):
         self.assertEqual(y.tolist(), [3.0, 4.0])
         self.assertEqual(z.tolist(), [5.0, 6.0])
 
+        a = mx.array(3)
+        with self.assertRaises(TypeError):
+            list(a)
+
     def test_array_pickle(self):
         dtypes = [
             mx.int8,


### PR DESCRIPTION
- ☑️ I understand it is strictly prohibited to use AI to write PR description
- AI usage disclosure: AI was not used anywhere to write the code.

Added TypeError with message iter() / list() 0-dimensional if ndim is 0

Fixes: #4423 
