### PR TITLE
Load global scales in qmm_t kernels

### DIFF
--- a/benchmarks/python/qqmm_bench.py
+++ b/benchmarks/python/qqmm_bench.py
@@ -1,0 +1,62 @@
+# Copyright © 2026 Apple Inc.
+
+import argparse
+
+import mlx.core as mx
+from time_utils import time_fn
+
+SHAPES = {
+    "qwen3.6-35b-a3b-up": (512, 2048),
+    "qwen3.6-35b-a3b-down": (2048, 512),
+}
+
+
+def qqmm(x, weight, scales, global_scale_x, global_scale_w):
+    return mx.qqmm(
+        x,
+        weight,
+        scales,
+        mode="nvfp4",
+        global_scale_x=global_scale_x,
+        global_scale_w=global_scale_w,
+    )
+
+
+def benchmark(shape, tokens):
+    output_dims, input_dims = shape
+    mx.random.seed(0)
+    global_scale_x = mx.array(1.0, dtype=mx.float32)
+    global_scale_w = mx.array(1.0, dtype=mx.float32)
+    x = mx.random.uniform(low=-0.5, high=0.5, shape=(tokens, input_dims)).astype(
+        mx.bfloat16
+    )
+    weight = mx.random.uniform(
+        low=-0.5, high=0.5, shape=(output_dims, input_dims)
+    ).astype(mx.bfloat16)
+    weight, scales = mx.quantize(
+        weight,
+        mode="nvfp4",
+        global_scale=global_scale_w,
+    )
+    mx.eval(x, weight, scales)
+
+    time_fn(
+        qqmm,
+        x,
+        weight,
+        scales,
+        global_scale_x,
+        global_scale_w,
+        msg=(
+            f"mode=nvfp4 dtype=bfloat16 tokens={tokens} "
+            f"N={output_dims} K={input_dims}"
+        ),
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--shape", choices=SHAPES, default="qwen3.6-35b-a3b-up")
+    parser.add_argument("--tokens", type=int, default=2048)
+    args = parser.parse_args()
+    benchmark(SHAPES[args.shape], args.tokens)

--- a/mlx/backend/metal/kernels/fp_quantized.h
+++ b/mlx/backend/metal/kernels/fp_quantized.h
@@ -1515,12 +1515,14 @@ template <
     const int bits,
     const bool aligned_N,
     const bool batched,
+    const bool has_global_scale = false,
     const int BM = 32,
     const int BK = 32,
     const int BN = 32>
 [[kernel]] void fp_qmm_t(
     const device uint32_t* w,
     const device uint8_t* scales,
+    const device float* global_scale,
     const device T* x,
     device T* y,
     const constant int& K,
@@ -1560,10 +1562,10 @@ template <
         s_strides,
         tid);
   }
-  fp_qmm_t_impl<T, group_size, bits, aligned_N, false, BM, BK, BN>(
+  fp_qmm_t_impl<T, group_size, bits, aligned_N, has_global_scale, BM, BK, BN>(
       w,
       scales,
-      nullptr,
+      global_scale,
       x,
       y,
       Xs,

--- a/mlx/backend/metal/kernels/fp_quantized.metal
+++ b/mlx/backend/metal/kernels/fp_quantized.metal
@@ -68,6 +68,17 @@
       aligned, \
       batched)
 
+#define instantiate_quantized_aligned_batched_hgs(mode, name, type, aligned, batched, group_size, bits) \
+  instantiate_kernel( \
+      #mode "_" #name "_" #type "_gs_" #group_size "_b_" #bits "_alN_" #aligned "_batch_" #batched "_hgs", \
+      fp_ ## name,    \
+      type,    \
+      group_size,      \
+      bits,       \
+      aligned, \
+      batched, \
+      true)
+
 #define instantiate_quantized_qmv_fast(mode, type, results, batched, group_size, bits) \
   instantiate_kernel( \
       #mode "_qmv_fast_" #type "_gs_" #group_size "_b_" #bits "_r_" #results "_batch_" #batched, \
@@ -173,6 +184,10 @@
   instantiate_quantized_aligned_batched(mode, qmm_t, type, false, 1, group_size, bits) \
   instantiate_quantized_aligned_batched(mode, qmm_t, type, false, 0, group_size, bits)
 
+#define instantiate_quantized_qmm_hgs(type) \
+  instantiate_quantized_aligned_batched_hgs(nvfp4, qmm_t, type, true, 0, 16, 4)  \
+  instantiate_quantized_aligned_batched_hgs(nvfp4, qmm_t, type, false, 0, 16, 4)
+
 #define instantiate_quantized_all_quad(type, mode, group_size, bits) \
   instantiate_quantized_quad(mode, qmv_quad, type, 64, 1, group_size, bits)  \
   instantiate_quantized_quad(mode, qmv_quad, type, 64, 0, group_size, bits)  \
@@ -245,4 +260,5 @@
 instantiate_quantized_types(float)
 instantiate_quantized_types(bfloat16_t)
 instantiate_quantized_types(float16_t)
+instantiate_quantized_qmm_hgs(bfloat16_t)
     // clang-format on

--- a/mlx/backend/metal/kernels/fp_quantized_nax.h
+++ b/mlx/backend/metal/kernels/fp_quantized_nax.h
@@ -1,4 +1,4 @@
-// Copyright © 2025 Apple Inc.
+// Copyright © 2025-2026 Apple Inc.
 
 #include <metal_simdgroup>
 #include <metal_stdlib>
@@ -561,10 +561,12 @@ template <
     const int BN = 64,
     const int WM = 2,
     const int WN = 2,
+    const bool has_global_scale = false,
     typename Wtype = bfloat>
 [[kernel]] void fp_qmm_t_nax(
     const device uint32_t* w,
     const device uint8_t* scales,
+    const device float* global_scale,
     const device T* x,
     device T* y,
     const constant int& K,
@@ -608,14 +610,14 @@ template <
       group_size,
       bits,
       aligned_N,
-      false,
+      has_global_scale,
       BM,
       BK,
       BN,
       WM,
       WN,
       Wtype>(
-      w, scales, nullptr, x, y, Ws, K, N, M, tid, lid, simd_gid, simd_lid);
+      w, scales, global_scale, x, y, Ws, K, N, M, tid, lid, simd_gid, simd_lid);
 }
 
 template <

--- a/mlx/backend/metal/kernels/fp_quantized_nax.metal
+++ b/mlx/backend/metal/kernels/fp_quantized_nax.metal
@@ -1,4 +1,4 @@
-// Copyright © 2025 Apple Inc.
+// Copyright © 2025-2026 Apple Inc.
 
 // clang-format off
 #include "mlx/backend/metal/kernels/utils.h"
@@ -43,6 +43,16 @@
       aligned, \
       batched, bm, bk, bn, wm, wn)
 
+#define instantiate_quantized_aligned_batched_hgs(mode, name, type, bm, bn, bk, wm, wn, aligned, batched, group_size, bits) \
+  instantiate_kernel( \
+      #mode "_" #name "_" #type "_gs_" #group_size "_b_" #bits "_bm" #bm "_bn" #bn "_bk" #bk "_wm" #wm "_wn" #wn "_alN_" #aligned "_batch_" #batched "_hgs", \
+      fp_ ## name,    \
+      type,    \
+      group_size,      \
+      bits,       \
+      aligned, \
+      batched, bm, bk, bn, wm, wn, true)
+
 #define instantiate_gather_qmm_rhs(func, name, type, bm, bn, bk, wm, wn, transpose, mode, group_size, bits) \
   instantiate_kernel( \
       #mode "_" #name "_" #type "_gs_" #group_size "_b_" #bits "_bm_" #bm "_bn_" #bn "_bk_" #bk "_wm_" #wm "_wn_" #wn, \
@@ -83,6 +93,12 @@
   instantiate_quantized_aligned_batched(mode, qmm_t_nax, type, 32, 64, 64, 2, 2, false, 1, group_size, bits) \
   instantiate_quantized_aligned_batched(mode, qmm_t_nax, type, 32, 64, 64, 2, 2, false, 0, group_size, bits)
 
+#define instantiate_quantized_qmm_hgs(type) \
+  instantiate_quantized_aligned_batched_hgs(nvfp4, qmm_t_nax, type, 64, 64, 64, 2, 2, true, 0, 16, 4)  \
+  instantiate_quantized_aligned_batched_hgs(nvfp4, qmm_t_nax, type, 64, 64, 64, 2, 2, false, 0, 16, 4) \
+  instantiate_quantized_aligned_batched_hgs(nvfp4, qmm_t_nax, type, 32, 64, 64, 2, 2, true, 0, 16, 4)  \
+  instantiate_quantized_aligned_batched_hgs(nvfp4, qmm_t_nax, type, 32, 64, 64, 2, 2, false, 0, 16, 4)
+
 
 #define instantiate_quantized_all_rhs(type, mode, group_size, bits) \
   instantiate_gather_qmm_rhs(fp_gather_qmm_rhs_nax, gather_qmm_rhs_nax_nt, type, 64, 64, 64, 2, 2, true, mode, group_size, bits) \
@@ -102,4 +118,5 @@
 instantiate_quantized_types(float)
 instantiate_quantized_types(bfloat16_t)
 instantiate_quantized_types(float16_t)
+instantiate_quantized_qmm_hgs(bfloat16_t)
     // clang-format on

--- a/mlx/backend/metal/kernels/quantized.h
+++ b/mlx/backend/metal/kernels/quantized.h
@@ -1896,6 +1896,7 @@ template <
     const int bits,
     const bool aligned_N,
     const bool batched,
+    const bool has_global_scale = false,
     const int BM = 32,
     const int BK = 32,
     const int BN = 32>

--- a/mlx/backend/metal/kernels/quantized_nax.h
+++ b/mlx/backend/metal/kernels/quantized_nax.h
@@ -1201,7 +1201,8 @@ template <
     const int BK = 32,
     const int BN = 64,
     const int WM = 2,
-    const int WN = 2>
+    const int WN = 2,
+    const bool has_global_scale = false>
 [[kernel]] void affine_qmm_t_nax(
     const device uint32_t* w [[buffer(0)]],
     const device T* scales [[buffer(1)]],

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -816,6 +816,7 @@ void qmm_nax(
     const array& w,
     const array& scales,
     const std::optional<array>& biases,
+    const std::optional<array>& global_scale,
     array& out,
     bool transpose,
     int group_size,
@@ -862,25 +863,42 @@ void qmm_nax(
       "_wn",
       wn,
       transpose ? (aligned ? "_alN_true" : "_alN_false") : "",
-      batched ? "_batch_1" : "_batch_0");
+      batched ? "_batch_1" : "_batch_0",
+      global_scale ? "_hgs" : "");
   std::string template_def;
   MTL::ComputePipelineState* kernel;
   if (transpose) {
-    kernel = get_qmm_nax_kernel_wrapped(
-        d,
-        kname,
-        "qmm_t_nax",
-        mode,
-        type_string,
-        group_size,
-        bits,
-        aligned,
-        batched,
-        bm,
-        bk,
-        bn,
-        wm,
-        wn);
+    kernel = global_scale ? get_qmm_nax_kernel_wrapped(
+                                d,
+                                kname,
+                                "qmm_t_nax",
+                                mode,
+                                type_string,
+                                group_size,
+                                bits,
+                                aligned,
+                                batched,
+                                bm,
+                                bk,
+                                bn,
+                                wm,
+                                wn,
+                                true)
+                          : get_qmm_nax_kernel_wrapped(
+                                d,
+                                kname,
+                                "qmm_t_nax",
+                                mode,
+                                type_string,
+                                group_size,
+                                bits,
+                                aligned,
+                                batched,
+                                bm,
+                                bk,
+                                bn,
+                                wm,
+                                wn);
   } else {
     kernel = get_qmm_nax_kernel_wrapped(
         d,
@@ -905,6 +923,11 @@ void qmm_nax(
   compute_encoder.set_input_array(scales, c++);
   if (biases) {
     compute_encoder.set_input_array(*biases, c++);
+  } else if (transpose) {
+    if (global_scale) {
+      compute_encoder.set_input_array(*global_scale, c);
+    }
+    c++;
   }
   compute_encoder.set_input_array(x, c++);
   compute_encoder.set_output_array(out, c++);
@@ -1032,6 +1055,7 @@ void qmm(
     const array& w,
     const array& scales,
     const std::optional<array>& biases,
+    const std::optional<array>& global_scale,
     array& out,
     bool transpose,
     int group_size,
@@ -1042,6 +1066,10 @@ void qmm(
     metal::Device& d,
     const Stream& s,
     const std::string& mode) {
+  assert(
+      (!global_scale || (transpose && !biases)) &&
+      "qmm global scale requires transposed weights without biases");
+
   bool has_nax_kernel =
       metal::is_nax_available() && (transpose || mode == "affine");
   bool nax_aligned = (K % 64 == 0) && (transpose || N % 64 == 0);
@@ -1052,6 +1080,7 @@ void qmm(
         /* const array& w = */ w,
         /* const array& scales = */ scales,
         /* const std::optional<array>& biases = */ biases,
+        /* const std::optional<array>& global_scale = */ global_scale,
         /* array& out = */ out,
         /* bool transpose = */ transpose,
         /* int group_size = */ group_size,
@@ -1087,20 +1116,32 @@ void qmm(
       "_b_",
       bits,
       transpose ? (aligned ? "_alN_true" : "_alN_false") : "",
-      batched ? "_batch_1" : "_batch_0");
+      batched ? "_batch_1" : "_batch_0",
+      global_scale ? "_hgs" : "");
   std::string template_def;
   MTL::ComputePipelineState* kernel;
   if (transpose) {
-    kernel = get_quantized_kernel_wrapped(
-        d,
-        kname,
-        "qmm_t",
-        mode,
-        type_string,
-        group_size,
-        bits,
-        aligned,
-        batched);
+    kernel = global_scale ? get_quantized_kernel_wrapped(
+                                d,
+                                kname,
+                                "qmm_t",
+                                mode,
+                                type_string,
+                                group_size,
+                                bits,
+                                aligned,
+                                batched,
+                                true)
+                          : get_quantized_kernel_wrapped(
+                                d,
+                                kname,
+                                "qmm_t",
+                                mode,
+                                type_string,
+                                group_size,
+                                bits,
+                                aligned,
+                                batched);
   } else {
     kernel = get_quantized_kernel_wrapped(
         d, kname, "qmm_n", mode, type_string, group_size, bits, batched);
@@ -1113,6 +1154,11 @@ void qmm(
   compute_encoder.set_input_array(scales, c++);
   if (biases) {
     compute_encoder.set_input_array(*biases, c++);
+  } else if (transpose) {
+    if (global_scale) {
+      compute_encoder.set_input_array(*global_scale, c);
+    }
+    c++;
   }
   compute_encoder.set_input_array(x, c++);
   compute_encoder.set_output_array(out, c++);
@@ -1158,7 +1204,21 @@ void qmm_splitk(
   }
   if (split_k <= 1) {
     return qmm(
-        x, w, scales, biases, out, true, group_size, bits, M, N, K, d, s, mode);
+        x,
+        w,
+        scales,
+        biases,
+        std::nullopt,
+        out,
+        true,
+        group_size,
+        bits,
+        M,
+        N,
+        K,
+        d,
+        s,
+        mode);
   }
 
   int k_partition_size = K / split_k;
@@ -1862,6 +1922,7 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
         w,
         scales,
         biases,
+        std::nullopt,
         out,
         transpose_,
         group_size_,
@@ -2078,6 +2139,26 @@ void QQMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
   int K = x.shape(-1);
   int M = non_batched ? x.size() / K : x.shape(-2);
   int N = out.shape(-1);
+  if (has_global_scales && w_quantized && non_batched &&
+      x.dtype() == bfloat16 && K % 32 == 0 &&
+      M >= get_qmv_batch_limit(K, N, d)) {
+    qmm(x,
+        w_q,
+        scales_w,
+        std::nullopt,
+        global_scale_w,
+        out,
+        true,
+        group_size_,
+        bits_,
+        M,
+        N,
+        K,
+        d,
+        s,
+        mode);
+    return;
+  }
   dispatch_qmv(
       x,
       w_q,

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -868,37 +868,22 @@ void qmm_nax(
   std::string template_def;
   MTL::ComputePipelineState* kernel;
   if (transpose) {
-    kernel = global_scale ? get_qmm_nax_kernel_wrapped(
-                                d,
-                                kname,
-                                "qmm_t_nax",
-                                mode,
-                                type_string,
-                                group_size,
-                                bits,
-                                aligned,
-                                batched,
-                                bm,
-                                bk,
-                                bn,
-                                wm,
-                                wn,
-                                true)
-                          : get_qmm_nax_kernel_wrapped(
-                                d,
-                                kname,
-                                "qmm_t_nax",
-                                mode,
-                                type_string,
-                                group_size,
-                                bits,
-                                aligned,
-                                batched,
-                                bm,
-                                bk,
-                                bn,
-                                wm,
-                                wn);
+    kernel = get_qmm_nax_kernel_wrapped(
+        d,
+        kname,
+        "qmm_t_nax",
+        mode,
+        type_string,
+        group_size,
+        bits,
+        aligned,
+        batched,
+        bm,
+        bk,
+        bn,
+        wm,
+        wn,
+        global_scale.has_value());
   } else {
     kernel = get_qmm_nax_kernel_wrapped(
         d,
@@ -1121,27 +1106,17 @@ void qmm(
   std::string template_def;
   MTL::ComputePipelineState* kernel;
   if (transpose) {
-    kernel = global_scale ? get_quantized_kernel_wrapped(
-                                d,
-                                kname,
-                                "qmm_t",
-                                mode,
-                                type_string,
-                                group_size,
-                                bits,
-                                aligned,
-                                batched,
-                                true)
-                          : get_quantized_kernel_wrapped(
-                                d,
-                                kname,
-                                "qmm_t",
-                                mode,
-                                type_string,
-                                group_size,
-                                bits,
-                                aligned,
-                                batched);
+    kernel = get_quantized_kernel_wrapped(
+        d,
+        kname,
+        "qmm_t",
+        mode,
+        type_string,
+        group_size,
+        bits,
+        aligned,
+        batched,
+        global_scale.has_value());
   } else {
     kernel = get_quantized_kernel_wrapped(
         d, kname, "qmm_n", mode, type_string, group_size, bits, batched);

--- a/python/tests/test_quantized.py
+++ b/python/tests/test_quantized.py
@@ -320,6 +320,52 @@ class TestQuantized(mlx_tests.MLXTestCase):
                 self.assertEqual(y_q.shape, y_hat.shape)
                 self.assertLess((y_q - y_hat).abs().max(), 1e-3)
 
+    @unittest.skipIf(
+        not mx.metal.is_available(), "Global scale is only supported on Metal backend"
+    )
+    def test_qqmm_global_scale_matrix_kernels(self):
+        mx.random.seed(0)
+        dtype = mx.bfloat16
+        for M, N, K in product(
+            [32, 64],
+            [128, 130],
+            [96, 128],
+        ):
+            with self.subTest(shape=(M, N, K)):
+                x = mx.random.normal((M, K)).astype(dtype)
+                w = mx.random.normal((N, K)).astype(dtype)
+                global_scale_x = mx.max(mx.abs(x)).astype(mx.float32)
+                global_scale_w = mx.max(mx.abs(w)).astype(mx.float32)
+                x_hat = mx.dequantize(
+                    *mx.quantize(x, mode="nvfp4", global_scale=global_scale_x),
+                    mode="nvfp4",
+                    dtype=dtype,
+                    global_scale=global_scale_x,
+                )
+                w_q, scales = mx.quantize(w, mode="nvfp4", global_scale=global_scale_w)
+                w_hat = mx.dequantize(
+                    w_q,
+                    scales,
+                    mode="nvfp4",
+                    dtype=dtype,
+                    global_scale=global_scale_w,
+                )
+
+                expected = x_hat @ mx.swapaxes(w_hat, -1, -2)
+                actual = mx.qqmm(
+                    x,
+                    w_q,
+                    scales,
+                    mode="nvfp4",
+                    global_scale_x=global_scale_x,
+                    global_scale_w=global_scale_w,
+                )
+                delta = mx.abs(actual.astype(mx.float32) - expected.astype(mx.float32))
+                relative_error = delta.max() / mx.maximum(
+                    mx.abs(expected.astype(mx.float32)).max(), 1e-20
+                )
+                self.assertLess(relative_error, 3e-2)
+
     def test_qmm(self):
         key = mx.random.key(0)
         k1, k2 = mx.random.split(key)


### PR DESCRIPTION
Compliments #4481 by adding global scale to the qmm_t kernels.

### Performance

Using the NVIDIA Model Optimizer on Qwen/Qwen3.6-35B-A3B with nvfp4_mlp_only p2048/g128

| GPU | upstream/main prompt tps | this PR prompt tps | this + #4481|
|---|---:|---:|---:|
| M5 Max | 1,267.5 | 1,365.9 | 4,256.2 |
| M3 Ultra | 1,603.2 | 1,683.5 | 2,819.9 |


- ☑️ I understand it is strictly prohibited to use AI to write PR description
- AI usage disclosure: co-developed with a coding agent
