### PR TITLE
sdpa_vector_2pass_1_gqa kernel batch offset for K/V in gqa decode

### DIFF
--- a/mlx/backend/metal/kernels/sdpa_vector.h
+++ b/mlx/backend/metal/kernels/sdpa_vector.h
@@ -357,6 +357,7 @@ template <typename T, int D, int V, int G, int HPT>
   const int num_kv_heads = tpg.x;
   const int num_q_heads = num_kv_heads * G;
   const int base_head = batch_idx * num_q_heads + kv_head_idx * G;
+  const int kv_batch_head_idx = batch_idx * num_kv_heads + kv_head_idx;
 
   const int chunk = (N + blocks - 1) / blocks;
   const int kstart = block_idx * chunk;
@@ -365,9 +366,9 @@ template <typename T, int D, int V, int G, int HPT>
   const int s0 = kstart + cchunk * sub;
   const int s1 = min(kend, s0 + sub);
 
-  const device T* kp = keys + kv_head_idx * k_head_stride + s0 * k_seq_stride +
-      simd_lid * qk_per_thread;
-  const device T* vp = values + kv_head_idx * v_head_stride +
+  const device T* kp = keys + kv_batch_head_idx * k_head_stride +
+      s0 * k_seq_stride + simd_lid * qk_per_thread;
+  const device T* vp = values + kv_batch_head_idx * v_head_stride +
       s0 * v_seq_stride + simd_lid * v_per_thread;
 
   U q[HPT][qk_per_thread];

--- a/python/tests/test_fast_sdpa.py
+++ b/python/tests/test_fast_sdpa.py
@@ -346,10 +346,10 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
         scale = 1.0
         mx.random.seed(0)
         for Nq, Nkv, D in [(32, 4, 128), (64, 8, 64), (48, 4, 128), (64, 4, 128)]:
-            for L in [8192, 8201]:
-                q = 5e-1 * mx.random.normal(shape=(1, Nq, 1, D))
-                k = 5e-1 * mx.random.normal(shape=(1, Nkv, L + 32, D))[:, :, :L]
-                v = 5e-1 * mx.random.normal(shape=(1, Nkv, L + 32, D))[:, :, :L]
+            for B, L in [(1, 8192), (1, 8201), (2, 8192)]:
+                q = 5e-1 * mx.random.normal(shape=(B, Nq, 1, D))
+                k = 5e-1 * mx.random.normal(shape=(B, Nkv, L + 32, D))[:, :, :L]
+                v = 5e-1 * mx.random.normal(shape=(B, Nkv, L + 32, D))[:, :, :L]
                 kr = mx.repeat(k, Nq // Nkv, axis=1)
                 vr = mx.repeat(v, Nq // Nkv, axis=1)
                 ref = mlx_primitives_sdpa(q, kr, vr, scale)


### PR DESCRIPTION
- ✅ I understand it is strictly prohibited to use AI to write PR description
- AI usage disclosure: Claude was used as coding agent and i've cross-checked the written codes.
---

# Fix batching idx for `sdpa_vector_2pass_1_gqa` kernel's K/V pointer

Following my recent PRs(#4077, #4380) introduced `sdqa_vector_2pass_1_gqa` for eliminating redundancy reading for each KV head, there was bug when using batched decode without mask.

So the batch idx is added for pointer update and properly works for batch inputs.

| kernel | batch offset | status |
|---|---|---|
| `sdpa_vector` (single-pass) | folded into `tid.x` → `kv_head_idx = q_batch_head_idx / gqa` | correct |
| `sdpa_vector_2pass_1` (non-GQA) | explicit `kv_batch_head_idx = batch_idx*num_kv_heads+kv_head_idx` | correct |
| `sdpa_vector_2pass_1_gqa` | batch term missing | THIS FIX |

### Test for before fix and after fix (following CONTRIBUTION.md)

- New test case `(B, L) = (2, 8192)` added to `test_sdpa_vector_gqa_long`: FAILS on upstream main (AssertionError), PASSES with the fix.
- No regression: B == 1 is byte-identical (batch_idx == 0 → kv_batch_head_idx == kv_head_idx), so all existing (B==1) benchmark shapes are unchanged by construction. `bench_sdpa_gqa.py` two-build compare confirms within measurement noise (the gqa-4 control, identical code on both builds, drifts as much as the gated kernels — that drift is the noise floor).
- pre-commit (clang-format / black / isort) passes on the 2 files.

### Formatting
```
uvx pre-commit run --all-files ✅ PASSED
```