### PR TITLE
Fix 32 bit dispatch grid overflow in Metal reductions

### DIFF
--- a/mlx/backend/metal/kernels/reduction/reduce_col.h
+++ b/mlx/backend/metal/kernels/reduction/reduce_col.h
@@ -172,6 +172,7 @@ template <
     const constant int64_t* reduce_strides [[buffer(8)]],
     const constant int& reduce_ndim [[buffer(9)]],
     const constant size_t& non_col_reductions [[buffer(10)]],
+    const constant int64_t& column_offset [[buffer(11)]],
     uint3 gid [[threadgroup_position_in_grid]],
     uint3 gsize [[threadgroups_per_grid]],
     uint simd_lane_id [[thread_index_in_simdgroup]],
@@ -193,7 +194,7 @@ template <
 
   short lid = simd_group_id * simd_size + simd_lane_id;
   short2 offset((lid % n_read_blocks) * n_reads, lid / n_read_blocks);
-  IdxT column = BN * gid.x + offset.x;
+  IdxT column = IdxT(BN) * gid.x + IdxT(column_offset) + offset.x;
   bool safe = column + n_reads <= reduction_stride;
 
   IdxT out_idx = gid.y + gsize.y * IdxT(gid.z);
@@ -243,7 +244,7 @@ template <
 
     // Write the output.
     if (simd_lane_id == 0) {
-      IdxT out_column = BN * gid.x + out_offset.x;
+      IdxT out_column = IdxT(BN) * gid.x + IdxT(column_offset) + out_offset.x;
       out += out_idx * IdxT(reduction_stride) + out_column;
       if (out_column + n_outputs <= reduction_stride) {
         for (int i = 0; i < n_outputs; i++) {
@@ -311,7 +312,8 @@ template <
     const constant int64_t* reduce_strides [[buffer(8)]],
     const constant int& reduce_ndim [[buffer(9)]],
     const constant size_t& non_col_reductions [[buffer(10)]],
-    const constant size_t& out_size [[buffer(11)]],
+    const constant int64_t& column_offset [[buffer(11)]],
+    const constant size_t& out_size [[buffer(12)]],
     uint3 gid [[threadgroup_position_in_grid]],
     uint3 gsize [[threadgroups_per_grid]],
     uint simd_lane_id [[thread_index_in_simdgroup]],
@@ -336,7 +338,7 @@ template <
 
   short lid = simd_group_id * simd_size + simd_lane_id;
   short2 offset((lid % n_read_blocks) * n_reads, lid / n_read_blocks);
-  IdxT column = BN * gid.x + offset.x;
+  IdxT column = IdxT(BN) * gid.x + IdxT(column_offset) + offset.x;
   bool safe = column + n_reads <= reduction_stride;
 
   IdxT full_idx = gid.y + gsize.y * IdxT(gid.z);
@@ -383,7 +385,7 @@ template <
 
   // Write the output.
   if (simd_lane_id == 0) {
-    IdxT out_column = BN * gid.x + out_offset.x;
+    IdxT out_column = IdxT(BN) * gid.x + IdxT(column_offset) + out_offset.x;
     out += full_idx * IdxT(reduction_stride) + out_column;
     if (out_column + n_outputs <= reduction_stride) {
       for (int i = 0; i < n_outputs; i++) {

--- a/mlx/backend/metal/kernels/reduction/reduce_init.h
+++ b/mlx/backend/metal/kernels/reduction/reduce_init.h
@@ -3,6 +3,7 @@
 template <typename T, typename Op>
 [[kernel]] void init_reduce(
     device T* out [[buffer(0)]],
-    uint tid [[thread_position_in_grid]]) {
-  out[tid] = Op::init;
+    uint2 index [[thread_position_in_grid]],
+    uint2 grid_dim [[threads_per_grid]]) {
+  out[index.x + grid_dim.x * int64_t(index.y)] = Op::init;
 }

--- a/mlx/backend/metal/reduce.cpp
+++ b/mlx/backend/metal/reduce.cpp
@@ -242,6 +242,27 @@ inline auto output_grid_for_col_reduce(
   return get_2d_grid_dims(out_shape, out_strides);
 }
 
+// Metal silently truncates a grid dimension past UINT32_MAX threads, so a
+// column reduction too wide for one dispatch is split into several, each
+// covering the BN-wide column blocks starting at column_offset.
+inline void dispatch_col_reduce(
+    CommandEncoder& compute_encoder,
+    int64_t n_columns,
+    int BN,
+    int threadgroup_size,
+    size_t grid_y,
+    size_t grid_z) {
+  const int64_t n_blocks = (n_columns + BN - 1) / BN;
+  const int64_t max_blocks = UINT32_MAX / threadgroup_size;
+  const MTL::Size group_dims(threadgroup_size, 1, 1);
+  for (int64_t start = 0; start < n_blocks; start += max_blocks) {
+    const int64_t blocks = std::min(max_blocks, n_blocks - start);
+    compute_encoder.set_bytes(start * BN, 11);
+    compute_encoder.dispatch_threads(
+        MTL::Size(threadgroup_size * blocks, grid_y, grid_z), group_dims);
+  }
+}
+
 std::pair<Dtype, Dtype> remap_reduce_types(
     const array& in,
     const std::string& op_name) {
@@ -315,11 +336,10 @@ void init_reduce(
   std::string kname = func_name;
   concatenate(kname, "_", op_name, type_to_name(out_type));
   auto kernel = get_reduce_init_kernel(d, kname, func_name, op_name, out_type);
-  size_t nthreads = out.size();
-  MTL::Size grid_dims = MTL::Size(nthreads, 1, 1);
+  MTL::Size grid_dims = get_2d_grid_dims(out.shape(), out.strides());
   NS::UInteger thread_group_size = kernel->maxTotalThreadsPerThreadgroup();
-  if (thread_group_size > nthreads) {
-    thread_group_size = nthreads;
+  if (thread_group_size > grid_dims.width) {
+    thread_group_size = grid_dims.width;
   }
   MTL::Size group_dims = MTL::Size(thread_group_size, 1, 1);
   compute_encoder.set_compute_pipeline_state(kernel);
@@ -728,8 +748,7 @@ void strided_reduce_longcolumn(
   second_args.reduce_strides.push_back(out.size());
   second_args.reduce_ndim++;
   int BN = 32;
-  grid_dims = MTL::Size(256 * ((out.size() + BN - 1) / BN), 1, 1);
-  group_dims = MTL::Size(256, 1, 1);
+  int threadgroup_size = 256;
 
   // Set the 2nd kernel
   func_name = "col_reduce_looped";
@@ -755,7 +774,7 @@ void strided_reduce_longcolumn(
   compute_encoder.set_input_array(intermediate, 0);
   compute_encoder.set_output_array(out, 1);
   second_args.encode(compute_encoder);
-  compute_encoder.dispatch_threads(grid_dims, group_dims);
+  dispatch_col_reduce(compute_encoder, out.size(), BN, threadgroup_size, 1, 1);
 }
 
 void strided_reduce_looped(
@@ -778,11 +797,6 @@ void strided_reduce_looped(
   int BN = 32;
   int BM = 1024 / BN;
   int threadgroup_size = 8 * 32;
-  MTL::Size grid_dims(
-      threadgroup_size * ((args.reduction_stride + BN - 1) / BN),
-      out_grid_size.width,
-      out_grid_size.height);
-  MTL::Size group_dims(threadgroup_size, 1, 1);
 
   // Set the kernel
   int n = get_kernel_reduce_ndim(args.reduce_ndim);
@@ -820,7 +834,13 @@ void strided_reduce_looped(
   compute_encoder.set_input_array(in, 0);
   compute_encoder.set_output_array(out, 1);
   args.encode(compute_encoder);
-  compute_encoder.dispatch_threads(grid_dims, group_dims);
+  dispatch_col_reduce(
+      compute_encoder,
+      args.reduction_stride,
+      BN,
+      threadgroup_size,
+      out_grid_size.width,
+      out_grid_size.height);
 }
 
 void strided_reduce_2pass(
@@ -855,11 +875,6 @@ void strided_reduce_2pass(
   int BN = 32;
   int BM = 1024 / BN;
   int threadgroup_size = 8 * 32;
-  MTL::Size grid_dims(
-      threadgroup_size * ((args.reduction_stride + BN - 1) / BN),
-      out_grid_size.width * outer_blocks,
-      out_grid_size.height);
-  MTL::Size group_dims(threadgroup_size, 1, 1);
 
   // Set the kernel
   int n = get_kernel_reduce_ndim(args.reduce_ndim);
@@ -897,15 +912,20 @@ void strided_reduce_2pass(
   compute_encoder.set_input_array(in, 0);
   compute_encoder.set_output_array(intermediate, 1);
   args.encode(compute_encoder);
-  compute_encoder.set_bytes(out_size, 11);
-  compute_encoder.dispatch_threads(grid_dims, group_dims);
+  compute_encoder.set_bytes(out_size, 12);
+  dispatch_col_reduce(
+      compute_encoder,
+      args.reduction_stride,
+      BN,
+      threadgroup_size,
+      out_grid_size.width * outer_blocks,
+      out_grid_size.height);
 
   // Make the 2nd pass arguments and grid_dims
   ColReduceArgs second_args(intermediate);
   second_args.reduce_shape.push_back(outer_blocks);
   second_args.reduce_strides.push_back(out.size());
   second_args.reduce_ndim++;
-  grid_dims = MTL::Size(threadgroup_size * ((out.size() + BN - 1) / BN), 1, 1);
 
   // Set the 2nd kernel
   func_name = "col_reduce_looped";
@@ -931,7 +951,7 @@ void strided_reduce_2pass(
   compute_encoder.set_input_array(intermediate, 0);
   compute_encoder.set_output_array(out, 1);
   second_args.encode(compute_encoder);
-  compute_encoder.dispatch_threads(grid_dims, group_dims);
+  dispatch_col_reduce(compute_encoder, out.size(), BN, threadgroup_size, 1, 1);
 }
 
 void strided_reduce_general_dispatch(

--- a/python/tests/test_reduce.py
+++ b/python/tests/test_reduce.py
@@ -282,6 +282,18 @@ class TestReduce(mlx_tests.MLXTestCase):
                 getattr(np, op)(x_np, axis=1).tolist(),
             )
 
+    def test_col_reduce_large_stride(self):
+        x = mx.full((32, 2**29 + 17), 3, dtype=mx.int8)
+        out = mx.max(x, axis=0)
+        mx.eval(out)
+        self.assertEqual(mx.min(out).item(), 3)
+        self.assertEqual(mx.max(out).item(), 3)
+
+    def test_init_reduce_large_output(self):
+        out = mx.all(mx.zeros((0, 4, 2**30), dtype=mx.bool_), axis=0)
+        mx.eval(out)
+        self.assertTrue(mx.all(out).item())
+
 
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner(failfast=True)


### PR DESCRIPTION
- ☑️ I understand it is strictly prohibited to use AI to write PR description

Fixes #3784

### Problem

Metal truncates each compute dispatch grid dimension to 32 bits without raising, so an oversized dispatch is silently dropped and the output keeps whatever was left in the buffer. `reduce.cpp` passes the y and z grid dimensions through `get_2d_grid_dims`, which caps them, but builds the x dimension by raw multiplication. Two paths can exceed the limit:

- `strided_reduce_looped` dispatches `8 * reduction_stride` threads, which overflows once the reduction stride reaches 2^29.
- `init_reduce` dispatches one thread per output element and indexes with a 32 bit thread id, so a zero-size input whose output has 2^32 or more elements is left uninitialized.

```python
import mlx.core as mx
x = mx.ones((1, 32, 4096, 131072), dtype=mx.float32)
print(mx.sum(x, axis=1).min().item())   # stale buffer contents, expected 32.0
```

The Metal validation layer:

```
-[MTLDebugComputeCommandEncoder dispatchThreads:threadsPerThreadgroup:]:1484:
failed assertion `threadsPerGrid.width(4294967296) must be <= UINT32_MAX.'
```

### Fix

Column reductions are issued as however many dispatches are needed, each covering the `BN`-wide column blocks starting at a new `column_offset` kernel argument. `init_reduce` uses a 2D grid with a 64 bit flat index. The in-kernel column arithmetic is widened so it no longer evaluates in 32 bits before the assignment widens it.

For every shape that works in main, the loop runs once at offset zero.

### Validation

Built both this branch and main, compared them on M3 Max.

Correctness: the fix produces bitwise identical output with main. The reported shape now returns 32.0 correctly.

Performance: no observable regression.

### Tests

Both added tests fail on the main and pass on this branch.