### PR TITLE
Add D512 support to Metal vector attention

### DIFF
--- a/mlx/backend/metal/kernels/scaled_dot_product_attention.metal
+++ b/mlx/backend/metal/kernels/scaled_dot_product_attention.metal
@@ -45,6 +45,7 @@ using namespace metal;
   instantiate_sdpa_vector(type, 192, 128)        \
   instantiate_sdpa_vector(type, 192, 192)        \
   instantiate_sdpa_vector(type, 256, 256)        \
+  instantiate_sdpa_vector(type, 512, 512)        \
   instantiate_sdpa_vector_gqa(type, 64, 64, 8, 8)     \
   instantiate_sdpa_vector_gqa(type, 128, 128, 8, 4)   \
   instantiate_sdpa_vector_gqa(type, 128, 128, 12, 4)  \
@@ -53,7 +54,8 @@ using namespace metal;
   instantiate_sdpa_vector_aggregation(type, 96)  \
   instantiate_sdpa_vector_aggregation(type, 128) \
   instantiate_sdpa_vector_aggregation(type, 192) \
-  instantiate_sdpa_vector_aggregation(type, 256)
+  instantiate_sdpa_vector_aggregation(type, 256) \
+  instantiate_sdpa_vector_aggregation(type, 512)
 
 instantiate_sdpa_vector_heads(float)
 instantiate_sdpa_vector_heads(bfloat16_t)

--- a/mlx/backend/metal/scaled_dot_product_attention.cpp
+++ b/mlx/backend/metal/scaled_dot_product_attention.cpp
@@ -780,6 +780,22 @@ std::tuple<bool, std::string> has_fused_kernel(
           << query_sequence_length << " and GQA factor " << gqa_factor << ".";
       return {false, msg.str()};
     }
+    // Head dim 512 sits on the generic (non-GQA) vector kernel, whose cost
+    // is dominated by reading K/V. Its measured win over the unfused path
+    // grows with the key length and is only a few percent at short ones,
+    // so admit it from a minimum key length and keep the existing path
+    // below that. The threshold is read per call so callers and tests can
+    // observe both routings in one process.
+    if (query_head_dim == 512) {
+      const int min_key_sequence_length =
+          env::get_var("MLX_SDPA_D512_MIN_KL", 1024);
+      if (key_sequence_length < min_key_sequence_length) {
+        msg << "the vector attention kernel for head dim 512 requires at "
+            << "least " << min_key_sequence_length << " keys; got key length "
+            << key_sequence_length << ".";
+        return {false, msg.str()};
+      }
+    }
   }
   return {true, ""};
 }

--- a/mlx/backend/metal/scaled_dot_product_attention.cpp
+++ b/mlx/backend/metal/scaled_dot_product_attention.cpp
@@ -780,28 +780,25 @@ std::tuple<bool, std::string> has_fused_kernel(
           << query_sequence_length << " and GQA factor " << gqa_factor << ".";
       return {false, msg.str()};
     }
-    // Head dim 512 sits on the generic vector kernel, whose cost is dominated
-    // by reading K/V. Default admission is limited to the measured decode
-    // surface: a single query, GQA factor 8, and no array mask.
-    // The threshold is read per call; setting it to zero deliberately expands
-    // admission for benchmarking and correctness coverage.
+    // Head dim 512 uses the generic vector kernel, reading K/V is its main
+    // cost. By default, use it only for one query, GQA factor 8, and no array
+    // mask.
     if (query_head_dim == 512) {
-      const int min_key_sequence_length =
-          env::get_var("MLX_SDPA_D512_MIN_KL", 1024);
-      const bool expand_admission = min_key_sequence_length == 0;
-      if (!expand_admission && query_sequence_length != 1) {
+      int min_key_sequence_length = env::get_var("MLX_SDPA_D512_MIN_KL", 1024);
+      bool always = (min_key_sequence_length == 0);
+      if (!always && query_sequence_length != 1) {
         msg << "the vector attention kernel for head dim 512 defaults to "
                "single-token queries; got query length "
             << query_sequence_length << ".";
         return {false, msg.str()};
       }
-      if (!expand_admission && gqa_factor != 8) {
+      if (!always && gqa_factor != 8) {
         msg << "the vector attention kernel for head dim 512 defaults to "
                "GQA factor 8; got GQA factor "
             << gqa_factor << ".";
         return {false, msg.str()};
       }
-      if (!expand_admission && has_arr_mask) {
+      if (!always && has_arr_mask) {
         msg << "the vector attention kernel for head dim 512 defaults to "
                "calls without array masks.";
         return {false, msg.str()};

--- a/mlx/backend/metal/scaled_dot_product_attention.cpp
+++ b/mlx/backend/metal/scaled_dot_product_attention.cpp
@@ -757,13 +757,13 @@ std::tuple<bool, std::string> has_fused_kernel(
         (query_head_dim == value_head_dim &&
          (query_head_dim == 64 || query_head_dim == 96 ||
           query_head_dim == 128 || query_head_dim == 192 ||
-          query_head_dim == 256)) ||
+          query_head_dim == 256 || query_head_dim == 512)) ||
         (query_head_dim == 192 && value_head_dim == 128);
     if (!supported_head_dim) {
       msg << "the vector attention kernel supports head dims "
-          << "{64, 96, 128, 192, 256} with matching query/value head dims, "
-          << "or query head dim 192 with value head dim 128; got query head "
-          << "dim " << query_head_dim << " and value head dim "
+          << "{64, 96, 128, 192, 256, 512} with matching query/value head "
+          << "dims, or query head dim 192 with value head dim 128; got "
+          << "query head dim " << query_head_dim << " and value head dim "
           << value_head_dim << ".";
       return {false, msg.str()};
     }

--- a/mlx/backend/metal/scaled_dot_product_attention.cpp
+++ b/mlx/backend/metal/scaled_dot_product_attention.cpp
@@ -780,15 +780,32 @@ std::tuple<bool, std::string> has_fused_kernel(
           << query_sequence_length << " and GQA factor " << gqa_factor << ".";
       return {false, msg.str()};
     }
-    // Head dim 512 sits on the generic (non-GQA) vector kernel, whose cost
-    // is dominated by reading K/V. Its measured win over the unfused path
-    // grows with the key length and is only a few percent at short ones,
-    // so admit it from a minimum key length and keep the existing path
-    // below that. The threshold is read per call so callers and tests can
-    // observe both routings in one process.
+    // Head dim 512 sits on the generic vector kernel, whose cost is dominated
+    // by reading K/V. Default admission is limited to the measured decode
+    // surface: a single query, GQA factor 8, and no array mask.
+    // The threshold is read per call; setting it to zero deliberately expands
+    // admission for benchmarking and correctness coverage.
     if (query_head_dim == 512) {
       const int min_key_sequence_length =
           env::get_var("MLX_SDPA_D512_MIN_KL", 1024);
+      const bool expand_admission = min_key_sequence_length == 0;
+      if (!expand_admission && query_sequence_length != 1) {
+        msg << "the vector attention kernel for head dim 512 defaults to "
+               "single-token queries; got query length "
+            << query_sequence_length << ".";
+        return {false, msg.str()};
+      }
+      if (!expand_admission && gqa_factor != 8) {
+        msg << "the vector attention kernel for head dim 512 defaults to "
+               "GQA factor 8; got GQA factor "
+            << gqa_factor << ".";
+        return {false, msg.str()};
+      }
+      if (!expand_admission && has_arr_mask) {
+        msg << "the vector attention kernel for head dim 512 defaults to "
+               "calls without array masks.";
+        return {false, msg.str()};
+      }
       if (key_sequence_length < min_key_sequence_length) {
         msg << "the vector attention kernel for head dim 512 requires at "
             << "least " << min_key_sequence_length << " keys; got key length "

--- a/python/tests/test_fast_sdpa.py
+++ b/python/tests/test_fast_sdpa.py
@@ -435,32 +435,22 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
         environment = patch.dict(os.environ)
         environment.start()
         self.addCleanup(environment.stop)
-        os.environ.pop("MLX_SDPA_D512_MIN_KL", None)
+        os.environ["MLX_SDPA_D512_MIN_KL"] = "0"
 
-        # Below the admission threshold the generic vector kernel stays on
-        # the unfused path, and force_fused says so. The threshold is read
-        # per call from MLX_SDPA_D512_MIN_KL (default 1024).
-        q = mx.random.normal(shape=(1, Nq, 1, D), dtype=mx.float16)
-        k = mx.random.normal(shape=(1, Nkv, 128, D), dtype=mx.float16)
-        v = mx.random.normal(shape=(1, Nkv, 128, D), dtype=mx.float16)
-        with self.assertRaisesRegex(ValueError, r"requires at least \d+ keys"):
-            mx.fast.scaled_dot_product_attention(q, k, v, scale=scale, force_fused=True)
+        # Test 1-pass kernel.
+        for dtype in (mx.float32, mx.float16, mx.bfloat16):
+            with self.subTest(L=128, dtype=dtype, threshold="off"):
+                q = mx.random.normal(shape=(1, Nq, 1, D), dtype=dtype)
+                k = mx.random.normal(shape=(1, Nkv, 128, D), dtype=dtype)
+                v = mx.random.normal(shape=(1, Nkv, 128, D), dtype=dtype)
+                ref = mlx_ref_attn(q, k, v, scale)
+                out = mx.fast.scaled_dot_product_attention(
+                    q, k, v, scale=scale, force_fused=True
+                )
+                atol = 1e-5 if dtype == mx.float32 else 2e-2
+                self.assertTrue(mx.allclose(ref, out, atol=atol))
 
-        # L = 128 admitted via the threshold override takes the 1-pass
-        # kernel; 8192 and 8201 take the 2-pass one at the default
-        # threshold.
-        with patch.dict(os.environ, {"MLX_SDPA_D512_MIN_KL": "0"}):
-            for dtype in (mx.float32, mx.float16, mx.bfloat16):
-                with self.subTest(L=128, dtype=dtype, threshold="off"):
-                    q = mx.random.normal(shape=(1, Nq, 1, D), dtype=dtype)
-                    k = mx.random.normal(shape=(1, Nkv, 128, D), dtype=dtype)
-                    v = mx.random.normal(shape=(1, Nkv, 128, D), dtype=dtype)
-                    ref = mlx_ref_attn(q, k, v, scale)
-                    out = mx.fast.scaled_dot_product_attention(
-                        q, k, v, scale=scale, force_fused=True
-                    )
-                    atol = 1e-5 if dtype == mx.float32 else 2e-2
-                    self.assertTrue(mx.allclose(ref, out, atol=atol))
+        # Test 2-pass kernel.
         for L, dtype in product((8192, 8201), (mx.float32, mx.float16, mx.bfloat16)):
             with self.subTest(L=L, dtype=dtype):
                 q = mx.random.normal(shape=(1, Nq, 1, D), dtype=dtype)
@@ -473,83 +463,23 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
                 atol = 1e-5 if dtype == mx.float32 else 2e-2
                 self.assertTrue(mx.allclose(ref, out, atol=atol))
 
-        # By default D=512 admits the measured single-token GQA surface, not
-        # MHA, multi-token queries, or array masks. The zero threshold is an
-        # explicit expansion used to retain correctness coverage for those
-        # otherwise supported vector-kernel shapes.
-        L = 1024
-        k = mx.random.normal(shape=(1, Nkv, L, D))
-        v = mx.random.normal(shape=(1, Nkv, L, D))
-
-        q = mx.random.normal(shape=(1, Nq, 4, D))
-        with self.assertRaisesRegex(ValueError, r"single-token queries"):
-            mx.fast.scaled_dot_product_attention(q, k, v, scale=scale, force_fused=True)
-
-        q = mx.random.normal(shape=(1, Nq, 1, D))
-        array_mask = mx.array([True] * (L - 10) + [False] * 10)
-        with self.assertRaisesRegex(ValueError, r"without array masks"):
-            mx.fast.scaled_dot_product_attention(
-                q, k, v, scale=scale, mask=array_mask, force_fused=True
-            )
-
+        # Test other heads.
         for q_heads, kv_heads in ((8, 8), (32, 8)):
             with self.subTest(q_heads=q_heads, kv_heads=kv_heads):
-                other_q = mx.random.normal(shape=(1, q_heads, 1, D))
-                other_k = mx.random.normal(shape=(1, kv_heads, L, D))
-                other_v = mx.random.normal(shape=(1, kv_heads, L, D))
-                with self.assertRaisesRegex(ValueError, r"GQA factor 8"):
-                    mx.fast.scaled_dot_product_attention(
-                        other_q,
-                        other_k,
-                        other_v,
-                        scale=scale,
-                        force_fused=True,
-                    )
-                with patch.dict(os.environ, {"MLX_SDPA_D512_MIN_KL": "0"}):
-                    ref = mlx_ref_attn(other_q, other_k, other_v, scale)
-                    out = mx.fast.scaled_dot_product_attention(
-                        other_q,
-                        other_k,
-                        other_v,
-                        scale=scale,
-                        force_fused=True,
-                    )
-                    self.assertTrue(mx.allclose(ref, out, atol=1e-4, rtol=1e-4))
+                q = mx.random.normal(shape=(1, q_heads, 1, D))
+                k = mx.random.normal(shape=(1, kv_heads, L, D))
+                v = mx.random.normal(shape=(1, kv_heads, L, D))
+                ref = mlx_ref_attn(q, k, v, scale)
+                out = mx.fast.scaled_dot_product_attention(
+                    q,
+                    k,
+                    v,
+                    scale=scale,
+                    force_fused=True,
+                )
+                self.assertTrue(mx.allclose(ref, out, atol=1e-4, rtol=1e-4))
 
-        for qL in (1, 4):
-            q = mx.random.normal(shape=(1, Nq, qL, D))
-            masks = [
-                None,
-                mx.array(True),
-                mx.array([True] * (L - 10) + [False] * 10),
-                mx.random.uniform(shape=(Nq, qL, L)) > 0.2,
-                mx.random.uniform(shape=(L, qL, Nq)).T > 0.2,
-                mx.random.uniform(shape=(Nq, qL, L)),
-                mx.random.uniform(shape=(L, qL, Nq)).T,
-                "causal",
-            ]
-            # The reference does the multi-query scores as a GEMM, which is
-            # the less accurate arm at qL > 1, so use the same tolerance as
-            # the other multi-query tests.
-            tol = 1e-4 if qL == 1 else 1e-3
-            for i, m in enumerate(masks):
-                with self.subTest(qL=qL, mask=i):
-                    needs_override = qL > 1 or i not in (0, 7)
-                    threshold = (
-                        patch.dict(os.environ, {"MLX_SDPA_D512_MIN_KL": "0"})
-                        if needs_override
-                        else nullcontext()
-                    )
-                    with threshold:
-                        ref = mlx_ref_attn(q, k, v, scale, mask=m)
-                        out = mx.fast.scaled_dot_product_attention(
-                            q, k, v, scale=scale, mask=m, force_fused=True
-                        )
-                        self.assertTrue(mx.allclose(ref, out, atol=tol, rtol=tol))
-
-        # Batched, with and without attention sinks, over both kernels.
-        # L = 256 is below the admission threshold, so the fused-1-pass leg
-        # runs with the threshold override; L = 8192 fuses by default.
+        # Test batched.
         B = 2
         sinks = 10 * mx.random.normal(shape=(Nq,))
         q = mx.random.normal(shape=(B, Nq, 1, D))
@@ -558,22 +488,16 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
             v = mx.random.normal(shape=(B, Nkv, L, D))
             for s_in in (None, sinks):
                 with self.subTest(L=L, sinks=s_in is not None):
-                    threshold = (
-                        patch.dict(os.environ, {"MLX_SDPA_D512_MIN_KL": "0"})
-                        if L == 256
-                        else nullcontext()
+                    ref = mlx_ref_attn(q, k, v, scale, sinks=s_in)
+                    out = mx.fast.scaled_dot_product_attention(
+                        q,
+                        k,
+                        v,
+                        scale=scale,
+                        sinks=s_in,
+                        force_fused=True,
                     )
-                    with threshold:
-                        ref = mlx_ref_attn(q, k, v, scale, sinks=s_in)
-                        out = mx.fast.scaled_dot_product_attention(
-                            q,
-                            k,
-                            v,
-                            scale=scale,
-                            sinks=s_in,
-                            force_fused=True,
-                        )
-                        self.assertTrue(mx.allclose(ref, out, atol=1e-4, rtol=1e-4))
+                    self.assertTrue(mx.allclose(ref, out, atol=1e-4, rtol=1e-4))
 
     def test_sdpa_fully_masked(self):
         Lkv = 8
@@ -1091,9 +1015,9 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
             mx.fast.scaled_dot_product_attention(
                 q, k, v, scale=64**-0.5, force_fused=True
             )
-        with patch.dict(os.environ):
-            os.environ.pop("MLX_SDPA_D512_MIN_KL", None)
-            with self.assertRaisesRegex(ValueError, r"requires at least \d+ keys"):
+        with self.assertRaisesRegex(ValueError, r"requires at least \d+ keys"):
+            with patch.dict(os.environ):
+                os.environ.pop("MLX_SDPA_D512_MIN_KL", None)
                 q, k, v = make_qkv(1, 512, 512, qH=32, kH=4)
                 mx.fast.scaled_dot_product_attention(
                     q, k, v, scale=512**-0.5, force_fused=True

--- a/python/tests/test_fast_sdpa.py
+++ b/python/tests/test_fast_sdpa.py
@@ -420,8 +420,10 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
                 out = mx.fast.scaled_dot_product_attention(q, k, v, scale=scale)
                 self.assertTrue(mx.allclose(ref, out, atol=1e-4, rtol=1e-4))
 
-    @unittest.skipIf(not mx.is_available(mx.gpu), "GPU kernel path only")
+    @unittest.skipIf(not mx.metal.is_available(), "Metal kernel path only")
     def test_sdpa_vector_head_dim_512(self):
+        if mx.default_device() != mx.gpu:
+            self.skipTest("requires GPU")
         # gemma-4 global attention: 32 query heads over 4 key/value heads.
         D = 512
         Nq, Nkv = 32, 4

--- a/python/tests/test_fast_sdpa.py
+++ b/python/tests/test_fast_sdpa.py
@@ -477,11 +477,53 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
                 atol = 1e-5 if dtype == mx.float32 else 2e-2
                 self.assertTrue(mx.allclose(ref, out, atol=atol))
 
-        # The vector kernel fuses while query length * GQA factor is at most
-        # 32, so with 8 repeats the query length can be up to 4.
+        # By default D=512 admits the measured single-token GQA surface, not
+        # MHA, multi-token queries, or array masks. The zero threshold is an
+        # explicit expansion used to retain correctness coverage for those
+        # otherwise supported vector-kernel shapes.
         L = 1024
         k = mx.random.normal(shape=(1, Nkv, L, D))
         v = mx.random.normal(shape=(1, Nkv, L, D))
+
+        q = mx.random.normal(shape=(1, Nq, 4, D))
+        with self.assertRaisesRegex(ValueError, r"single-token queries"):
+            mx.fast.scaled_dot_product_attention(
+                q, k, v, scale=scale, force_fused=True
+            )
+
+        q = mx.random.normal(shape=(1, Nq, 1, D))
+        array_mask = mx.array([True] * (L - 10) + [False] * 10)
+        with self.assertRaisesRegex(ValueError, r"without array masks"):
+            mx.fast.scaled_dot_product_attention(
+                q, k, v, scale=scale, mask=array_mask, force_fused=True
+            )
+
+        for q_heads, kv_heads in ((8, 8), (32, 8)):
+            with self.subTest(q_heads=q_heads, kv_heads=kv_heads):
+                other_q = mx.random.normal(shape=(1, q_heads, 1, D))
+                other_k = mx.random.normal(shape=(1, kv_heads, L, D))
+                other_v = mx.random.normal(shape=(1, kv_heads, L, D))
+                with self.assertRaisesRegex(ValueError, r"GQA factor 8"):
+                    mx.fast.scaled_dot_product_attention(
+                        other_q,
+                        other_k,
+                        other_v,
+                        scale=scale,
+                        force_fused=True,
+                    )
+                with patch.dict(os.environ, {"MLX_SDPA_D512_MIN_KL": "0"}):
+                    ref = mlx_ref_attn(other_q, other_k, other_v, scale)
+                    out = mx.fast.scaled_dot_product_attention(
+                        other_q,
+                        other_k,
+                        other_v,
+                        scale=scale,
+                        force_fused=True,
+                    )
+                    self.assertTrue(
+                        mx.allclose(ref, out, atol=1e-4, rtol=1e-4)
+                    )
+
         for qL in (1, 4):
             q = mx.random.normal(shape=(1, Nq, qL, D))
             masks = [
@@ -500,11 +542,20 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
             tol = 1e-4 if qL == 1 else 1e-3
             for i, m in enumerate(masks):
                 with self.subTest(qL=qL, mask=i):
-                    ref = mlx_ref_attn(q, k, v, scale, mask=m)
-                    out = mx.fast.scaled_dot_product_attention(
-                        q, k, v, scale=scale, mask=m, force_fused=True
+                    needs_override = qL > 1 or i not in (0, 7)
+                    threshold = (
+                        patch.dict(os.environ, {"MLX_SDPA_D512_MIN_KL": "0"})
+                        if needs_override
+                        else nullcontext()
                     )
-                    self.assertTrue(mx.allclose(ref, out, atol=tol, rtol=tol))
+                    with threshold:
+                        ref = mlx_ref_attn(q, k, v, scale, mask=m)
+                        out = mx.fast.scaled_dot_product_attention(
+                            q, k, v, scale=scale, mask=m, force_fused=True
+                        )
+                        self.assertTrue(
+                            mx.allclose(ref, out, atol=tol, rtol=tol)
+                        )
 
         # Batched, with and without attention sinks, over both kernels.
         # L = 256 is below the admission threshold, so the fused-1-pass leg
@@ -1010,11 +1061,17 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
             with self.subTest(head_dim=D):
                 q, k, v = make_qkv(4, 16385, D, 4, 2)
                 scale = D**-0.5
-                ref = mlx_ref_attn(q, k, v, scale=scale)
-                out = mx.fast.scaled_dot_product_attention(
-                    q, k, v, scale=scale, force_fused=True
+                threshold = (
+                    patch.dict(os.environ, {"MLX_SDPA_D512_MIN_KL": "0"})
+                    if D == 512
+                    else nullcontext()
                 )
-                self.assertTrue(mx.allclose(ref, out, atol=1e-3, rtol=1e-3))
+                with threshold:
+                    ref = mlx_ref_attn(q, k, v, scale=scale)
+                    out = mx.fast.scaled_dot_product_attention(
+                        q, k, v, scale=scale, force_fused=True
+                    )
+                    self.assertTrue(mx.allclose(ref, out, atol=1e-3, rtol=1e-3))
 
         # No full attention fused kernels.
         with self.assertRaisesRegex(ValueError, "supports head dims"):

--- a/python/tests/test_fast_sdpa.py
+++ b/python/tests/test_fast_sdpa.py
@@ -418,6 +418,71 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
                 out = mx.fast.scaled_dot_product_attention(q, k, v, scale=scale)
                 self.assertTrue(mx.allclose(ref, out, atol=1e-4, rtol=1e-4))
 
+    @unittest.skipIf(not mx.is_available(mx.gpu), "GPU kernel path only")
+    def test_sdpa_vector_head_dim_512(self):
+        # gemma-4 global attention: 32 query heads over 4 key/value heads.
+        D = 512
+        Nq, Nkv = 32, 4
+        scale = D**-0.5
+        mx.random.seed(0)
+
+        # L = 128 takes the 1-pass kernel, 8192 and 8201 the 2-pass one.
+        for L, dtype in product(
+            (128, 8192, 8201), (mx.float32, mx.float16, mx.bfloat16)
+        ):
+            with self.subTest(L=L, dtype=dtype):
+                q = mx.random.normal(shape=(1, Nq, 1, D), dtype=dtype)
+                k = mx.random.normal(shape=(1, Nkv, L, D), dtype=dtype)
+                v = mx.random.normal(shape=(1, Nkv, L, D), dtype=dtype)
+                ref = mlx_ref_attn(q, k, v, scale)
+                out = mx.fast.scaled_dot_product_attention(q, k, v, scale=scale)
+                atol = 1e-5 if dtype == mx.float32 else 2e-2
+                self.assertTrue(mx.allclose(ref, out, atol=atol))
+
+        # The vector kernel fuses while query length * GQA factor is at most
+        # 32, so with 8 repeats the query length can be up to 4.
+        L = 1024
+        k = mx.random.normal(shape=(1, Nkv, L, D))
+        v = mx.random.normal(shape=(1, Nkv, L, D))
+        for qL in (1, 4):
+            q = mx.random.normal(shape=(1, Nq, qL, D))
+            masks = [
+                None,
+                mx.array(True),
+                mx.array([True] * (L - 10) + [False] * 10),
+                mx.random.uniform(shape=(Nq, qL, L)) > 0.2,
+                mx.random.uniform(shape=(L, qL, Nq)).T > 0.2,
+                mx.random.uniform(shape=(Nq, qL, L)),
+                mx.random.uniform(shape=(L, qL, Nq)).T,
+                "causal",
+            ]
+            # The reference does the multi-query scores as a GEMM, which is
+            # the less accurate arm at qL > 1, so use the same tolerance as
+            # the other multi-query tests.
+            tol = 1e-4 if qL == 1 else 1e-3
+            for i, m in enumerate(masks):
+                with self.subTest(qL=qL, mask=i):
+                    ref = mlx_ref_attn(q, k, v, scale, mask=m)
+                    out = mx.fast.scaled_dot_product_attention(
+                        q, k, v, scale=scale, mask=m
+                    )
+                    self.assertTrue(mx.allclose(ref, out, atol=tol, rtol=tol))
+
+        # Batched, with and without attention sinks, over both kernels.
+        B = 2
+        sinks = 10 * mx.random.normal(shape=(Nq,))
+        q = mx.random.normal(shape=(B, Nq, 1, D))
+        for L in (256, 8192):
+            k = mx.random.normal(shape=(B, Nkv, L, D))
+            v = mx.random.normal(shape=(B, Nkv, L, D))
+            for s_in in (None, sinks):
+                with self.subTest(L=L, sinks=s_in is not None):
+                    ref = mlx_ref_attn(q, k, v, scale, sinks=s_in)
+                    out = mx.fast.scaled_dot_product_attention(
+                        q, k, v, scale=scale, sinks=s_in
+                    )
+                    self.assertTrue(mx.allclose(ref, out, atol=1e-4, rtol=1e-4))
+
     def test_sdpa_fully_masked(self):
         Lkv = 8
         mask = mx.array(False)
@@ -888,7 +953,7 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
                 self.assertTrue(mx.allclose(ref, out, atol=1e-3, rtol=1e-3))
 
         # Vector attention kernel.
-        for D in (192, 256):
+        for D in (192, 256, 512):
             with self.subTest(head_dim=D):
                 q, k, v = make_qkv(4, 16385, D, 4, 2)
                 scale = D**-0.5

--- a/python/tests/test_fast_sdpa.py
+++ b/python/tests/test_fast_sdpa.py
@@ -426,9 +426,39 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
         scale = D**-0.5
         mx.random.seed(0)
 
-        # L = 128 takes the 1-pass kernel, 8192 and 8201 the 2-pass one.
+        # Below the admission threshold the generic vector kernel stays on
+        # the unfused path, and force_fused says so. The threshold is read
+        # per call from MLX_SDPA_D512_MIN_KL (default 1024).
+        q = mx.random.normal(shape=(1, Nq, 1, D), dtype=mx.float16)
+        k = mx.random.normal(shape=(1, Nkv, 128, D), dtype=mx.float16)
+        v = mx.random.normal(shape=(1, Nkv, 128, D), dtype=mx.float16)
+        with self.assertRaisesRegex(
+            ValueError, r"requires at least \d+ keys"
+        ):
+            mx.fast.scaled_dot_product_attention(
+                q, k, v, scale=scale, force_fused=True
+            )
+
+        # L = 128 admitted via the threshold override takes the 1-pass
+        # kernel; 8192 and 8201 take the 2-pass one at the default
+        # threshold.
+        os.environ["MLX_SDPA_D512_MIN_KL"] = "0"
+        try:
+            for dtype in (mx.float32, mx.float16, mx.bfloat16):
+                with self.subTest(L=128, dtype=dtype, threshold="off"):
+                    q = mx.random.normal(shape=(1, Nq, 1, D), dtype=dtype)
+                    k = mx.random.normal(shape=(1, Nkv, 128, D), dtype=dtype)
+                    v = mx.random.normal(shape=(1, Nkv, 128, D), dtype=dtype)
+                    ref = mlx_ref_attn(q, k, v, scale)
+                    out = mx.fast.scaled_dot_product_attention(
+                        q, k, v, scale=scale
+                    )
+                    atol = 1e-5 if dtype == mx.float32 else 2e-2
+                    self.assertTrue(mx.allclose(ref, out, atol=atol))
+        finally:
+            os.environ.pop("MLX_SDPA_D512_MIN_KL", None)
         for L, dtype in product(
-            (128, 8192, 8201), (mx.float32, mx.float16, mx.bfloat16)
+            (8192, 8201), (mx.float32, mx.float16, mx.bfloat16)
         ):
             with self.subTest(L=L, dtype=dtype):
                 q = mx.random.normal(shape=(1, Nq, 1, D), dtype=dtype)
@@ -469,6 +499,8 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
                     self.assertTrue(mx.allclose(ref, out, atol=tol, rtol=tol))
 
         # Batched, with and without attention sinks, over both kernels.
+        # L = 256 is below the admission threshold, so the fused-1-pass leg
+        # runs with the threshold override; L = 8192 fuses by default.
         B = 2
         sinks = 10 * mx.random.normal(shape=(Nq,))
         q = mx.random.normal(shape=(B, Nq, 1, D))
@@ -477,11 +509,19 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
             v = mx.random.normal(shape=(B, Nkv, L, D))
             for s_in in (None, sinks):
                 with self.subTest(L=L, sinks=s_in is not None):
-                    ref = mlx_ref_attn(q, k, v, scale, sinks=s_in)
-                    out = mx.fast.scaled_dot_product_attention(
-                        q, k, v, scale=scale, sinks=s_in
-                    )
-                    self.assertTrue(mx.allclose(ref, out, atol=1e-4, rtol=1e-4))
+                    if L == 256:
+                        os.environ["MLX_SDPA_D512_MIN_KL"] = "0"
+                    try:
+                        ref = mlx_ref_attn(q, k, v, scale, sinks=s_in)
+                        out = mx.fast.scaled_dot_product_attention(
+                            q, k, v, scale=scale, sinks=s_in
+                        )
+                        self.assertTrue(
+                            mx.allclose(ref, out, atol=1e-4, rtol=1e-4)
+                        )
+                    finally:
+                        if L == 256:
+                            os.environ.pop("MLX_SDPA_D512_MIN_KL", None)
 
     def test_sdpa_fully_masked(self):
         Lkv = 8
@@ -992,6 +1032,11 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
             q, k, v = make_qkv(8, 128, 64, qH=8, kH=1)
             mx.fast.scaled_dot_product_attention(
                 q, k, v, scale=64**-0.5, force_fused=True
+            )
+        with self.assertRaisesRegex(ValueError, r"requires at least \d+ keys"):
+            q, k, v = make_qkv(1, 512, 512, qH=32, kH=4)
+            mx.fast.scaled_dot_product_attention(
+                q, k, v, scale=512**-0.5, force_fused=True
             )
 
         # No CPU fused kernel.

--- a/python/tests/test_fast_sdpa.py
+++ b/python/tests/test_fast_sdpa.py
@@ -1103,11 +1103,13 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
             mx.fast.scaled_dot_product_attention(
                 q, k, v, scale=64**-0.5, force_fused=True
             )
-        with self.assertRaisesRegex(ValueError, r"requires at least \d+ keys"):
-            q, k, v = make_qkv(1, 512, 512, qH=32, kH=4)
-            mx.fast.scaled_dot_product_attention(
-                q, k, v, scale=512**-0.5, force_fused=True
-            )
+        with patch.dict(os.environ):
+            os.environ.pop("MLX_SDPA_D512_MIN_KL", None)
+            with self.assertRaisesRegex(ValueError, r"requires at least \d+ keys"):
+                q, k, v = make_qkv(1, 512, 512, qH=32, kH=4)
+                mx.fast.scaled_dot_product_attention(
+                    q, k, v, scale=512**-0.5, force_fused=True
+                )
 
         # No CPU fused kernel.
         with mx.stream(mx.cpu):

--- a/python/tests/test_fast_sdpa.py
+++ b/python/tests/test_fast_sdpa.py
@@ -1,7 +1,9 @@
 import math
 import os
 import unittest
+from contextlib import nullcontext
 from itertools import product
+from unittest.mock import patch
 
 import mlx.core as mx
 import mlx_tests
@@ -426,6 +428,13 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
         scale = D**-0.5
         mx.random.seed(0)
 
+        # Keep the test hermetic if the caller already configured a threshold.
+        # addCleanup restores the complete environment snapshot on every exit.
+        environment = patch.dict(os.environ)
+        environment.start()
+        self.addCleanup(environment.stop)
+        os.environ.pop("MLX_SDPA_D512_MIN_KL", None)
+
         # Below the admission threshold the generic vector kernel stays on
         # the unfused path, and force_fused says so. The threshold is read
         # per call from MLX_SDPA_D512_MIN_KL (default 1024).
@@ -442,8 +451,7 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
         # L = 128 admitted via the threshold override takes the 1-pass
         # kernel; 8192 and 8201 take the 2-pass one at the default
         # threshold.
-        os.environ["MLX_SDPA_D512_MIN_KL"] = "0"
-        try:
+        with patch.dict(os.environ, {"MLX_SDPA_D512_MIN_KL": "0"}):
             for dtype in (mx.float32, mx.float16, mx.bfloat16):
                 with self.subTest(L=128, dtype=dtype, threshold="off"):
                     q = mx.random.normal(shape=(1, Nq, 1, D), dtype=dtype)
@@ -451,12 +459,10 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
                     v = mx.random.normal(shape=(1, Nkv, 128, D), dtype=dtype)
                     ref = mlx_ref_attn(q, k, v, scale)
                     out = mx.fast.scaled_dot_product_attention(
-                        q, k, v, scale=scale
+                        q, k, v, scale=scale, force_fused=True
                     )
                     atol = 1e-5 if dtype == mx.float32 else 2e-2
                     self.assertTrue(mx.allclose(ref, out, atol=atol))
-        finally:
-            os.environ.pop("MLX_SDPA_D512_MIN_KL", None)
         for L, dtype in product(
             (8192, 8201), (mx.float32, mx.float16, mx.bfloat16)
         ):
@@ -465,7 +471,9 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
                 k = mx.random.normal(shape=(1, Nkv, L, D), dtype=dtype)
                 v = mx.random.normal(shape=(1, Nkv, L, D), dtype=dtype)
                 ref = mlx_ref_attn(q, k, v, scale)
-                out = mx.fast.scaled_dot_product_attention(q, k, v, scale=scale)
+                out = mx.fast.scaled_dot_product_attention(
+                    q, k, v, scale=scale, force_fused=True
+                )
                 atol = 1e-5 if dtype == mx.float32 else 2e-2
                 self.assertTrue(mx.allclose(ref, out, atol=atol))
 
@@ -494,7 +502,7 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
                 with self.subTest(qL=qL, mask=i):
                     ref = mlx_ref_attn(q, k, v, scale, mask=m)
                     out = mx.fast.scaled_dot_product_attention(
-                        q, k, v, scale=scale, mask=m
+                        q, k, v, scale=scale, mask=m, force_fused=True
                     )
                     self.assertTrue(mx.allclose(ref, out, atol=tol, rtol=tol))
 
@@ -509,19 +517,24 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
             v = mx.random.normal(shape=(B, Nkv, L, D))
             for s_in in (None, sinks):
                 with self.subTest(L=L, sinks=s_in is not None):
-                    if L == 256:
-                        os.environ["MLX_SDPA_D512_MIN_KL"] = "0"
-                    try:
+                    threshold = (
+                        patch.dict(os.environ, {"MLX_SDPA_D512_MIN_KL": "0"})
+                        if L == 256
+                        else nullcontext()
+                    )
+                    with threshold:
                         ref = mlx_ref_attn(q, k, v, scale, sinks=s_in)
                         out = mx.fast.scaled_dot_product_attention(
-                            q, k, v, scale=scale, sinks=s_in
+                            q,
+                            k,
+                            v,
+                            scale=scale,
+                            sinks=s_in,
+                            force_fused=True,
                         )
                         self.assertTrue(
                             mx.allclose(ref, out, atol=1e-4, rtol=1e-4)
                         )
-                    finally:
-                        if L == 256:
-                            os.environ.pop("MLX_SDPA_D512_MIN_KL", None)
 
     def test_sdpa_fully_masked(self):
         Lkv = 8

--- a/python/tests/test_fast_sdpa.py
+++ b/python/tests/test_fast_sdpa.py
@@ -443,12 +443,8 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
         q = mx.random.normal(shape=(1, Nq, 1, D), dtype=mx.float16)
         k = mx.random.normal(shape=(1, Nkv, 128, D), dtype=mx.float16)
         v = mx.random.normal(shape=(1, Nkv, 128, D), dtype=mx.float16)
-        with self.assertRaisesRegex(
-            ValueError, r"requires at least \d+ keys"
-        ):
-            mx.fast.scaled_dot_product_attention(
-                q, k, v, scale=scale, force_fused=True
-            )
+        with self.assertRaisesRegex(ValueError, r"requires at least \d+ keys"):
+            mx.fast.scaled_dot_product_attention(q, k, v, scale=scale, force_fused=True)
 
         # L = 128 admitted via the threshold override takes the 1-pass
         # kernel; 8192 and 8201 take the 2-pass one at the default
@@ -465,9 +461,7 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
                     )
                     atol = 1e-5 if dtype == mx.float32 else 2e-2
                     self.assertTrue(mx.allclose(ref, out, atol=atol))
-        for L, dtype in product(
-            (8192, 8201), (mx.float32, mx.float16, mx.bfloat16)
-        ):
+        for L, dtype in product((8192, 8201), (mx.float32, mx.float16, mx.bfloat16)):
             with self.subTest(L=L, dtype=dtype):
                 q = mx.random.normal(shape=(1, Nq, 1, D), dtype=dtype)
                 k = mx.random.normal(shape=(1, Nkv, L, D), dtype=dtype)
@@ -489,9 +483,7 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
 
         q = mx.random.normal(shape=(1, Nq, 4, D))
         with self.assertRaisesRegex(ValueError, r"single-token queries"):
-            mx.fast.scaled_dot_product_attention(
-                q, k, v, scale=scale, force_fused=True
-            )
+            mx.fast.scaled_dot_product_attention(q, k, v, scale=scale, force_fused=True)
 
         q = mx.random.normal(shape=(1, Nq, 1, D))
         array_mask = mx.array([True] * (L - 10) + [False] * 10)
@@ -522,9 +514,7 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
                         scale=scale,
                         force_fused=True,
                     )
-                    self.assertTrue(
-                        mx.allclose(ref, out, atol=1e-4, rtol=1e-4)
-                    )
+                    self.assertTrue(mx.allclose(ref, out, atol=1e-4, rtol=1e-4))
 
         for qL in (1, 4):
             q = mx.random.normal(shape=(1, Nq, qL, D))
@@ -555,9 +545,7 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
                         out = mx.fast.scaled_dot_product_attention(
                             q, k, v, scale=scale, mask=m, force_fused=True
                         )
-                        self.assertTrue(
-                            mx.allclose(ref, out, atol=tol, rtol=tol)
-                        )
+                        self.assertTrue(mx.allclose(ref, out, atol=tol, rtol=tol))
 
         # Batched, with and without attention sinks, over both kernels.
         # L = 256 is below the admission threshold, so the fused-1-pass leg
@@ -585,9 +573,7 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
                             sinks=s_in,
                             force_fused=True,
                         )
-                        self.assertTrue(
-                            mx.allclose(ref, out, atol=1e-4, rtol=1e-4)
-                        )
+                        self.assertTrue(mx.allclose(ref, out, atol=1e-4, rtol=1e-4))
 
     def test_sdpa_fully_masked(self):
         Lkv = 8


### PR DESCRIPTION
D512 attention can now use the existing single-pass and two-pass Metal vector kernels. In the five cases below, this is 1.11–1.23× faster than the unfused fallback on M5 Max.

Potential users include Gemma 4 [31B](https://huggingface.co/google/gemma-4-31B-it/blob/main/config.json), [26B-A4B](https://huggingface.co/google/gemma-4-26B-A4B-it/blob/main/config.json), and [E2B](https://huggingface.co/google/gemma-4-E2B-it/blob/main/config.json), whose global attention layers use head dimension 512 and a query-to-KV head ratio of 8. Single-token decoding with at least 1024 keys and no array mask can take this path.

I've enabled it by default for one query, GQA factor 8, no array mask and at least 1024 keys. Other supported D512 vector shapes can use it with `MLX_SDPA_D512_MIN_KL=0`; setting the threshold above the key length selects the fallback.

I measured `c6dc20d95`. The final head `5528d75b9` only adds test changes and has the same runtime source, but I haven't retimed it.

All rows use D=512, one query, 32 query / 4 KV heads and 1024 keys. Speedups are paired geometric means of fallback time / fused time.

| Case | Speedup | 95% CI |
|---|---:|---:|
| B1, fp16 | 1.1105× | [1.1031, 1.1179] |
| B2, fp16 | 1.1572× | [1.1421, 1.1724] |
| B1, fp16, sinks | 1.2095× | [1.1916, 1.2276] |
| B1, bf16 | 1.1125× | [1.1037, 1.1213] |
| B1, fp32 | 1.2335× | [1.2139, 1.2534] |

With TF32 disabled, `test_fast_sdpa` passed 22 tests with 2 skipped. These cover both kernels and the default dispatch restrictions. I haven't measured model performance; the results here are for the five operator cases above.

<details>
<summary>Controls and reproduction</summary>

At D=512 and kL=1024, the excluded fp16 controls were: GQA4 (`B1, qL1, hq32/hk8`) 1.0400 [1.0179, 1.0627], with improvement magnitude unresolved; MHA (`B1, qL1, hq8/hk8`) 0.9555 [0.9382, 0.9732]; and multi-query GQA8 (`B1, qL4, hq32/hk4`) 1.0277 [1.0208, 1.0346]. They retain the fallback by default. Array-mask calibration failed the drift check, so no timing claim is made for it.

Device: M5 Max, 128 GB. The local release build adds 102,944 bytes to `mlx.metallib`. Each reported cell passed A/A calibration and the 5% drift check.

Measured binary: `libmlx.dylib:1bec8a11f32a+mlx.metallib:ba939f89e04b`, at `c6dc20d9575bbde819ae731b73b49a53cafcf5b0`. The final-head test build has the same library hashes.

Build the reviewed commit from source and run the tests:

```sh
test "$(git rev-parse HEAD)" = 5528d75b9b7b8c5818242abe6593ceac92401262
python -m pip install -e .
cd python/tests
MLX_ENABLE_TF32=0 python -m unittest -v test_fast_sdpa
MLX_ENABLE_TF32=0 DEVICE=cpu python -m unittest -v \
  test_fast_sdpa.TestFastSDPA.test_sdpa_vector_head_dim_512
```

Save the script below as `repro_4459.py` in the built checkout root. Use the same Python environment used to build MLX, and stop other GPU work before measuring.

```sh
# Run from the checkout root, after building the pinned commit above.
python repro_4459.py --source . --smoke --output smoke.json
python repro_4459.py --source . --case all --output results.json
```

`--smoke` checks outputs and exercises short timing loops without estimating speedups. Use `--help` to select a single case. Output files must be new names.

The script includes the five reported cases and the three excluded controls. It uses seed 0, 250 batches of eight dependent calls, and checks fused admission with `force_fused`. The table used adaptive A/B sampling (9–12 pairs); this script uses 15 fixed pairs.

This is an independent reproducer of the workloads, not the driver used for the existing table. It warms both arms, runs 15 alternating A/A pairs, then 15 alternating A/B pairs. Each stage gets 60 seconds of saturation, with a 90-second cooldown before A/B. It reports the geometric mean of OFF/ON time ratios and a Student-t 95% interval in log space. A/A must include 1 in its interval; either stage stops on more than 5% within-arm drift, retaining the rejected result without retrying. It does not implement the original sign-test, Wilcoxon or A/A-noise significance checks.

The JSON includes raw sample times, input shapes, numerical checks, source revision, device and binary hashes. New estimates depend on the machine and build; they do not replace the measurements above.

```python
"""Independent MLX PR #4459 reproducer. Requires a built PR checkout and mlx.

Uses public MLX APIs only. Fixed 15-pair estimates are new observations, not
a replay of the original benchmark driver. Stop other GPU work before running.
"""

HEADS = ['c6dc20d9575bbde819ae731b73b49a53cafcf5b0', '5528d75b9b7b8c5818242abe6593ceac92401262']
CASES = {'b1_fp16': {'b': 1,
             'h': 32,
             'hk': 4,
             'ql': 1,
             'kl': 1024,
             'd': 512,
             'dtype': 'float16',
             'sinks': False},
 'b2_fp16': {'b': 2,
             'h': 32,
             'hk': 4,
             'ql': 1,
             'kl': 1024,
             'd': 512,
             'dtype': 'float16',
             'sinks': False},
 'sinks_fp16': {'b': 1,
                'h': 32,
                'hk': 4,
                'ql': 1,
                'kl': 1024,
                'd': 512,
                'dtype': 'float16',
                'sinks': True},
 'b1_bf16': {'b': 1,
             'h': 32,
             'hk': 4,
             'ql': 1,
             'kl': 1024,
             'd': 512,
             'dtype': 'bfloat16',
             'sinks': False},
 'b1_fp32': {'b': 1,
             'h': 32,
             'hk': 4,
             'ql': 1,
             'kl': 1024,
             'd': 512,
             'dtype': 'float32',
             'sinks': False},
 'gqa4_fp16': {'b': 1,
               'h': 32,
               'hk': 8,
               'ql': 1,
               'kl': 1024,
               'd': 512,
               'dtype': 'float16',
               'sinks': False},
 'mha_fp16': {'b': 1,
              'h': 8,
              'hk': 8,
              'ql': 1,
              'kl': 1024,
              'd': 512,
              'dtype': 'float16',
              'sinks': False},
 'q4_fp16': {'b': 1,
             'h': 32,
             'hk': 4,
             'ql': 4,
             'kl': 1024,
             'd': 512,
             'dtype': 'float16',
             'sinks': False}}
SWITCH="MLX_SDPA_D512_MIN_KL"
VALUES={"off":"999999", "on":"0"}
SEED=0
DIRECT_DTYPE=True
OUTER=250
CHAIN=8

import argparse
import hashlib
import json
import math
import os
from pathlib import Path
import platform
import statistics as st
import subprocess
import time


def summary(a, b):
    if len(a) != 15 or len(b) != 15 or any(
        not math.isfinite(x) or x <= 0 for x in a + b
    ):
        raise ValueError("Expected 15 positive finite samples in each arm")
    logs = [math.log(x / y) for x, y in zip(a, b)]
    center = st.mean(logs)
    # Two-sided Student-t 95% interval, df=14; fixed 15 pairs, no early stopping.
    half = 2.1447866879169273 * st.stdev(logs) / math.sqrt(15)
    drift = [st.median(v[7:]) / st.median(v[:7]) for v in (a, b)]
    return dict(ratio=math.exp(center), ci95=[math.exp(center-half), math.exp(center+half)],
                drift=drift, drift_ok=all(abs(x-1) <= .05 for x in drift))


def collect(sample, tags):
    values = [[], []]
    for i in range(15):
        for j in ((0, 1) if i % 2 == 0 else (1, 0)):
            values[j].append(sample(tags[j]))
    return dict(samples_seconds=values, **summary(*values))


def main():
    p = argparse.ArgumentParser(description=__doc__)
    p.add_argument("--source", type=Path, required=True, help="built PR checkout")
    p.add_argument("--case", choices=["all", *CASES], default="all")
    p.add_argument("--output", type=Path, required=True)
    p.add_argument("--smoke", action="store_true", help="check outputs and short timing loops; no performance verdict")
    args = p.parse_args()
    source = args.source.resolve(strict=True)
    head = subprocess.check_output(["git", "-C", str(source), "rev-parse", "HEAD"], text=True).strip()
    if head not in HEADS:
        p.error(f"Expected source head in {HEADS}; found {head}")
    dirty = subprocess.check_output(["git", "-C", str(source), "status", "--porcelain", "--untracked-files=no"], text=True)
    if dirty.strip():
        p.error("Use a clean source checkout")
    if os.environ.get("DYLD_INSERT_LIBRARIES"):
        p.error("Remove profiling/dispatch instrumentation before timing")
    # Bind the requested source build instead of silently using another pip package.
    import sys
    sys.path.insert(0, str(source / "python"))
    os.environ["MLX_ENABLE_TF32"] = "0"
    import mlx.core as mx
    if not Path(mx.__file__).resolve().is_relative_to(source):
        p.error(f"MLX imported from the wrong build: {mx.__file__}")
    if not mx.metal.is_available():
        p.error("A Metal GPU is required")
    mx.set_default_device(mx.gpu)
    core = Path(mx.__file__).resolve()
    binaries = [core, core.parent / "lib/libmlx.dylib", core.parent / "lib/mlx.metallib"]
    def fingerprints():
        return {f.name: hashlib.sha256(f.read_bytes()).hexdigest() for f in binaries}
    result = dict(source_head=head, device=mx.metal.device_info(), os=platform.platform(),
                  python=platform.python_version(), binaries=fingerprints(),
                  script_sha256=hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
                  protocol="Independent fixed-15-pair reproduction, Student-t log CI, 5% drift gate; no retry or sequential stopping",
                  smoke=args.smoke, cases={})
    # Refuse to overwrite an earlier run, including a rejected calibration.
    with args.output.open("x") as output:
        def save():
            output.seek(0)
            json.dump(result, output, indent=2)
            output.write("\n")
            output.truncate()
            output.flush()
        save()
        try:
            for name in CASES if args.case == "all" else [args.case]:
                row = result["cases"][name] = dict(config=CASES[name], status="checking")
                sample, check = workload(mx, CASES[name])
                row["check"] = check
                if args.smoke:
                    sample("off", short=True)
                    sample("on", short=True)
                    row["status"] = "smoke_only_no_performance_result"
                else:
                    for tag in ("off", "on"):
                        for _ in range(3):
                            sample(tag)
                    for stage, tags in (("aa", ("on", "on")), ("ab", ("off", "on"))):
                        if stage == "ab":
                            time.sleep(90)
                        end = time.monotonic() + 60
                        while time.monotonic() < end:
                            for tag in tags:
                                sample(tag)
                        row[stage] = collect(sample, tags)
                        s = row[stage]
                        ok = s["drift_ok"] and (stage != "aa" or s["ci95"][0] <= 1 <= s["ci95"][1])
                        row["status"] = "in_progress" if ok else f"rejected_{stage}"
                        save()
                        if not ok:
                            raise RuntimeError(f"{name}: rejected {stage}; retain this output, do not quote its effect")
                    row["status"] = "completed_independent_reproduction"
                if fingerprints() != result["binaries"]:
                    raise RuntimeError("Binary files changed during the run")
                save()
                print(name, row["status"], row.get("ab", {}).get("ratio", ""), flush=True)
                del sample
        except BaseException as error:
            result["error"] = f"{type(error).__name__}: {error}"
            save()
            raise


def workload(mx, c):
    dtype = getattr(mx, c["dtype"])
    b, h, hk, ql, kl, d = (c[k] for k in ("b", "h", "hk", "ql", "kl", "d"))
    mx.random.seed(SEED)
    def normal(shape):
        x = mx.random.normal(shape, dtype=dtype) if DIRECT_DTYPE else mx.random.normal(shape).astype(dtype)
        return x
    q, k, v = normal((b, h, ql, d)), normal((b, hk, kl, d)), normal((b, hk, kl, d))
    sinks = 10 * normal((h,)) if c.get("sinks") else None
    mx.eval(q, k, v, *([] if sinks is None else [sinks]))
    def select(tag):
        os.environ[SWITCH] = VALUES[tag]
    def call(x, force=False):
        return mx.fast.scaled_dot_product_attention(x, k, v, scale=d**-0.5,
                                                    sinks=sinks, force_fused=force)
    outputs = []
    for tag in ("off", "on"):
        select(tag)
        value = call(q)
        mx.eval(value)
        if not bool(mx.all(mx.isfinite(value)).item()):
            raise RuntimeError("Non-finite output")
        outputs.append(value)
    equal = bool(mx.array_equal(*outputs).item())
    atol, rtol = (1e-4, 1e-4) if c["dtype"] == "float32" else ((.005, .005) if d != 512 else (.02, 0.0))
    if not bool(mx.allclose(*outputs, atol=atol, rtol=rtol).item()):
        raise RuntimeError("OFF/ON numerical comparison failed")
    if d == 512:
        select("on")
        mx.eval(call(q, force=True))
        select("off")
        try:
            mx.eval(call(q, force=True))
        except ValueError as e:
            if "force_fused=True but no fused kernel is available" not in str(e):
                raise
        else:
            raise RuntimeError("D512 fallback unexpectedly admitted a fused kernel")
    elif equal:
        # Conservative guard: a non-NAX device/build can ignore this switch.
        # Different outputs are NOT a kernel-name witness.
        raise RuntimeError("Padding arms are identical; verify NAX engagement before benchmarking")
    def sample(tag, short=False):
        select(tag)
        mx.synchronize()
        start = time.perf_counter()
        outer = 1 if short else OUTER
        for _ in range(outer):
            x = q
            for _ in range(CHAIN):
                x = call(x)
            mx.eval(x)
        mx.synchronize()
        return (time.perf_counter()-start) / (outer*CHAIN)
    return sample, dict(finite=True, allclose=True, atol=atol, rtol=rtol, bitwise_equal=equal,
                        route_check="force_fused admission" if d == 512 else "output difference only; no pipeline witness")


if __name__ == "__main__":
    main()
```

</details>

---

- ☑️ I understand it is strictly prohibited to use AI to write PR description
- AI usage disclosure: AI assistance was used in preparing this contribution. I am responsible for the contribution.
