### PR TITLE
python: fix bytes() on non-contiguous arrays

### DIFF
--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -1046,9 +1046,10 @@ void init_array(nb::module_& m) {
       .def(
           "__bytes__",
           [](mx::array& a) {
-            a.eval();
+            auto c = mx::contiguous(a);
+            c.eval();
             return nb::bytes(
-                reinterpret_cast<const char*>(a.data<void>()), a.nbytes());
+                reinterpret_cast<const char*>(c.data<void>()), c.nbytes());
           })
       .def(
           "__format__",

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -2042,6 +2042,15 @@ class TestArray(mlx_tests.MLXTestCase):
             self.assertEqual(b"aaaaaaaaaa", ab[::2])
             self.assertEqual(b"abcdefghij", ab[1::2])
 
+        # Test bytes on non-contiguous arrays
+        a = mx.arange(10, dtype=mx.uint8)
+        self.assertEqual(bytes(a[::2]), b"\x00\x02\x04\x06\x08")
+        self.assertEqual(bytes(a[::-1]), b"\x09\x08\x07\x06\x05\x04\x03\x02\x01\x00")
+        b = mx.arange(6, dtype=mx.int32).reshape(2, 3).T
+        self.assertEqual(bytes(b), np.array(b).tobytes())
+        c = mx.broadcast_to(mx.array([1, 2], dtype=mx.uint8), (3, 2))
+        self.assertEqual(bytes(c), np.array(c).tobytes())
+
     def test_buffer_protocol_ref_counting(self):
         a = mx.arange(3)
         wr = weakref.ref(a)


### PR DESCRIPTION
`__bytes__` reads the raw buffer pointer, which for a strided view (slice, transpose, broadcast) points into the parent array, so `bytes(x[::2])` dumps neighboring memory instead of the view's values.

Make the array row-contiguous before reading, which is a no-op copy for already-packed arrays. Fixes #4445.