### PR TITLE
Fix SGD and Adafactor weight decay mutating caller arrays

### DIFF
--- a/python/mlx/optimizers/optimizers.py
+++ b/python/mlx/optimizers/optimizers.py
@@ -274,7 +274,7 @@ class SGD(Optimizer):
         optimizer state."""
 
         if self.weight_decay != 0:
-            gradient += self.weight_decay * parameter
+            gradient = gradient + self.weight_decay * parameter
 
         if self.momentum <= 0:
             return parameter - self.learning_rate.astype(gradient.dtype) * gradient
@@ -856,7 +856,7 @@ class Adafactor(Optimizer):
             update = exp_avg
 
         if self.weight_decay != 0:
-            parameter += parameter * (-self.weight_decay * learning_rate)
+            parameter = parameter + parameter * (-self.weight_decay * learning_rate)
         return parameter - update
 
 

--- a/python/tests/test_optimizers.py
+++ b/python/tests/test_optimizers.py
@@ -364,6 +364,29 @@ class TestOptimizers(mlx_tests.MLXTestCase):
         optim_no_momentum = opt.Muon(learning_rate=1e-2, momentum=0.0)
         optim_no_momentum.apply_gradients(grads, params)
 
+    def test_weight_decay_keeps_inputs_unchanged(self):
+        # Weight decay must not write into the gradients or the parameters
+        # that the caller passed in.
+        params = {"w": mx.ones((3, 3))}
+        grads = {"w": mx.full((3, 3), 2.0)}
+
+        optimizer = opt.SGD(learning_rate=1e-2, weight_decay=0.1)
+        optimizer.apply_gradients(grads, params)
+        self.assertTrue(mx.array_equal(grads["w"], mx.full((3, 3), 2.0)))
+        self.assertTrue(mx.array_equal(params["w"], mx.ones((3, 3))))
+
+        optimizer = opt.Adafactor(learning_rate=1e-2, weight_decay=0.1)
+        optimizer.apply_gradients(grads, params)
+        self.assertTrue(mx.array_equal(grads["w"], mx.full((3, 3), 2.0)))
+        self.assertTrue(mx.array_equal(params["w"], mx.ones((3, 3))))
+
+        # The same gradients applied twice give the same update
+        optimizer = opt.SGD(learning_rate=1e-2, weight_decay=0.1)
+        first = optimizer.apply_gradients(grads, params)
+        optimizer = opt.SGD(learning_rate=1e-2, weight_decay=0.1)
+        second = optimizer.apply_gradients(grads, params)
+        self.assertTrue(mx.array_equal(first["w"], second["w"]))
+
     def test_compiled_optimizer(self):
         model = nn.Linear(10, 10)
         x = mx.random.uniform(shape=(2, 10))


### PR DESCRIPTION
- ☑️ I understand it is strictly prohibited to use AI to write PR description
changed a += b to a = a + b. so a stays as a, not confuse training. 