### PR TITLE
Add get_array_buffer_size to query buffer size for arrays

### DIFF
--- a/docs/src/python/memory_management.rst
+++ b/docs/src/python/memory_management.rst
@@ -7,6 +7,7 @@ Memory Management
   :toctree: _autosummary
 
   get_active_memory
+  get_array_buffer_size
   get_peak_memory
   reset_peak_memory
   get_cache_memory

--- a/mlx/CMakeLists.txt
+++ b/mlx/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(
           ${CMAKE_CURRENT_SOURCE_DIR}/transforms.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/utils.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/linalg.cpp
+          ${CMAKE_CURRENT_SOURCE_DIR}/memory.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/backend/metal/metal.h)
 
 # Define MLX_VERSION only in the version.cpp file.

--- a/mlx/memory.cpp
+++ b/mlx/memory.cpp
@@ -1,0 +1,30 @@
+// Copyright © 2026 Apple Inc.
+
+#include <stdexcept>
+#include <unordered_set>
+
+#include "mlx/memory.h"
+
+namespace mlx::core {
+
+size_t get_array_buffer_size(const std::vector<array>& arrays) {
+  std::unordered_set<const void*> buffers;
+  buffers.reserve(arrays.size());
+
+  size_t total = 0;
+  for (const auto& arr : arrays) {
+    if (arr.status() == array::Status::unscheduled) {
+      throw std::invalid_argument(
+          "[get_array_buffer_size] Arrays must be evaluated before querying "
+          "buffer size.");
+    }
+
+    const auto& buffer = arr.buffer();
+    if (buffer.ptr() != nullptr && buffers.insert(buffer.ptr()).second) {
+      total += arr.buffer_size();
+    }
+  }
+  return total;
+}
+
+} // namespace mlx::core

--- a/mlx/memory.h
+++ b/mlx/memory.h
@@ -3,8 +3,10 @@
 #pragma once
 
 #include <cstdlib>
+#include <vector>
 
 #include "mlx/api.h"
+#include "mlx/array.h"
 
 namespace mlx::core {
 
@@ -14,6 +16,14 @@ namespace mlx::core {
  * it does not include cached memory buffers.
  * */
 MLX_API size_t get_active_memory();
+
+/* Get the size of the buffers backing the given arrays in bytes.
+ *
+ * Each unique buffer is counted once. The full allocator size of each buffer
+ * is used, which can exceed the logical size of its arrays. The arrays must be
+ * evaluated before calling this function.
+ * */
+MLX_API size_t get_array_buffer_size(const std::vector<array>& arrays);
 
 /* Get the peak amount of used memory in bytes.
  *

--- a/python/src/memory.cpp
+++ b/python/src/memory.cpp
@@ -3,6 +3,8 @@
 #include "mlx/memory.h"
 #include <nanobind/nanobind.h>
 
+#include "python/src/trees.h"
+
 namespace mx = mlx::core;
 namespace nb = nanobind;
 using namespace nb::literals;
@@ -16,6 +18,30 @@ void init_memory(nb::module_& m) {
 
       Note, this will not always match memory use reported by the system because
       it does not include cached memory buffers.
+      )pbdoc");
+  m.def(
+      "get_array_buffer_size",
+      [](const nb::args& args) {
+        std::vector<mx::array> arrays = tree_flatten(args, false);
+        nb::gil_scoped_release nogil;
+        return mx::get_array_buffer_size(arrays);
+      },
+      nb::arg(),
+      nb::sig("def get_array_buffer_size(*args) -> int"),
+      R"pbdoc(
+      Get the size of the buffers backing arrays in bytes.
+
+      Each unique buffer is counted once. The full allocator size of each
+      buffer is used, which can exceed the logical size of its arrays. Arrays
+      must be evaluated before calling this function. The result does not
+      include graph objects, cached buffers, or other non-buffer memory.
+
+      Args:
+        *args (arrays or trees of arrays): Each argument can be a single array
+          or a tree of arrays. Leaves which are not arrays are ignored.
+
+      Returns:
+        int: The size of the unique buffers in bytes.
       )pbdoc");
   m.def(
       "get_peak_memory",

--- a/python/tests/test_memory.py
+++ b/python/tests/test_memory.py
@@ -7,6 +7,31 @@ import mlx_tests
 
 
 class TestMemory(mlx_tests.MLXTestCase):
+    def test_array_buffer_size(self):
+        a = mx.array([1.0, 2.0, 3.0, 4.0])
+        view = a[:1]
+        lazy = a + 1
+
+        with self.assertRaises(ValueError):
+            mx.get_array_buffer_size({"lazy": lazy})
+
+        mx.eval(view)
+        a_size = mx.get_array_buffer_size(a)
+        self.assertGreaterEqual(a_size, a.nbytes)
+        self.assertLess(view.nbytes, a.nbytes)
+        self.assertEqual(mx.get_array_buffer_size(), 0)
+        self.assertEqual(mx.get_array_buffer_size(view), a_size)
+        self.assertEqual(
+            mx.get_array_buffer_size({"a": a, "nested": (a, None)}), a_size
+        )
+        self.assertEqual(mx.get_array_buffer_size(mx.array([])), 0)
+
+        b = mx.array([5.0, 6.0])
+        self.assertEqual(
+            mx.get_array_buffer_size(a, b),
+            a_size + mx.get_array_buffer_size(b),
+        )
+
     def test_memory_info(self):
         old_limit = mx.set_cache_limit(0)
 

--- a/tests/allocator_tests.cpp
+++ b/tests/allocator_tests.cpp
@@ -11,8 +11,10 @@
 #include "mlx/allocator.h"
 #include "mlx/device.h"
 #include "mlx/memory.h"
+#include "mlx/ops.h"
 #include "mlx/scheduler.h"
 #include "mlx/stream.h"
+#include "mlx/transforms.h"
 
 using namespace mlx::core;
 
@@ -64,6 +66,24 @@ TEST_CASE("test cached allocation keeps capacity") {
 
   clear_cache();
   set_cache_limit(old_limit);
+}
+
+TEST_CASE("test array buffer size") {
+  auto a = array({1.0f, 2.0f, 3.0f, 4.0f});
+  auto view = reshape(a, {2, 2});
+
+  CHECK_THROWS_AS(get_array_buffer_size({view}), std::invalid_argument);
+
+  eval(view);
+  auto a_size = a.buffer_size();
+  CHECK_EQ(get_array_buffer_size({}), 0);
+  CHECK_EQ(get_array_buffer_size({a}), a_size);
+  CHECK_EQ(get_array_buffer_size({a, a}), a_size);
+  CHECK_EQ(get_array_buffer_size({a, view}), a_size);
+
+  auto b = array({5.0f, 6.0f});
+  CHECK_EQ(get_array_buffer_size({a, b}), a_size + b.buffer_size());
+  CHECK_EQ(get_array_buffer_size({array({})}), 0);
 }
 
 TEST_CASE("test clear cache synchronizes cpu streams") {


### PR DESCRIPTION
Adds `get_array_memory` to report the allocator memory used by the unique buffers behind a list of evaluated arrays.

This is meant for measuring accurate in-memory model size in my app that may load several models: pass each model’s arrays and get the real buffer footprint.  This API is the missing per-model breakdown I need. 

- ☑️ I understand it is strictly prohibited to use AI to write PR description
- AI usage disclosure: 
