### PR TITLE
Use precise::exp in Sigmoid so compiled and eager sigmoid agree

### DIFF
--- a/mlx/backend/metal/kernels/unary_ops.h
+++ b/mlx/backend/metal/kernels/unary_ops.h
@@ -308,7 +308,7 @@ struct Round {
 struct Sigmoid {
   template <typename T>
   T operator()(T x) thread {
-    auto y = 1 / (1 + metal::exp(metal::abs(x)));
+    auto y = 1 / (1 + metal::precise::exp(metal::abs(x)));
     return (x < 0) ? y : 1 - y;
   }
 };

--- a/python/tests/test_compile.py
+++ b/python/tests/test_compile.py
@@ -45,6 +45,22 @@ class TestCompile(mlx_tests.MLXTestCase):
         self.assertEqual(out.dtype, mx.int32)
         self.assertTrue(mx.array_equal(out, mx.array([2, 4])))
 
+    def test_compile_sigmoid_matches_eager(self):
+        # Regression test: `Sigmoid` spelled an unqualified `metal::exp`, which
+        # the prebuilt metallib (-fno-fast-math) resolves to the precise
+        # implementation but a runtime-compiled kernel resolves to the fast
+        # approximation -- so a fused compiled chain returned a different, less
+        # accurate sigmoid than the eager primitive. `Exp` in the same header
+        # already spells `metal::precise::exp`.
+        x = mx.linspace(-12, 12, 4001)
+
+        for dtype in (mx.float32, mx.bfloat16):
+            xd = x.astype(dtype)
+            expected = mx.sigmoid(xd)
+            fused = mx.compile(lambda a: mx.sigmoid(a) * 1.0)(xd)
+            mx.eval(expected, fused)
+            self.assertTrue(mx.array_equal(fused, expected))
+
     def test_compile_nonfinite_constants(self):
         # Regression test: a non-finite scalar constant (NaN / infinity) baked
         # into a fused compiled kernel used to stream a bare token (e.g. `nan`)


### PR DESCRIPTION
`mx.sigmoid` returns a different, less accurate result inside an `mx.compile`d
graph than it does eagerly on Metal.

```python
import mlx.core as mx
x = mx.linspace(-12, 12, 4001)
eager = mx.sigmoid(x)
fused = mx.compile(lambda a: mx.sigmoid(a) * 1.0)(x)
mx.eval(eager, fused)
print(mx.array_equal(fused, eager))   # False
```

On this sweep 1362 of 4001 float32 elements differ, and the compiled result has
5.13x the maximum relative error against a float64 reference (8.0910e-07 vs
1.5768e-07). In bfloat16 the two also disagree; I did not characterise the
bfloat16 error ratio.

## Cause

`Sigmoid` spells an unqualified `metal::exp`:

```cpp
// mlx/backend/metal/kernels/unary_ops.h
struct Sigmoid {
  template <typename T>
  T operator()(T x) thread {
    auto y = 1 / (1 + metal::exp(metal::abs(x)));
    return (x < 0) ? y : 1 - y;
  }
};
```

`Exp` in the same header already uses `metal::precise::exp`.

The prebuilt `mlx.metallib` is compiled with `-fno-fast-math`, and there the
unqualified spelling gives the precise result — which is why eager `mx.sigmoid`
is accurate. `Compiled` primitives are instead built at runtime, and there the
same text gives the fast approximation. Note that `CompileOptions::math_mode`
already defaults to `MathMode::Safe` and `set_compile_options` sets only
`mathMode`; math mode is not the control that selects between the fast and
precise floating-point function sets, so defaulting it to safe does not prevent
this.

Evidence that the `exp` spelling is what moves, rather than fusion
(reassociation, contraction, intermediate precision): a hand-written
`mx.fast.metal_kernel` carrying the struct body verbatim reproduces the
*compiled* result bit for bit; substituting `metal::precise::exp` reproduces the
*eager* result bit for bit; and `metal::fast::exp` is bit-identical to the
unqualified spelling. That trio isolates the spelling inside one JIT
environment, with no fusion partner involved.

This is not a proof that fusion contributes nothing — but multiplying by exactly
`1.0` offers no reassociation or FMA opportunity, and could not explain exact
bit-for-bit agreement with an independently hand-written fast-`exp` kernel.

## Scope

`Sigmoid` is not the only unqualified transcendental in these headers —
`LogAddExp` and the complex `Power` path in `binary_ops.h`, `cexpf.h`, the
`log1p` helpers in `utils.h`, and `erfinv` in `erf.h` are in the same position.
This PR changes only `Sigmoid`, the one with a demonstrated user-visible
divergence. The others are left alone deliberately; happy to widen it if you
would rather fix the class.

## Effect on nn.silu

`nn.silu` is `@partial(mx.compile)`, so today it gets the fast sigmoid. This
patch changes its output. It changes it to agree with the eager path:

| | nn.silu vs fp64 | eager `x * mx.sigmoid(x)` vs fp64 | elements differing |
|---|---|---|---|
| before | 8.2263e-07 | 1.9370e-07 | 1332 / 4001 |
| after | 1.9370e-07 | 1.9370e-07 | 0 / 4001 |

Measured on one M5 Max, float32, over that sweep. Anyone pinning exact `nn.silu`
outputs in that configuration will see them move. I have not characterised the
change on other devices or dtypes, and have not added an `nn.silu` regression
test — say the word if you want one.

## float16 is unaffected

Exhaustively, over all 65536 half bit patterns including NaN, Inf, subnormals
and -0: `fast::exp` and `precise::exp` inside this expression produce
bit-identical float16 results (0 differ, including all 2046 NaN inputs). The
substitution is inert for float16.

## Performance

`precise::exp` is the more expensive implementation.

Isolated, in an `exp`-dominated loop (512 `exp` per thread over 2^20 threads,
hand-written kernels, best of 60, M5 Max, float32):

| | min | median |
|---|---:|---:|
| `metal::fast::exp` | 0.549 ms | 0.756 ms |
| `metal::precise::exp` | 0.727 ms | 0.823 ms |
| `metal::exp` (unqualified) | 0.541 ms | 0.592 ms |

1.33x on the minima. The unqualified row landing near `fast::exp` is consistent
with the bit-identity result above, though the medians are noisy enough that I
would not lean on the timing as independent evidence.

**I have no valid end-to-end before/after number.** Two attempts failed and I am
reporting them rather than the third: in the first, a control computation proven
bit-identical across both builds itself moved 0.1979 -> 0.2621 ms, so the
comparison was noise; in the second, a chain of 32 and then 384 sigmoids timed
identically to a sigmoid-free chain of the same length (0.3800 / 0.3800 ms at
384), so the benchmark had no sensitivity to `exp` cost at all. I could not
construct an elementwise graph in which the difference was measurable. I am not
claiming the end-to-end cost is zero.

## Testing

One machine (M5 Max, macOS 26.6.2, Xcode 26.6), one checkout of main at
b6368984b, one venv. Both arms are that same tree rebuilt in place — stock,
then patched, then reverted and rebuilt to re-confirm the baseline.

- Added a regression test asserting compiled sigmoid equals eager sigmoid in
  float32 and bfloat16. It fails before the patch and passes after.
- After the patch, eager and fused-compiled sigmoid are bit-identical, and the
  eager result is unchanged from before the patch.
- `test_compile.py`, `test_ops.py`, `test_fast.py`, `test_bf16.py` pass on both
  arms. `test_nn.py` has one failure, `test_sin_pe`
  (`0.000858784 not less than 1e-05`), which reproduced 3/3 on the unpatched
  build as well, so it is not introduced by this patch. It is a sin/cos test and
  the magnitude resembles #4411.

Not verified on M1-M4 or on iOS/visionOS.

---

This issue was discovered by me during fused-kernel development QA, augmented with CC and OAI.

When mapping back test data to stock, we discovered misalignment and discovered the source of divergence was present upstream; we applied local fixes but this issue appears to impact correctness upstream. I don't know if this is an explicit tradeoff that was accepted for performance, suspect that it's not.