### PR TITLE
Fix save and save_safetensors corrupting a lazily loaded source file

### DIFF
--- a/mlx/export.cpp
+++ b/mlx/export.cpp
@@ -702,6 +702,7 @@ FunctionExporter::FunctionExporter(
       fun(std::move(fun)),
       ftable(std::make_shared<FunctionTable>(shapeless)),
       metadata_(std::move(metadata)) {
+  os.open();
   if (!os.is_open()) {
     throw std::runtime_error("[export_function] Failed to open " + file);
   }

--- a/mlx/io/load.cpp
+++ b/mlx/io/load.cpp
@@ -149,6 +149,10 @@ void save(std::shared_ptr<io::Writer> out_stream, array a) {
   a = contiguous(a, true);
   a.eval();
 
+  // Open only after the inputs are evaluated: opening a FileWriter
+  // truncates the file and lazy inputs may still read from it.
+  out_stream->open();
+
   ////////////////////////////////////////////////////////
   // Check file
   if (!out_stream->good() || !out_stream->is_open()) {

--- a/mlx/io/load.cpp
+++ b/mlx/io/load.cpp
@@ -222,6 +222,11 @@ void save(std::string file, array a) {
   if (file.length() < 4 || file.substr(file.length() - 4, 4) != ".npy")
     file += ".npy";
 
+  // Materialize the array before opening the file. Opening truncates it and
+  // a lazily loaded input may still read from it.
+  a = contiguous(a, true);
+  a.eval();
+
   // Serialize array
   save(std::make_shared<io::FileWriter>(std::move(file)), a);
 }

--- a/mlx/io/load.cpp
+++ b/mlx/io/load.cpp
@@ -222,11 +222,6 @@ void save(std::string file, array a) {
   if (file.length() < 4 || file.substr(file.length() - 4, 4) != ".npy")
     file += ".npy";
 
-  // Materialize the array before opening the file. Opening truncates it and
-  // a lazily loaded input may still read from it.
-  a = contiguous(a, true);
-  a.eval();
-
   // Serialize array
   save(std::make_shared<io::FileWriter>(std::move(file)), a);
 }

--- a/mlx/io/load.h
+++ b/mlx/io/load.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <mutex>
 #include <sstream>
+#include <utility>
 
 #include <fcntl.h>
 #ifdef _MSC_VER
@@ -120,27 +121,23 @@ class ParallelFileReader : public Reader {
 class FileWriter : public Writer {
  public:
   explicit FileWriter() {}
-  explicit FileWriter(std::string file_path)
-      : fd_(open(
-            file_path.c_str(),
-            O_CREAT | O_WRONLY | O_TRUNC | O_BINARY,
-            0644)),
-        label_(std::move(file_path)) {}
+  explicit FileWriter(std::string file_path) : label_(std::move(file_path)) {}
 
   FileWriter(const FileWriter&) = delete;
   FileWriter& operator=(const FileWriter&) = delete;
-  FileWriter(FileWriter&& other) {
-    std::swap(fd_, other.fd_);
-  }
+  FileWriter(FileWriter&& other)
+      : fd_(std::exchange(other.fd_, -1)),
+        label_(std::move(other.label_)),
+        attempted_(std::exchange(other.attempted_, true)) {}
 
   ~FileWriter() override {
-    if (fd_ != 0) {
+    if (fd_ >= 0) {
       close(fd_);
     }
   }
 
   bool is_open() const override {
-    return fd_ >= 0;
+    return ensure_open();
   }
 
   bool good() const override {
@@ -148,11 +145,13 @@ class FileWriter : public Writer {
   }
 
   size_t tell() override {
+    check_open();
     return lseek(fd_, 0, SEEK_CUR);
   }
 
   void seek(int64_t off, std::ios_base::seekdir way = std::ios_base::beg)
       override {
+    check_open();
     if (way == std::ios_base::beg) {
       lseek(fd_, off, SEEK_SET);
     } else if (way == std::ios_base::end) {
@@ -163,6 +162,7 @@ class FileWriter : public Writer {
   }
 
   void write(const char* data, size_t n) override {
+    check_open();
     while (n != 0) {
       auto m = ::write(fd_, data, std::min(n, static_cast<size_t>(INT32_MAX)));
       if (m <= 0) {
@@ -180,8 +180,28 @@ class FileWriter : public Writer {
   }
 
  private:
-  int fd_{0};
+  // Not thread-safe. The file is opened on first use, not at construction:
+  // opening truncates it and lazy inputs may still read from it.
+  bool ensure_open() const {
+    if (!attempted_) {
+      attempted_ = true;
+      if (!label_.empty()) {
+        fd_ =
+            open(label_.c_str(), O_CREAT | O_WRONLY | O_TRUNC | O_BINARY, 0644);
+      }
+    }
+    return fd_ >= 0;
+  }
+
+  void check_open() const {
+    if (!ensure_open()) {
+      throw std::runtime_error("[write] Failed to open " + label());
+    }
+  }
+
+  mutable int fd_{-1};
   std::string label_;
+  mutable bool attempted_{false};
 };
 
 } // namespace io

--- a/mlx/io/load.h
+++ b/mlx/io/load.h
@@ -55,6 +55,8 @@ class Writer {
       std::ios_base::seekdir way = std::ios_base::beg) = 0;
   virtual void write(const char* data, size_t n) = 0;
   virtual std::string label() const = 0;
+  virtual void open() {}
+
   virtual ~Writer() = default;
 };
 
@@ -121,14 +123,16 @@ class ParallelFileReader : public Reader {
 class FileWriter : public Writer {
  public:
   explicit FileWriter() {}
-  explicit FileWriter(std::string file_path) : label_(std::move(file_path)) {}
+  explicit FileWriter(std::string file_path)
+      : file_path_(std::move(file_path)) {}
 
   FileWriter(const FileWriter&) = delete;
   FileWriter& operator=(const FileWriter&) = delete;
   FileWriter(FileWriter&& other)
       : fd_(std::exchange(other.fd_, -1)),
-        label_(std::move(other.label_)),
-        attempted_(std::exchange(other.attempted_, true)) {}
+        file_path_(std::move(other.file_path_)) {
+    other.file_path_.clear();
+  }
 
   ~FileWriter() override {
     if (fd_ >= 0) {
@@ -136,8 +140,17 @@ class FileWriter : public Writer {
     }
   }
 
+  // Kept separate from construction so lazy inputs can be evaluated first,
+  // they may still read from the file.
+  void open() override {
+    if (fd_ < 0 && !file_path_.empty()) {
+      fd_ = ::open(
+          file_path_.c_str(), O_CREAT | O_WRONLY | O_TRUNC | O_BINARY, 0644);
+    }
+  }
+
   bool is_open() const override {
-    return ensure_open();
+    return fd_ >= 0;
   }
 
   bool good() const override {
@@ -176,32 +189,18 @@ class FileWriter : public Writer {
   }
 
   std::string label() const override {
-    return "file " + label_;
+    return "file " + file_path_;
   }
 
  private:
-  // Not thread-safe. The file is opened on first use, not at construction:
-  // opening truncates it and lazy inputs may still read from it.
-  bool ensure_open() const {
-    if (!attempted_) {
-      attempted_ = true;
-      if (!label_.empty()) {
-        fd_ =
-            open(label_.c_str(), O_CREAT | O_WRONLY | O_TRUNC | O_BINARY, 0644);
-      }
-    }
-    return fd_ >= 0;
-  }
-
   void check_open() const {
-    if (!ensure_open()) {
-      throw std::runtime_error("[write] Failed to open " + label());
+    if (!is_open()) {
+      throw std::runtime_error("[write] File " + file_path_ + " is not open.");
     }
   }
 
-  mutable int fd_{-1};
-  std::string label_;
-  mutable bool attempted_{false};
+  int fd_{-1};
+  std::string file_path_;
 };
 
 } // namespace io

--- a/mlx/io/safetensors.cpp
+++ b/mlx/io/safetensors.cpp
@@ -280,6 +280,18 @@ void save_safetensors(
       file.substr(file.length() - 12, 12) != ".safetensors")
     file += ".safetensors";
 
+  // Materialize the arrays before opening the file. Opening truncates it and
+  // a lazily loaded input may still read from it.
+  {
+    std::vector<array> to_eval;
+    to_eval.reserve(a.size());
+    for (auto& p : a) {
+      p.second = contiguous(p.second);
+      to_eval.push_back(p.second);
+    }
+    eval(std::move(to_eval));
+  }
+
   // Serialize array
   save_safetensors(
       std::make_shared<io::FileWriter>(std::move(file)), a, metadata);

--- a/mlx/io/safetensors.cpp
+++ b/mlx/io/safetensors.cpp
@@ -221,6 +221,18 @@ void save_safetensors(
     std::shared_ptr<io::Writer> out_stream,
     std::unordered_map<std::string, array> a,
     std::unordered_map<std::string, std::string> metadata /* = {} */) {
+  // Materialize the arrays before the lazy FileWriter opens and truncates
+  // the file during the file check. Lazy inputs may still read from it.
+  {
+    std::vector<array> to_eval;
+    to_eval.reserve(a.size());
+    for (auto& p : a) {
+      p.second = contiguous(p.second);
+      to_eval.push_back(p.second);
+    }
+    eval(std::move(to_eval));
+  }
+
   ////////////////////////////////////////////////////////
   // Check file
   if (!out_stream->good() || !out_stream->is_open()) {
@@ -237,16 +249,6 @@ void save_safetensors(
     _metadata[key] = value;
   }
   parent["__metadata__"] = _metadata;
-
-  {
-    std::vector<array> to_eval;
-    to_eval.reserve(a.size());
-    for (auto& p : a) {
-      p.second = contiguous(p.second);
-      to_eval.push_back(p.second);
-    }
-    eval(std::move(to_eval));
-  }
 
   size_t offset = 0;
   for (auto& [key, arr] : a) {
@@ -279,18 +281,6 @@ void save_safetensors(
   if (file.length() < 12 ||
       file.substr(file.length() - 12, 12) != ".safetensors")
     file += ".safetensors";
-
-  // Materialize the arrays before opening the file. Opening truncates it and
-  // a lazily loaded input may still read from it.
-  {
-    std::vector<array> to_eval;
-    to_eval.reserve(a.size());
-    for (auto& p : a) {
-      p.second = contiguous(p.second);
-      to_eval.push_back(p.second);
-    }
-    eval(std::move(to_eval));
-  }
 
   // Serialize array
   save_safetensors(

--- a/mlx/io/safetensors.cpp
+++ b/mlx/io/safetensors.cpp
@@ -221,8 +221,6 @@ void save_safetensors(
     std::shared_ptr<io::Writer> out_stream,
     std::unordered_map<std::string, array> a,
     std::unordered_map<std::string, std::string> metadata /* = {} */) {
-  // Materialize the arrays before the lazy FileWriter opens and truncates
-  // the file during the file check. Lazy inputs may still read from it.
   {
     std::vector<array> to_eval;
     to_eval.reserve(a.size());
@@ -232,6 +230,10 @@ void save_safetensors(
     }
     eval(std::move(to_eval));
   }
+
+  // Open only after the inputs are evaluated: opening a FileWriter
+  // truncates the file and lazy inputs may still read from it.
+  out_stream->open();
 
   ////////////////////////////////////////////////////////
   // Check file

--- a/python/tests/test_load.py
+++ b/python/tests/test_load.py
@@ -122,6 +122,24 @@ class TestLoad(mlx_tests.MLXTestCase):
         except Exception:
             pass
 
+    def test_save_over_lazily_loaded_safetensors(self):
+        # The save must eval the lazy input before truncating the file it was
+        # loaded from. Shift the data so stale content cannot pass.
+        save_file = os.path.join(self.test_dir, "resave.safetensors")
+        mx.save_safetensors(save_file, {"a": mx.ones((4, 4))})
+        a = mx.load(save_file, stream=mx.cpu)["a"]
+        mx.save_safetensors(save_file, {"a": a + 1})
+        out = mx.load(save_file, stream=mx.cpu)["a"]
+        self.assertTrue(np.array_equal(np.array(out), 2 * np.ones((4, 4))))
+
+    def test_save_over_lazily_loaded_npy(self):
+        save_file = os.path.join(self.test_dir, "resave.npy")
+        mx.save(save_file, mx.ones((4, 4)))
+        a = mx.load(save_file, stream=mx.cpu)
+        mx.save(save_file, a + 2)
+        out = mx.load(save_file, stream=mx.cpu)
+        self.assertTrue(np.array_equal(np.array(out), 3 * np.ones((4, 4))))
+
     def test_save_and_load_safetensors(self):
         test_file = os.path.join(self.test_dir, "test.safetensors")
         with self.assertRaises(Exception):


### PR DESCRIPTION
- ☑️ I understand it is strictly prohibited to use AI to write PR description
- AI usage disclosure: GLM5.3 was used to further diagnose the issue and confirm the solution, as well as to draft the tests

Fixes #4427 

**Issue**
As described in the issue, both save and save_safetensors functions construct a io::FileWriter, which opens the file with O_TRUNC flag, before evaluating the input arrays. An input lazily loaded from the same file is still backed by a Load primitive holding an open reader on it, so that evaluation reads the now-truncated file. 
The error is stored in the stream and either surfaces at a later eval or simply terminates the process, while the save will silently write whatever junk was in the unfilled buffer back to the file.

**Solution**
Now both save and save_safetensors materialize the inputs before constructing the FileWriter.
Also added the tests that currently fail on main and will pass after the fix.

The save_safetensors duplicates the materialization block from its io::Writer overload, so the arrays are materialized before the FileWriter is constructed and passed there.