### PR TITLE
Refactor: Extract set_output Function from utils.h

### DIFF
--- a/mlx/backend/metal/normalization.cpp
+++ b/mlx/backend/metal/normalization.cpp
@@ -22,31 +22,7 @@ void RMSNorm::eval_gpu(
   auto& out = outputs[0];
 
   // Make sure that the last dimension is contiguous
-  auto set_output = [&s, &out](const array& x) {
-    bool no_copy = x.flags().contiguous && x.strides()[x.ndim() - 1] == 1;
-    if (no_copy && x.ndim() > 1) {
-      auto s = x.strides()[x.ndim() - 2];
-      no_copy &= (s == 0 || s == x.shape().back() || x.shape(-2) == 1);
-    }
-    if (no_copy) {
-      if (x.is_donatable()) {
-        out.copy_shared_buffer(x);
-      } else {
-        out.set_data(
-            allocator::malloc(x.data_size() * x.itemsize()),
-            x.data_size(),
-            x.strides(),
-            x.flags());
-      }
-      return x;
-    } else {
-      array x_copy = contiguous_copy_gpu(x, s);
-      out.copy_shared_buffer(x_copy);
-      return x_copy;
-    }
-  };
-
-  const array x = set_output(inputs[0]);
+  const array x = ensure_innermost_contiguous(out, inputs[0], s, true);
   const array& w = inputs[1];
 
   auto axis_size = static_cast<uint32_t>(x.shape().back());
@@ -224,31 +200,7 @@ void LayerNorm::eval_gpu(
   auto& out = outputs[0];
 
   // Make sure that the last dimension is contiguous
-  auto set_output = [&s, &out](const array& x) {
-    bool no_copy = x.flags().contiguous && x.strides()[x.ndim() - 1] == 1;
-    if (no_copy && x.ndim() > 1) {
-      auto s = x.strides()[x.ndim() - 2];
-      no_copy &= (s == 0 || s == x.shape().back() || x.shape(-2) == 1);
-    }
-    if (no_copy) {
-      if (x.is_donatable()) {
-        out.copy_shared_buffer(x);
-      } else {
-        out.set_data(
-            allocator::malloc(x.data_size() * x.itemsize()),
-            x.data_size(),
-            x.strides(),
-            x.flags());
-      }
-      return x;
-    } else {
-      array x_copy = contiguous_copy_gpu(x, s);
-      out.copy_shared_buffer(x_copy);
-      return x_copy;
-    }
-  };
-
-  const array x = set_output(inputs[0]);
+  const array x = ensure_innermost_contiguous(out, inputs[0], s, true);
   const array& w = inputs[1];
   const array& b = inputs[2];
 

--- a/mlx/backend/metal/softmax.cpp
+++ b/mlx/backend/metal/softmax.cpp
@@ -22,26 +22,7 @@ void Softmax::eval_gpu(const std::vector<array>& inputs, array& out) {
   auto& d = metal::device(s.device);
 
   // Make sure that the last dimension is contiguous
-  auto set_output = [&s, &out](const array& x) {
-    if (x.flags().contiguous && x.strides()[x.ndim() - 1] == 1) {
-      if (x.is_donatable()) {
-        out.copy_shared_buffer(x);
-      } else {
-        out.set_data(
-            allocator::malloc(x.data_size() * x.itemsize()),
-            x.data_size(),
-            x.strides(),
-            x.flags());
-      }
-      return x;
-    } else {
-      array x_copy = contiguous_copy_gpu(x, s);
-      out.copy_shared_buffer(x_copy);
-      return x_copy;
-    }
-  };
-
-  const array in = set_output(inputs[0]);
+  const array in = ensure_innermost_contiguous(out, inputs[0], s);
 
   int axis_size = in.shape().back();
   int n_rows = in.data_size() / axis_size;

--- a/mlx/backend/metal/utils.h
+++ b/mlx/backend/metal/utils.h
@@ -82,9 +82,6 @@ inline size_t ceildiv(size_t n, size_t m) {
   return (n + m - 1) / m;
 }
 
-// Ensure the last dimension of x is contiguous, donating or copying the
-// buffer into out. With relax_prev_stride, a second-to-last stride of 0,
-// D, or a size-1 axis is also accepted.
 inline array ensure_innermost_contiguous(
     array& out,
     const array& x,

--- a/mlx/backend/metal/utils.h
+++ b/mlx/backend/metal/utils.h
@@ -5,6 +5,7 @@
 #include <type_traits>
 
 #include "mlx/array.h"
+#include "mlx/backend/gpu/copy.h"
 #include "mlx/backend/metal/device.h"
 #include "mlx/primitives.h"
 
@@ -79,6 +80,36 @@ inline int get_work_per_thread(Dtype dtype, size_t size) {
 
 inline size_t ceildiv(size_t n, size_t m) {
   return (n + m - 1) / m;
+}
+
+// Ensure the last dimension of x is contiguous, donating or copying the
+// buffer into out. With relax_prev_stride, a second-to-last stride of 0,
+// D, or a size-1 axis is also accepted.
+inline array ensure_innermost_contiguous(
+    array& out,
+    const array& x,
+    const Stream& s,
+    bool relax_prev_stride = false) {
+  bool no_copy = x.flags().contiguous && x.strides()[x.ndim() - 1] == 1;
+  if (relax_prev_stride && no_copy && x.ndim() > 1) {
+    auto stride = x.strides()[x.ndim() - 2];
+    no_copy &= (stride == 0 || stride == x.shape().back() || x.shape(-2) == 1);
+  }
+  if (no_copy) {
+    if (x.is_donatable()) {
+      out.copy_shared_buffer(x);
+    } else {
+      out.set_data(
+          allocator::malloc(x.data_size() * x.itemsize()),
+          x.data_size(),
+          x.strides(),
+          x.flags());
+    }
+    return x;
+  }
+  array x_copy = contiguous_copy_gpu(x, s);
+  out.copy_shared_buffer(x_copy);
+  return x_copy;
 }
 
 inline void check_kernel_threadgroup_size(


### PR DESCRIPTION
- ☑️ I understand it is strictly prohibited to use AI to write PR description

This PR extracts set_output function from normalization.cpp and softmax.cpp. 

In total there are 3 same function call but using lambda function currently. This refactor allows us to reuse and reduce the complexity from the code.

- AI usage disclosure: 

Umm I used AI to move the the block to utils.h and understand this function especially the following line haha and also use some it to help me do the formatting and running the testing (I'm lazy to type the command loll) 

`no_copy &= (s == 0 || s == x.shape().back() || x.shape(-2) == 1);`

