### PR TITLE
Add missing defaults to tri, tril, triu, gather_mm signatures

### DIFF
--- a/python/src/ops.cpp
+++ b/python/src/ops.cpp
@@ -2106,7 +2106,7 @@ void init_ops(nb::module_& m) {
       nb::kw_only(),
       "stream"_a = nb::none(),
       nb::sig(
-          "def tri(n: int, m: int, k: int, dtype: Dtype | None = None, *, stream: StreamOrDevice = None) -> array"),
+          "def tri(n: int, m: int | None = None, k: int = 0, dtype: Dtype | None = None, *, stream: StreamOrDevice = None) -> array"),
       R"pbdoc(
         An array with ones at and below the given diagonal and zeros elsewhere.
 
@@ -2128,7 +2128,7 @@ void init_ops(nb::module_& m) {
       nb::kw_only(),
       "stream"_a = nb::none(),
       nb::sig(
-          "def tril(x: array, k: int, *, stream: StreamOrDevice = None) -> array"),
+          "def tril(x: array, k: int = 0, *, stream: StreamOrDevice = None) -> array"),
       R"pbdoc(
         Zeros the array above the given diagonal.
 
@@ -2148,7 +2148,7 @@ void init_ops(nb::module_& m) {
       nb::kw_only(),
       "stream"_a = nb::none(),
       nb::sig(
-          "def triu(x: array, k: int, *, stream: StreamOrDevice = None) -> array"),
+          "def triu(x: array, k: int = 0, *, stream: StreamOrDevice = None) -> array"),
       R"pbdoc(
         Zeros the array below the given diagonal.
 
@@ -5153,7 +5153,7 @@ void init_ops(nb::module_& m) {
       "sorted_indices"_a = false,
       "stream"_a = nb::none(),
       nb::sig(
-          "def gather_mm(a: array, b: array, /, lhs_indices: array, rhs_indices: array, *, sorted_indices: bool = False, stream: StreamOrDevice = None) -> array"),
+          "def gather_mm(a: array, b: array, /, lhs_indices: array | None = None, rhs_indices: array | None = None, *, sorted_indices: bool = False, stream: StreamOrDevice = None) -> array"),
       R"pbdoc(
         Matrix multiplication with matrix-level gather.
 


### PR DESCRIPTION
The signatures for `tri`, `tril`, `triu`, and `gather_mm` omit defaults that their Python bindings already provide. The generated stubs therefore mark these arguments as required, causing Pyright to reject valid calls such as `mx.tri(3)` and `mx.gather_mm(x, x)`.

This updates the four `nb::sig` strings in `python/src/ops.cpp` to match the existing bindings and docstrings:

* `tri`: declare `m: int | None = None` and `k: int = 0`.
* `tril` and `triu`: declare `k: int = 0`.
* `gather_mm`: declare both index arguments as `array | None = None`.

There is no runtime behavior change.

Validation used a CPU-only source build. The regenerated stubs contain the corrected signatures, and Pyright reports zero errors on six example calls that previously produced six missing-argument errors. Those calls execute successfully both before and after the change. The existing `tri`, `tril`, and `triu` tests pass, as does the clang-format check.
