### PR TITLE
leak global CommandEncoder -- avoid cuda synchronize on process shutdown

### DIFF
--- a/mlx/backend/cuda/device.cpp
+++ b/mlx/backend/cuda/device.cpp
@@ -617,8 +617,10 @@ std::unordered_map<int, CommandEncoder>& get_command_encoders() {
 }
 
 std::unordered_map<int, CommandEncoder>& get_global_command_encoders() {
-  static std::unordered_map<int, CommandEncoder> encoders;
-  return encoders;
+  // encoders are leaked intentionally as they would synchronize on process
+  // shutdown
+  static auto* encoders = new std::unordered_map<int, CommandEncoder>();
+  return *encoders;
 }
 
 } // namespace mlx::core::cu


### PR DESCRIPTION
- used in mlx-swift
- global CommandEncoder are still alive after exit even if no work is happening
- the destructor tries to call cuda api, which causes a fatal error

```
terminate called after throwing an instance of 'std::runtime_error'
 what(): cudaStreamSynchronize(stream_) failed: driver shutting down
```

from

```
frame #11: 0x0000560c45de753f example1`mlx::core::cu::CommandEncoder::synchronize() + 73
frame #12: 0x0000560c45de5c8a example1`mlx::core::cu::CommandEncoder::~CommandEncoder() + 28
frame #13: 0x0000560c45df3ee4 example1`std::pair<int const, mlx::core::cu::CommandEncoder>::~pair() + 32
```

- ☑️ I understand it is strictly prohibited to use AI to write PR description
- AI usage disclosure: none used
