### PR TITLE
 Add a scoped_env utility for tests

### DIFF
--- a/python/tests/mlx_tests.py
+++ b/python/tests/mlx_tests.py
@@ -1,5 +1,6 @@
 # Copyright © 2023 Apple Inc.
 
+import contextlib
 import os
 import platform
 import sys
@@ -8,6 +9,26 @@ from typing import Any, Callable, List, Tuple, Union
 
 import mlx.core as mx
 import numpy as np
+
+
+@contextlib.contextmanager
+def scoped_env(**environ):
+    """
+    Temporarily set the process environment variables.
+
+    Passing a value of None removes the variable for the duration of the context.
+    """
+    old_environ = dict(os.environ)
+    for key, value in environ.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(old_environ)
 
 
 class MLXTestRunner(unittest.TestProgram):

--- a/python/tests/test_conv.py
+++ b/python/tests/test_conv.py
@@ -1220,7 +1220,6 @@ class TestConv(mlx_tests.MLXTestCase):
         # Use envs to test tiling without allocating large buffers.
         tile_key = "MLX_CONV_WINOGRAD_TILE_BATCH"
         ws_key = "MLX_CONV_WINOGRAD_WORKING_SET"
-        prev = {k: os.environ.get(k) for k in (tile_key, ws_key)}
 
         # Winograd needs 3x3 stride-1, channels in multiples of 32,
         # C + O >= 256 and N * iH * iW >= 4096.
@@ -1231,81 +1230,68 @@ class TestConv(mlx_tests.MLXTestCase):
         )
 
         def run(x, w, env={}):
-            for k in (tile_key, ws_key):
-                os.environ.pop(k, None)
-            os.environ.update(env)
-            y = mx.conv2d(x, w, padding=1)
-            mx.eval(y)
-            return np.array(y)
+            with mlx_tests.scoped_env(**env):
+                y = mx.conv2d(x, w, padding=1)
+                mx.eval(y)
+                return np.array(y)
 
-        try:
-            for in_shape, wt_shape in cases:
-                np.random.seed(0)
-                x = mx.array(np.random.normal(size=in_shape).astype(np.float32))
-                # Small weights keep the output near unit scale.
-                w = mx.array(
-                    (np.random.normal(size=wt_shape) * 0.05).astype(np.float32)
-                )
-                b = mx.zeros((wt_shape[0],))
-                mx.eval(x, w, b)
-                cpu_ref = np.array(mx.conv2d(x, w, padding=1, stream=mx.cpu))
+        for in_shape, wt_shape in cases:
+            np.random.seed(0)
+            x = mx.array(np.random.normal(size=in_shape).astype(np.float32))
+            # Small weights keep the output near unit scale.
+            w = mx.array((np.random.normal(size=wt_shape) * 0.05).astype(np.float32))
+            b = mx.zeros((wt_shape[0],))
+            mx.eval(x, w, b)
+            cpu_ref = np.array(mx.conv2d(x, w, padding=1, stream=mx.cpu))
 
-                untiled = run(x, w)
-                self.assertGreater(np.abs(untiled).max(), 0)
-                self.assertTrue(np.allclose(untiled, cpu_ref, atol=1e-3))
+            untiled = run(x, w)
+            self.assertGreater(np.abs(untiled).max(), 0)
+            self.assertTrue(np.allclose(untiled, cpu_ref, atol=1e-3))
 
-                # Tiled winograd keeps the same per-element reduction order,
-                # so it is bit-identical to untiled; the implicit gemm
-                # fallback never is. Exact equality pins each run to its path.
-                # 3 divides none of the batches, so it also covers a short
-                # final tile.
-                for tile in (1, 3):
-                    with self.subTest(in_shape=in_shape, tile=tile):
-                        tiled = run(x, w, {tile_key: str(tile)})
-                        self.assertTrue(np.array_equal(untiled, tiled))
-
-                        # A consumer op checks the output is fenced across
-                        # command encoders.
-                        os.environ[tile_key] = str(tile)
-                        fused = mx.conv2d(x, w, padding=1) + b
-                        mx.eval(fused)
-                        self.assertTrue(np.allclose(untiled, fused, atol=1e-4))
-                        os.environ.pop(tile_key, None)
-
-                # Budget for ~2 batch elements so the selector itself must
-                # tile; mirrors the winograd_batch_step arithmetic.
-                n, iH, iW, C = in_shape
-                O = wt_shape[0]
-                pH = 6 * ((iH + 2 - 2 + 5) // 6) + 2
-                pW = 6 * ((iW + 2 - 2 + 5) // 6) + 2
-                per_n = (
-                    pH * pW * C * 4
-                    + 64 * ((iH + 5) // 6) * ((iW + 5) // 6) * (C + O) * 4
-                )
-                used = (n * iH * iW * (C + O) + 64 * C * O) * 4
-                with self.subTest(in_shape=in_shape, budget="tiled"):
-                    budget = str(int((used + 5 * per_n // 2) / 0.75))
-                    tiled = run(x, w, {ws_key: budget})
+            # Tiled winograd keeps the same per-element reduction order,
+            # so it is bit-identical to untiled; the implicit gemm
+            # fallback never is. Exact equality pins each run to its path.
+            # 3 divides none of the batches, so it also covers a short
+            # final tile.
+            for tile in (1, 3):
+                with self.subTest(in_shape=in_shape, tile=tile):
+                    tiled = run(x, w, {tile_key: str(tile)})
                     self.assertTrue(np.array_equal(untiled, tiled))
 
-                # Too small for even one batch element: must fall back.
-                with self.subTest(in_shape=in_shape, budget="infeasible"):
-                    fallback = run(x, w, {ws_key: "1"})
-                    self.assertFalse(np.array_equal(untiled, fallback))
-                    self.assertTrue(np.allclose(fallback, cpu_ref, atol=1e-3))
+                    # A consumer op checks the output is fenced across
+                    # command encoders.
+                    with mlx_tests.scoped_env(MLX_CONV_WINOGRAD_TILE_BATCH=str(tile)):
+                        fused = mx.conv2d(x, w, padding=1) + b
+                        mx.eval(fused)
+                    self.assertTrue(np.allclose(untiled, fused, atol=1e-4))
 
-                # A forced tile is capped by the budget, so this must still
-                # fall back.
-                with self.subTest(in_shape=in_shape, budget="forced+infeasible"):
-                    capped = run(x, w, {ws_key: "1", tile_key: "1"})
-                    self.assertFalse(np.array_equal(untiled, capped))
-                    self.assertTrue(np.allclose(capped, cpu_ref, atol=1e-3))
-        finally:
-            for k, v in prev.items():
-                if v is None:
-                    os.environ.pop(k, None)
-                else:
-                    os.environ[k] = v
+            # Budget for ~2 batch elements so the selector itself must
+            # tile; mirrors the winograd_batch_step arithmetic.
+            n, iH, iW, C = in_shape
+            O = wt_shape[0]
+            pH = 6 * ((iH + 2 - 2 + 5) // 6) + 2
+            pW = 6 * ((iW + 2 - 2 + 5) // 6) + 2
+            per_n = (
+                pH * pW * C * 4 + 64 * ((iH + 5) // 6) * ((iW + 5) // 6) * (C + O) * 4
+            )
+            used = (n * iH * iW * (C + O) + 64 * C * O) * 4
+            with self.subTest(in_shape=in_shape, budget="tiled"):
+                budget = str(int((used + 5 * per_n // 2) / 0.75))
+                tiled = run(x, w, {ws_key: budget})
+                self.assertTrue(np.array_equal(untiled, tiled))
+
+            # Too small for even one batch element: must fall back.
+            with self.subTest(in_shape=in_shape, budget="infeasible"):
+                fallback = run(x, w, {ws_key: "1"})
+                self.assertFalse(np.array_equal(untiled, fallback))
+                self.assertTrue(np.allclose(fallback, cpu_ref, atol=1e-3))
+
+            # A forced tile is capped by the budget, so this must still
+            # fall back.
+            with self.subTest(in_shape=in_shape, budget="forced+infeasible"):
+                capped = run(x, w, {ws_key: "1", tile_key: "1"})
+                self.assertFalse(np.array_equal(untiled, capped))
+                self.assertTrue(np.allclose(capped, cpu_ref, atol=1e-3))
 
     def test_conv2d_large_filter_small_channels(self):
         x = mx.random.normal(shape=(1, 181, 181, 1))

--- a/python/tests/test_conv_transpose.py
+++ b/python/tests/test_conv_transpose.py
@@ -813,37 +813,27 @@ class TestConvTranspose(mlx_tests.MLXTestCase):
         # The explicit-GEMM conv path unfolds into one buffer that can exceed
         # maxBufferLength for large outputs; it unfolds and runs the gemm in row
         # tiles instead (issue #3082).
-        key = "MLX_CONV_UNFOLD_TILE_ROWS"
-        prev = os.environ.get(key)
         cases = (
             (mx.conv_transpose1d, (2, 9, 4), (5, 3, 4), {"stride": 2}),
             (mx.conv_transpose2d, (2, 5, 5, 4), (5, 3, 3, 4), {"stride": 2}),
             (mx.conv_transpose3d, (1, 4, 4, 4, 2), (3, 2, 2, 2, 2), {"stride": 2}),
             (mx.conv_transpose1d, (2, 9, 4), (6, 3, 2), {"stride": 2, "groups": 2}),
         )
-        try:
-            # tile_rows=1 forces uniform tiles; 7 does not divide any output, so
-            # it exercises a partial final tile too.
-            for conv, in_shape, wt_shape, kwargs in cases:
-                for tile_rows in (1, 7):
-                    with self.subTest(
-                        conv=conv.__name__, tile_rows=tile_rows, **kwargs
-                    ):
-                        np.random.seed(0)
-                        x = mx.array(np.random.normal(size=in_shape).astype(np.float32))
-                        w = mx.array(np.random.normal(size=wt_shape).astype(np.float32))
-                        os.environ.pop(key, None)
+        # tile_rows=1 forces uniform tiles; 7 does not divide any output, so
+        # it exercises a partial final tile too.
+        for conv, in_shape, wt_shape, kwargs in cases:
+            for tile_rows in (1, 7):
+                with self.subTest(conv=conv.__name__, tile_rows=tile_rows, **kwargs):
+                    np.random.seed(0)
+                    x = mx.array(np.random.normal(size=in_shape).astype(np.float32))
+                    w = mx.array(np.random.normal(size=wt_shape).astype(np.float32))
+                    with mlx_tests.scoped_env(MLX_CONV_UNFOLD_TILE_ROWS=None):
                         untiled = conv(x, w, **kwargs)
                         mx.eval(untiled)
-                        os.environ[key] = str(tile_rows)
+                    with mlx_tests.scoped_env(MLX_CONV_UNFOLD_TILE_ROWS=str(tile_rows)):
                         tiled = conv(x, w, **kwargs)
                         mx.eval(tiled)
-                        self.assertTrue(np.allclose(untiled, tiled, atol=1e-4))
-        finally:
-            if prev is None:
-                os.environ.pop(key, None)
-            else:
-                os.environ[key] = prev
+                    self.assertTrue(np.allclose(untiled, tiled, atol=1e-4))
 
 
 if __name__ == "__main__":

--- a/python/tests/test_fast_sdpa.py
+++ b/python/tests/test_fast_sdpa.py
@@ -1,9 +1,7 @@
 import math
 import os
 import unittest
-from contextlib import nullcontext
 from itertools import product
-from unittest.mock import patch
 
 import mlx.core as mx
 import mlx_tests
@@ -150,18 +148,10 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
     def test_sdpa_pad_head_dim_opt_in(self):
         if mx.default_device() != mx.gpu:
             self.skipTest("requires GPU")
-        name = "MLX_SDPA_PAD_HEAD_DIM"
-        previous = os.environ.get(name)
-        try:
-            os.environ[name] = "1"
+        with mlx_tests.scoped_env(MLX_SDPA_PAD_HEAD_DIM="1"):
             self.test_sdpa_head_dim_72()
             self.test_sdpa_head_dim_80()
             self.test_sdpa_head_dim_72_80_sinks()
-        finally:
-            if previous is None:
-                os.environ.pop(name, None)
-            else:
-                os.environ[name] = previous
 
     @unittest.skipIf(not mx.is_available(mx.gpu), "GPU kernel path only")
     def test_sdpa_head_dim_80(self):
@@ -430,74 +420,70 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
         scale = D**-0.5
         mx.random.seed(0)
 
-        # Keep the test hermetic if the caller already configured a threshold.
-        # addCleanup restores the complete environment snapshot on every exit.
-        environment = patch.dict(os.environ)
-        environment.start()
-        self.addCleanup(environment.stop)
-        os.environ["MLX_SDPA_D512_MIN_KL"] = "0"
+        with mlx_tests.scoped_env(MLX_SDPA_D512_MIN_KL="0"):
+            # Test 1-pass kernel.
+            for dtype in (mx.float32, mx.float16, mx.bfloat16):
+                with self.subTest(L=128, dtype=dtype, threshold="off"):
+                    q = mx.random.normal(shape=(1, Nq, 1, D), dtype=dtype)
+                    k = mx.random.normal(shape=(1, Nkv, 128, D), dtype=dtype)
+                    v = mx.random.normal(shape=(1, Nkv, 128, D), dtype=dtype)
+                    ref = mlx_ref_attn(q, k, v, scale)
+                    out = mx.fast.scaled_dot_product_attention(
+                        q, k, v, scale=scale, force_fused=True
+                    )
+                    atol = 1e-5 if dtype == mx.float32 else 2e-2
+                    self.assertTrue(mx.allclose(ref, out, atol=atol))
 
-        # Test 1-pass kernel.
-        for dtype in (mx.float32, mx.float16, mx.bfloat16):
-            with self.subTest(L=128, dtype=dtype, threshold="off"):
-                q = mx.random.normal(shape=(1, Nq, 1, D), dtype=dtype)
-                k = mx.random.normal(shape=(1, Nkv, 128, D), dtype=dtype)
-                v = mx.random.normal(shape=(1, Nkv, 128, D), dtype=dtype)
-                ref = mlx_ref_attn(q, k, v, scale)
-                out = mx.fast.scaled_dot_product_attention(
-                    q, k, v, scale=scale, force_fused=True
-                )
-                atol = 1e-5 if dtype == mx.float32 else 2e-2
-                self.assertTrue(mx.allclose(ref, out, atol=atol))
+            # Test 2-pass kernel.
+            for L, dtype in product(
+                (8192, 8201), (mx.float32, mx.float16, mx.bfloat16)
+            ):
+                with self.subTest(L=L, dtype=dtype):
+                    q = mx.random.normal(shape=(1, Nq, 1, D), dtype=dtype)
+                    k = mx.random.normal(shape=(1, Nkv, L, D), dtype=dtype)
+                    v = mx.random.normal(shape=(1, Nkv, L, D), dtype=dtype)
+                    ref = mlx_ref_attn(q, k, v, scale)
+                    out = mx.fast.scaled_dot_product_attention(
+                        q, k, v, scale=scale, force_fused=True
+                    )
+                    atol = 1e-5 if dtype == mx.float32 else 2e-2
+                    self.assertTrue(mx.allclose(ref, out, atol=atol))
 
-        # Test 2-pass kernel.
-        for L, dtype in product((8192, 8201), (mx.float32, mx.float16, mx.bfloat16)):
-            with self.subTest(L=L, dtype=dtype):
-                q = mx.random.normal(shape=(1, Nq, 1, D), dtype=dtype)
-                k = mx.random.normal(shape=(1, Nkv, L, D), dtype=dtype)
-                v = mx.random.normal(shape=(1, Nkv, L, D), dtype=dtype)
-                ref = mlx_ref_attn(q, k, v, scale)
-                out = mx.fast.scaled_dot_product_attention(
-                    q, k, v, scale=scale, force_fused=True
-                )
-                atol = 1e-5 if dtype == mx.float32 else 2e-2
-                self.assertTrue(mx.allclose(ref, out, atol=atol))
-
-        # Test other heads.
-        for q_heads, kv_heads in ((8, 8), (32, 8)):
-            with self.subTest(q_heads=q_heads, kv_heads=kv_heads):
-                q = mx.random.normal(shape=(1, q_heads, 1, D))
-                k = mx.random.normal(shape=(1, kv_heads, L, D))
-                v = mx.random.normal(shape=(1, kv_heads, L, D))
-                ref = mlx_ref_attn(q, k, v, scale)
-                out = mx.fast.scaled_dot_product_attention(
-                    q,
-                    k,
-                    v,
-                    scale=scale,
-                    force_fused=True,
-                )
-                self.assertTrue(mx.allclose(ref, out, atol=1e-4, rtol=1e-4))
-
-        # Test batched.
-        B = 2
-        sinks = 10 * mx.random.normal(shape=(Nq,))
-        q = mx.random.normal(shape=(B, Nq, 1, D))
-        for L in (256, 8192):
-            k = mx.random.normal(shape=(B, Nkv, L, D))
-            v = mx.random.normal(shape=(B, Nkv, L, D))
-            for s_in in (None, sinks):
-                with self.subTest(L=L, sinks=s_in is not None):
-                    ref = mlx_ref_attn(q, k, v, scale, sinks=s_in)
+            # Test other heads.
+            for q_heads, kv_heads in ((8, 8), (32, 8)):
+                with self.subTest(q_heads=q_heads, kv_heads=kv_heads):
+                    q = mx.random.normal(shape=(1, q_heads, 1, D))
+                    k = mx.random.normal(shape=(1, kv_heads, L, D))
+                    v = mx.random.normal(shape=(1, kv_heads, L, D))
+                    ref = mlx_ref_attn(q, k, v, scale)
                     out = mx.fast.scaled_dot_product_attention(
                         q,
                         k,
                         v,
                         scale=scale,
-                        sinks=s_in,
                         force_fused=True,
                     )
                     self.assertTrue(mx.allclose(ref, out, atol=1e-4, rtol=1e-4))
+
+            # Test batched.
+            B = 2
+            sinks = 10 * mx.random.normal(shape=(Nq,))
+            q = mx.random.normal(shape=(B, Nq, 1, D))
+            for L in (256, 8192):
+                k = mx.random.normal(shape=(B, Nkv, L, D))
+                v = mx.random.normal(shape=(B, Nkv, L, D))
+                for s_in in (None, sinks):
+                    with self.subTest(L=L, sinks=s_in is not None):
+                        ref = mlx_ref_attn(q, k, v, scale, sinks=s_in)
+                        out = mx.fast.scaled_dot_product_attention(
+                            q,
+                            k,
+                            v,
+                            scale=scale,
+                            sinks=s_in,
+                            force_fused=True,
+                        )
+                        self.assertTrue(mx.allclose(ref, out, atol=1e-4, rtol=1e-4))
 
     def test_sdpa_fully_masked(self):
         Lkv = 8
@@ -648,13 +634,10 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
         k = mx.random.normal(shape=(1, 8, 8192, D), dtype=mx.float16)
         v = mx.random.normal(shape=(1, 8, 8192, D), dtype=mx.float16)
         ref = mx.fast.scaled_dot_product_attention(q, k, v, scale=D**-0.5)
-        try:
-            for blocks in (16, 33, 48, 100):
-                os.environ["MLX_SDPA_BLOCKS"] = str(blocks)
+        for blocks in (16, 33, 48, 100):
+            with mlx_tests.scoped_env(MLX_SDPA_BLOCKS=str(blocks)):
                 out = mx.fast.scaled_dot_product_attention(q, k, v, scale=D**-0.5)
                 self.assertTrue(mx.allclose(ref, out, atol=1e-4, rtol=1e-4))
-        finally:
-            del os.environ["MLX_SDPA_BLOCKS"]
 
     @unittest.skipIf(not mx.is_available(mx.gpu), "too slow on CPU")
     def test_sdpa(self):
@@ -971,14 +954,9 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
         # Vector attention kernel.
         for D in (192, 256, 512):
             with self.subTest(head_dim=D):
-                q, k, v = make_qkv(4, 16385, D, 4, 2)
-                scale = D**-0.5
-                threshold = (
-                    patch.dict(os.environ, {"MLX_SDPA_D512_MIN_KL": "0"})
-                    if D == 512
-                    else nullcontext()
-                )
-                with threshold:
+                with mlx_tests.scoped_env(MLX_SDPA_D512_MIN_KL="0"):
+                    q, k, v = make_qkv(4, 16385, D, 4, 2)
+                    scale = D**-0.5
                     ref = mlx_ref_attn(q, k, v, scale=scale)
                     out = mx.fast.scaled_dot_product_attention(
                         q, k, v, scale=scale, force_fused=True
@@ -1016,8 +994,7 @@ class TestFastSDPA(mlx_tests.MLXTestCase):
                 q, k, v, scale=64**-0.5, force_fused=True
             )
         with self.assertRaisesRegex(ValueError, r"requires at least \d+ keys"):
-            with patch.dict(os.environ):
-                os.environ.pop("MLX_SDPA_D512_MIN_KL", None)
+            with mlx_tests.scoped_env(MLX_SDPA_D512_MIN_KL=None):
                 q, k, v = make_qkv(1, 512, 512, qH=32, kH=4)
                 mx.fast.scaled_dot_product_attention(
                     q, k, v, scale=512**-0.5, force_fused=True


### PR DESCRIPTION
Replace a common pattern in tests:

```python
        name = "MLX_SDPA_PAD_HEAD_DIM"
        previous = os.environ.get(name)
        try:
            os.environ[name] = "1"
            run_tests()
        finally:
            if previous is None:
                os.environ.pop(name, None)
            else:
                os.environ[name] = previous
```

With a utility:

```python
        with mlx_tests.scoped_env(MLX_SDPA_PAD_HEAD_DIM=1):
            run_tests()
```
