### PR TITLE
python: Make unstack return tuple instead of list

### DIFF
--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -213,14 +213,14 @@ void init_ops(nb::module_& m) {
   m.def(
       "unstack",
       [](const mx::array& a, int axis, mx::StreamOrDevice s) {
-        return mx::unstack(a, axis, s);
+        return nb::tuple(nb::cast(mx::unstack(a, axis, s)));
       },
       nb::arg(),
       nb::kw_only(),
       "axis"_a = 0,
       "stream"_a = nb::none(),
       nb::sig(
-          "def unstack(x: array, /, *, axis: int = 0, stream: StreamOrDevice = None) -> list[array]"),
+          "def unstack(x: array, /, *, axis: int = 0, stream: StreamOrDevice = None) -> tuple[array, ...]"),
       R"pbdoc(
         Split an array into a sequence of arrays along the given axis.
 
@@ -232,7 +232,7 @@ void init_ops(nb::module_& m) {
             axis (int, optional): Axis along which to unstack. Default: ``0``.
 
         Returns:
-            list(array): A list of arrays, one for each index along ``axis``.
+            tuple(array): A tuple of arrays, one for each index along ``axis``.
       )pbdoc");
   m.def(
       "expand_dims",

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -1674,6 +1674,11 @@ class TestOps(mlx_tests.MLXTestCase):
     def test_unstack(self):
         a_np = np.arange(6).reshape(3, 2)
         a = mx.array(a_np)
+
+        self.assertIsInstance(mx.unstack(a), tuple)
+        self.assertIsInstance(mx.unstack(a, axis=1), tuple)
+        self.assertEqual(mx.unstack(mx.zeros((0, 2)), axis=0), ())
+
         for axis in [0, 1, -1]:
             parts = mx.unstack(a, axis=axis)
             expected = np.unstack(a_np, axis=axis)


### PR DESCRIPTION
- ☑️ I understand it is strictly prohibited to use AI to write PR description

fix #4429 


- AI usage disclosure: 
generate the test 
```py
        self.assertIsInstance(mx.unstack(a), tuple)
        self.assertIsInstance(mx.unstack(a, axis=1), tuple)
        self.assertEqual(mx.unstack(mx.zeros((0, 2)), axis=0), ())
```