### PR TITLE
compile: Support shapeless compile for Scan primitive

### DIFF
--- a/mlx/primitives.h
+++ b/mlx/primitives.h
@@ -1888,6 +1888,7 @@ class Scan : public UnaryPrimitive {
 
   DEFINE_VMAP()
   DEFINE_GRADS();
+  DEFINE_INPUT_OUTPUT_SHAPE()
 
   const char* name() const override {
     switch (reduce_type_) {

--- a/python/tests/test_compile.py
+++ b/python/tests/test_compile.py
@@ -643,6 +643,39 @@ class TestCompile(mlx_tests.MLXTestCase):
 
         self.assertEqual(mx.compile(fun, shapeless=True)(x).shape, (1, 1, 4, 32))
 
+    def test_shapeless_compile_scan(self):
+        @partial(mx.compile, shapeless=True)
+        def fun(x):
+            return mx.cumsum(x, axis=0)
+
+        x1 = mx.arange(4, dtype=mx.float32)
+        out1 = fun(x1)
+        mx.eval(out1)
+        self.assertTrue(mx.array_equal(out1, mx.array([0.0, 1.0, 3.0, 6.0])))
+
+        x2 = mx.arange(6, dtype=mx.float32)
+        out2 = fun(x2)
+        mx.eval(out2)
+        self.assertTrue(
+            mx.array_equal(out2, mx.array([0.0, 1.0, 3.0, 6.0, 10.0, 15.0]))
+        )
+
+        @partial(mx.compile, shapeless=True)
+        def fun2d(x):
+            return mx.cumsum(x, axis=-1)
+
+        x2d = mx.ones((2, 3), dtype=mx.float32)
+        out2d = fun2d(x2d)
+        mx.eval(out2d)
+        self.assertTrue(
+            mx.array_equal(out2d, mx.array([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]]))
+        )
+
+        x2d_larger = mx.ones((3, 5), dtype=mx.float32)
+        out2d_larger = fun2d(x2d_larger)
+        mx.eval(out2d_larger)
+        self.assertEqual(out2d_larger.shape, (3, 5))
+
     def test_shapeless_compile_gather(self):
         x = mx.zeros((1, 1, 32))
 

--- a/tests/compile_tests.cpp
+++ b/tests/compile_tests.cpp
@@ -748,6 +748,18 @@ TEST_CASE("test shapeless compile") {
     out2 = cfun({array({1.0, 2.0}, {1, 2})})[0];
     CHECK_NE(out.inputs()[1].id(), out2.inputs()[1].id());
   }
+
+  {
+    auto compile_shapeless_scan = [](const std::vector<array>& inputs) {
+      return std::vector<array>{cumsum(inputs[0], 0)};
+    };
+    auto cfun = compile(compile_shapeless_scan, /* shapeless */ true);
+    auto out1 = cfun({array({1.0f, 2.0f, 3.0f})})[0];
+    CHECK(array_equal(out1, array({1.0f, 3.0f, 6.0f})).item<bool>());
+
+    auto out2 = cfun({array({1.0f, 2.0f, 3.0f, 4.0f})})[0];
+    CHECK(array_equal(out2, array({1.0f, 3.0f, 6.0f, 10.0f})).item<bool>());
+  }
 }
 
 auto compile_broadcast_add(const std::vector<array>& inputs) {


### PR DESCRIPTION
Fixes #4460

### Motivation
The `Scan` primitive (backing `cumsum`, `cumprod`, `cummin`, `cummax`, and `cumlogaddexp`) did not override `Primitive::output_shapes`. As a result, compiling a graph containing cumulative operations with `shapeless=True` failed with:
```text
[Primitive::output_shapes] CumSum cannot infer output shapes.
```

Because all operations derived from `Scan` preserve their input tensor shape, `Scan::output_shapes` can safely return the first input's shape.

### Changes
1. Added `DEFINE_INPUT_OUTPUT_SHAPE()` to `class Scan : public UnaryPrimitive` in `mlx/primitives.h`.
2. Added unit test coverage in `python/tests/test_compile.py` verifying dynamic shape execution across 1D and 2D arrays under `mx.compile(..., shapeless=True)`.
3. Added C++ test case in `tests/compile_tests.cpp` asserting dynamic shape compilation with `cumsum`.