### PR TITLE
Fix CUDA test synchronization flake

### DIFF
--- a/tests/cuda_tests.cpp
+++ b/tests/cuda_tests.cpp
@@ -86,10 +86,11 @@ TEST_CASE("test clear cache trims CUDA pool") {
           pool, cudaMemPoolAttrReservedMemCurrent, &initial_reserved),
       cudaSuccess);
 
+  auto s = default_stream(Device::gpu);
   {
-    auto a = zeros({16 * 1024 * 1024}, float32, Device::gpu);
+    auto a = zeros({16 * 1024 * 1024}, float32, s);
     eval(a);
-    synchronize();
+    synchronize(s);
   }
   CHECK_GE(get_cache_memory(), 64ULL << 20);
 


### PR DESCRIPTION
Follow up from #4457 

The new test was improperly synchronizing on CPU (default) instead of the GPU stream leading to flaky behavior.

- ☑️ I understand it is strictly prohibited to use AI to write PR description
- AI usage disclosure: co-developed with coding agent
