### PR TITLE
 Fix strided_scan reading/writing out-of-bounds

### DIFF
--- a/mlx/backend/cuda/scan.cu
+++ b/mlx/backend/cuda/scan.cu
@@ -206,7 +206,8 @@ __global__ void strided_scan(
     U* out,
     int32_t axis_size,
     int64_t stride,
-    int64_t stride_blocks) {
+    int64_t stride_blocks,
+    int64_t data_size) {
   auto grid = cg::this_grid();
   auto block = cg::this_thread_block();
   auto warp = cg::tiled_partition<WARP_SIZE>(block);
@@ -233,7 +234,10 @@ __global__ void strided_scan(
   uint32_t scan_offset_y = warp.thread_rank();
   uint32_t scan_offset_x = warp.meta_group_rank() * n_scans;
 
-  uint32_t stride_limit = stride - global_index_x;
+  int64_t stride_limit = cuda::std::min(
+      stride - global_index_x,
+      data_size - offset - global_index_x);
+
   in += offset + global_index_x + read_offset_x;
   out += offset + global_index_x + read_offset_x;
   U* read_into = read_buffer + read_offset_y * BN_pad + read_offset_x;
@@ -435,7 +439,8 @@ void scan_gpu_inplace(
                   gpu_ptr<U>(out),
                   axis_size,
                   stride,
-                  stride_blocks);
+                  stride_blocks,
+                  int64_t(in.data_size()));
             }
           });
         });

--- a/mlx/backend/metal/kernels/scan.h
+++ b/mlx/backend/metal/kernels/scan.h
@@ -411,8 +411,9 @@ template <
     const device T* in [[buffer(0)]],
     device U* out [[buffer(1)]],
     const constant size_t& axis_size [[buffer(2)]],
-    const constant size_t& stride [[buffer(3)]],
-    const constant size_t& stride_blocks [[buffer(4)]],
+    const constant int64_t& stride [[buffer(3)]],
+    const constant int64_t& stride_blocks [[buffer(4)]],
+    const constant int64_t& data_size [[buffer(5)]],
     uint3 gid [[threadgroup_position_in_grid]],
     uint3 gsize [[threadgroups_per_grid]],
     uint3 lid [[thread_position_in_threadgroup]],
@@ -434,15 +435,17 @@ template <
   }
 
   // Compute offsets
-  size_t full_gid = gid.y + gsize.y * size_t(gid.z);
-  size_t offset = full_gid / stride_blocks * axis_size * stride;
-  size_t global_index_x = full_gid % stride_blocks * BN;
+  int64_t full_gid = gid.y + int64_t(gsize.y) * gid.z;
+  int64_t offset = full_gid / stride_blocks * axis_size * stride;
+  int64_t global_index_x = full_gid % stride_blocks * BN;
   uint read_offset_y = (lid.x * N_READS) / BN;
   uint read_offset_x = (lid.x * N_READS) % BN;
   uint scan_offset_y = simd_lane_id;
   uint scan_offset_x = simd_group_id * n_scans;
 
-  uint stride_limit = stride - global_index_x;
+  int64_t stride_limit =
+      min(stride - global_index_x, data_size - offset - global_index_x);
+
   in += offset + global_index_x + read_offset_x;
   out += offset + global_index_x + read_offset_x;
   threadgroup U* read_into =

--- a/mlx/backend/metal/kernels/scan.metal
+++ b/mlx/backend/metal/kernels/scan.metal
@@ -32,8 +32,9 @@ using namespace metal;
       const device itype* in [[buffer(0)]],                          \
       device otype* out [[buffer(1)]],                               \
       const constant size_t& axis_size [[buffer(2)]],                \
-      const constant size_t& stride [[buffer(3)]],                   \
-      const constant size_t& stride_blocks [[buffer(4)]],            \
+      const constant int64_t& stride [[buffer(3)]],                  \
+      const constant int64_t& stride_blocks [[buffer(4)]],           \
+      const constant int64_t& data_size [[buffer(5)]],               \
       uint3 gid [[threadgroup_position_in_grid]],                    \
       uint3 gsize [[threadgroups_per_grid]],                         \
       uint3 lid [[thread_position_in_threadgroup]],                  \

--- a/mlx/backend/metal/scan.cpp
+++ b/mlx/backend/metal/scan.cpp
@@ -89,11 +89,12 @@ void scan_gpu_inplace(
     MTL::Size group_dims(thread_group_size, 1, 1);
     compute_encoder.dispatch_threads(grid_dims, group_dims);
   } else {
-    size_t stride = in.strides()[axis];
+    size_t stride = in.strides(axis);
     int bn = 32;
     size_t stride_blocks = (stride + bn - 1) / bn;
-    compute_encoder.set_bytes(stride, 3);
-    compute_encoder.set_bytes(stride_blocks, 4);
+    compute_encoder.set_bytes(int64_t(stride), 3);
+    compute_encoder.set_bytes(int64_t(stride_blocks), 4);
+    compute_encoder.set_bytes(int64_t(in.data_size()), 5);
 
     // Compute the thread grid
     int n_reads = (in.itemsize() <= 4) ? 4 : 2;

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -2715,6 +2715,18 @@ class TestOps(mlx_tests.MLXTestCase):
                     msg=f"{op} reverse={reverse}",
                 )
 
+    def test_scan_does_not_write_past_the_output(self):
+        for n, off in ((64, 63), (512, 400)):
+            with self.subTest(n=n, off=off):
+                base = mx.arange(1, n + 1, dtype=mx.float32).reshape(1, n)
+                canaries = [mx.zeros((16,)) + i for i in range(12)]
+                mx.eval(base, *canaries)
+                before = [np.array(x) for x in [base] + canaries]
+                mx.eval(mx.cumsum(base[:, off:], axis=0))
+                after = [np.array(x) for x in [base] + canaries]
+                for b, a in zip(before, after):
+                    self.assertTrue(np.array_equal(b, a))
+
     def test_cummax_cummin_nan(self):
         nan = float("nan")
         cases = [


### PR DESCRIPTION
The GPU `strided_scan` kernels can read/write out-of-bounds when the scanned axis is a slice. The test is from #4254.

Note that this is only a correctness fix, and does not try to optimize the mentioned case which currently has most of the threads wasted. At the moment I'm conservative on complicating the kernel for a crafted edge case.