### PR TITLE
Lower power(x, 2) to square() for a scalar exponent of exactly 2

### DIFF
--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -4132,6 +4132,69 @@ array softmax(
 }
 
 array power(const array& a, const array& b, StreamOrDevice s /* = {} */) {
+  // Exponent 2 lowers to square(): the general Power kernel computes
+  // exp(b * log(a)), which loses up to ~1 ULP over a plain multiply
+  // (see #4162). mx.square is bit-identical to x * x, so for a scalar
+  // exponent of exactly 2 we route through square() — on CPU, Metal and
+  // CUDA alike. Only taken when the scalar is already available (i.e. it
+  // can be read without scheduling work); otherwise the graph stays lazy.
+  // The scalar is read with the C++ type that matches its storage —
+  // item<T>() reinterprets the buffer, so reading it with the wrong type
+  // would be OOB for narrower dtypes.
+  // Scope note: this only fires for 0-dim scalars. A size-1 array with
+  // ndim > 0 still goes through the general power kernel.
+  if (b.ndim() == 0 && b.size() == 1 && b.is_available() &&
+      (issubdtype(b.dtype(), integer) || issubdtype(b.dtype(), floating) ||
+       issubdtype(b.dtype(), complexfloating))) {
+    bool is_two = false;
+    switch (b.dtype().val()) {
+      case Dtype::Val::uint8:
+        is_two = b.item<uint8_t>() == 2;
+        break;
+      case Dtype::Val::uint16:
+        is_two = b.item<uint16_t>() == 2;
+        break;
+      case Dtype::Val::uint32:
+        is_two = b.item<uint32_t>() == 2;
+        break;
+      case Dtype::Val::uint64:
+        is_two = b.item<uint64_t>() == 2;
+        break;
+      case Dtype::Val::int8:
+        is_two = b.item<int8_t>() == 2;
+        break;
+      case Dtype::Val::int16:
+        is_two = b.item<int16_t>() == 2;
+        break;
+      case Dtype::Val::int32:
+        is_two = b.item<int32_t>() == 2;
+        break;
+      case Dtype::Val::int64:
+        is_two = b.item<int64_t>() == 2;
+        break;
+      case Dtype::Val::float16:
+        is_two = b.item<float16_t>() == float16_t(2.0f);
+        break;
+      case Dtype::Val::bfloat16:
+        is_two = b.item<bfloat16_t>() == bfloat16_t(2.0f);
+        break;
+      case Dtype::Val::float32:
+        is_two = b.item<float>() == 2.0f;
+        break;
+      case Dtype::Val::float64:
+        is_two = b.item<double>() == 2.0;
+        break;
+      case Dtype::Val::complex64:
+        is_two = b.item<complex64_t>() == complex64_t(2, 0);
+        break;
+      default:
+        break;
+    }
+    if (is_two) {
+      auto dtype = promote_types(a.dtype(), b.dtype());
+      return square(astype(a, dtype, s), s);
+    }
+  }
   auto dtype = promote_types(a.dtype(), b.dtype());
   std::vector<array> inputs = {astype(a, dtype, s), astype(b, dtype, s)};
   if (a.shape() != b.shape()) {

--- a/python/tests/test_ops.py
+++ b/python/tests/test_ops.py
@@ -1148,6 +1148,84 @@ class TestOps(mlx_tests.MLXTestCase):
 
         self.assertTrue(np.allclose(result, expected))
 
+    def test_power_two_matches_square(self):
+        # `x ** 2` must be bit-identical to `x * x` / `mx.square`: the
+        # general power kernel computes exp(b * log(a)) and loses up to
+        # ~1 ULP over a multiply (see #4162). Contiguous inputs exercise
+        # the SIMD path, strided ones the scalar fallback.
+        rng = np.random.default_rng(42)
+        xs = rng.uniform(-3, 3, 4096)
+        for dtype in (mx.float32, mx.float64):
+            a = mx.array(xs, dtype=dtype)
+            sq, mul, pw = mx.square(a), a * a, a**2
+            mx.eval(sq, mul, pw)
+            self.assertTrue(
+                np.array_equal(np.asarray(pw), np.asarray(mul)),
+                f"power(x, 2) != x*x for {dtype}",
+            )
+            # contiguous vs strided must agree with each other too
+            strided = pw[::2]
+            self.assertTrue(
+                np.array_equal(
+                    np.asarray(strided), np.asarray(mx.square(a[::2]))
+                ),
+                f"power(x, 2) SIMD/scalar mismatch for {dtype}",
+            )
+
+        # The shortcut preserves power's output dtype rule:
+        # promote_types(a, b). Integer base with integer exponent stays
+        # integer and stays exact, including values beyond float32.
+        for dtype in (
+            mx.int8,
+            mx.int16,
+            mx.int32,
+            mx.int64,
+            mx.uint8,
+            mx.uint16,
+            mx.uint32,
+            mx.uint64,
+            mx.float16,
+            mx.bfloat16,
+            mx.float32,
+            mx.float64,
+        ):
+            a = mx.array([3, 7], dtype=dtype)
+            out = a**2
+            self.assertEqual(out.dtype, mx.square(a).dtype, f"{dtype}")
+            self.assertEqual(
+                out.tolist(), [9, 49], f"value mismatch for {dtype}"
+            )
+        big = mx.array([3_000_000_007], dtype=mx.int64)
+        self.assertEqual((big**2).dtype, mx.int64)
+        self.assertEqual((big**2).item(), 9000000042000000049)
+
+        # complex keeps its dtype and its value
+        c = mx.array(np.array([1 + 2j], dtype=np.complex64))
+        self.assertEqual((c**2).dtype, mx.complex64)
+        self.assertEqual((c**2).item(), -3 + 4j)
+
+        # gradient of power(x, 2) matches the square gradient, 2 * x
+        xg = mx.array([1.5, -2.0, 0.5])
+        g_pw = mx.grad(lambda x: mx.sum(mx.power(x, 2)))(xg)
+        g_sq = mx.grad(lambda x: mx.sum(mx.square(x)))(xg)
+        self.assertTrue(np.array_equal(np.asarray(g_pw), np.asarray(g_sq)))
+
+        # exponent gradient equals x^b * ln(x): bases 2 and 3, one 0-dim
+        # exponent of 2 (the only shape the shortcut guards on)
+        x = mx.array([2.0, 3.0])
+        g_b = mx.grad(lambda b: mx.sum(mx.power(x, b)))(mx.array(2.0))
+        self.assertTrue(
+            np.allclose(
+                np.asarray(g_b),
+                4.0 * np.log(2.0) + 9.0 * np.log(3.0),
+                rtol=1e-5,
+            )
+        )
+
+        # mx.compile agrees with eager
+        comp = mx.compile(lambda x: x**2)
+        self.assertTrue(np.array_equal(np.asarray(comp(xg)), np.asarray(xg**2)))
+
     def test_sqrt(self):
         a = mx.array([0.1, 0.5, 1.0, 10.0])
         result = mx.sqrt(a)


### PR DESCRIPTION
Title: Lower power(x, 2) to square() for a scalar exponent of exactly 2

Fixes #4162.

`x ** 2` went through the general Power kernel, which computes exp(b * log(a)) and
loses up to ~1 ULP over a multiply; on CPU the contiguous (SIMD) and strided (scalar)
paths also disagreed with each other. As suggested in the issue thread, `power()` now
lowers a 0-dim exponent of exactly 2 to `square()`, so CPU, Metal and CUDA get the
same one-line fix and `x ** 2` becomes bit-identical to `x * x`.

Semantics preserved:
- output dtype follows the existing promote_types(a, b) rule, so integer bases with an
  integer exponent stay integer and exact (int64 included);
- the exponent is read with the C++ type matching its storage (item<T>() reinterprets
  the buffer, so a fixed-type read would be out of bounds for narrower dtypes);
- the shortcut only fires when the exponent is already available, so under function
  transforms a traced exponent still takes the general kernel and d/db x**b = x**b ln x
  is unchanged;
- only 0-dim exponents are lowered; a size-1 array with ndim > 0 still uses the general
  kernel (documented in the code).

Tests (test_power_two_matches_square): f32/f64 contiguous and strided bit-equality with
x*x; dtype/value table over 12 dtypes including an int64 value beyond float32; complex;
gradient wrt the base (bit-equal to 2x) and wrt a 0-dim exponent (x^b ln x);
mx.compile agrees with eager.

Local validation: python/tests/test_ops.py 163 passed; autograd/array/bf16/blas/conv/fft/
reduce suites green. test_linalg.py was not run locally: this machine's OpenBLAS 0.3.33
(nixpkgs) segfaults inside LAPACK's Cholesky on a clean master checkout as well, which is
unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GUaS6bXQ7Tmwd3fSP5smHi
