### PR TITLE
einsum: Fallback to multiply-and-reduce for integer contractions

### DIFF
--- a/mlx/einsum.cpp
+++ b/mlx/einsum.cpp
@@ -867,7 +867,12 @@ array einsum(
     preprocess_einsum_inputs(
         node.inputs, node.output, node.positions, inputs, s);
 
-    if (can_dot(node.inputs, node.output)) {
+    if (can_dot(node.inputs, node.output) &&
+        issubdtype(
+            promote_types(
+                inputs[node.positions[0]].dtype(),
+                inputs[node.positions[1]].dtype()),
+            inexact)) {
       auto& in_a = node.inputs[0];
       auto& in_b = node.inputs[1];
       auto& out = node.output;

--- a/python/tests/test_einsum.py
+++ b/python/tests/test_einsum.py
@@ -424,6 +424,35 @@ class TestEinsum(mlx_tests.MLXTestCase):
         self.assertEqual(mx_out.shape, np_out.shape)
         self.assertTrue(np.allclose(mx_out, np_out, rtol=1e-4, atol=1e-4))
 
+    def test_integer_contractions(self):
+        dtypes = [
+            mx.int8,
+            mx.int16,
+            mx.int32,
+            mx.int64,
+            mx.uint8,
+            mx.uint16,
+            mx.uint32,
+            mx.uint64,
+        ]
+        for dtype in dtypes:
+            a = mx.array([[1, 2], [3, 4]], dtype=dtype)
+            b = mx.array([[5, 6], [7, 8]], dtype=dtype)
+            np_a = np.array(a)
+            np_b = np.array(b)
+
+            mx_out = mx.einsum("ij,jk->ik", a, b)
+            np_out = np.einsum("ij,jk->ik", np_a, np_b)
+            self.assertEqual(mx_out.shape, np_out.shape)
+            self.assertEqual(mx_out.dtype, dtype)
+            self.assertTrue(np.array_equal(np.array(mx_out), np_out))
+
+            # Inner product contraction
+            mx_dot = mx.einsum("i,i->", a[0], b[0])
+            np_dot = np.einsum("i,i->", np_a[0], np_b[0])
+            self.assertEqual(mx_dot.dtype, dtype)
+            self.assertEqual(mx_dot.item(), int(np_dot))
+
 
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner()

--- a/tests/einsum_tests.cpp
+++ b/tests/einsum_tests.cpp
@@ -82,4 +82,11 @@ TEST_CASE("test einsum") {
   x = einsum("i,j->ij", {full({2}, 15.0f), full({4}, 20.0f)});
   expected = full({2, 4}, 300.0f);
   CHECK_EQ(allclose(x, expected).item<bool>(), true);
+
+  // Test integer contraction (einsum fallback for non-floating types)
+  auto a_int = array({1, 2, 3, 4}, {2, 2}, int32);
+  auto b_int = array({5, 6, 7, 8}, {2, 2}, int32);
+  auto res_int = einsum("ij,jk->ik", {a_int, b_int});
+  auto expected_int = array({19, 22, 43, 50}, {2, 2}, int32);
+  CHECK_EQ(array_equal(res_int, expected_int).item<bool>(), true);
 }


### PR DESCRIPTION
[x] I understand it is strictly prohibited to use AI to write PR description
- AI usage disclosure: None

Fixes #4463

### Problem
mx.einsum lowers contractions using can_dot, which selects batch_tensordot (and subsequently matmul). Because matmul rejects non-floating point types, valid integer contractions (such as mx.einsum("ij,jk->ik", x, x)) fail with:
ValueError: [matmul] Only inexact types are supported but int32 and int32 were provided...

### Solution
Update can_dot in mlx/einsum.cpp to verify that the promoted operand dtype is an inexact type before selecting the batch_tensordot fast path. When contracting integer or boolean arrays, can_dot evaluates to false, routing the operation to einsum_naive. einsum_naive uses general multiply-and-reduce, which natively supports all integer, unsigned integer, and boolean dtypes with exact mathematical precision.

### Verification
- Added C++ test case in tests/einsum_tests.cpp validating integer matrix contraction ("ij,jk->ik") with array_equal.
- Added Python test case test_integer_contractions in python/tests/test_einsum.py testing contractions across int8, int16, int32, int64, uint8, uint16, uint32, uint64 with NumPy parity.
- Passed pre-commit hooks: clang-format, black, isort.