### PR TITLE
Fix compile_dfs multi-output trace leaks

### DIFF
--- a/mlx/compile.cpp
+++ b/mlx/compile.cpp
@@ -553,8 +553,6 @@ std::pair<std::vector<array>, ParentsMap> compile_dfs(
       }
     }
   }
-  tape = std::move(new_tape);
-
   std::unordered_map<std::uintptr_t, std::vector<std::pair<array, int>>>
       new_parents_map;
   for (auto& [id, vec] : parents_map) {
@@ -564,6 +562,12 @@ std::pair<std::vector<array>, ParentsMap> compile_dfs(
     new_parents_map[old_to_new.find(id)->second.id()] = std::move(vec);
   }
   parents_map = std::move(new_parents_map);
+
+  // Release temporary parent references to the old tape before destroying it.
+  // This lets the existing array destructor break otherwise-unreachable
+  // multi-output sibling cycles. Externally owned arrays retain their extra
+  // references and are left intact.
+  tape = std::move(new_tape);
   return {tape, parents_map};
 }
 

--- a/tests/compile_tests.cpp
+++ b/tests/compile_tests.cpp
@@ -7,6 +7,7 @@
 
 #include <cmath>
 #include <limits>
+#include <memory>
 
 #include "mlx/mlx.h"
 #include "mlx/primitives.h"
@@ -874,4 +875,38 @@ TEST_CASE("test compile throwing first trace does not poison cache") {
   auto out = cfun({});
   REQUIRE_EQ(out.size(), 1);
   CHECK_EQ(out[0].item<float>(), 3.0f);
+}
+
+TEST_CASE("test compile releases replaced multi-output trace nodes") {
+  std::weak_ptr<array::Data> tracker;
+  {
+    auto weight = array({1.0f, 2.0f, 3.0f, 4.0f});
+    eval(weight);
+    tracker = weight.data_shared_ptr();
+
+    auto fun = [weight](const std::vector<array>& inputs) {
+      auto hidden = multiply(inputs[0], weight);
+      auto parts = split(hidden, 2);
+      return std::vector<array>{concatenate({parts[1], parts[0]})};
+    };
+
+    auto out = compile(fun)({array({1.0f, 1.0f, 1.0f, 1.0f})})[0];
+    eval(out);
+    CHECK(array_equal(out, array({3.0f, 4.0f, 1.0f, 2.0f})).item<bool>());
+  }
+  CHECK(tracker.expired());
+}
+
+TEST_CASE("test compile preserves externally owned multi-output graphs") {
+  auto parts = split(array({1.0f, 2.0f, 3.0f, 4.0f}), 2);
+  auto fun = [parts](const std::vector<array>& inputs) {
+    return std::vector<array>{add(add(inputs[0], parts[0]), parts[1])};
+  };
+
+  auto out = compile(fun)({array({10.0f, 20.0f})})[0];
+  eval(out);
+  CHECK(array_equal(out, array({14.0f, 26.0f})).item<bool>());
+
+  eval(parts[0]);
+  CHECK(array_equal(parts[0], array({1.0f, 2.0f})).item<bool>());
 }

--- a/tests/export_import_tests.cpp
+++ b/tests/export_import_tests.cpp
@@ -1,6 +1,7 @@
 // Copyright © 2024 Apple Inc.
 
 #include <filesystem>
+#include <memory>
 #include <stdexcept>
 #include <vector>
 
@@ -75,6 +76,25 @@ TEST_CASE("test export multi output primitives") {
   auto out = imported_fun(inputs);
   CHECK(allclose(expected[0], out[0]).item<bool>());
   CHECK(allclose(expected[1], out[1]).item<bool>());
+}
+
+TEST_CASE("test export releases replaced multi-output trace nodes") {
+  std::weak_ptr<array::Data> tracker;
+  {
+    auto weight = array({1.0f, 2.0f, 3.0f, 4.0f});
+    eval(weight);
+    tracker = weight.data_shared_ptr();
+
+    auto fun = [weight](const std::vector<array>& inputs) {
+      auto hidden = multiply(inputs[0], weight);
+      auto parts = split(hidden, 2);
+      return std::vector<array>{concatenate({parts[1], parts[0]})};
+    };
+    auto callback = [](const ExportCallbackInput&) {};
+
+    export_function(callback, fun, {array({1.0f, 1.0f, 1.0f, 1.0f})});
+  }
+  CHECK(tracker.expired());
 }
 
 TEST_CASE("test export primitives with state") {


### PR DESCRIPTION
Remap temporary parent references before replacing the old tape so the existing sibling-cycle breaker can reclaim unreachable trace nodes without mutating externally owned graphs.

Add compile and export leak regressions plus an externally owned capture control.

- ☑️ I understand it is strictly prohibited to use AI to write PR description
- AI usage disclosure: 
