### PR TITLE
Don't restore a thread-affine stream when StreamContext dies on another thread

### DIFF
--- a/mlx/utils.h
+++ b/mlx/utils.h
@@ -7,6 +7,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string_view>
+#include <thread>
 #include <variant>
 
 #include "mlx/api.h"
@@ -28,7 +29,9 @@ MLX_API Stream to_stream(StreamOrDevice s, Device default_);
 
 struct StreamContext {
  public:
-  StreamContext(StreamOrDevice s) : _stream(default_stream(default_device())) {
+  StreamContext(StreamOrDevice s)
+      : _stream(default_stream(default_device())),
+        _owner(std::this_thread::get_id()) {
     if (std::holds_alternative<std::monostate>(s)) {
       throw std::runtime_error(
           "[StreamContext] Invalid argument, please specify a stream or device.");
@@ -38,13 +41,21 @@ struct StreamContext {
     set_default_stream(_s);
   }
 
-  ~StreamContext() {
+  // noexcept(false) so the thread check below can throw. A destructor that
+  // throws while another exception unwinds this thread calls std::terminate.
+  ~StreamContext() noexcept(false) {
+    if (std::this_thread::get_id() != _owner) {
+      throw std::runtime_error(
+          "[StreamContext] Destroyed in a different thread than it was "
+          "constructed in.");
+    }
     set_default_device(_stream.device);
     set_default_stream(_stream);
   }
 
  private:
   Stream _stream;
+  std::thread::id _owner;
 };
 
 struct MLX_API PrintOptions {

--- a/python/src/stream.cpp
+++ b/python/src/stream.cpp
@@ -37,7 +37,8 @@ class PyStreamContext {
     delete inner;
   }
 
-  // ~StreamContext throws when destroyed on a different thread, which Python cannot control
+  // ~StreamContext throws when destroyed on a different thread, which Python
+  // cannot control
   ~PyStreamContext() {
     try {
       exit();

--- a/python/src/stream.cpp
+++ b/python/src/stream.cpp
@@ -31,9 +31,17 @@ class PyStreamContext {
   }
 
   void exit() {
-    if (_inner != nullptr) {
-      delete _inner;
-      _inner = nullptr;
+    auto* inner = _inner;
+    _inner = nullptr;
+    // the destructor can throw, _inner is freed regardless.
+    delete inner;
+  }
+
+  // ~StreamContext throws when destroyed on a different thread, which Python cannot control
+  ~PyStreamContext() {
+    try {
+      exit();
+    } catch (...) {
     }
   }
 

--- a/python/tests/test_device.py
+++ b/python/tests/test_device.py
@@ -1,5 +1,7 @@
 # Copyright © 2023 Apple Inc.
 
+import concurrent.futures
+import gc
 import unittest
 
 import mlx.core as mx
@@ -111,6 +113,33 @@ class TestStream(mlx_tests.MLXTestCase):
         s_cpu = mx.new_stream(mx.cpu)
         b = mx.add(x, y, stream=s_cpu)
         self.assertEqual(a.item(), b.item())
+
+    def test_stream_context_exited_on_another_thread(self):
+        # A generator suspended inside `mx.stream(...)` and abandoned is
+        # finalized by the GC on whatever thread drops the last reference.
+        # Restoring there would install a foreign, thread-affine stream as
+        # that thread's default and break every later op on it.
+        abandoned = {}
+
+        def on_worker():
+            def gen():
+                with mx.stream(mx.new_stream(mx.default_device())):
+                    yield 1
+                    yield 2
+
+            g = gen()
+            next(g)
+            abandoned["gen"] = g
+
+        before = mx.default_stream(mx.default_device())
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            pool.submit(on_worker).result()
+
+        del abandoned["gen"]
+        gc.collect()
+
+        self.assertEqual(mx.default_stream(mx.default_device()), before)
+        mx.eval(mx.add(mx.array(1.0), mx.array(1.0)))
 
 
 class TestDeviceInfo(mlx_tests.MLXTestCase):


### PR DESCRIPTION
Fix restoring stream on a different thread.

Spotted this when looking at: https://github.com/ml-explore/mlx-lm/pull/1839