### PR TITLE
[Metal] Add additional template type S for scales and biases

### DIFF
--- a/mlx/backend/metal/kernels/quantized.h
+++ b/mlx/backend/metal/kernels/quantized.h
@@ -754,11 +754,11 @@ METAL_FUNC void qmv_quad_impl(
   }
 }
 
-template <typename T, int group_size, int bits>
+template <typename T, int group_size, int bits, typename S = T>
 METAL_FUNC void qmv_fast_impl(
     const device uint32_t* w,
-    const device T* scales,
-    const device T* biases,
+    const device S* scales,
+    const device S* biases,
     const device T* x,
     device T* y,
     const constant int& in_vec_size,
@@ -799,8 +799,8 @@ METAL_FUNC void qmv_fast_impl(
 
     for (int row = 0; row < results_per_simdgroup; row++) {
       auto wl = (const device uint8_t*)(ws + row * in_vec_size_w);
-      const device T* sl = scales + row * in_vec_size_g;
-      const device T* bl = biases + row * in_vec_size_g;
+      const device S* sl = scales + row * in_vec_size_g;
+      const device S* bl = biases + row * in_vec_size_g;
 
       U s = sl[0];
       U b = bl[0];
@@ -821,11 +821,11 @@ METAL_FUNC void qmv_fast_impl(
   }
 }
 
-template <typename T, int group_size, int bits>
+template <typename T, int group_size, int bits, typename S = T>
 METAL_FUNC void qmv_impl(
     const device uint32_t* w,
-    const device T* scales,
-    const device T* biases,
+    const device S* scales,
+    const device S* biases,
     const device T* x,
     device T* y,
     const constant int& in_vec_size,
@@ -879,8 +879,8 @@ METAL_FUNC void qmv_impl(
            row < results_per_simdgroup && out_row + row < out_vec_size;
            row++) {
         auto wl = (const device uint8_t*)(ws + row * in_vec_size_w);
-        const device T* sl = scales + row * in_vec_size_g;
-        const device T* bl = biases + row * in_vec_size_g;
+        const device S* sl = scales + row * in_vec_size_g;
+        const device S* bl = biases + row * in_vec_size_g;
 
         U s = sl[0];
         U b = bl[0];
@@ -905,8 +905,8 @@ METAL_FUNC void qmv_impl(
            row < results_per_simdgroup && out_row + row < out_vec_size;
            row++) {
         auto wl = (const device uint8_t*)(ws + row * in_vec_size_w);
-        const device T* sl = scales + row * in_vec_size_g;
-        const device T* bl = biases + row * in_vec_size_g;
+        const device S* sl = scales + row * in_vec_size_g;
+        const device S* bl = biases + row * in_vec_size_g;
 
         U s = sl[0];
         U b = bl[0];
@@ -940,8 +940,8 @@ METAL_FUNC void qmv_impl(
 
       for (int row = 0; row < results_per_simdgroup; row++) {
         auto wl = (const device uint8_t*)(ws + row * in_vec_size_w);
-        const device T* sl = scales + row * in_vec_size_g;
-        const device T* bl = biases + row * in_vec_size_g;
+        const device S* sl = scales + row * in_vec_size_g;
+        const device S* bl = biases + row * in_vec_size_g;
 
         U s = sl[0];
         U b = bl[0];
@@ -964,8 +964,8 @@ METAL_FUNC void qmv_impl(
 
       for (int row = 0; row < results_per_simdgroup; row++) {
         auto wl = (const device uint8_t*)(ws + row * in_vec_size_w);
-        const device T* sl = scales + row * in_vec_size_g;
-        const device T* bl = biases + row * in_vec_size_g;
+        const device S* sl = scales + row * in_vec_size_g;
+        const device S* bl = biases + row * in_vec_size_g;
 
         U s = sl[0];
         U b = bl[0];
@@ -1453,12 +1453,12 @@ METAL_FUNC void qmm_n_impl(
   }
 }
 
-template <typename T>
+template <typename T, typename S = T>
 METAL_FUNC void adjust_matrix_offsets(
     const device T*& x,
     const device uint32_t*& w,
-    const device T*& scales,
-    const device T*& biases,
+    const device S*& scales,
+    const device S*& biases,
     device T*& y,
     int output_stride,
     const constant int& x_batch_ndims,
@@ -1492,12 +1492,12 @@ METAL_FUNC void adjust_matrix_offsets(
   y += tid.z * output_stride;
 }
 
-template <typename T>
+template <typename T, typename S = T>
 METAL_FUNC void adjust_matrix_offsets(
     const device T*& x,
     const device uint32_t*& w,
-    const device T*& scales,
-    const device T*& biases,
+    const device S*& scales,
+    const device S*& biases,
     const device uint32_t* lhs_indices,
     const device uint32_t* rhs_indices,
     device T*& y,
@@ -1604,11 +1604,12 @@ template <
     int bits,
     bool batched,
     bool has_global_scale = false,
-    int results_per_simdgroup = 4>
+    int results_per_simdgroup = 4,
+    typename S = T>
 [[kernel]] void affine_qmv_fast(
     const device uint32_t* w [[buffer(0)]],
-    const device T* scales [[buffer(1)]],
-    const device T* biases [[buffer(2)]],
+    const device S* scales [[buffer(1)]],
+    const device S* biases [[buffer(2)]],
     const device T* x [[buffer(3)]],
     device T* y [[buffer(4)]],
     const constant int& in_vec_size [[buffer(5)]],
@@ -1643,7 +1644,7 @@ template <
         b_strides,
         tid);
   }
-  qmv_fast_impl<T, group_size, bits>(
+  qmv_fast_impl<T, group_size, bits, S>(
       w,
       scales,
       biases,
@@ -1662,11 +1663,12 @@ template <
     const int bits,
     bool batched,
     bool has_global_scale = false,
-    int results_per_simdgroup = 4>
+    int results_per_simdgroup = 4,
+    typename S = T>
 [[kernel]] void affine_qmv(
     const device uint32_t* w [[buffer(0)]],
-    const device T* scales [[buffer(1)]],
-    const device T* biases [[buffer(2)]],
+    const device S* scales [[buffer(1)]],
+    const device S* biases [[buffer(2)]],
     const device T* x [[buffer(3)]],
     device T* y [[buffer(4)]],
     const constant int& in_vec_size [[buffer(5)]],
@@ -1701,7 +1703,7 @@ template <
         b_strides,
         tid);
   }
-  qmv_impl<T, group_size, bits>(
+  qmv_impl<T, group_size, bits, S>(
       w,
       scales,
       biases,
@@ -2084,11 +2086,16 @@ template <
       w, scales, biases, x, y, Xs, Ws, K, N, M, tid, lid, simd_gid, simd_lid);
 }
 
-template <typename T, int group_size, int bits, bool has_global_scale = false>
+template <
+    typename T,
+    int group_size,
+    int bits,
+    bool has_global_scale = false,
+    typename S = T>
 [[kernel]] void affine_gather_qmv_fast(
     const device uint32_t* w [[buffer(0)]],
-    const device T* scales [[buffer(1)]],
-    const device T* biases [[buffer(2)]],
+    const device S* scales [[buffer(1)]],
+    const device S* biases [[buffer(2)]],
     const device T* x [[buffer(3)]],
     const device uint32_t* lhs_indices [[buffer(4)]],
     const device uint32_t* rhs_indices [[buffer(5)]],
@@ -2133,7 +2140,7 @@ template <typename T, int group_size, int bits, bool has_global_scale = false>
       s_strides,
       b_strides,
       tid);
-  qmv_fast_impl<T, group_size, bits>(
+  qmv_fast_impl<T, group_size, bits, S>(
       w,
       scales,
       biases,
@@ -2146,11 +2153,16 @@ template <typename T, int group_size, int bits, bool has_global_scale = false>
       simd_lid);
 }
 
-template <typename T, int group_size, int bits, bool has_global_scale = false>
+template <
+    typename T,
+    int group_size,
+    int bits,
+    bool has_global_scale = false,
+    typename S = T>
 [[kernel]] void affine_gather_qmv(
     const device uint32_t* w [[buffer(0)]],
-    const device T* scales [[buffer(1)]],
-    const device T* biases [[buffer(2)]],
+    const device S* scales [[buffer(1)]],
+    const device S* biases [[buffer(2)]],
     const device T* x [[buffer(3)]],
     const device uint32_t* lhs_indices [[buffer(4)]],
     const device uint32_t* rhs_indices [[buffer(5)]],
@@ -2195,7 +2207,7 @@ template <typename T, int group_size, int bits, bool has_global_scale = false>
       s_strides,
       b_strides,
       tid);
-  qmv_impl<T, group_size, bits>(
+  qmv_impl<T, group_size, bits, S>(
       w,
       scales,
       biases,

--- a/mlx/backend/metal/kernels/quantized.metal
+++ b/mlx/backend/metal/kernels/quantized.metal
@@ -180,3 +180,36 @@
   instantiate_quantized_groups(8)
 
 instantiate_quantized_all() // clang-format on
+
+// Mixed-dtype instantiations: activations in `type`, scales/biases in `stype`.
+// Lets a checkpoint whose scales were stored in the other 16-bit float run
+// without promoting (and re-casting the whole scales table) on every call.
+#define instantiate_quantized_mixed(type, stype, group_size, bits)                                                     \
+  instantiate_kernel("affine_qmv_fast_" #type "_s_" #stype "_gs_" #group_size "_b_" #bits "_batch_0",                 \
+      affine_qmv_fast, type, group_size, bits, false, false, 4, stype)                                                  \
+  instantiate_kernel("affine_qmv_fast_" #type "_s_" #stype "_gs_" #group_size "_b_" #bits "_batch_1",                 \
+      affine_qmv_fast, type, group_size, bits, true, false, 4, stype)                                                   \
+  instantiate_kernel("affine_qmv_" #type "_s_" #stype "_gs_" #group_size "_b_" #bits "_batch_0",                      \
+      affine_qmv, type, group_size, bits, false, false, 4, stype)                                                       \
+  instantiate_kernel("affine_qmv_" #type "_s_" #stype "_gs_" #group_size "_b_" #bits "_batch_1",                      \
+      affine_qmv, type, group_size, bits, true, false, 4, stype)                                                        \
+  instantiate_kernel("affine_gather_qmv_fast_" #type "_s_" #stype "_gs_" #group_size "_b_" #bits,                     \
+      affine_gather_qmv_fast, type, group_size, bits, false, stype)                                                     \
+  instantiate_kernel("affine_gather_qmv_" #type "_s_" #stype "_gs_" #group_size "_b_" #bits,                          \
+      affine_gather_qmv, type, group_size, bits, false, stype)
+
+#define instantiate_quantized_mixed_groups(type, stype, bits) \
+  instantiate_quantized_mixed(type, stype, 128, bits)         \
+  instantiate_quantized_mixed(type, stype, 64, bits)          \
+  instantiate_quantized_mixed(type, stype, 32, bits)
+
+#define instantiate_quantized_mixed_all(type, stype)  \
+  instantiate_quantized_mixed_groups(type, stype, 2)  \
+  instantiate_quantized_mixed_groups(type, stype, 3)  \
+  instantiate_quantized_mixed_groups(type, stype, 4)  \
+  instantiate_quantized_mixed_groups(type, stype, 5)  \
+  instantiate_quantized_mixed_groups(type, stype, 6)  \
+  instantiate_quantized_mixed_groups(type, stype, 8)
+
+instantiate_quantized_mixed_all(bfloat16_t, float16_t)
+instantiate_quantized_mixed_all(float16_t, bfloat16_t)

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -481,6 +481,9 @@ void qmv(
   std::string kname;
   kname.reserve(64);
   std::string type_string = get_type_string(x.dtype());
+  if (mode == "affine" && scales.dtype() != x.dtype()) {
+    type_string += "_s_" + get_type_string(scales.dtype());
+  }
   bool fast = N % bn == 0 && K % qmv_fast_k_alignment(bits) == 0;
   // A narrower output tile reduces register pressure for large
   // floating-point quantized matrix-vector products on M5 Max GPUs.
@@ -1361,6 +1364,9 @@ void gather_qmv(
   std::string kname;
   kname.reserve(64);
   std::string type_string = get_type_string(x.dtype());
+  if (mode == "affine" && scales.dtype() != x.dtype()) {
+    type_string += "_s_" + get_type_string(scales.dtype());
+  }
   bool fast = N % bn == 0 && K % qmv_fast_k_alignment(bits) == 0;
   concatenate(
       kname,
@@ -1798,14 +1804,15 @@ void dispatch_qmv(
     const Stream& s,
     const std::string& mode) {
   // It is a qmv with a small inner dimension so route to qmv_quad kernel
-  if ((K == 128 || K == 64) && is_power_of_2(bits) && !global_scale) {
+  bool mixed = mode == "affine" && scales.dtype() != x.dtype();
+  if (!mixed && (K == 128 || K == 64) && is_power_of_2(bits) && !global_scale) {
     qmv_quad(x, w, scales, biases, out, group_size, bits, M, N, K, d, s, mode);
     return;
   }
 
   // Small batch so route to qmv_wide, which reuses each weight group across the
   // M vectors.
-  if (M >= 2 && use_qmv_wide(mode, d) && !global_scale) {
+  if (!mixed && M >= 2 && use_qmv_wide(mode, d) && !global_scale) {
     qmv_wide(x, w, scales, biases, out, group_size, bits, M, N, K, d, s, mode);
     return;
   }
@@ -1825,22 +1832,44 @@ void dispatch_qmv(
       mode);
 }
 
-void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
-  auto& s = stream();
-  auto& d = metal::device(s.device);
-
+// Mixed 16-bit scales reach the affine matvec kernels natively; every other
+// path runs the promoted float32 computation the op would otherwise have
+// built, with the casts done here as temporaries, and the result cast back
+// to the activation dtype.
+static array promoted_copy(const array& in, const Stream& s) {
+  array out(in.shape(), float32, nullptr, {});
   out.set_data(allocator::malloc(out.nbytes()));
+  copy_gpu(
+      in,
+      out,
+      in.flags().row_contiguous ? CopyType::Vector : CopyType::General,
+      s);
+  metal::get_command_encoder(s).add_temporary(out);
+  return out;
+}
 
-  // Make sure the last two dims of x and w, s, b are contiguous. This should
-  // be relaxed for x.
-  array x = ensure_row_contiguous_matrix(inputs[0], d, s);
-  array w = ensure_row_contiguous_matrix(inputs[1], d, s);
-  array scales = ensure_row_contiguous_matrix(inputs[2], d, s);
-  std::optional<array> biases = std::nullopt;
-  if (inputs.size() == 4) {
-    biases = ensure_row_contiguous_matrix(inputs[3], d, s);
-  }
+static bool mixed_scales(
+    const array& x,
+    const array& scales,
+    const std::optional<array>& biases,
+    QuantizationMode mode) {
+  auto is16 = [](Dtype d) { return d == float16 || d == bfloat16; };
+  return mode == QuantizationMode::Affine && biases.has_value() &&
+      is16(x.dtype()) && is16(scales.dtype()) && scales.dtype() != x.dtype();
+}
 
+static void quantized_matmul_dispatch(
+    array x,
+    array w,
+    array scales,
+    std::optional<array> biases,
+    array& out,
+    bool transpose_,
+    int group_size_,
+    int bits_,
+    QuantizationMode mode_,
+    metal::Device& d,
+    const Stream& s) {
   // Extract the matmul shapes
   bool non_batched = w.ndim() == 2 && x.flags().row_contiguous;
   int K = x.shape(-1);
@@ -1920,26 +1949,61 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
   return;
 }
 
-void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
+void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
   auto& s = stream();
   auto& d = metal::device(s.device);
 
   out.set_data(allocator::malloc(out.nbytes()));
 
+  // Make sure the last two dims of x and w, s, b are contiguous. This should
+  // be relaxed for x.
   array x = ensure_row_contiguous_matrix(inputs[0], d, s);
   array w = ensure_row_contiguous_matrix(inputs[1], d, s);
   array scales = ensure_row_contiguous_matrix(inputs[2], d, s);
-  // Affine gets biases at index 3, nvfp4 an optional global scale.
   std::optional<array> biases = std::nullopt;
-  std::optional<array> global_scale = std::nullopt;
-  if (mode_ == QuantizationMode::Affine) {
+  if (inputs.size() == 4) {
     biases = ensure_row_contiguous_matrix(inputs[3], d, s);
-  } else if (inputs.size() == 6) {
-    global_scale = ensure_row_contiguous(inputs[3], d, s);
   }
-  const array& lhs_indices = inputs[inputs.size() - 2];
-  const array& rhs_indices = inputs[inputs.size() - 1];
 
+  if (mixed_scales(x, scales, biases, mode_)) {
+    bool non_batched = w.ndim() == 2 && x.flags().row_contiguous;
+    int K = x.shape(-1);
+    int M = non_batched ? x.size() / K : x.shape(-2);
+    int N = out.shape(-1);
+    bool matvec = transpose_ && M < get_qmv_batch_limit(K, N, d);
+    if (!matvec) {
+      array x32 = promoted_copy(x, s);
+      array s32 = promoted_copy(scales, s);
+      array b32 = promoted_copy(*biases, s);
+      array out32(out.shape(), float32, nullptr, {});
+      out32.set_data(allocator::malloc(out32.nbytes()));
+      metal::get_command_encoder(s).add_temporary(out32);
+      quantized_matmul_dispatch(
+          x32, w, s32, b32, out32, transpose_, group_size_, bits_, mode_, d, s);
+      copy_gpu(out32, out, CopyType::Vector, s);
+      return;
+    }
+  }
+  quantized_matmul_dispatch(
+      x, w, scales, biases, out, transpose_, group_size_, bits_, mode_, d, s);
+}
+
+static void gather_qmm_dispatch(
+    array x,
+    array w,
+    array scales,
+    std::optional<array> biases,
+    const std::optional<array>& global_scale,
+    const array& lhs_indices,
+    const array& rhs_indices,
+    array& out,
+    bool transpose_,
+    int group_size_,
+    int bits_,
+    QuantizationMode mode_,
+    bool right_sorted_,
+    metal::Device& d,
+    const Stream& s) {
   int K = x.shape(-1);
   int M = x.shape(-2);
   int N = out.shape(-1);
@@ -2034,6 +2098,80 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
       d,
       s,
       mode);
+}
+
+void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
+  auto& s = stream();
+  auto& d = metal::device(s.device);
+
+  out.set_data(allocator::malloc(out.nbytes()));
+
+  array x = ensure_row_contiguous_matrix(inputs[0], d, s);
+  array w = ensure_row_contiguous_matrix(inputs[1], d, s);
+  array scales = ensure_row_contiguous_matrix(inputs[2], d, s);
+  // Affine gets biases at index 3, nvfp4 an optional global scale.
+  std::optional<array> biases = std::nullopt;
+  std::optional<array> global_scale = std::nullopt;
+  if (mode_ == QuantizationMode::Affine) {
+    biases = ensure_row_contiguous_matrix(inputs[3], d, s);
+  } else if (inputs.size() == 6) {
+    global_scale = ensure_row_contiguous(inputs[3], d, s);
+  }
+  const array& lhs_indices = inputs[inputs.size() - 2];
+  const array& rhs_indices = inputs[inputs.size() - 1];
+
+  if (mixed_scales(x, scales, biases, mode_)) {
+    int K = x.shape(-1);
+    int M = x.shape(-2);
+    int N = out.shape(-1);
+    int B = out.size() / M / N;
+    int E = w.size() / w.shape(-1) / w.shape(-2);
+    bool sorted_rhs_path = M == 1 && B >= 16 && right_sorted_ && B / E >= 4;
+    bool matvec =
+        transpose_ && !sorted_rhs_path && M < get_qmv_batch_limit(K, N, d);
+    if (!matvec) {
+      array x32 = promoted_copy(x, s);
+      array s32 = promoted_copy(scales, s);
+      array b32 = promoted_copy(*biases, s);
+      array out32(out.shape(), float32, nullptr, {});
+      out32.set_data(allocator::malloc(out32.nbytes()));
+      metal::get_command_encoder(s).add_temporary(out32);
+      gather_qmm_dispatch(
+          x32,
+          w,
+          s32,
+          b32,
+          global_scale,
+          lhs_indices,
+          rhs_indices,
+          out32,
+          transpose_,
+          group_size_,
+          bits_,
+          mode_,
+          right_sorted_,
+          d,
+          s);
+      copy_gpu(out32, out, CopyType::Vector, s);
+      return;
+    }
+  }
+  gather_qmm_dispatch(
+      x,
+      w,
+      scales,
+      biases,
+      global_scale,
+      lhs_indices,
+      rhs_indices,
+      out,
+      transpose_,
+      group_size_,
+      bits_,
+      mode_,
+      right_sorted_,
+      d,
+      s);
 }
 
 void QQMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {

--- a/mlx/ops.cpp
+++ b/mlx/ops.cpp
@@ -4750,6 +4750,25 @@ void validate_global_scale(
   }
 }
 
+// Affine quantized matmuls accept scales/biases in the other 16-bit float
+// (float16 scales with bfloat16 activations, or the reverse) without
+// promoting: the Metal matvec kernels convert the scale per group in
+// registers, and the other Metal paths fall back to a float32 computation
+// inside the primitive. Other backends keep the promotion.
+static bool mixed_qscales_allowed(
+    const array& x,
+    const array& scales,
+    const std::optional<array>& biases,
+    const Stream& s) {
+  if (!biases.has_value() || s.device != Device::gpu ||
+      !metal::is_available()) {
+    return false;
+  }
+  auto is16 = [](Dtype d) { return d == float16 || d == bfloat16; };
+  return is16(x.dtype()) && is16(scales.dtype()) &&
+      x.dtype() != scales.dtype() && biases->dtype() == scales.dtype();
+}
+
 array quantized_matmul(
     const array& x,
     const array& w,
@@ -4769,7 +4788,11 @@ array quantized_matmul(
   auto [w_inner_dims, w_outer_dims] = extract_quantized_matmul_dims(
       "quantized_matmul", x, w, scales, biases, transpose, group_size, bits);
 
-  if (qmode == QuantizationMode::Affine) {
+  bool mixed = qmode == QuantizationMode::Affine &&
+      mixed_qscales_allowed(x, scales, biases, to_stream(s));
+  if (mixed) {
+    dtype = x.dtype();
+  } else if (qmode == QuantizationMode::Affine) {
     dtype = promote_types(x.dtype(), dtype);
   } else {
     dtype = x.dtype();
@@ -4782,7 +4805,9 @@ array quantized_matmul(
     throw std::invalid_argument(msg.str());
   }
   std::vector<array> inputs;
-  if (qmode == QuantizationMode::Affine) {
+  if (mixed) {
+    inputs = {x, w, scales, *biases};
+  } else if (qmode == QuantizationMode::Affine) {
     inputs = {
         astype(x, dtype), w, astype(scales, dtype), astype(*biases, dtype)};
   } else {
@@ -5580,7 +5605,11 @@ array gather_qmm(
           "[gather_qmm] Global scale is only supported on the Metal backend.");
     }
   }
-  if (qmode == QuantizationMode::Affine) {
+  bool mixed = qmode == QuantizationMode::Affine &&
+      mixed_qscales_allowed(x, scales, biases, to_stream(s));
+  if (mixed) {
+    out_type = x.dtype();
+  } else if (qmode == QuantizationMode::Affine) {
     out_type = promote_types(x.dtype(), out_type);
   } else {
     out_type = x.dtype();
@@ -5604,7 +5633,15 @@ array gather_qmm(
   out_shape.push_back(x.shape(-2));
   out_shape.push_back(w_outer_dims);
   std::vector<array> inputs;
-  if (qmode == QuantizationMode::Affine) {
+  if (mixed) {
+    inputs = {
+        x,
+        std::move(w),
+        scales,
+        *biases,
+        std::move(lhs_indices),
+        std::move(rhs_indices)};
+  } else if (qmode == QuantizationMode::Affine) {
     inputs = {
         astype(x, out_type, s),
         std::move(w),

--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -4649,7 +4649,9 @@ void init_ops(nb::module_& m) {
         Args:
           x (array): Input array
           w (array): Quantized matrix packed in unsigned integers
-          scales (array): The scales to use per ``group_size`` elements of ``w``
+          scales (array): The scales to use per ``group_size`` elements of ``w``.
+            For affine quantization the scales and biases may be ``float16`` or
+            ``bfloat16`` independently of ``x``; the output takes the dtype of ``x``.
           biases (array, optional): The biases to use per ``group_size``
             elements of ``w``. Default: ``None``.
           transpose (bool, optional): Defines whether to multiply with the
@@ -4849,7 +4851,9 @@ void init_ops(nb::module_& m) {
         Args:
             x (array): Input array
             w (array): Quantized matrix packed in unsigned integers
-            scales (array): The scales to use per ``group_size`` elements of ``w``
+            scales (array): The scales to use per ``group_size`` elements of ``w``.
+              For affine quantization the scales and biases may be ``float16`` or
+              ``bfloat16`` independently of ``x``; the output takes the dtype of ``x``.
             biases (array, optional): The biases to use per ``group_size``
               elements of ``w``. Default: ``None``.
             lhs_indices (array, optional): Integer indices for ``x``. Default: ``None``.

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -1900,6 +1900,76 @@ class TestQuantized(mlx_tests.MLXTestCase):
         expected = mx.dequantize(w_q, mx.contiguous(scales), mode=mode)
         self.assertTrue(mx.allclose(w_hat, expected))
 
+    def test_mixed_scale_dtype(self):
+        # Affine scales/biases in the other 16-bit float than the activations
+        # must run without promotion: the output keeps the activation dtype
+        # and matches the float32 computation with the exact scale values.
+        key = mx.random.key(0)
+        pairs = [(mx.bfloat16, mx.float16), (mx.float16, mx.bfloat16)]
+        for x_dtype, s_dtype in pairs:
+            for gs in [32, 64, 128]:
+                for bits in [2, 3, 4, 5, 6, 8]:
+                    for K, N in [(512, 256), (512, 250)]:
+                        w = mx.random.normal(shape=(N, K), key=key).astype(s_dtype)
+                        w_q, scales, biases = mx.quantize(w, gs, bits)
+                        self.assertEqual(scales.dtype, s_dtype)
+                        for M, transpose in [
+                            (1, True),
+                            (5, True),
+                            (64, True),
+                            (1, False),
+                        ]:
+                            x = mx.random.normal(
+                                shape=(M, K if transpose else N), key=key
+                            ).astype(x_dtype)
+                            y = mx.quantized_matmul(
+                                x,
+                                w_q,
+                                scales,
+                                biases,
+                                transpose=transpose,
+                                group_size=gs,
+                                bits=bits,
+                            )
+                            ref = mx.quantized_matmul(
+                                x.astype(mx.float32),
+                                w_q,
+                                scales.astype(mx.float32),
+                                biases.astype(mx.float32),
+                                transpose=transpose,
+                                group_size=gs,
+                                bits=bits,
+                            )
+                            self.assertEqual(y.dtype, x_dtype)
+                            tol = 3e-2 * float(mx.abs(ref).max())
+                            self.assertLess(
+                                float(mx.abs(y.astype(mx.float32) - ref).max()), tol
+                            )
+
+        # gather_qmm, matvec and matrix paths
+        for x_dtype, s_dtype in pairs:
+            E, K, N = 8, 512, 256
+            w = mx.random.normal(shape=(E, N, K), key=key).astype(s_dtype)
+            w_q, scales, biases = mx.quantize(w, 64, 4)
+            rhs = mx.array([[0, 3, 5, 7]], dtype=mx.uint32)
+            for M in [1, 64]:
+                x = mx.random.normal(shape=(1, 1, M, K), key=key).astype(x_dtype)
+                y = mx.gather_qmm(
+                    x, w_q, scales, biases, rhs_indices=rhs, group_size=64, bits=4
+                )
+                ref = mx.gather_qmm(
+                    x.astype(mx.float32),
+                    w_q,
+                    scales.astype(mx.float32),
+                    biases.astype(mx.float32),
+                    rhs_indices=rhs,
+                    group_size=64,
+                    bits=4,
+                )
+                self.assertEqual(y.dtype, x_dtype)
+                tol = 3e-2 * float(mx.abs(ref).max())
+                self.assertLess(float(mx.abs(y.astype(mx.float32) - ref).max()), tol)
+
 
 if __name__ == "__main__":
     mlx_tests.MLXTestRunner()


### PR DESCRIPTION
- ☑️ I understand it is strictly prohibited to use AI to write PR description
- AI usage disclosure: the kernel change was drafted with Claude Code from my design, built and measured on my machines, and reviewed by me.

The c++ template assumes a single typed parameter, T, across activations, scales, biases, and the output. If activations are bfloat16 and scales are float16, no kernel exists. The common type conversion penalty is especially expensive for scales and biases which could convert on every call, which comes back and poisons the rest of the network. Proposing giving scales and biases their own type parameter, S, with default to T.

all 39 quantized tests pass, test_ops passes. Mismatched gather_qmm at decode: 0.245 to 0.269 ms against 0.254 to 0.274 for a consistent checkpoint, down from 0.465 as float32. Prefill-shaped fallback at M=512: 1.92 ms against 1.47 consistent, the one-time cast now amortized over 512 rows. CPU stream: float32 output, exact, unchanged.